### PR TITLE
[LI-HOTFIX] Clean up inFlightBatches in Sender when ProducerBatch split happens

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -595,6 +595,7 @@ public class Sender implements Runnable {
             this.accumulator.splitAndReenqueue(batch);
             this.accumulator.deallocate(batch);
             this.sensors.recordBatchSplit();
+            maybeRemoveFromInflightBatches(batch);
         } else if (error != Errors.NONE) {
             if (canRetry(batch, response, now)) {
                 log.warn(

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1873,6 +1873,11 @@ public class SenderTest {
             responseMap.put(tp, new ProduceResponse.PartitionResponse(Errors.MESSAGE_TOO_LARGE));
             client.respond(new ProduceResponse(responseMap));
             sender.run(time.milliseconds()); // split and reenqueue
+
+            // Make sure that there is no inflight batch for the topic partition
+            // (i.e. the original big batch has been cleaned up)
+            assertTrue("There should be only no inflight batch for the topic partition", sender.inFlightBatches(tp).isEmpty());
+
             assertEquals("The next sequence should be 2", 2, txnManager.sequenceNumber(tp).longValue());
             // The compression ratio should have been improved once.
             assertEquals(CompressionType.GZIP.rate - CompressionRatioEstimator.COMPRESSION_RATIO_IMPROVING_STEP,


### PR DESCRIPTION
TICKET = KAFKA-8202
LI_DESCRIPTION =
As part of the producer delivery timeout support (KAFKA-5886, KIP-91),
the inFlightBatches map is introduced in the producer Sender but
currently the batches in that map will only be cleaned up when
completing, expiring and failing a batch. However, when batch split
happens, the original batch (created prior to the split) will never be
cleaned up from inFlightBatches map. This cause excessive memory
pressure in the producer because these zombie batches are normally big
batches and eventully it will cause OutOfMemory in the producer.

This patch addresses the issue by removing the original batch from the
Sender inFlightBatchMap after split happens. The test case in SenderTest
also gets modified accordingly to cover this scenario.

EXIT_CRITERIA = TICKET [KAFKA-8202]