### PR TITLE
[LI-HOTFIX] Do not throw exceptions when internal headers are set and…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -409,7 +409,8 @@ public class MemoryRecordsBuilder {
         if (magic < RecordBatch.MAGIC_VALUE_V2 && headers != null && headers.length > 0) {
             for (Header header : headers) {
                 if (!header.key().startsWith(INTERNAL_HEADER_PREFIX)) {
-                    throw new IllegalArgumentException("Magic v" + magic + " does not support record headers");
+                    throw new IllegalArgumentException("Magic v" + magic + " does not support record headers. [Key = "
+                        + header.key() + "]");
                 }
             }
         }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -809,7 +809,7 @@ public class RecordAccumulatorTest {
             );
             throw new IllegalStateException("The append of a record with non internal headers should have failed");
         } catch (IllegalArgumentException exception) {
-            assertEquals(exception.getMessage(), "Magic v1 does not support record headers");
+            assertEquals(exception.getMessage(), "Magic v1 does not support record headers. [Key = key]");
         }
         batch.tryAppend(
                 1L,

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -29,6 +29,8 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.record.CompressionRatioEstimator;
@@ -782,6 +784,41 @@ public class RecordAccumulatorTest {
             CompressionType.NONE, lingerMs, retryBackoffMs, deliveryTimeoutMs, metrics, metricGrpName, time, apiVersions, new TransactionManager(),
             new BufferPool(totalSize, batchSize, metrics, time, metricGrpName));
         accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, 0);
+    }
+
+    @Test
+    public void testRecordHeadersWithMagicV1() {
+        ByteBuffer buffer = ByteBuffer.allocate(4096);
+        MemoryRecordsBuilder builder = MemoryRecords.builder(
+            buffer,
+            (byte) 1, // Enforces that Message format v1 is used on the client
+            CompressionType.NONE,
+            TimestampType.CREATE_TIME,
+            0L
+        );
+        long now = System.currentTimeMillis();
+        ProducerBatch batch = new ProducerBatch(tp1, builder, now, true);
+        try {
+            batch.tryAppend(
+                1L,
+                new byte[10],
+                new byte[20],
+                new Header[] {new RecordHeader("key", new byte[20])},
+                null,
+                now
+            );
+            throw new IllegalStateException("The append of a record with non internal headers should have failed");
+        } catch (IllegalArgumentException exception) {
+            assertEquals(exception.getMessage(), "Magic v1 does not support record headers");
+        }
+        batch.tryAppend(
+                1L,
+                new byte[10],
+                new byte[20],
+                new Header[] {new RecordHeader("_key", new byte[20])},
+                null,
+                now
+        );
     }
 
     @Test

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -40,8 +40,10 @@ import scala.concurrent.ExecutionException
 
 abstract class BaseProducerSendTest extends KafkaServerTestHarness {
 
+  def overrideConfigs() : Properties = {new Properties()}
+
   def generateConfigs = {
-    val overridingProps = new Properties()
+    val overridingProps = overrideConfigs()
     val numServers = 2
     overridingProps.put(KafkaConfig.NumPartitionsProp, 4.toString)
     TestUtils.createBrokerConfigs(numServers, zkConnect, false, interBrokerSecurityProtocol = Some(securityProtocol),

--- a/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
@@ -114,5 +114,4 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
       compressedProducer.close()
     }
   }
-
 }

--- a/core/src/test/scala/integration/kafka/api/RecordHeaderProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/RecordHeaderProducerSendTest.scala
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.kafka.api
+
+import java.util.Properties
+
+import kafka.api.BaseProducerSendTest
+import kafka.server.KafkaConfig
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.header.internals.RecordHeaders
+import org.junit.Test
+
+class RecordHeaderProducerSendTest extends BaseProducerSendTest {
+
+  @Test
+  def testRecordHeaders(): Unit = {
+    val producerProps = new Properties()
+    producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
+    producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
+    val producer = new KafkaProducer[String, String](producerProps)
+    var invalidRecordHeaders = new RecordHeaders()
+    invalidRecordHeaders.add("RecordHeaderKey", "RecordHeaderValue".getBytes)
+    // The record is invalid because it contain header with keys that doesn't start with a "_"
+    // Keys that do start with a "_" are internal to the clients and are dropped at the producer.
+    val invalidRecord = new ProducerRecord[String, String](
+      topic,
+      new Integer(0),
+      "RecordKey",
+      "RecordValue",
+      invalidRecordHeaders
+    )
+    try {
+      producer.send(invalidRecord).get
+      throw new IllegalStateException("The invalid record should have thrown an exception")
+    } catch {
+      // Ignore the exception because a non internal header was introduced into the producer record
+      case ignored: IllegalArgumentException =>
+    }
+
+    val validRecordHeaders = new RecordHeaders()
+    validRecordHeaders.add("_RecordHeaderKey", "RecordHeaderValue".getBytes)
+    val record = new ProducerRecord[String, String](
+      topic,
+      new Integer(0),
+      "RecordKey",
+      "RecordValue",
+      validRecordHeaders
+    )
+    producer.send(record).get
+  }
+
+  override def overrideConfigs(): Properties = {
+    val properties = new Properties()
+    properties.put(KafkaConfig.InterBrokerProtocolVersionProp, "0.10.2")
+    properties.put(KafkaConfig.LogMessageFormatVersionProp, "0.10.2")
+    properties
+  }
+}


### PR DESCRIPTION
[LI-HOTFIX] Do not throw exceptions when internal headers are set and the coordinated channel with the broker is using Message_v1(magic = 1)
