### PR TITLE
Disable delete snapshot file during topic deletion and fix bug in gro…

### DIFF
--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -204,7 +204,7 @@ class ReplicaStateMachine(config: KafkaConfig,
       case OfflineReplica =>
         validReplicas.foreach { replica =>
           controllerBrokerRequestBatch.addStopReplicaRequestForBrokers(Seq(replicaId), replica.topicPartition,
-            deletePartition = false, (_, _) => ())
+            deletePartition = false, null)
         }
         val (replicasWithLeadershipInfo, replicasWithoutLeadershipInfo) = validReplicas.partition { replica =>
           controllerContext.partitionLeadershipInfo.contains(replica.topicPartition)

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -807,7 +807,9 @@ class LogManager(logDirs: Seq[File],
         // Now that replica in source log directory has been successfully renamed for deletion.
         // Close the log, update checkpoint files, and enqueue this log to be deleted.
         sourceLog.close()
-        checkpointLogRecoveryOffsetsInDir(sourceLog.dir.getParentFile)
+        // Set deleteSnapshotFiles to false to speed up topic deletion, since snapshot file is only used
+        // for transaction, which is not used anywhere in LinkedIn
+        checkpointLogRecoveryOffsetsInDir(sourceLog.dir.getParentFile, false)
         checkpointLogStartOffsetsInDir(sourceLog.dir.getParentFile)
         addLogToBeDeleted(sourceLog)
       } catch {


### PR DESCRIPTION
Problem:
1. Snapshot files are always deleted during topic deletion, since it involves disk IOs and we do delete for each topic partition, this can slow down the deletion process thus blocking the controller from picking up other requests when there are large number of topic partitions. Since snapshot files are only used for transaction, which is not used in LinkedIn, it can be disabled.

2. During replica offline, controller is expected to send only one batched STOP_REPLICA request to destination broker with callback set to null. But currently the callback is set to **_(_,_) => ()_**, which is not empty, thus preventing the grouping of message, so we end up sending one STOP_REPLICA request for each partition.

Testing:
Verified the fix in cert2 cluster by creating and deleting topics at the same time. With deleting snapshot files during topic deletion, we see ~1.5min delay in controller sending/receiving LEADER_AND_ISR request, and deleting snapshot files takes ~500ms for each partition, which contributes most to the broker processing time of STOP_REPLICA request; without the deleting, the processing time drops to ~10ms.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
