### PR TITLE
[LI-HOTFIX] Clean up purgatory when leader replica is kicked out of replica list.

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -274,7 +274,7 @@ class Partition(val topic: String,
       if (logManager.getLog(topicPartition, isFuture = true).isDefined)
         logManager.asyncDelete(topicPartition, isFuture = true)
     }
-    // If the deleted replica was leader replica, there might be delayed produce requests in purgatory need to be cleaned up.
+    // If the deleted replica was leader replica, there might be delayed requests in purgatory need to be cleaned up.
     if (wasLeader) {
       tryCompleteDelayedRequests()
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -358,6 +358,9 @@ class ReplicaManager(val config: KafkaConfig,
     }
 
     if (removedPartition != null) {
+      // If the deleted replica was leader replica, there might be delayed requests in purgatory need to be cleaned up.
+      if (removedPartition.leaderReplicaIdOpt.map(_ == localBrokerId).getOrElse(false))
+        removedPartition.tryCompleteDelayedRequests()
       val topicHasPartitions = allPartitions.values.exists(partition => topicPartition.topic == partition.topic)
       if (!topicHasPartitions)
         brokerTopicStats.removeMetrics(topicPartition.topic)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -219,10 +219,15 @@ class ReplicaManagerTest {
         assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, response.error)
       }
 
-      // Send a StopReplicaRequest to replica manager.
-      val stopReplicaRequest =  new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion(), 0, 0, brokerEpoch, true,
+      // Send StopReplicaRequest(delete = false) to move replica to OfflineReplica state.
+      val stopReplicaRequest1 =  new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion(), 0, 0, brokerEpoch, false,
         Set(new TopicPartition(topic, 0)).asJava).build()
-      rm.stopReplicas(stopReplicaRequest)
+      rm.stopReplicas(stopReplicaRequest1)
+
+      // Send StopReplicaRequest(delete = true) to move replica to NonExistentReplica state.
+      val stopReplicaRequest2 =  new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion(), 0, 0, brokerEpoch, true,
+        Set(new TopicPartition(topic, 0)).asJava).build()
+      rm.stopReplicas(stopReplicaRequest2)
 
       assertTrue(appendResult.isFired)
     } finally {


### PR DESCRIPTION
In Current implementation,  if a broker receives `StopReplicaRequest` for leader replica it hosts(which can happen in a partition reassignment and new replica list does not include old leader replica) , it does not check (and try to complete) pending delayed operations for this partition, which could result in observable produce delay. 

One example scenario:
Partition reassignment  of partition A  
[leader : B1, replica list : [B1, B2] ] -> [leader : B2, replica list : [B2, B3] ] 

t0: Controller expands the replica set to [B1, B2, B3]

t1: B1 receives produce request on partition A with` acks=all` and `timetout=T(could be a large value)`. B1 puts request into the `DelayedProducePurgatory`.

t2: Controller elects B2 as the new leader and shrinks the replica set fo [B2, B3], send 
     `LeaderAndIsrRequest`  to B2 and B3; send `StopReplicaRequest` to B1.

t3: B1 wait until T and return `TimeoutException` to producer.

If B1 checks for `DelayedProducePurgatory` upon receiving `StopReplicaRequest`, it could fail the produce request sooner with a `KafkaException`.
