### PR TITLE
[LI-HOTFIX] add back old parseAndValidateAddresses API for backward c…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -47,6 +47,14 @@ public final class ClientUtils {
         return parseAndValidateAddresses(urls, ClientDnsLookup.forConfig(clientDnsLookupConfig));
     }
 
+    /**
+     * Kafka does not use this function directly. However,
+     * some third-party applications still rely on this API to parse and validate addresses.
+     */
+    public static List<InetSocketAddress> parseAndValidateAddresses(List<String> urls) {
+        return parseAndValidateAddresses(urls, ClientDnsLookup.DEFAULT);
+    }
+
     public static List<InetSocketAddress> parseAndValidateAddresses(List<String> urls, ClientDnsLookup clientDnsLookup) {
         List<InetSocketAddress> addresses = new ArrayList<>();
         for (String url : urls) {


### PR DESCRIPTION
…ompatibility

TICKET =
LI_DESCRIPTION =
Some apps such as linkedin-kafka-clients and likafka-cruise-control still reply on this API:
parseAndValidateAddresses(List<String> urls).
This patch adds back the function.

EXIT_CRITERIA = MANUAL ["when no APP makes direct use of this API"]