### PR TITLE
Exclude topics being deleted from the offlinePartitionCount metric and clean up partitionState in PartitionStateMachine after topic deletion is done

### DIFF
--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -63,27 +63,6 @@ class TopicDeletionManager(controller: KafkaController,
   val controllerContext = controller.controllerContext
   var isDeleteTopicEnabled = controller.config.deleteTopicEnable
   val topicsToBeDeleted = mutable.Set.empty[String]
-  /** The following topicsWithDeletionStarted variable is used to properly update the offlinePartitionCount metric.
-    * When a topic is going through deletion, we don't want to keep track of its partition state
-    * changes in the offlinePartitionCount metric, see the PartitionStateMachine#updateControllerMetrics
-    * for detailed logic. This goal means if some partitions of a topic are already
-    * in OfflinePartition state when deletion starts, we need to change the corresponding partition
-    * states to NonExistentPartition first before starting the deletion.
-    *
-    * However we can NOT change partition states to NonExistentPartition at the time of enqueuing topics
-    * for deletion. The reason is that when a topic is enqueued for deletion, it may be ineligible for
-    * deletion due to ongoing partition reassignments. Hence there might be a delay between enqueuing
-    * a topic for deletion and the actual start of deletion. In this delayed interval, partitions may still
-    * transition to or out of the OfflinePartition state.
-    *
-    * Hence we decide to change partition states to NonExistentPartition only when the actual deletion have started.
-    * For topics whose deletion have actually started, we keep track of them in the following topicsWithDeletionStarted
-    * variable. And once a topic is in the topicsWithDeletionStarted set, we are sure there will no longer
-    * be partition reassignments to any of its partitions, and only then it's safe to move its partitions to
-    * NonExistentPartition state. Once a topic is in the topicsWithDeletionStarted set, we will stop monitoring
-    * its partition state changes in the offlinePartitionCount metric
-    */
-  val topicsWithDeletionStarted = mutable.Set.empty[String]
   val topicsIneligibleForDeletion = mutable.Set.empty[String]
 
   // Try to create the znode for delete topic flag
@@ -118,7 +97,6 @@ class TopicDeletionManager(controller: KafkaController,
   def reset() {
     if (isDeleteTopicEnabled) {
       topicsToBeDeleted.clear()
-      topicsWithDeletionStarted.clear()
       topicsIneligibleForDeletion.clear()
     }
   }
@@ -132,6 +110,7 @@ class TopicDeletionManager(controller: KafkaController,
   def enqueueTopicsForDeletion(topics: Set[String]) {
     if (isDeleteTopicEnabled) {
       topicsToBeDeleted ++= topics
+      topics.foreach(controller.partitionStateMachine.excludeDeletingTopicFromOfflinePartitionCount)
       resumeDeletions()
     }
   }
@@ -201,13 +180,6 @@ class TopicDeletionManager(controller: KafkaController,
       false
   }
 
-  def isTopicWithDeletionStarted(topic: String) = {
-    if (isDeleteTopicEnabled) {
-      topicsWithDeletionStarted.contains(topic)
-    } else
-      false
-  }
-
   def isTopicQueuedUpForDeletion(topic: String): Boolean = {
     if (isDeleteTopicEnabled) {
       topicsToBeDeleted.contains(topic)
@@ -260,10 +232,10 @@ class TopicDeletionManager(controller: KafkaController,
     // controller will remove this replica from the state machine as well as its partition assignment cache
     controller.replicaStateMachine.handleStateChanges(replicasForDeletedTopic.toSeq, NonExistentReplica)
     topicsToBeDeleted -= topic
-    topicsWithDeletionStarted -= topic
     zkClient.deleteTopicZNode(topic, controllerContext.epochZkVersion)
     zkClient.deleteTopicConfigs(Seq(topic), controllerContext.epochZkVersion)
     zkClient.deleteTopicDeletions(Seq(topic), controllerContext.epochZkVersion)
+    controller.partitionStateMachine.removePartitionStatesForTopic(topic)
     controllerContext.removeTopic(topic)
   }
 
@@ -277,18 +249,11 @@ class TopicDeletionManager(controller: KafkaController,
   private def onTopicDeletion(topics: Set[String]) {
     info(s"Topic deletion callback for ${topics.mkString(",")}")
     // send update metadata so that brokers stop serving data for topics to be deleted
-    val partitions = topics.flatMap(controllerContext.partitionsForTopic)
-    val unseenTopicsForDeletion = topics -- topicsWithDeletionStarted
-    if (unseenTopicsForDeletion.nonEmpty) {
-      val unseenPartitionsForDeletion = unseenTopicsForDeletion.flatMap(controllerContext.partitionsForTopic)
-      controller.partitionStateMachine.handleStateChanges(unseenPartitionsForDeletion.toSeq, OfflinePartition)
-      controller.partitionStateMachine.handleStateChanges(unseenPartitionsForDeletion.toSeq, NonExistentPartition)
-      // adding of unseenTopicsForDeletion to topicsBeingDeleted must be done after the partition state changes
-      // to make sure the offlinePartitionCount metric is properly updated
-      topicsWithDeletionStarted ++= unseenTopicsForDeletion
-    }
+    val partitionsForDeletion = topics.flatMap(controllerContext.partitionsForTopic)
+    controller.partitionStateMachine.handleStateChanges(partitionsForDeletion.toSeq, OfflinePartition)
+    controller.partitionStateMachine.handleStateChanges(partitionsForDeletion.toSeq, NonExistentPartition)
 
-    controller.sendUpdateMetadataRequest(controllerContext.liveOrShuttingDownBrokerIds.toSeq, partitions)
+    controller.sendUpdateMetadataRequest(controllerContext.liveOrShuttingDownBrokerIds.toSeq, partitionsForDeletion)
     topics.foreach { topic =>
       onPartitionDeletion(controllerContext.partitionsForTopic(topic))
     }

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -109,8 +109,9 @@ class TopicDeletionManager(controller: KafkaController,
    */
   def enqueueTopicsForDeletion(topics: Set[String]) {
     if (isDeleteTopicEnabled) {
-      topicsToBeDeleted ++= topics
-      topics.foreach(controller.partitionStateMachine.excludeDeletingTopicFromOfflinePartitionCount)
+      val newTopicsToBeDeleted = topics -- topicsToBeDeleted
+      topicsToBeDeleted ++= newTopicsToBeDeleted
+      newTopicsToBeDeleted.foreach(controller.partitionStateMachine.excludeDeletingTopicFromOfflinePartitionCount)
       resumeDeletions()
     }
   }

--- a/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
@@ -381,7 +381,7 @@ class PartitionStateMachineTest extends JUnitSuite {
       controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     }
 
-    EasyMock.expect(mockTopicDeletionManager.isTopicWithDeletionStarted(topic)).andReturn(false)
+    EasyMock.expect(mockTopicDeletionManager.isTopicQueuedUpForDeletion(topic)).andReturn(false)
     EasyMock.expectLastCall().anyTimes()
     prepareMockToElectLeaderForPartitions(partitions)
     EasyMock.replay(mockZkClient, mockTopicDeletionManager)
@@ -404,7 +404,7 @@ class PartitionStateMachineTest extends JUnitSuite {
     val topic = "test"
     val partitions = partitionIds.map(new TopicPartition("test", _))
 
-    EasyMock.expect(mockTopicDeletionManager.isTopicWithDeletionStarted(topic)).andReturn(true)
+    EasyMock.expect(mockTopicDeletionManager.isTopicQueuedUpForDeletion(topic)).andReturn(true)
     EasyMock.expectLastCall().anyTimes()
     EasyMock.replay(mockTopicDeletionManager)
 


### PR DESCRIPTION
Currently the offlinePartitionCount metric also reports the partitions of the topic
that has already been queued for deletion, which creates noise for the alerting
system, especially for the cluster that has frequent topic deletion operation. This
patch adds a mechanism to exclude partitions already been queued for deletion from
the offlinePartitionCount metric and also remove the in-memory topicsWithDeletionStarted
in TopicDeletionManager since we no longer use it to update the metric.

This patch also addresses a potential memory pressure issue of not cleaning up the in-memory
partition states in PartitionStateMachine even after the topic has already been deleted.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
