### PR TITLE
fix in parallel topic deletion and partition reassignment issue

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -900,7 +900,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
    * `ControllerContext.partitionsBeingReassigned` must be populated with all partitions being reassigned before this
    * method is invoked to avoid premature deletion of the `reassign_partitions` znode.
    */
-  private def removePartitionsFromReassignedPartitions(partitionsToBeRemoved: Set[TopicPartition]) {
+  def removePartitionsFromReassignedPartitions(partitionsToBeRemoved: Set[TopicPartition]) {
     if (partitionsToBeRemoved.nonEmpty) {
       partitionsToBeRemoved.map(controllerContext.partitionsBeingReassigned).foreach { reassignContext =>
         reassignContext.unregisterReassignIsrChangeHandler(zkClient)

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -900,7 +900,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
    * `ControllerContext.partitionsBeingReassigned` must be populated with all partitions being reassigned before this
    * method is invoked to avoid premature deletion of the `reassign_partitions` znode.
    */
-  def removePartitionsFromReassignedPartitions(partitionsToBeRemoved: Set[TopicPartition]) {
+  private[controller] def removePartitionsFromReassignedPartitions(partitionsToBeRemoved: Set[TopicPartition]) {
     if (partitionsToBeRemoved.nonEmpty) {
       partitionsToBeRemoved.map(controllerContext.partitionsBeingReassigned).foreach { reassignContext =>
         reassignContext.unregisterReassignIsrChangeHandler(zkClient)

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -226,8 +226,8 @@ class TopicDeletionManager(controller: KafkaController,
   }
 
   private def completeDeleteTopic(topic: String) {
-    // complete pending partition reassignments for deleted topic
-    completePartitionReassignmentForDeletedTopic(topic)
+    // abort pending partition reassignments for deleted topic
+    abortPartitionReassignmentForTopic(topic)
     // deregister partition change listener on the deleted topic. This is to prevent the partition change listener
     // firing before the new topic listener when a deleted topic gets auto created
     controller.unregisterPartitionModificationsHandlers(Seq(topic))
@@ -242,7 +242,7 @@ class TopicDeletionManager(controller: KafkaController,
     controllerContext.removeTopic(topic)
   }
 
-  private def completePartitionReassignmentForDeletedTopic(topic: String): Unit = {
+  private def abortPartitionReassignmentForTopic(topic: String): Unit = {
     val partitionsBeingReassignedForDeletedTopic =
       controllerContext.partitionsBeingReassigned.keySet.filter(_.topic().equals(topic))
     controller.removePartitionsFromReassignedPartitions(partitionsBeingReassignedForDeletedTopic)

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -226,6 +226,8 @@ class TopicDeletionManager(controller: KafkaController,
   }
 
   private def completeDeleteTopic(topic: String) {
+    // complete pending partition reassignments for deleted topic
+    completePartitionReassignmentForDeletedTopic(topic)
     // deregister partition change listener on the deleted topic. This is to prevent the partition change listener
     // firing before the new topic listener when a deleted topic gets auto created
     controller.unregisterPartitionModificationsHandlers(Seq(topic))
@@ -238,6 +240,12 @@ class TopicDeletionManager(controller: KafkaController,
     zkClient.deleteTopicDeletions(Seq(topic), controllerContext.epochZkVersion)
     controller.partitionStateMachine.removePartitionStatesForTopic(topic)
     controllerContext.removeTopic(topic)
+  }
+
+  private def completePartitionReassignmentForDeletedTopic(topic: String): Unit = {
+    val partitionsBeingReassignedForDeletedTopic =
+      controllerContext.partitionsBeingReassigned.keySet.filter(_.topic().equals(topic))
+    controller.removePartitionsFromReassignedPartitions(partitionsBeingReassignedForDeletedTopic)
   }
 
   /**


### PR DESCRIPTION
kafka allows topic deletion to complete successfully when there are pending partition reassignments of the same topics. This leads several issues: 1) pending partition reassignments of the deleted topic never complete because the topic is deleted. 2) onPartitionReassignment -> updateAssignedReplicasForPartition will throw out IllegalStateException for non-existing node. This in turns causes controller doesn't resume topic deletion for online broker and register broker notification handler (etc.) during onBrokerStartup.

The fix cleans up pending partition reassignment during topic deletion.
