### PR TITLE
HOTFIX - LIKAFKA-24478: Reduce UpdateMetadataRequest toString() result

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -207,22 +207,22 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
 
         @Override
         public String toString() {
-          StringBuilder bld = new StringBuilder();
-          // HOTFIX: LIKAFKA-24478
-          // large cluster with large metadata can create really large string
-          // potentially causing OOM
-          bld.append("(type: UpdateMetadataRequest=").
-              append(", controllerId=").append(controllerId).
-              append(", controllerEpoch=").append(controllerEpoch).
-              append(", brokerEpoch=").append(brokerEpoch).
-              append(")");
-              // bld.append("(type: UpdateMetadataRequest=").
-              //   append(", controllerId=").append(controllerId).
-              //   append(", controllerEpoch=").append(controllerEpoch).
-              //   append(", brokerEpoch=").append(brokerEpoch).
-              //   append(", partitionStates=").append(partitionStates).
-              //   append(", liveBrokers=").append(Utils.join(liveBrokers, ", ")).
-              //   append(")");
+            StringBuilder bld = new StringBuilder();
+            // HOTFIX: LIKAFKA-24478
+            // large cluster with large metadata can create really large string
+            // potentially causing OOM
+            bld.append("(type: UpdateMetadataRequest=").
+                append(", controllerId=").append(controllerId).
+                append(", controllerEpoch=").append(controllerEpoch).
+                append(", brokerEpoch=").append(brokerEpoch).
+                append(")");
+            // bld.append("(type: UpdateMetadataRequest=").
+            //   append(", controllerId=").append(controllerId).
+            //   append(", controllerEpoch=").append(controllerEpoch).
+            //   append(", brokerEpoch=").append(brokerEpoch).
+            //   append(", partitionStates=").append(partitionStates).
+            //   append(", liveBrokers=").append(Utils.join(liveBrokers, ", ")).
+            //   append(")");
             return bld.toString();
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -217,6 +217,7 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
                 append(", brokerEpoch=").append(brokerEpoch).
                 append(", liveBrokers=").append(Utils.join(liveBrokers, ", ")).
                 append(")");
+
             // bld.append("(type: UpdateMetadataRequest=").
             //   append(", controllerId=").append(controllerId).
             //   append(", controllerEpoch=").append(controllerEpoch).

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -215,6 +215,7 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
                 append(", controllerId=").append(controllerId).
                 append(", controllerEpoch=").append(controllerEpoch).
                 append(", brokerEpoch=").append(brokerEpoch).
+                append(", liveBrokers=").append(Utils.join(liveBrokers, ", ")).
                 append(")");
             // bld.append("(type: UpdateMetadataRequest=").
             //   append(", controllerId=").append(controllerId).

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -207,14 +207,22 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
 
         @Override
         public String toString() {
-            StringBuilder bld = new StringBuilder();
-            bld.append("(type: UpdateMetadataRequest=").
-                append(", controllerId=").append(controllerId).
-                append(", controllerEpoch=").append(controllerEpoch).
-                append(", brokerEpoch=").append(brokerEpoch).
-                append(", partitionStates=").append(partitionStates).
-                append(", liveBrokers=").append(Utils.join(liveBrokers, ", ")).
-                append(")");
+          StringBuilder bld = new StringBuilder();
+          // HOTFIX: LIKAFKA-24478
+          // large cluster with large metadata can create really large string
+          // potentially causing OOM
+          bld.append("(type: UpdateMetadataRequest=").
+              append(", controllerId=").append(controllerId).
+              append(", controllerEpoch=").append(controllerEpoch).
+              append(", brokerEpoch=").append(brokerEpoch).
+              append(")");
+              // bld.append("(type: UpdateMetadataRequest=").
+              //   append(", controllerId=").append(controllerId).
+              //   append(", controllerEpoch=").append(controllerEpoch).
+              //   append(", brokerEpoch=").append(brokerEpoch).
+              //   append(", partitionStates=").append(partitionStates).
+              //   append(", liveBrokers=").append(Utils.join(liveBrokers, ", ")).
+              //   append(")");
             return bld.toString();
         }
     }


### PR DESCRIPTION
In large clusters with large metadata size the UpdateMetadataRequest::toString can generate really large strings. If there are n/w issue these strings are logged resulting in lots of these string to be generated and causes high memory usage.

No tests as this are just reducing the size of the string by limiting the amount of data injected into the string.