### PR TITLE
Add sensor to collect statistics of KafkaChannel memory allocation size.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPool.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPool.java
@@ -41,8 +41,8 @@ public class GarbageCollectedMemoryPool extends SimpleMemoryPool implements Auto
     private final Thread gcListenerThread;
     private volatile boolean alive = true;
 
-    public GarbageCollectedMemoryPool(long sizeBytes, int maxSingleAllocationSize, boolean strict, Sensor oomPeriodSensor, Sensor allocateSensor) {
-        super(sizeBytes, maxSingleAllocationSize, strict, oomPeriodSensor, allocateSensor);
+    public GarbageCollectedMemoryPool(long sizeBytes, int maxSingleAllocationSize, boolean strict, Sensor oomPeriodSensor) {
+        super(sizeBytes, maxSingleAllocationSize, strict, oomPeriodSensor, null);
         this.alive = true;
         this.gcListenerThread = new Thread(gcListener, "memory pool GC listener");
         this.gcListenerThread.setDaemon(true); //so we dont need to worry about shutdown

--- a/clients/src/main/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPool.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPool.java
@@ -41,8 +41,8 @@ public class GarbageCollectedMemoryPool extends SimpleMemoryPool implements Auto
     private final Thread gcListenerThread;
     private volatile boolean alive = true;
 
-    public GarbageCollectedMemoryPool(long sizeBytes, int maxSingleAllocationSize, boolean strict, Sensor oomPeriodSensor) {
-        super(sizeBytes, maxSingleAllocationSize, strict, oomPeriodSensor);
+    public GarbageCollectedMemoryPool(long sizeBytes, int maxSingleAllocationSize, boolean strict, Sensor oomPeriodSensor, Sensor allocateSensor) {
+        super(sizeBytes, maxSingleAllocationSize, strict, oomPeriodSensor, allocateSensor);
         this.alive = true;
         this.gcListenerThread = new Thread(gcListener, "memory pool GC listener");
         this.gcListenerThread.setDaemon(true); //so we dont need to worry about shutdown

--- a/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
@@ -28,63 +28,63 @@ public class GarbageCollectedMemoryPoolTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testZeroSize() throws Exception {
-        new GarbageCollectedMemoryPool(0, 7, true, null, null);
+        new GarbageCollectedMemoryPool(0, 7, true, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativeSize() throws Exception {
-        new GarbageCollectedMemoryPool(-1, 7, false, null, null);
+        new GarbageCollectedMemoryPool(-1, 7, false, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testZeroMaxAllocation() throws Exception {
-        new GarbageCollectedMemoryPool(100, 0, true, null, null);
+        new GarbageCollectedMemoryPool(100, 0, true, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativeMaxAllocation() throws Exception {
-        new GarbageCollectedMemoryPool(100, -1, false, null, null);
+        new GarbageCollectedMemoryPool(100, -1, false, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMaxAllocationLargerThanSize() throws Exception {
-        new GarbageCollectedMemoryPool(100, 101, true, null, null);
+        new GarbageCollectedMemoryPool(100, 101, true, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAllocationOverMaxAllocation() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         pool.tryAllocate(11);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAllocationZero() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         pool.tryAllocate(0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAllocationNegative() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         pool.tryAllocate(-1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testReleaseNull() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         pool.release(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testReleaseForeignBuffer() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         ByteBuffer fellOffATruck = ByteBuffer.allocate(1);
         pool.release(fellOffATruck);
     }
 
     @Test
     public void testDoubleFree() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         ByteBuffer buffer = pool.tryAllocate(5);
         Assert.assertNotNull(buffer);
         pool.release(buffer); //so far so good
@@ -100,7 +100,7 @@ public class GarbageCollectedMemoryPoolTest {
 
     @Test
     public void testAllocationBound() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(21, 10, false, null, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(21, 10, false, null);
         ByteBuffer buf1 = pool.tryAllocate(10);
         Assert.assertNotNull(buf1);
         Assert.assertEquals(10, buf1.capacity());
@@ -129,7 +129,7 @@ public class GarbageCollectedMemoryPoolTest {
         long maxPool = maxHeap / 2;
         long maxSingleAllocation = maxPool / 10;
         Assert.assertTrue(maxSingleAllocation < Integer.MAX_VALUE / 2); //test JVM running with too much memory for this test logic (?)
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(maxPool, (int) maxSingleAllocation, false, null, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(maxPool, (int) maxSingleAllocation, false, null);
 
         //we will allocate 30 buffers from this pool, which is sized such that at-most
         //11 should coexist and 30 do not fit in the JVM memory, proving that:

--- a/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
@@ -28,63 +28,63 @@ public class GarbageCollectedMemoryPoolTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testZeroSize() throws Exception {
-        new GarbageCollectedMemoryPool(0, 7, true, null);
+        new GarbageCollectedMemoryPool(0, 7, true, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativeSize() throws Exception {
-        new GarbageCollectedMemoryPool(-1, 7, false, null);
+        new GarbageCollectedMemoryPool(-1, 7, false, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testZeroMaxAllocation() throws Exception {
-        new GarbageCollectedMemoryPool(100, 0, true, null);
+        new GarbageCollectedMemoryPool(100, 0, true, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativeMaxAllocation() throws Exception {
-        new GarbageCollectedMemoryPool(100, -1, false, null);
+        new GarbageCollectedMemoryPool(100, -1, false, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMaxAllocationLargerThanSize() throws Exception {
-        new GarbageCollectedMemoryPool(100, 101, true, null);
+        new GarbageCollectedMemoryPool(100, 101, true, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAllocationOverMaxAllocation() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null, null);
         pool.tryAllocate(11);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAllocationZero() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null, null);
         pool.tryAllocate(0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAllocationNegative() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null, null);
         pool.tryAllocate(-1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testReleaseNull() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null, null);
         pool.release(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testReleaseForeignBuffer() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null, null);
         ByteBuffer fellOffATruck = ByteBuffer.allocate(1);
         pool.release(fellOffATruck);
     }
 
     @Test
     public void testDoubleFree() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null, null);
         ByteBuffer buffer = pool.tryAllocate(5);
         Assert.assertNotNull(buffer);
         pool.release(buffer); //so far so good
@@ -100,7 +100,7 @@ public class GarbageCollectedMemoryPoolTest {
 
     @Test
     public void testAllocationBound() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(21, 10, false, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(21, 10, false, null, null);
         ByteBuffer buf1 = pool.tryAllocate(10);
         Assert.assertNotNull(buf1);
         Assert.assertEquals(10, buf1.capacity());
@@ -129,7 +129,7 @@ public class GarbageCollectedMemoryPoolTest {
         long maxPool = maxHeap / 2;
         long maxSingleAllocation = maxPool / 10;
         Assert.assertTrue(maxSingleAllocation < Integer.MAX_VALUE / 2); //test JVM running with too much memory for this test logic (?)
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(maxPool, (int) maxSingleAllocation, false, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(maxPool, (int) maxSingleAllocation, false, null, null);
 
         //we will allocate 30 buffers from this pool, which is sized such that at-most
         //11 should coexist and 30 do not fit in the JVM memory, proving that:

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -467,7 +467,7 @@ public class SelectorTest {
     public void testMuteOnOOM() throws Exception {
         //clean up default selector, replace it with one that uses a finite mem pool
         selector.close();
-        MemoryPool pool = new SimpleMemoryPool(900, 900, false, null);
+        MemoryPool pool = new SimpleMemoryPool(900, 900, false, null, null);
         selector = new Selector(NetworkReceive.UNLIMITED, 5000, metrics, time, "MetricGroup",
             new HashMap<String, String>(), true, false, channelBuilder, pool, new LogContext());
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -21,7 +21,9 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.memory.SimpleMemoryPool;
 import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -76,6 +78,7 @@ public class SelectorTest {
     protected Selector selector;
     protected ChannelBuilder channelBuilder;
     protected Metrics metrics;
+    protected Sensor sensor;
 
     @Before
     public void setUp() throws Exception {
@@ -87,6 +90,7 @@ public class SelectorTest {
         this.channelBuilder.configure(configs);
         this.metrics = new Metrics();
         this.selector = new Selector(5000, this.metrics, time, "MetricGroup", channelBuilder, new LogContext());
+        this.sensor = metrics.sensor("infoSensor", new MetricConfig().recordLevel(Sensor.RecordingLevel.INFO), Sensor.RecordingLevel.INFO, null);
     }
 
     @After
@@ -467,7 +471,7 @@ public class SelectorTest {
     public void testMuteOnOOM() throws Exception {
         //clean up default selector, replace it with one that uses a finite mem pool
         selector.close();
-        MemoryPool pool = new SimpleMemoryPool(900, 900, false, null, null);
+        MemoryPool pool = new SimpleMemoryPool(900, 900, false, null, sensor);
         selector = new Selector(NetworkReceive.UNLIMITED, 5000, metrics, time, "MetricGroup",
             new HashMap<String, String>(), true, false, channelBuilder, pool, new LogContext());
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -219,7 +219,7 @@ public class SslSelectorTest extends SelectorTest {
     public void testMuteOnOOM() throws Exception {
         //clean up default selector, replace it with one that uses a finite mem pool
         selector.close();
-        MemoryPool pool = new SimpleMemoryPool(900, 900, false, null);
+        MemoryPool pool = new SimpleMemoryPool(900, 900, false, null, null);
         //the initial channel builder is for clients, we need a server one
         File trustStoreFile = File.createTempFile("truststore", ".jks");
         Map<String, Object> sslServerConfigs = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -20,7 +20,9 @@ import java.nio.channels.SelectionKey;
 import javax.net.ssl.SSLEngine;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.memory.SimpleMemoryPool;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.common.utils.LogContext;
@@ -71,6 +73,7 @@ public class SslSelectorTest extends SelectorTest {
         this.channelBuilder.configure(sslClientConfigs);
         this.metrics = new Metrics();
         this.selector = new Selector(5000, metrics, time, "MetricGroup", channelBuilder, new LogContext());
+        this.sensor = metrics.sensor("infoSensor", new MetricConfig().recordLevel(Sensor.RecordingLevel.INFO), Sensor.RecordingLevel.INFO, null);
     }
 
     @After
@@ -219,7 +222,7 @@ public class SslSelectorTest extends SelectorTest {
     public void testMuteOnOOM() throws Exception {
         //clean up default selector, replace it with one that uses a finite mem pool
         selector.close();
-        MemoryPool pool = new SimpleMemoryPool(900, 900, false, null, null);
+        MemoryPool pool = new SimpleMemoryPool(900, 900, false, null, sensor);
         //the initial channel builder is for clients, we need a server one
         File trustStoreFile = File.createTempFile("truststore", ".jks");
         Map<String, Object> sslServerConfigs = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -72,10 +72,10 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
   private val memoryPoolAllocationSensor = metrics.sensor("MemoryPoolAllocation")
   private val memoryPoolMaxAllocateSizeMetricName = metrics.metricName("MemoryPoolMaxAllocateSize", "socket-server-metrics")
   private val memoryPoolAllocateSizePercentilesMetricName = metrics.metricName("MemoryPoolAllocateSizePercentiles", "socket-server-metrics")
-  private val List<Percentile> percentiles = List.range(1, 10).map( i => new Percentile(metrics.metricName("MemoryPoolAllocateSize%dPercentile".format(i * 10), "socket-server-metrics"), i * 10))
+  private val percentiles = (1 to 10).map( i => new Percentile(metrics.metricName("MemoryPoolAllocateSize%dPercentile".format(i * 10), "socket-server-metrics"), i * 10))
   memoryPoolAllocationSensor.add(memoryPoolMaxAllocateSizeMetricName, new Max())
   // At current stage, we do not know the max decrypted request size, temporarily set it to 10MB.
-  memoryPoolAllocationSensor.add(memoryPoolAllocateSizePercentilesMetricName, new Percentiles(400, 0.0, 10485760, BucketSizing.CONSTANT, percentiles))
+  memoryPoolAllocationSensor.add(memoryPoolAllocateSizePercentilesMetricName, new Percentiles(400, 0.0, 10485760, BucketSizing.CONSTANT, percentiles:_*))
 
   private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolUtilizationSensor, memoryPoolAllocationSensor)
                            else MemoryPool.NONE

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -72,7 +72,7 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
   private val memoryPoolAllocationSensor = metrics.sensor("MemoryPoolAllocation")
   private val memoryPoolMaxAllocateSizeMetricName = metrics.metricName("MemoryPoolMaxAllocateSize", "socket-server-metrics")
   private val memoryPoolAllocateSizePercentilesMetricName = metrics.metricName("MemoryPoolAllocateSizePercentiles", "socket-server-metrics")
-  private val percentiles = (1 to 10).map( i => new Percentile(metrics.metricName("MemoryPoolAllocateSize%dPercentile".format(i * 10), "socket-server-metrics"), i * 10))
+  private val percentiles = (1 to 9).map( i => new Percentile(metrics.metricName("MemoryPoolAllocateSize%dPercentile".format(i * 10), "socket-server-metrics"), i * 10))
   memoryPoolAllocationSensor.add(memoryPoolMaxAllocateSizeMetricName, new Max())
   // At current stage, we do not know the max decrypted request size, temporarily set it to 10MB.
   memoryPoolAllocationSensor.add(memoryPoolAllocateSizePercentilesMetricName, new Percentiles(400, 0.0, 10485760, BucketSizing.CONSTANT, percentiles:_*))

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -64,10 +64,10 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
   private val logContext = new LogContext(s"[SocketServer brokerId=${config.brokerId}] ")
   this.logIdent = logContext.logPrefix
 
-  private val memoryPoolUtilizationSensor = metrics.sensor("MemoryPoolUtilization")
+  private val memoryPoolUsageSensor = metrics.sensor("MemoryPoolUsage")
   private val memoryPoolDepletedPercentMetricName = metrics.metricName("MemoryPoolAvgDepletedPercent", "socket-server-metrics")
   private val memoryPoolDepletedTimeMetricName = metrics.metricName("MemoryPoolDepletedTimeTotal", "socket-server-metrics")
-  memoryPoolUtilizationSensor.add(new Meter(TimeUnit.MILLISECONDS, memoryPoolDepletedPercentMetricName, memoryPoolDepletedTimeMetricName))
+  memoryPoolUsageSensor.add(new Meter(TimeUnit.MILLISECONDS, memoryPoolDepletedPercentMetricName, memoryPoolDepletedTimeMetricName))
 
   private val memoryPoolAllocationSensor = metrics.sensor("MemoryPoolAllocation")
   private val memoryPoolMaxAllocateSizeMetricName = metrics.metricName("MemoryPoolMaxAllocateSize", "socket-server-metrics")
@@ -77,7 +77,7 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
   // At current stage, we do not know the max decrypted request size, temporarily set it to 10MB.
   memoryPoolAllocationSensor.add(memoryPoolAllocateSizePercentilesMetricName, new Percentiles(400, 0.0, 10485760, BucketSizing.CONSTANT, percentiles:_*))
 
-  private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolUtilizationSensor, memoryPoolAllocationSensor)
+  private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolUsageSensor, memoryPoolAllocationSensor)
                            else MemoryPool.NONE
   val requestChannel = new RequestChannel(maxQueuedRequests, time)
   private val processors = new ConcurrentHashMap[Int, Processor]()

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -34,7 +34,8 @@ import kafka.utils._
 import org.apache.kafka.common.{KafkaException, Reconfigurable}
 import org.apache.kafka.common.memory.{MemoryPool, SimpleMemoryPool}
 import org.apache.kafka.common.metrics._
-import org.apache.kafka.common.metrics.stats.Meter
+import org.apache.kafka.common.metrics.stats.Percentiles.BucketSizing
+import org.apache.kafka.common.metrics.stats.{Max, Meter, Percentile, Percentiles}
 import org.apache.kafka.common.network.KafkaChannel.ChannelMuteEvent
 import org.apache.kafka.common.network.{ChannelBuilder, ChannelBuilders, KafkaChannel, ListenerName, Selectable, Send, Selector => KSelector}
 import org.apache.kafka.common.requests.{RequestContext, RequestHeader}
@@ -63,11 +64,21 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
   private val logContext = new LogContext(s"[SocketServer brokerId=${config.brokerId}] ")
   this.logIdent = logContext.logPrefix
 
-  private val memoryPoolSensor = metrics.sensor("MemoryPoolUtilization")
+  private val memoryPoolUtilizationSensor = metrics.sensor("MemoryPoolUtilization")
   private val memoryPoolDepletedPercentMetricName = metrics.metricName("MemoryPoolAvgDepletedPercent", "socket-server-metrics")
   private val memoryPoolDepletedTimeMetricName = metrics.metricName("MemoryPoolDepletedTimeTotal", "socket-server-metrics")
-  memoryPoolSensor.add(new Meter(TimeUnit.MILLISECONDS, memoryPoolDepletedPercentMetricName, memoryPoolDepletedTimeMetricName))
-  private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolSensor) else MemoryPool.NONE
+  memoryPoolUtilizationSensor.add(new Meter(TimeUnit.MILLISECONDS, memoryPoolDepletedPercentMetricName, memoryPoolDepletedTimeMetricName))
+
+  private val memoryPoolAllocationSensor = metrics.sensor("MemoryPoolAllocation")
+  private val memoryPoolMaxAllocateSizeMetricName = metrics.metricName("MemoryPoolMaxAllocateSize", "socket-server-metrics")
+  private val memoryPoolAllocateSizePercentilesMetricName = metrics.metricName("MemoryPoolAllocateSizePercentiles", "socket-server-metrics")
+  private val List<Percentile> percentiles = List.range(1, 10).map( i => new Percentile(metrics.metricName("MemoryPoolAllocateSize%dPercentile".format(i * 10), "socket-server-metrics"), i * 10))
+  memoryPoolAllocationSensor.add(memoryPoolMaxAllocateSizeMetricName, new Max())
+  // At current stage, we do not know the max decrypted request size, temporarily set it to 10MB.
+  memoryPoolAllocationSensor.add(memoryPoolAllocateSizePercentilesMetricName, new Percentiles(400, 0.0, 10485760, BucketSizing.CONSTANT, percentiles))
+
+  private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolUtilizationSensor, memoryPoolAllocationSensor)
+                           else MemoryPool.NONE
   val requestChannel = new RequestChannel(maxQueuedRequests, time)
   private val processors = new ConcurrentHashMap[Int, Processor]()
   private var nextProcessorId = 0


### PR DESCRIPTION
This patch adds two sensors to memory pool used by broker to allocate buffers for received requests.

(1) A `Max`  to get the max allocated buffer size
(2) A `Percentiles` to get the 10,20,30 etc percentile of allocated buffer size

This is a prerequisite patch for potential optimization for the memory pool( to preallocate and reuse buffers). 