### PR TITLE
[LI-CHERRY-PICK] [31d191fc] KAFKA-7904; Add AtMinIsr partition metric…

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -106,6 +106,15 @@ class Partition(val topic: String,
       tags
     )
 
+    newGauge("AtMinIsr",
+      new Gauge[Int] {
+        def value = {
+          if (isAtMinIsr) 1 else 0
+        }
+      },
+      tags
+    )
+
     newGauge("ReplicasCount",
       new Gauge[Int] {
         def value = {
@@ -136,6 +145,15 @@ class Partition(val topic: String,
     leaderReplicaIfLocal match {
       case Some(leaderReplica) =>
         inSyncReplicas.size < leaderReplica.log.get.config.minInSyncReplicas
+      case None =>
+        false
+    }
+  }
+
+  def isAtMinIsr: Boolean = {
+    leaderReplicaIfLocal match {
+      case Some(leaderReplica) =>
+        inSyncReplicas.size == leaderReplica.log.get.config.minInSyncReplicas
       case None =>
         false
     }
@@ -763,6 +781,7 @@ class Partition(val topic: String,
     removeMetric("InSyncReplicasCount", tags)
     removeMetric("ReplicasCount", tags)
     removeMetric("LastStableOffsetLag", tags)
+    removeMetric("AtMinIsr", tags)
   }
 
   override def equals(that: Any): Boolean = that match {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -234,6 +234,12 @@ class ReplicaManager(val config: KafkaConfig,
       def value = leaderPartitionsIterator.count(_.isUnderMinIsr)
     }
   )
+  val atMinIsrPartitionCount = newGauge(
+    "AtMinIsrPartitionCount",
+    new Gauge[Int] {
+      def value = leaderPartitionsIterator.count(_.isAtMinIsr)
+    }
+  )
 
   val recompressionCount = newGauge(
     "recompressionCount",
@@ -1479,6 +1485,7 @@ class ReplicaManager(val config: KafkaConfig,
     removeMetric("UnderReplicatedPartitions")
     removeMetric("UnderMinIsrPartitionCount")
     removeMetric("recompressedBatch")
+    removeMetric("AtMinIsrPartitionCount")
   }
 
   // High watermark do not need to be checkpointed only when under unit tests

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -828,6 +828,11 @@
         <td>0</td>
       </tr>
       <tr>
+        <td># of at minIsr partitions (|ISR| = min.insync.replicas)</td>
+        <td>kafka.server:type=ReplicaManager,name=AtMinIsrPartitionCount</td>
+        <td>0</td>
+      </tr>
+      <tr>
         <td># of offline log directories</td>
         <td>kafka.log:type=LogManager,name=OfflineLogDirectoryCount</td>
         <td>0</td>


### PR DESCRIPTION
… and TopicCommand option (KIP-427)

TICKET = KAFKA-7904
LI_DESCRIPTION =
This patch includes broker metrics for AtMinIsr and modified unit tests. However, it doesn't include topiccommand related change from the original cherry-picked commit because of extra dependency.

EXIT_CRITERIA = HASH [31d191fc85229c9b0a6e85aad56e8a7975b295e1]
ORIGINAL_DESCRIPTION =

- Add `AtMinIsrPartitionCount` metric to `ReplicaManager`
- Add `AtMinIsr` metric to `Partition`
- Add `--at-min-isr-partitions` describe `TopicCommand` option

https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=103089398

Author: Kevin Lu <lu.kevin@berkeley.edu>
Author: lu.kevin@berkeley.edu <kelu@paypal.com>

Reviewers: Gwen Shapira

Closes #6421 from KevinLiLu/KAFKA-7904

(cherry picked from commit 31d191fc85229c9b0a6e85aad56e8a7975b295e1)

