### PR TITLE
Log unclean leader election.

### DIFF
--- a/core/src/test/scala/unit/kafka/controller/PartitionLeaderElectionAlgorithmsTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionLeaderElectionAlgorithmsTest.scala
@@ -39,7 +39,7 @@ class PartitionLeaderElectionAlgorithmsTest  extends JUnitSuite {
       liveReplicas,
       uncleanLeaderElectionEnabled = false,
       controllerContext)
-    assertEquals(Option(4), leaderOpt)
+    assertEquals(Option(4, false), leaderOpt)
   }
 
   @Test
@@ -66,8 +66,7 @@ class PartitionLeaderElectionAlgorithmsTest  extends JUnitSuite {
       liveReplicas,
       uncleanLeaderElectionEnabled = true,
       controllerContext)
-    assertEquals(Option(4), leaderOpt)
-    assertEquals(1, controllerContext.stats.uncleanLeaderElectionRate.count())
+    assertEquals(Option(4, true), leaderOpt)
   }
 
   @Test


### PR DESCRIPTION
This adds a warning level log message to the PartitionStateMachine to let us know when an unclean leader election has occurred.  Instead of changing offlinePartitionLeaderElection() to have more side effects, the side effects have been moved out of that function and into the calling logic which deals with side effects.

A new unit tests was added to test that  PartitionStateMachine correctly deals with the unclean leader election case.