### PR TITLE
Adjust broker-side observer interface so that the interface only take Java objects as argument.

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2376,7 +2376,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           if (RequestChannel.isRequestLoggingEnabled) Some(response.toString(request.context.apiVersion))
           else None
         try {
-          observer.observe(request, response)
+          observer.observe(request.context, request.body[AbstractRequest], response)
         } catch {
           case e: Exception => error(s"Observer failed to observe ${Observer.describeRequestAndResponse(request, response)}", e)
         }

--- a/core/src/main/scala/kafka/server/NoOpObserver.scala
+++ b/core/src/main/scala/kafka/server/NoOpObserver.scala
@@ -19,8 +19,7 @@ package kafka.server
 
 import java.util.Map
 import java.util.concurrent.TimeUnit
-import kafka.network.RequestChannel
-import org.apache.kafka.common.requests.AbstractResponse
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, RequestContext}
 
 /**
   * An observer implementation that has no operation and serves as a place holder.
@@ -32,7 +31,7 @@ class NoOpObserver extends Observer {
   /**
     * Observer the record based on the given information.
     */
-  def observe(request: RequestChannel.Request, response: AbstractResponse): Unit = {}
+  def observe(requestContext: RequestContext, request: AbstractRequest, response: AbstractResponse): Unit = {}
 
   /**
     * Close the observer with timeout.

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -20,6 +20,8 @@ package kafka.server
 import java.util.concurrent.TimeUnit
 import kafka.network.RequestChannel
 import org.apache.kafka.common.requests.AbstractResponse
+import org.apache.kafka.common.requests.AbstractRequest
+import org.apache.kafka.common.requests.RequestContext
 import org.apache.kafka.common.Configurable
 
 /**
@@ -37,10 +39,11 @@ trait Observer extends Configurable {
   /**
     * Observe the record based on the given information.
     *
+    * @param requestContext the context information about the request
     * @param request  the request being observed for a various purpose(s)
     * @param response the response to the request
     */
-  def observe(request: RequestChannel.Request, response: AbstractResponse): Unit
+  def observe(requestContext: RequestContext, request: AbstractRequest, response: AbstractResponse): Unit
 
   /**
     * Close the observer with timeout.


### PR DESCRIPTION
The previous observer interface has a method called "observe" which takes `RequestChannel.Request` and `AbstractResponse` as arguments. However, `RequestChannel.Request` is a class defined in Scala. Since the implementation of the observer interface is actually in Java. That means the Scala object needs to be converted in Java in the implementation. This conversion is prone to bugs, hard to read and can easily break compatibility if in the future upstream modify the structure of `RequestChannel.Request`, which they did before and considered MINOR: https://github.com/apache/kafka/pull/3673/files#diff-d0332a0ff31df50afce3809d90505b25R49.

Therefore, the adjusted observer interface takes 3 objects as shown below:
- The metadata of the request including principal, header, client address. This is captured by the `RequestContext` object.
- The payload of the request. This is captured by `AbstractReqeust` object.
- The payload of the response. This is captured by `AbstractResponse` object.