### PR TITLE
Fix flush behavior

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.producer.internals;
 
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -273,6 +274,11 @@ public final class ProducerBatch {
         if (batch != null)
             batches.add(batch);
 
+        List<ProduceRequestResult> produceRequestResultList =
+            batches.stream().map(b -> b.produceFuture).collect(Collectors.toList());
+
+        // Chain the produceFuture's before marking as #done()
+        produceFuture.chain(produceRequestResultList);
         produceFuture.set(ProduceResponse.INVALID_OFFSET, NO_TIMESTAMP, new RecordBatchTooLargeException());
         produceFuture.done();
 


### PR DESCRIPTION
Context:
kafkaProducer#flush() api is expected to evaluate all record futures previously obtained via kafkaProducer#send(). The record futures can either be successful or may throw exception depending on the produce response by the broker but nonetheless, they should all be evaluated. This behavior is broken when a produce batch is split into smaller batches(because of RecordTooLargeException) and rescheduled to be sent to the broker. That is, it can so happen that after successfully executing #flush() api, there may exist few record futures which are not evaluated.

This change chains the produce batch result and makes sure that a parent batch only gets evaluated if all it's child batches are evaluated. Since all the record futures depend on produce batch future internally, a record future depending on a parent produce batch will only get evaluated if all the split batches are evaluated.

