### PR TITLE
Optionally support OpenSSL for SSL/TLS.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ buildscript {
     classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
     classpath 'org.owasp:dependency-check-gradle:3.2.1'
     classpath "com.diffplug.spotless:spotless-plugin-gradle:3.10.0"
+    classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
   }
 }
 
@@ -41,6 +42,9 @@ spotless {
   }
 }
 
+// Use the osdetector-gradle-plugin
+apply plugin: "com.google.osdetector"
+
 apply from: "$rootDir/gradle/dependencies.gradle"
 
 allprojects {
@@ -48,7 +52,7 @@ allprojects {
   repositories {
     mavenCentral()
   }
-  
+
   apply plugin: 'idea'
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'com.github.ben-manes.versions'
@@ -102,7 +106,7 @@ ext {
   mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : bintrayUrl
   mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : bintrayUsername
   mavenPassword = project.hasProperty('mavenPassword') ? project.mavenPassword : bintrayKey
- 
+
   userShowStandardStreams = project.hasProperty("showStandardStreams") ? showStandardStreams : null
 
   userTestLoggingEvents = project.hasProperty("testLoggingEvents") ? Arrays.asList(testLoggingEvents.split(",")) : null
@@ -250,7 +254,7 @@ subprojects {
     useJUnit {
       excludeCategories 'org.apache.kafka.test.IntegrationTest'
     }
-    
+
   }
 
   jar {
@@ -434,8 +438,8 @@ def fineTuneEclipseClasspathFile(eclipse, project) {
       if (project.name.equals('core')) {
         cp.entries.findAll { it.kind == "src" && it.path.equals("src/test/scala") }*.excludes = ["integration/", "other/", "unit/"]
       }
-      /* 
-       * Set all eclipse build output to go to 'build_eclipse' directory. This is to ensure that gradle and eclipse use different 
+      /*
+       * Set all eclipse build output to go to 'build_eclipse' directory. This is to ensure that gradle and eclipse use different
        * build output directories, and also avoid using the eclpise default of 'bin' which clashes with some of our script directories.
        * https://discuss.gradle.org/t/eclipse-generated-files-should-be-put-in-the-same-place-as-the-gradle-generated-files/6986/2
        */
@@ -598,7 +602,7 @@ project(':core') {
     scoverage libs.scoveragePlugin
     scoverage libs.scoverageRuntime
   }
-  
+
   scoverage {
     reportDir = file("${rootProject.buildDir}/scoverage")
     highlighting = false
@@ -814,6 +818,7 @@ project(':clients') {
     compile libs.snappy
     compile libs.slf4jApi
     compileOnly libs.jacksonDatabind // for SASL/OAUTHBEARER bearer token parsing
+    compile libs.conscrypt
 
     jacksonDatabindConfig libs.jacksonDatabind // to publish as provided scope dependency.
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ spotless {
   }
 }
 
-// Use the osdetector-gradle-plugin
+// Use the osdetector-gradle-plugin in combination with the consrypt library
 apply plugin: "com.google.osdetector"
 
 apply from: "$rootDir/gradle/dependencies.gradle"

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -53,6 +53,7 @@
     <allow pkg="org.apache.kafka.common.config" exact-match="true" />
     <allow pkg="org.apache.kafka.common.internals" exact-match="true" />
     <allow pkg="org.apache.kafka.test" />
+    <allow pkg="org.conscrypt" />
 
     <subpackage name="acl">
       <allow pkg="org.apache.kafka.common.annotation" />

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.config;
 
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.security.ssl.SimpleSslContextProvider;
 import org.apache.kafka.common.utils.Utils;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -46,6 +47,11 @@ public class SslConfigs {
     @Deprecated
     public static final String DEFAULT_PRINCIPAL_BUILDER_CLASS =
             org.apache.kafka.common.security.auth.DefaultPrincipalBuilder.class.getName();
+
+    public static final String SSL_CONTEXT_PROVIDER_CLASS_CONFIG = "ssl.context.provider.class";
+    public static final String SSL_CONTEXT_PROVIDER_CLASS_DOC = "The fully qualified name of a class that implements the " +
+        "SslContextProvider interface, which is used to build SSLContext insides encrypted channels.";
+    public static final String DEFAULT_SSL_CONTEXT_PROVIDER_CLASS = SimpleSslContextProvider.class.getName();
 
     public static final String SSL_PROTOCOL_CONFIG = "ssl.protocol";
     public static final String SSL_PROTOCOL_DOC = "The SSL protocol used to generate the SSLContext. "
@@ -123,6 +129,7 @@ public class SslConfigs {
 
     public static void addClientSslSupport(ConfigDef config) {
         config.define(SslConfigs.SSL_PROTOCOL_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_PROTOCOL, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_PROTOCOL_DOC)
+                .define(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_CONTEXT_PROVIDER_CLASS, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_DOC)
                 .define(SslConfigs.SSL_PROVIDER_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_PROVIDER_DOC)
                 .define(SslConfigs.SSL_CIPHER_SUITES_CONFIG, ConfigDef.Type.LIST, null, ConfigDef.Importance.LOW, SslConfigs.SSL_CIPHER_SUITES_DOC)
                 .define(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, ConfigDef.Type.LIST, SslConfigs.DEFAULT_SSL_ENABLED_PROTOCOLS, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_ENABLED_PROTOCOLS_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -413,7 +413,7 @@ public class SslTransportLayer implements TransportLayer {
                 key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE);
                 SSLSession session = sslEngine.getSession();
                 log.debug("SSL handshake completed successfully with peerHost '{}' peerPort {} peerPrincipal '{}' cipherSuite '{}'",
-                          session.getPeerHost(), session.getPeerPort(), peerPrincipal(), session.getCipherSuite());
+                            session.getPeerHost(), session.getPeerPort(), peerPrincipal(), session.getCipherSuite());
             }
 
             log.trace("SSLHandshake FINISHED channelId {}, appReadBuffer pos {}, netReadBuffer pos {}, netWriteBuffer pos {} ",

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -413,7 +413,7 @@ public class SslTransportLayer implements TransportLayer {
                 key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE);
                 SSLSession session = sslEngine.getSession();
                 log.debug("SSL handshake completed successfully with peerHost '{}' peerPort {} peerPrincipal '{}' cipherSuite '{}'",
-                        session.getPeerHost(), session.getPeerPort(), peerPrincipal(), session.getCipherSuite());
+                          session.getPeerHost(), session.getPeerPort(), peerPrincipal(), session.getCipherSuite());
             }
 
             log.trace("SSLHandshake FINISHED channelId {}, appReadBuffer pos {}, netReadBuffer pos {}, netWriteBuffer pos {} ",

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/BoringSslContextProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/BoringSslContextProvider.java
@@ -24,9 +24,9 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.conscrypt.Conscrypt;
 
 /**
- * A OpenSslContext provider based on Conscrypt library.
+ * A BoringSslContext provider based on Conscrypt library.
  */
-public class OpenSslContextProvider implements SslContextProvider {
+public class BoringSslContextProvider implements SslContextProvider {
     private String protocol;
     private Provider provider;
 

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/OpenSslContextProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/OpenSslContextProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
+import org.apache.kafka.common.config.SslConfigs;
+import org.conscrypt.Conscrypt;
+
+/**
+ * A OpenSslContext provider based on Conscrypt library.
+ */
+public class OpenSslContextProvider implements SslContextProvider {
+    private String protocol;
+    private Provider provider;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        protocol = (String) configs.get(SslConfigs.SSL_PROTOCOL_CONFIG);
+        provider = Conscrypt.newProvider();
+    }
+
+    @Override
+    public SSLContext getInstance()  throws NoSuchAlgorithmException {
+        return SSLContext.getInstance(protocol, provider);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/OpenSslContextProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/OpenSslContextProvider.java
@@ -37,7 +37,7 @@ public class OpenSslContextProvider implements SslContextProvider {
     }
 
     @Override
-    public SSLContext getInstance()  throws NoSuchAlgorithmException {
+    public SSLContext getSSLContext()  throws NoSuchAlgorithmException {
         return SSLContext.getInstance(protocol, provider);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SimpleSslContextProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SimpleSslContextProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
+import org.apache.kafka.common.config.SslConfigs;
+
+
+public class SimpleSslContextProvider implements SslContextProvider {
+    private String protocol;
+    private String provider;
+
+    @Override
+    public SSLContext getInstance() throws NoSuchAlgorithmException, NoSuchProviderException {
+        if (provider == null)
+            return SSLContext.getInstance(protocol);
+        else
+            return SSLContext.getInstance(protocol, provider);
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.protocol =  (String) configs.get(SslConfigs.SSL_PROTOCOL_CONFIG);
+        this.provider = (String) configs.get(SslConfigs.SSL_PROVIDER_CONFIG);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SimpleSslContextProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SimpleSslContextProvider.java
@@ -28,7 +28,7 @@ public class SimpleSslContextProvider implements SslContextProvider {
     private String provider;
 
     @Override
-    public SSLContext getInstance() throws NoSuchAlgorithmException, NoSuchProviderException {
+    public SSLContext getSSLContext() throws NoSuchAlgorithmException, NoSuchProviderException {
         if (provider == null)
             return SSLContext.getInstance(protocol);
         else

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SimpleSslContextProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SimpleSslContextProvider.java
@@ -28,16 +28,16 @@ public class SimpleSslContextProvider implements SslContextProvider {
     private String provider;
 
     @Override
-    public SSLContext getSSLContext() throws NoSuchAlgorithmException, NoSuchProviderException {
-        if (provider == null)
-            return SSLContext.getInstance(protocol);
-        else
-            return SSLContext.getInstance(protocol, provider);
-    }
-
-    @Override
     public void configure(Map<String, ?> configs) {
         this.protocol =  (String) configs.get(SslConfigs.SSL_PROTOCOL_CONFIG);
         this.provider = (String) configs.get(SslConfigs.SSL_PROVIDER_CONFIG);
+    }
+
+    @Override
+    public SSLContext getSSLContext() throws NoSuchAlgorithmException, NoSuchProviderException {
+        if (provider == null) {
+            return SSLContext.getInstance(protocol);
+        }
+        return SSLContext.getInstance(protocol, provider);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslContextProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslContextProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.ssl;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import javax.net.ssl.SSLContext;
+import org.apache.kafka.common.Configurable;
+
+/**
+ * A SSLContext provider interface to create SSLContext based on configs
+ */
+public interface SslContextProvider extends Configurable {
+
+    /**
+    * Create a SSLContext based on protocol and provider config.
+    * @return SSLContext
+    * @throws NoSuchAlgorithmException if protocol config is invalid.
+    * @throws NoSuchProviderException if provider config is invalid.
+    */
+    SSLContext getInstance() throws NoSuchAlgorithmException, NoSuchProviderException;
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslContextProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslContextProvider.java
@@ -33,5 +33,5 @@ public interface SslContextProvider extends Configurable {
     * @throws NoSuchAlgorithmException if protocol config is invalid.
     * @throws NoSuchProviderException if provider config is invalid.
     */
-    SSLContext getInstance() throws NoSuchAlgorithmException, NoSuchProviderException;
+    SSLContext getSSLContext() throws NoSuchAlgorithmException, NoSuchProviderException;
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.HashSet;
+import org.conscrypt.Conscrypt;
 
 
 public class SslFactory implements Reconfigurable {
@@ -209,7 +210,10 @@ public class SslFactory implements Reconfigurable {
     SSLContext createSSLContext(SecurityStore keystore, SecurityStore truststore) throws GeneralSecurityException, IOException  {
         SSLContext sslContext;
         if (provider != null)
-            sslContext = SSLContext.getInstance(protocol, provider);
+            if (provider.equals("Conscrypt"))
+                sslContext = SSLContext.getInstance(protocol, Conscrypt.newProvider());
+            else
+                sslContext = SSLContext.getInstance(protocol, provider);
         else
             sslContext = SSLContext.getInstance(protocol);
 

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -214,7 +214,7 @@ public class SslFactory implements Reconfigurable {
 
     // package access for testing
     SSLContext createSSLContext(SecurityStore keystore, SecurityStore truststore) throws GeneralSecurityException, IOException  {
-        SSLContext sslContext = sslContextProvider.getInstance();
+        SSLContext sslContext = sslContextProvider.getSSLContext();
 
         KeyManager[] keyManagers = null;
         if (keystore != null) {

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -87,10 +87,7 @@ public class SslFactory implements Reconfigurable {
     public void configure(Map<String, ?> configs) throws KafkaException {
         try {
             String sslContextProvider = (String) configs.get(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG);
-            if (sslContextProvider == null || sslContextProvider.isEmpty())
-                this.sslContextProvider = new SimpleSslContextProvider();
-            else
-                this.sslContextProvider = (SslContextProvider) Class.forName(sslContextProvider).newInstance();
+            this.sslContextProvider = (SslContextProvider) Class.forName(sslContextProvider).newInstance();
         } catch (Exception e) {
             throw new KafkaException(e);
         }

--- a/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
@@ -41,23 +41,23 @@ public class CertStores {
 
     private final Map<String, Object> sslConfig;
 
-    public CertStores(boolean server, String hostName) throws Exception {
-        this(server, hostName, new TestSslUtils.CertificateBuilder());
+    public CertStores(boolean server, String hostName, boolean usingOpenSsl) throws Exception {
+        this(server, hostName, new TestSslUtils.CertificateBuilder(), usingOpenSsl);
     }
 
-    public CertStores(boolean server, String commonName, String sanHostName) throws Exception {
-        this(server, commonName, new TestSslUtils.CertificateBuilder().sanDnsName(sanHostName));
+    public CertStores(boolean server, String commonName, String sanHostName, boolean usingOpenSsl) throws Exception {
+        this(server, commonName, new TestSslUtils.CertificateBuilder().sanDnsName(sanHostName), usingOpenSsl);
     }
 
-    public CertStores(boolean server, String commonName, InetAddress hostAddress) throws Exception {
-        this(server, commonName, new TestSslUtils.CertificateBuilder().sanIpAddress(hostAddress));
+    public CertStores(boolean server, String commonName, InetAddress hostAddress, boolean usingOpenSsl) throws Exception {
+        this(server, commonName, new TestSslUtils.CertificateBuilder().sanIpAddress(hostAddress), usingOpenSsl);
     }
 
-    private CertStores(boolean server, String commonName, TestSslUtils.CertificateBuilder certBuilder) throws Exception {
+    private CertStores(boolean server, String commonName, TestSslUtils.CertificateBuilder certBuilder, boolean usingOpenSsl) throws Exception {
         String name = server ? "server" : "client";
         Mode mode = server ? Mode.SERVER : Mode.CLIENT;
         File truststoreFile = File.createTempFile(name + "TS", ".jks");
-        sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name, commonName, certBuilder);
+        sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name, commonName, certBuilder, usingOpenSsl);
     }
 
     public Map<String, Object> getTrustingConfig(CertStores truststoreConfig) {

--- a/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
@@ -41,23 +41,23 @@ public class CertStores {
 
     private final Map<String, Object> sslConfig;
 
-    public CertStores(boolean server, String hostName, boolean usingOpenSsl) throws Exception {
-        this(server, hostName, new TestSslUtils.CertificateBuilder(), usingOpenSsl);
+    public CertStores(boolean server, String hostName, TestSslUtils.SSLProvider provider) throws Exception {
+        this(server, hostName, new TestSslUtils.CertificateBuilder(), provider);
     }
 
-    public CertStores(boolean server, String commonName, String sanHostName, boolean usingOpenSsl) throws Exception {
-        this(server, commonName, new TestSslUtils.CertificateBuilder().sanDnsName(sanHostName), usingOpenSsl);
+    public CertStores(boolean server, String commonName, String sanHostName, TestSslUtils.SSLProvider provider) throws Exception {
+        this(server, commonName, new TestSslUtils.CertificateBuilder().sanDnsName(sanHostName), provider);
     }
 
-    public CertStores(boolean server, String commonName, InetAddress hostAddress, boolean usingOpenSsl) throws Exception {
-        this(server, commonName, new TestSslUtils.CertificateBuilder().sanIpAddress(hostAddress), usingOpenSsl);
+    public CertStores(boolean server, String commonName, InetAddress hostAddress, TestSslUtils.SSLProvider provider) throws Exception {
+        this(server, commonName, new TestSslUtils.CertificateBuilder().sanIpAddress(hostAddress), provider);
     }
 
-    private CertStores(boolean server, String commonName, TestSslUtils.CertificateBuilder certBuilder, boolean usingOpenSsl) throws Exception {
+    private CertStores(boolean server, String commonName, TestSslUtils.CertificateBuilder certBuilder, TestSslUtils.SSLProvider provider) throws Exception {
         String name = server ? "server" : "client";
         Mode mode = server ? Mode.SERVER : Mode.CLIENT;
         File truststoreFile = File.createTempFile(name + "TS", ".jks");
-        sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name, commonName, certBuilder, usingOpenSsl);
+        sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name, commonName, certBuilder, provider);
     }
 
     public Map<String, Object> getTrustingConfig(CertStores truststoreConfig) {

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.common.network;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.SslConfigs;
@@ -36,7 +38,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import java.io.ByteArrayOutputStream;
@@ -52,6 +53,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -61,7 +64,13 @@ import static org.junit.Assert.fail;
 /**
  * Tests for the SSL transport layer. These use a test harness that runs a simple socket server that echos back responses.
  */
+@RunWith(Parameterized.class)
 public class SslTransportLayerTest {
+    private final boolean usingOpenSsl;
+
+    public SslTransportLayerTest(boolean usingOpenSsl) {
+        this.usingOpenSsl = usingOpenSsl;
+    }
 
     private static final int BUFFER_SIZE = 4 * 1024;
 
@@ -76,8 +85,8 @@ public class SslTransportLayerTest {
     @Before
     public void setup() throws Exception {
         // Create certificates for use by client and server. Add server cert to client truststore and vice versa.
-        serverCertStores = new CertStores(true, "server",  "localhost");
-        clientCertStores = new CertStores(false, "client", "localhost");
+        serverCertStores = new CertStores(true, "server",  "localhost", usingOpenSsl);
+        clientCertStores = new CertStores(false, "client", "localhost", usingOpenSsl);
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
         this.channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false);
@@ -117,8 +126,8 @@ public class SslTransportLayerTest {
     @Test
     public void testValidEndpointIdentificationSanIp() throws Exception {
         String node = "0";
-        serverCertStores = new CertStores(true, "server", InetAddress.getByName("127.0.0.1"));
-        clientCertStores = new CertStores(false, "client", InetAddress.getByName("127.0.0.1"));
+        serverCertStores = new CertStores(true, "server", InetAddress.getByName("127.0.0.1"), usingOpenSsl);
+        clientCertStores = new CertStores(false, "client", InetAddress.getByName("127.0.0.1"), usingOpenSsl);
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
         server = createEchoServer(SecurityProtocol.SSL);
@@ -137,8 +146,8 @@ public class SslTransportLayerTest {
     @Test
     public void testValidEndpointIdentificationCN() throws Exception {
         String node = "0";
-        serverCertStores = new CertStores(true, "localhost");
-        clientCertStores = new CertStores(false, "localhost");
+        serverCertStores = new CertStores(true, "localhost", usingOpenSsl);
+        clientCertStores = new CertStores(false, "localhost", usingOpenSsl);
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
         server = createEchoServer(SecurityProtocol.SSL);
@@ -187,8 +196,8 @@ public class SslTransportLayerTest {
         String node = "0";
 
         // Create client certificate with an invalid hostname
-        clientCertStores = new CertStores(false, "non-existent.com");
-        serverCertStores = new CertStores(true, "localhost");
+        clientCertStores = new CertStores(false, "non-existent.com", usingOpenSsl);
+        serverCertStores = new CertStores(true, "localhost", usingOpenSsl);
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
 
@@ -222,8 +231,8 @@ public class SslTransportLayerTest {
     @Test
     public void testInvalidEndpointIdentification() throws Exception {
         String node = "0";
-        serverCertStores = new CertStores(true, "server", "notahost");
-        clientCertStores = new CertStores(false, "client", "localhost");
+        serverCertStores = new CertStores(true, "server", "notahost", usingOpenSsl);
+        clientCertStores = new CertStores(false, "client", "localhost", usingOpenSsl);
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
         sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
@@ -242,8 +251,8 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testEndpointIdentificationDisabled() throws Exception {
-        serverCertStores = new CertStores(true, "server", "notahost");
-        clientCertStores = new CertStores(false, "client", "localhost");
+        serverCertStores = new CertStores(true, "server", "notahost", usingOpenSsl);
+        clientCertStores = new CertStores(false, "client", "localhost", usingOpenSsl);
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
 
@@ -543,11 +552,12 @@ public class SslTransportLayerTest {
     @Test
     public void testUnsupportedCiphers() throws Exception {
         String node = "0";
-        String[] cipherSuites = SSLContext.getDefault().getDefaultSSLParameters().getCipherSuites();
-        sslServerConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[0]));
+        // Since Conscrypt does not support all the default JDK cipher suites, specifically pick two suites which are supported
+        // by both JDK and Conscrypt.
+        sslServerConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"));
         server = createEchoServer(SecurityProtocol.SSL);
 
-        sslClientConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[1]));
+        sslClientConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"));
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
@@ -882,7 +892,7 @@ public class SslTransportLayerTest {
         oldClientSelector.connect(oldNode, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, oldNode, 100, 10);
 
-        CertStores newServerCertStores = new CertStores(true, "server", "localhost");
+        CertStores newServerCertStores = new CertStores(true, "server", "localhost", usingOpenSsl);
         Map<String, Object> newKeystoreConfigs = newServerCertStores.keyStoreProps();
         assertTrue("SslChannelBuilder not reconfigurable", serverChannelBuilder instanceof ListenerReconfigurable);
         ListenerReconfigurable reconfigurableBuilder = (ListenerReconfigurable) serverChannelBuilder;
@@ -903,7 +913,7 @@ public class SslTransportLayerTest {
         // Verify that old client continues to work
         NetworkTestUtils.checkClientConnection(oldClientSelector, oldNode, 100, 10);
 
-        CertStores invalidCertStores = new CertStores(true, "server", "127.0.0.1");
+        CertStores invalidCertStores = new CertStores(true, "server", "127.0.0.1", usingOpenSsl);
         Map<String, Object>  invalidConfigs = invalidCertStores.getTrustingConfig(clientCertStores);
         verifyInvalidReconfigure(reconfigurableBuilder, invalidConfigs, "keystore with different SubjectAltName");
 
@@ -942,7 +952,7 @@ public class SslTransportLayerTest {
         oldClientSelector.connect(oldNode, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, oldNode, 100, 10);
 
-        CertStores newClientCertStores = new CertStores(true, "client", "localhost");
+        CertStores newClientCertStores = new CertStores(true, "client", "localhost", usingOpenSsl);
         sslClientConfigs = newClientCertStores.getTrustingConfig(serverCertStores);
         Map<String, Object> newTruststoreConfigs = newClientCertStores.trustStoreProps();
         assertTrue("SslChannelBuilder not reconfigurable", serverChannelBuilder instanceof ListenerReconfigurable);
@@ -1145,5 +1155,13 @@ public class SslTransportLayerTest {
                 return size;
             }
         }
+    }
+
+    @Parameterized.Parameters(name = "usingOpenSsl={0}")
+    public static Collection<Object[]> data() {
+        Collection<Object[]> p = new ArrayList<>();
+        p.add(new Object[]{true});
+        p.add(new Object[]{false});
+        return p;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -23,6 +23,7 @@ import java.nio.channels.SelectionKey;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -95,6 +96,8 @@ import org.apache.kafka.common.security.plain.internals.PlainServerCallbackHandl
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -104,7 +107,13 @@ import static org.junit.Assert.fail;
 /**
  * Tests for the Sasl authenticator. These use a test harness that runs a simple socket server that echos back responses.
  */
+@RunWith(Parameterized.class)
 public class SaslAuthenticatorTest {
+    private final boolean usingOpenSsl;
+
+    public SaslAuthenticatorTest(boolean usingOpenSsl) {
+        this.usingOpenSsl = usingOpenSsl;
+    }
 
     private static final int BUFFER_SIZE = 4 * 1024;
 
@@ -121,8 +130,8 @@ public class SaslAuthenticatorTest {
     @Before
     public void setup() throws Exception {
         LoginManager.closeAll();
-        serverCertStores = new CertStores(true, "localhost");
-        clientCertStores = new CertStores(false, "localhost");
+        serverCertStores = new CertStores(true, "localhost", usingOpenSsl);
+        clientCertStores = new CertStores(false, "localhost", usingOpenSsl);
         saslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         saslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
         credentialCache = new CredentialCache();
@@ -1694,5 +1703,13 @@ public class SaslAuthenticatorTest {
                 throw new SaslAuthenticationException("Login initialization failed", e);
             }
         }
+    }
+
+    @Parameterized.Parameters(name = "usingOpenSsl={0}")
+    public static Collection<Object[]> data() {
+        Collection<Object[]> p = new ArrayList<>();
+        p.add(new Object[]{true});
+        p.add(new Object[]{false});
+        return p;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -93,6 +93,7 @@ import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.authenticator.TestDigestLoginModule.DigestServerCallbackHandler;
 import org.apache.kafka.common.security.plain.internals.PlainServerCallbackHandler;
 
+import org.apache.kafka.test.TestSslUtils.SSLProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -109,10 +110,10 @@ import static org.junit.Assert.fail;
  */
 @RunWith(Parameterized.class)
 public class SaslAuthenticatorTest {
-    private final boolean usingOpenSsl;
+    private final SSLProvider provider;
 
-    public SaslAuthenticatorTest(boolean usingOpenSsl) {
-        this.usingOpenSsl = usingOpenSsl;
+    public SaslAuthenticatorTest(SSLProvider provider) {
+        this.provider = provider;
     }
 
     private static final int BUFFER_SIZE = 4 * 1024;
@@ -130,8 +131,8 @@ public class SaslAuthenticatorTest {
     @Before
     public void setup() throws Exception {
         LoginManager.closeAll();
-        serverCertStores = new CertStores(true, "localhost", usingOpenSsl);
-        clientCertStores = new CertStores(false, "localhost", usingOpenSsl);
+        serverCertStores = new CertStores(true, "localhost", provider);
+        clientCertStores = new CertStores(false, "localhost", provider);
         saslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         saslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
         credentialCache = new CredentialCache();
@@ -1705,11 +1706,11 @@ public class SaslAuthenticatorTest {
         }
     }
 
-    @Parameterized.Parameters(name = "usingOpenSsl={0}")
+    @Parameterized.Parameters(name = "SSLProvider={0}")
     public static Collection<Object[]> data() {
         Collection<Object[]> p = new ArrayList<>();
-        p.add(new Object[]{true});
-        p.add(new Object[]{false});
+        p.add(new Object[]{SSLProvider.DEFAULT});
+        p.add(new Object[]{SSLProvider.OPENSSL});
         return p;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -44,6 +44,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.security.ssl.OpenSslContextProvider;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
@@ -175,9 +176,8 @@ public class TestSslUtils {
         List<String> enabledProtocols  = new ArrayList<>();
         enabledProtocols.add("TLSv1.2");
         sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
-        // Use Conscrypt's OpenSSL implementation.
         if (provider.equals(SSLProvider.OPENSSL)) {
-            sslConfigs.put(SslConfigs.SSL_PROVIDER_CONFIG, "Conscrypt");
+            sslConfigs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, OpenSslContextProvider.class.getName());
         }
 
         return sslConfigs;

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -45,6 +45,7 @@ import java.security.cert.X509Certificate;
 
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.security.ssl.BoringSslContextProvider;
+import org.apache.kafka.common.security.ssl.SimpleSslContextProvider;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
@@ -178,6 +179,8 @@ public class TestSslUtils {
         sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
         if (provider.equals(SSLProvider.OPENSSL)) {
             sslConfigs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, BoringSslContextProvider.class.getName());
+        } else {
+            sslConfigs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, SimpleSslContextProvider.class.getName());
         }
 
         return sslConfigs;

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -151,7 +151,7 @@ public class TestSslUtils {
     }
 
     private static Map<String, Object> createSslConfig(Mode mode, File keyStoreFile, Password password, Password keyPassword,
-                                                       File trustStoreFile, Password trustStorePassword) {
+                                                       File trustStoreFile, Password trustStorePassword, boolean usingConscrypt) {
         Map<String, Object> sslConfigs = new HashMap<>();
         sslConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2"); // protocol to create SSLContext
 
@@ -171,6 +171,9 @@ public class TestSslUtils {
         List<String> enabledProtocols  = new ArrayList<>();
         enabledProtocols.add("TLSv1.2");
         sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
+        if (usingConscrypt) {
+            sslConfigs.put(SslConfigs.SSL_PROVIDER_CONFIG, "Conscrypt");
+        }
 
         return sslConfigs;
     }
@@ -183,11 +186,11 @@ public class TestSslUtils {
     public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean trustStore,
             Mode mode, File trustStoreFile, String certAlias, String cn)
         throws IOException, GeneralSecurityException {
-        return createSslConfig(useClientCert, trustStore, mode, trustStoreFile, certAlias, cn, new CertificateBuilder());
+        return createSslConfig(useClientCert, trustStore, mode, trustStoreFile, certAlias, cn, new CertificateBuilder(), false);
     }
 
     public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean trustStore,
-            Mode mode, File trustStoreFile, String certAlias, String cn, CertificateBuilder certBuilder)
+            Mode mode, File trustStoreFile, String certAlias, String cn, CertificateBuilder certBuilder, boolean usingConscrypt)
             throws IOException, GeneralSecurityException {
         Map<String, X509Certificate> certs = new HashMap<>();
         File keyStoreFile = null;
@@ -216,7 +219,7 @@ public class TestSslUtils {
             trustStoreFile.deleteOnExit();
         }
 
-        return createSslConfig(mode, keyStoreFile, password, password, trustStoreFile, trustStorePassword);
+        return createSslConfig(mode, keyStoreFile, password, password, trustStoreFile, trustStorePassword, usingConscrypt);
     }
 
     public static class CertificateBuilder {

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -70,6 +70,10 @@ import java.util.ArrayList;
 
 public class TestSslUtils {
 
+    public enum SSLProvider {
+        DEFAULT, OPENSSL
+    }
+
     /**
      * Create a self-signed X.509 Certificate.
      * From http://bfo.com/blog/2011/03/08/odds_and_ends_creating_a_new_x_509_certificate.html.
@@ -151,7 +155,7 @@ public class TestSslUtils {
     }
 
     private static Map<String, Object> createSslConfig(Mode mode, File keyStoreFile, Password password, Password keyPassword,
-                                                       File trustStoreFile, Password trustStorePassword, boolean usingConscrypt) {
+                                                       File trustStoreFile, Password trustStorePassword, SSLProvider provider) {
         Map<String, Object> sslConfigs = new HashMap<>();
         sslConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2"); // protocol to create SSLContext
 
@@ -171,7 +175,8 @@ public class TestSslUtils {
         List<String> enabledProtocols  = new ArrayList<>();
         enabledProtocols.add("TLSv1.2");
         sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
-        if (usingConscrypt) {
+        // Use Conscrypt's OpenSSL implementation.
+        if (provider.equals(SSLProvider.OPENSSL)) {
             sslConfigs.put(SslConfigs.SSL_PROVIDER_CONFIG, "Conscrypt");
         }
 
@@ -186,11 +191,11 @@ public class TestSslUtils {
     public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean trustStore,
             Mode mode, File trustStoreFile, String certAlias, String cn)
         throws IOException, GeneralSecurityException {
-        return createSslConfig(useClientCert, trustStore, mode, trustStoreFile, certAlias, cn, new CertificateBuilder(), false);
+        return createSslConfig(useClientCert, trustStore, mode, trustStoreFile, certAlias, cn, new CertificateBuilder(), SSLProvider.DEFAULT);
     }
 
     public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean trustStore,
-            Mode mode, File trustStoreFile, String certAlias, String cn, CertificateBuilder certBuilder, boolean usingConscrypt)
+            Mode mode, File trustStoreFile, String certAlias, String cn, CertificateBuilder certBuilder, SSLProvider provider)
             throws IOException, GeneralSecurityException {
         Map<String, X509Certificate> certs = new HashMap<>();
         File keyStoreFile = null;
@@ -219,7 +224,7 @@ public class TestSslUtils {
             trustStoreFile.deleteOnExit();
         }
 
-        return createSslConfig(mode, keyStoreFile, password, password, trustStoreFile, trustStorePassword, usingConscrypt);
+        return createSslConfig(mode, keyStoreFile, password, password, trustStoreFile, trustStorePassword, provider);
     }
 
     public static class CertificateBuilder {

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -44,7 +44,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import org.apache.kafka.common.config.types.Password;
-import org.apache.kafka.common.security.ssl.OpenSslContextProvider;
+import org.apache.kafka.common.security.ssl.BoringSslContextProvider;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
@@ -177,7 +177,7 @@ public class TestSslUtils {
         enabledProtocols.add("TLSv1.2");
         sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
         if (provider.equals(SSLProvider.OPENSSL)) {
-            sslConfigs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, OpenSslContextProvider.class.getName());
+            sslConfigs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, BoringSslContextProvider.class.getName());
         }
 
         return sslConfigs;

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -216,6 +216,7 @@ object Defaults {
 
   /** ********* SSL configuration ***********/
   val SslProtocol = SslConfigs.DEFAULT_SSL_PROTOCOL
+  val SslContextProviderClass = SslConfigs.DEFAULT_SSL_CONTEXT_PROVIDER_CLASS
   val SslEnabledProtocols = SslConfigs.DEFAULT_SSL_ENABLED_PROTOCOLS
   val SslKeystoreType = SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE
   val SslTruststoreType = SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE
@@ -439,6 +440,7 @@ object KafkaConfig {
   /** ********* SSL Configuration ****************/
   val SslProtocolProp = SslConfigs.SSL_PROTOCOL_CONFIG
   val SslProviderProp = SslConfigs.SSL_PROVIDER_CONFIG
+  val SslContextProviderClassProp = SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG
   val SslCipherSuitesProp = SslConfigs.SSL_CIPHER_SUITES_CONFIG
   val SslEnabledProtocolsProp = SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG
   val SslKeystoreTypeProp = SslConfigs.SSL_KEYSTORE_TYPE_CONFIG
@@ -757,6 +759,7 @@ object KafkaConfig {
   /** ********* SSL Configuration ****************/
   val SslProtocolDoc = SslConfigs.SSL_PROTOCOL_DOC
   val SslProviderDoc = SslConfigs.SSL_PROVIDER_DOC
+  val SslContextProviderClassDoc = SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_DOC
   val SslCipherSuitesDoc = SslConfigs.SSL_CIPHER_SUITES_DOC
   val SslEnabledProtocolsDoc = SslConfigs.SSL_ENABLED_PROTOCOLS_DOC
   val SslKeystoreTypeDoc = SslConfigs.SSL_KEYSTORE_TYPE_DOC
@@ -1008,6 +1011,7 @@ object KafkaConfig {
       .define(PrincipalBuilderClassProp, CLASS, null, MEDIUM, PrincipalBuilderClassDoc)
       .define(SslProtocolProp, STRING, Defaults.SslProtocol, MEDIUM, SslProtocolDoc)
       .define(SslProviderProp, STRING, null, MEDIUM, SslProviderDoc)
+      .define(SslContextProviderClassProp, STRING, Defaults.SslContextProviderClass, MEDIUM, SslContextProviderClassDoc)
       .define(SslEnabledProtocolsProp, LIST, Defaults.SslEnabledProtocols, MEDIUM, SslEnabledProtocolsDoc)
       .define(SslKeystoreTypeProp, STRING, Defaults.SslKeystoreType, MEDIUM, SslKeystoreTypeDoc)
       .define(SslKeystoreLocationProp, STRING, null, MEDIUM, SslKeystoreLocationDoc)

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -680,6 +680,7 @@ class KafkaConfigTest {
         case KafkaConfig.PrincipalBuilderClassProp =>
         case KafkaConfig.SslProtocolProp => // ignore string
         case KafkaConfig.SslProviderProp => // ignore string
+        case KafkaConfig.SslContextProviderClassProp => // ignore string
         case KafkaConfig.SslEnabledProtocolsProp =>
         case KafkaConfig.SslKeystoreTypeProp => // ignore string
         case KafkaConfig.SslKeystoreLocationProp => // ignore string

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@
 ext {
   versions = [:]
   libs = [:]
-  
+
   // Enabled by default when commands like `testAll` are invoked
   defaultScalaVersions = [ '2.11', '2.12' ]
   // Available if -PscalaVersion is used. This is useful when we want to support a Scala version that has
@@ -82,7 +82,8 @@ versions += [
   slf4j: "1.7.25",
   snappy: "1.1.7.2",
   zkclient: "0.10",
-  zookeeper: "3.4.13"
+  zookeeper: "3.4.13",
+  conscrypt: "2.1.0"
 ]
 
 libs += [
@@ -139,5 +140,6 @@ libs += [
   zkclient: "com.101tec:zkclient:$versions.zkclient",
   zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper",
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
-  mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact"
+  mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
+  conscrypt: "org.conscrypt:conscrypt-openjdk:$versions.conscrypt:" + osdetector.classifier
 ]


### PR DESCRIPTION
In a recent benchmark work for performance of OpenSSL vs JDK8 SSL engine. we observe significant improvement in throughput/latency/CPU saving(see detail of benchmark in 
https://docs.google.com/document/d/1MRi36_ElA9tzylbaczc71-RewinJXhmD8eSMHxUOSnw/edit#heading=h.wn7uhw2wltm3)

Also in a recently heap dump analysis, the JDK SSL engine generates many under-utilized byte array(see detail in https://docs.google.com/document/d/1vbdPRj7CTx5Job7aTYlZ-tOK43PPYEWOd3RtuqfB62Y/edit#heading=h.ko5vd87v6ui7), using OpenSSL also helps to reduce the memory footprint of broker.

This patch adds support of using OpenSSL for Kafka, it use [Conscrypt](https://github.com/google/conscrypt)'s implementation.
To switch to OpenSSL,  a simple config change of "ssl.provider=Conscrypt" is enough. 

I feel the adoption of this patch in upstream will be slow since in  [related discussion](https://issues.apache.org/jira/browse/KAFKA-2561), the community is reluctant to pick up OpenSsl given the performance improvement in JDK9(through OpenSSL still outperforms). This patch will be more meaningful for Kafka running with JDK8.  
