### PR TITLE
[LI-HOTFIX] Separate Kafka Controller Node from Data Node

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -63,6 +63,7 @@ class ControllerContext {
   val topicsWithDeletionStarted = mutable.Set.empty[String]
   val topicsIneligibleForDeletion = mutable.Set.empty[String]
 
+  @volatile var livePreferredControllerIds: Set[Int] = Set.empty
 
   def partitionReplicaAssignment(topicPartition: TopicPartition): Seq[Int] = {
     partitionAssignments.getOrElse(topicPartition.topic, mutable.Map.empty)
@@ -121,12 +122,18 @@ class ControllerContext {
     liveBrokers += newMetadata
   }
 
+  def setLivePreferredControllerIds(preferredControllerIds: Set[Int]): Unit = {
+    livePreferredControllerIds = preferredControllerIds
+  }
+
   // getter
   def liveBrokerIds: Set[Int] = liveBrokerEpochs.keySet -- shuttingDownBrokerIds
   def liveOrShuttingDownBrokerIds: Set[Int] = liveBrokerEpochs.keySet
   def liveOrShuttingDownBrokers: Set[Broker] = liveBrokers
   def liveBrokerIdAndEpochs: Map[Int, Long] = liveBrokerEpochs
   def liveOrShuttingDownBroker(brokerId: Int): Option[Broker] = liveOrShuttingDownBrokers.find(_.id == brokerId)
+
+  def getLivePreferredControllerIds : Set[Int] = livePreferredControllerIds
 
   def partitionsOnBroker(brokerId: Int): Set[TopicPartition] = {
     partitionAssignments.flatMap {

--- a/core/src/main/scala/kafka/controller/ControllerState.scala
+++ b/core/src/main/scala/kafka/controller/ControllerState.scala
@@ -102,7 +102,11 @@ object ControllerState {
     def value = 15
   }
 
+  case object PreferredControllerChange extends ControllerState {
+    def value = 16
+  }
+
   val values: Seq[ControllerState] = Seq(Idle, ControllerChange, BrokerChange, TopicChange, TopicDeletion,
     PartitionReassignment, AutoLeaderBalance, ManualLeaderBalance, ControlledShutdown, IsrChange, LeaderAndIsrResponseReceived,
-    LogDirChange, ControllerShutdown, UncleanLeaderElectionEnable, TopicUncleanLeaderElectionEnable, TopicDeletionFlagChange)
+    LogDirChange, ControllerShutdown, UncleanLeaderElectionEnable, TopicUncleanLeaderElectionEnable, TopicDeletionFlagChange, PreferredControllerChange)
 }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1382,9 +1382,11 @@ class KafkaController(val config: KafkaConfig,
     * PreferredControllerChange event should be handled by all brokers to perform:
     * 1) update preferred controllers
     * 2) non-preferred active controller resign
-    * 3) elect controller in the absence of preferred controllers. Since ControllerChange event might be fired
-    * before the PreferredControllerChange event, this ensures a non preferred controller node eventually attempts
-    * to elect itself after the last preferred controller goes offline.
+    * 3) elect controller in the absence of preferred controllers. When the last preferred controller goes offline,
+    * ControllerChange event might be fired before the PreferredControllerChange event. When ControllerChange event
+    * is processed, a broker may still see the preferred controller under preferred controller znode and not to elect
+    * itself as controller. Therefore, when PreferredControllerChange event is processed,
+    * a controller election needs to be attempted.
     */
   private def processPreferredControllerChange(): Unit = {
     // refresh the preferred controller list and reset zookeeper watch by reading the list

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -125,6 +125,7 @@ class KafkaController(val config: KafkaConfig,
 
   private val controllerChangeHandler = new ControllerChangeHandler(eventManager)
   private val brokerChangeHandler = new BrokerChangeHandler(eventManager)
+  private val preferredControllerChangeHandler = new PreferredControllerChangeHandler(eventManager)
   private val brokerModificationsHandlers: mutable.Map[Int, BrokerModificationsHandler] = mutable.Map.empty
   private val topicChangeHandler = new TopicChangeHandler(eventManager)
   private val topicDeletionHandler = new TopicDeletionHandler(eventManager)
@@ -150,6 +151,20 @@ class KafkaController(val config: KafkaConfig,
     "ActiveControllerCount",
     new Gauge[Int] {
       def value = if (isActive) 1 else 0
+    }
+  )
+
+  newGauge(
+    "ActivePreferredControllerCount",
+    new Gauge[Int] {
+      def value = if (isActive && config.preferredController) 1 else 0
+    }
+  )
+
+  newGauge(
+    "StandbyPreferredControllerCount",
+    new Gauge[Int] {
+      def value = if (!isActive && config.preferredController) 1 else 0
     }
   )
 
@@ -196,6 +211,11 @@ class KafkaController(val config: KafkaConfig,
   def brokerEpoch: Long = _brokerEpoch
 
   def epoch: Int = controllerContext.epoch
+
+  /**
+    * @return brokers that don't accept new replicas, including maintenance brokers and preferred controller brokers
+    */
+  def noNewPartitionBrokerIds: Seq[Int] = config.getMaintenanceBrokerList ++ controllerContext.getLivePreferredControllerIds
 
   /**
    * Invoked when the controller module of a Kafka server is started up. This does not assume that the current broker
@@ -257,6 +277,10 @@ class KafkaController(val config: KafkaConfig,
     if (isActive) {
       eventManager.put(TopicUncleanLeaderElectionEnable(topic))
     }
+  }
+
+  private[kafka] def enablePreferredControllerFallback(): Unit = {
+    eventManager.put(PreferredControllerChange)
   }
 
   private def state: ControllerState = eventManager.state
@@ -783,14 +807,14 @@ class KafkaController(val config: KafkaConfig,
   // maintenance brokers that do not take new partitions
   private def rearrangePartitionReplicaAssignmentForNewTopics(topics: Set[String]) {
     try {
-      val noNewPartitionBrokerIds = config.getMaintenanceBrokerList
-      if (noNewPartitionBrokerIds.nonEmpty) {
+      val noNewPartitionBrokers = noNewPartitionBrokerIds
+      if (noNewPartitionBrokers.nonEmpty) {
         val newTopics = zkClient.getPartitionNodeNonExistsTopics(topics.toSet)
         val newTopicsToBeArranged = zkClient.getPartitionAssignmentForTopics(newTopics).filter {
           case (_, partitionMap) =>
             partitionMap.exists {
               case (_, assignedReplicas) =>
-                assignedReplicas.intersect(noNewPartitionBrokerIds).nonEmpty
+                assignedReplicas.intersect(noNewPartitionBrokers).nonEmpty
             }
         }
         newTopicsToBeArranged.foreach {
@@ -799,7 +823,7 @@ class KafkaController(val config: KafkaConfig,
             val numReplica = partitionMap.head._2.size
             val brokers = controllerContext.liveOrShuttingDownBrokers.map { b => kafka.admin.BrokerMetadata(b.id, b.rack) }.toSeq
 
-            val replicaAssignment = adminZkClient.assignReplicasToAvailableBrokers(brokers, noNewPartitionBrokerIds.toSet, numPartitions, numReplica)
+            val replicaAssignment = adminZkClient.assignReplicasToAvailableBrokers(brokers, noNewPartitionBrokers.toSet, numPartitions, numReplica)
             adminZkClient.writeTopicPartitionAssignment(topic, replicaAssignment, true)
             info(s"Rearrange partition and replica assignment for topic [$topic]")
         }
@@ -1205,6 +1229,7 @@ class KafkaController(val config: KafkaConfig,
 
   private def processStartup(): Unit = {
     zkClient.registerZNodeChangeHandlerAndCheckExistence(controllerChangeHandler)
+    zkClient.registerZNodeChildChangeHandler(preferredControllerChangeHandler)
     elect()
   }
 
@@ -1257,6 +1282,10 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def elect(): Unit = {
+
+    // refresh preferred controller nodes
+    controllerContext.setLivePreferredControllerIds(zkClient.getPreferredControllerList.toSet)
+
     activeControllerId = zkClient.getControllerId.getOrElse(-1)
     /*
      * We can get here during the initial startup and the handleDeleted ZK callback. Because of the potential race condition,
@@ -1266,6 +1295,16 @@ class KafkaController(val config: KafkaConfig,
     if (activeControllerId != -1) {
       debug(s"Broker $activeControllerId has been elected as the controller, so stopping the election process.")
       return
+    }
+
+    if (!config.preferredController) {
+      /*
+       * A broker that is not preferred controller only elects itself when there is no preferred controllers in cluster
+       * and allowPreferredControllerFallback is set to true.
+       */
+      if (!config.allowPreferredControllerFallback || controllerContext.getLivePreferredControllerIds.nonEmpty) {
+        return
+      }
     }
 
     try {
@@ -1336,6 +1375,31 @@ class KafkaController(val config: KafkaConfig,
 
     if (newBrokerIds.nonEmpty || deadBrokerIds.nonEmpty || bouncedBrokerIds.nonEmpty) {
       info(s"Updated broker epochs cache: ${controllerContext.liveBrokerIdAndEpochs}")
+    }
+  }
+
+  /**
+    * PreferredControllerChange event should be handled by all brokers to perform:
+    * 1) update preferred controllers
+    * 2) non-preferred active controller resign
+    * 3) elect controller in the absence of preferred controllers. Since ControllerChange event might be fired
+    * before the PreferredControllerChange event, this ensures a non preferred controller node eventually attempts
+    * to elect itself after the last preferred controller goes offline.
+    */
+  private def processPreferredControllerChange(): Unit = {
+    // refresh the preferred controller list and reset zookeeper watch by reading the list
+    controllerContext.setLivePreferredControllerIds(zkClient.getPreferredControllerList.toSet)
+    if (isActive) {
+      if (!config.preferredController && controllerContext.getLivePreferredControllerIds.nonEmpty) {
+        // resign if a non-preferred active controller detects any live preferred controller
+        info(s"Resign when detecting preferred controllers.")
+        triggerControllerMove()
+      }
+    } else {
+      if (controllerContext.getLivePreferredControllerIds.isEmpty) {
+        // trigger election in the absence of preferred controllers
+        processReelect()
+      }
     }
   }
 
@@ -1620,6 +1684,9 @@ class KafkaController(val config: KafkaConfig,
 
   private def processRegisterBrokerAndReelect(): Unit = {
     _brokerEpoch = zkClient.registerBroker(brokerInfo)
+    if (config.preferredController) {
+      zkClient.registerPreferredControllerId(brokerInfo.broker.id)
+    }
     processReelect()
   }
 
@@ -1628,20 +1695,18 @@ class KafkaController(val config: KafkaConfig,
     onControllerResignation()
   }
 
-
-
   // For any topics that fail to meet min RF requirement, generate new valid partition assignment and reset ZNode
   private def fixTopicsFailingPolicy(topicsReplicaAssignment : Map[String, Map[Int, Seq[Int]]]) : Unit = {
     if (topicsReplicaAssignment.isEmpty) return
 
     val replicationFactor = config.defaultReplicationFactor
     val brokers = controllerContext.liveOrShuttingDownBrokers.map { sb => kafka.admin.BrokerMetadata(sb.id, sb.rack) }.toSeq
-    val noNewPartitionBrokerIds = config.getMaintenanceBrokerList.toSet
+    val noNewPartitionBrokers = noNewPartitionBrokerIds.toSet
 
     topicsReplicaAssignment.foreach{
       case(topic, partitionAssignment) => {
         val numPartitions = partitionAssignment.size
-        val assignment = adminZkClient.assignReplicasToAvailableBrokers(brokers, noNewPartitionBrokerIds, numPartitions, replicationFactor)
+        val assignment = adminZkClient.assignReplicasToAvailableBrokers(brokers, noNewPartitionBrokers, numPartitions, replicationFactor)
           .map{ case(partition, replicas) => {
             (new TopicPartition(topic, partition), replicas)
           }}.toMap
@@ -1698,6 +1763,8 @@ class KafkaController(val config: KafkaConfig,
           processTopicDeletionStopReplicaResponseReceived(replicaId, requestError, partitionErrors)
         case BrokerChange =>
           processBrokerChange()
+        case PreferredControllerChange =>
+          processPreferredControllerChange()
         case BrokerModifications(brokerId) =>
           processBrokerModification(brokerId)
         case ControllerChange =>
@@ -1754,6 +1821,14 @@ class BrokerChangeHandler(eventManager: ControllerEventManager) extends ZNodeChi
 
   override def handleChildChange(): Unit = {
     eventManager.put(BrokerChange)
+  }
+}
+
+class PreferredControllerChangeHandler(eventManager: ControllerEventManager) extends ZNodeChildChangeHandler {
+  override val path: String = PreferredControllersZNode.path
+
+  override def handleChildChange(): Unit = {
+    eventManager.put(PreferredControllerChange)
   }
 }
 
@@ -1947,6 +2022,10 @@ case object Startup extends ControllerEvent {
 
 case object BrokerChange extends ControllerEvent {
   override def state: ControllerState = ControllerState.BrokerChange
+}
+
+case object PreferredControllerChange extends ControllerEvent {
+  override def state: ControllerState = ControllerState.PreferredControllerChange
 }
 
 case class BrokerModifications(brokerId: Int) extends ControllerEvent {

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -98,7 +98,7 @@ class AdminManager(val config: KafkaConfig,
             "Both cannot be used at the same time.")
         }
         val assignments = if (topic.assignments().isEmpty) {
-          adminZkClient.assignReplicasToAvailableBrokers(brokers, controller.noNewPartitionBrokerIds.toSet, topic.numPartitions, topic.replicationFactor)
+          adminZkClient.assignReplicasToAvailableBrokers(brokers, controller.partitionUnassignableBrokerIds.toSet, topic.numPartitions, topic.replicationFactor)
         } else {
           val assignments = new mutable.HashMap[Int, Seq[Int]]
           // Note: we don't check that replicaAssignment contains unknown brokers - unlike in add-partitions case,
@@ -279,7 +279,7 @@ class AdminManager(val config: KafkaConfig,
 
         val updatedReplicaAssignment = adminZkClient.addPartitions(topic, existingAssignment, allBrokers,
           newPartition.totalCount, reassignment, validateOnly = validateOnly,
-          noNewPartitionBrokerIds = controller.noNewPartitionBrokerIds.toSet)
+          noNewPartitionBrokerIds = controller.partitionUnassignableBrokerIds.toSet)
         CreatePartitionsMetadata(topic, updatedReplicaAssignment, ApiError.NONE)
       } catch {
         case e: AdminOperationException =>

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -87,6 +87,8 @@ object DynamicBrokerConfig {
     SocketServer.ReconfigurableConfigs
 
   private val ClusterLevelListenerConfigs = Set(KafkaConfig.MaxConnectionsProp)
+  private val ClusterLevelConfigs = Set(KafkaConfig.AllowPreferredControllerFallbackProp) ++
+    DynamicConfig.Broker.ClusterLevelConfigs
   private val PerBrokerConfigs = DynamicSecurityConfigs  ++
     DynamicListenerConfig.ReconfigurableConfigs -- ClusterLevelListenerConfigs
   private val ListenerMechanismConfigs = Set(KafkaConfig.SaslJaasConfigProp)
@@ -153,7 +155,7 @@ object DynamicBrokerConfig {
 
   private def clusterLevelConfigs(props: Properties): Set[String] = {
     val configNames = props.asScala.keySet
-    configNames.intersect(DynamicConfig.Broker.ClusterLevelConfigs)
+    configNames.intersect(ClusterLevelConfigs)
   }
 
   private def nonDynamicConfigs(props: Properties): Set[String] = {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -547,7 +547,10 @@ object KafkaConfig {
   val HeapDumpTimeoutDoc = "The max amount of time (in millis) to wait for heap dump to complete before halting regardless"
   val ProducerBatchDecompressionEnableDoc = "Decompress batch sent by producer to perform verification of individual records inside the batch"
   val PreferredControllerDoc = "Specifies whether the broker is a dedicated controller node. If set to true, the broker is a preferred controller node."
-  val AllowPreferredControllerFallbackDoc = "Specifies whether a non-preferred controller node (broker) is allowed to become the controller. " +
+  // Although AllowPreferredControllerFallback is expected to be configured dynamically at per cluster level, providing a static configuration entry
+  // here allows its value to be obtained without holding the dynamic broker configuration lock.
+  val AllowPreferredControllerFallbackDoc = "Specifies whether a non-preferred controller node (broker) is allowed to become the controller." +
+  " This configuration is expected to be configured at cluster level via dynamic broker configuration to provide a consistent configuration among all brokers." +
   " If AllowPreferredControllerFallback is dynamically set to false and there is no preferred controllers, the non-preferred active controller does not resign."
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameDoc = "The authorizer class that should be used for authorization"

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -547,7 +547,8 @@ object KafkaConfig {
   val HeapDumpTimeoutDoc = "The max amount of time (in millis) to wait for heap dump to complete before halting regardless"
   val ProducerBatchDecompressionEnableDoc = "Decompress batch sent by producer to perform verification of individual records inside the batch"
   val PreferredControllerDoc = "Specifies whether the broker is a dedicated controller node. If set to true, the broker is a preferred controller node."
-  val AllowPreferredControllerFallbackDoc = "Specifies whether a non-preferred controller node (broker) is allowed to become the controller."
+  val AllowPreferredControllerFallbackDoc = "Specifies whether a non-preferred controller node (broker) is allowed to become the controller. " +
+  " If AllowPreferredControllerFallback is dynamically set to false and there is no preferred controllers, the non-preferred active controller does not resign."
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameDoc = "The authorizer class that should be used for authorization"
   /** ********* Socket Server Configuration ***********/

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -60,6 +60,8 @@ object Defaults {
   val QueuedMaxRequests = 500
   val QueuedMaxRequestBytes = -1
   val ProducerBatchDecompressionEnable = true
+  val PreferredController = false
+  val AllowPreferredControllerFallback = true
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassName = ""
@@ -294,6 +296,9 @@ object KafkaConfig {
   val HeapDumpFolderProp = "heap.dump.folder"
   val HeapDumpTimeoutProp = "heap.dump.timeout"
   val ProducerBatchDecompressionEnableProp = "producer.batch.decompression.enable"
+  val PreferredControllerProp = "preferred.controller"
+  val AllowPreferredControllerFallbackProp = "allow.preferred.controller.fallback"
+
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameProp = "authorizer.class.name"
 
@@ -541,6 +546,8 @@ object KafkaConfig {
   val HeapDumpFolderDoc = "The Folder under which heap dumps will be written by the watchdog"
   val HeapDumpTimeoutDoc = "The max amount of time (in millis) to wait for heap dump to complete before halting regardless"
   val ProducerBatchDecompressionEnableDoc = "Decompress batch sent by producer to perform verification of individual records inside the batch"
+  val PreferredControllerDoc = "Specifies whether the broker is a dedicated controller node. If set to true, the broker is a preferred controller node."
+  val AllowPreferredControllerFallbackDoc = "Specifies whether a non-preferred controller node (broker) is allowed to become the controller."
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameDoc = "The authorizer class that should be used for authorization"
   /** ********* Socket Server Configuration ***********/
@@ -915,6 +922,8 @@ object KafkaConfig {
       .define(HeapDumpFolderProp, STRING, Defaults.HeapDumpFolder, LOW, HeapDumpFolderDoc)
       .define(HeapDumpTimeoutProp, LONG, Defaults.HeapDumpTimeout, LOW, HeapDumpTimeoutDoc)
       .define(ProducerBatchDecompressionEnableProp, BOOLEAN, Defaults.ProducerBatchDecompressionEnable, LOW, ProducerBatchDecompressionEnableDoc)
+      .define(PreferredControllerProp, BOOLEAN, Defaults.PreferredController, HIGH, PreferredControllerDoc)
+      .define(AllowPreferredControllerFallbackProp, BOOLEAN, Defaults.AllowPreferredControllerFallback, HIGH, AllowPreferredControllerFallbackDoc)
 
       /************* Authorizer Configuration ***********/
       .define(AuthorizerClassNameProp, STRING, Defaults.AuthorizerClassName, LOW, AuthorizerClassNameDoc)
@@ -1217,6 +1226,9 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val heapDumpFolder = new File(getString(KafkaConfig.HeapDumpFolderProp))
   val heapDumpTimeout = getLong(KafkaConfig.HeapDumpTimeoutProp)
   val producerBatchDecompressionEnable = getBoolean(KafkaConfig.ProducerBatchDecompressionEnableProp)
+
+  var preferredController = getBoolean(KafkaConfig.PreferredControllerProp)
+  def allowPreferredControllerFallback: Boolean = getBoolean(KafkaConfig.AllowPreferredControllerFallbackProp)
 
   def getNumReplicaAlterLogDirsThreads: Int = {
     val numThreads: Integer = Option(getInt(KafkaConfig.NumReplicaAlterLogDirsThreadsProp)).getOrElse(logDirs.size)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -273,6 +273,9 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
         val brokerInfo = createBrokerInfo
         val brokerEpoch = zkClient.registerBroker(brokerInfo)
+        if (config.preferredController) {
+          zkClient.registerPreferredControllerId(brokerInfo.broker.id)
+        }
 
         healthCheckScheduler = new KafkaScheduler(threads = 1, threadNamePrefix = "kafka-healthcheck-scheduler-")
         healthCheckScheduler.startup()
@@ -292,7 +295,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch, tokenManager, threadNamePrefix)
         kafkaController.startup()
 
-        adminManager = new AdminManager(config, metrics, metadataCache, zkClient)
+        adminManager = new AdminManager(config, metrics, metadataCache, zkClient, kafkaController)
 
         /* start group coordinator */
         // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -272,10 +272,10 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         replicaManager.startup()
 
         val brokerInfo = createBrokerInfo
-        val brokerEpoch = zkClient.registerBroker(brokerInfo)
         if (config.preferredController) {
           zkClient.registerPreferredControllerId(brokerInfo.broker.id)
         }
+        val brokerEpoch = zkClient.registerBroker(brokerInfo)
 
         healthCheckScheduler = new KafkaScheduler(threads = 1, threadNamePrefix = "kafka-healthcheck-scheduler-")
         healthCheckScheduler.startup()

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -100,8 +100,8 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
   }
 
   /**
-    * Registers the preferred controller node in zookeeper.
-    * @param preferred controller id
+    * Registers the preferred controller id in zookeeper.
+    * @param id controller id
     */
   def registerPreferredControllerId(id: Int): Unit = {
     val path = PreferredControllerIdZNode.path(id)

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -100,6 +100,16 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
   }
 
   /**
+    * Registers the preferred controller node in zookeeper.
+    * @param preferred controller id
+    */
+  def registerPreferredControllerId(id: Int): Unit = {
+    val path = PreferredControllerIdZNode.path(id)
+    val stat = checkedEphemeralCreate(path, null)
+    info(s"Registered preferred controller ${id} at path $path with czxid (preferred controller epoch): ${stat.getCzxid}")
+  }
+
+  /**
    * Registers a given broker in zookeeper as the controller and increments controller epoch.
    * @param controllerId the id of the broker that is to be registered as the controller.
    * @return the (updated controller epoch, epoch zkVersion) tuple
@@ -448,6 +458,11 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
    * Gets the list of sorted broker Ids
    */
   def getSortedBrokerList: Seq[Int] = getChildren(BrokerIdsZNode.path).map(_.toInt).sorted
+
+  /**
+    * Gets the list of preferred controller Ids
+    */
+  def getPreferredControllerList: Seq[Int] = getChildren(PreferredControllersZNode.path).map(_.toInt)
 
   /**
    * Gets all topics in the cluster.

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -72,6 +72,15 @@ object BrokersZNode {
   def path = "/brokers"
 }
 
+object PreferredControllersZNode {
+  def path = s"${BrokersZNode.path}/preferred_controllers"
+  def encode: Array[Byte] = null
+}
+
+object PreferredControllerIdZNode {
+  def path(id: Int) = s"${BrokersZNode.path}/preferred_controllers/$id"
+}
+
 object BrokerIdsZNode {
   def path = s"${BrokersZNode.path}/ids"
   def encode: Array[Byte] = null
@@ -737,6 +746,7 @@ object ZkData {
   val PersistentZkPaths = Seq(
     ConsumerPathZNode.path, // old consumer path
     BrokerIdsZNode.path,
+    PreferredControllersZNode.path,
     TopicsZNode.path,
     ConfigEntityChangeNotificationZNode.path,
     DeleteTopicsZNode.path,

--- a/core/src/test/scala/unit/kafka/server/PreferredControllerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/PreferredControllerTest.scala
@@ -72,7 +72,7 @@ class PreferredControllerTest extends ZooKeeperTestHarness {
   }
 
   @Test
-  def testDataNodeElectionWithoutPreferredControllers(): Unit = {
+  def testElectionWithoutPreferredControllersAndNoFallback(): Unit = {
     val brokerConfigs = Seq((0, false), (1, false), (2, false))
     createBrokersWithPreferredControllers(brokerConfigs, false)
     // no broker can be elected as controller
@@ -89,7 +89,7 @@ class PreferredControllerTest extends ZooKeeperTestHarness {
 
 
   @Test
-  def testDataControllerResign(): Unit = {
+  def testNonPreferredControllerResignation(): Unit = {
     val brokerConfigs = Seq((0, false), (1, true), (2, false))
     createBrokersWithPreferredControllers(brokerConfigs, true)
 
@@ -114,6 +114,19 @@ class PreferredControllerTest extends ZooKeeperTestHarness {
     setAllowPreferredControllerFallback(true)
     // controller can be now elected among non preferred controller nodes
     TestUtils.waitUntilControllerElected(zkClient)
+  }
+
+  @Test
+  def testCurrentControllerDoesNotResignWithoutPreferredControllersAndNoFallback(): Unit = {
+    val brokerConfigs = Seq((0, false), (1, false), (2, false))
+    createBrokersWithPreferredControllers(brokerConfigs, true)
+
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+
+    setAllowPreferredControllerFallback(false)
+
+    // current controller does not move
+    ensureControllersInBrokers(Seq(controllerId))
   }
 
   private def ensureControllersInBrokers(brokerIds: Seq[Int], timeout: Long = 15000L): Unit = {

--- a/core/src/test/scala/unit/kafka/server/PreferredControllerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/PreferredControllerTest.scala
@@ -1,0 +1,160 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import java.util.Properties
+
+import kafka.server.KafkaConfig.fromProps
+import kafka.utils.CoreUtils._
+import kafka.utils.TestUtils
+import kafka.utils.TestUtils._
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.clients.admin._
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.junit.Assert._
+import org.junit.{After, Test}
+import org.scalatest.Assertions.fail
+
+import scala.collection.JavaConverters._
+import scala.collection.Map
+
+class PreferredControllerTest extends ZooKeeperTestHarness {
+
+  var brokers: Seq[KafkaServer] = null
+
+  @After
+  override def tearDown() {
+    shutdownServers(brokers)
+    super.tearDown()
+  }
+
+  @Test
+  def testPartitionCreatedByAdminClientShouldNotBeAssignedToPreferredControllers(): Unit = {
+    val brokerConfigs = Seq((0, false), (1, true), (2, false))
+    createBrokersWithPreferredControllers(brokerConfigs, true)
+
+    val brokerList = TestUtils.bootstrapServers(brokers, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))
+    val adminClientConfig = new Properties
+    adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    val client = AdminClient.create(adminClientConfig)
+
+    TestUtils.waitUntilControllerElected(zkClient)
+    // create topic using admin client
+    val future1 = client.createTopics(Seq("topic1").map(new NewTopic(_, 3, 2)).asJava,
+      new CreateTopicsOptions()).all()
+    future1.get()
+
+    assertTrue("topic1 should not be in broker 1", ensureTopicNotInBrokers("topic1", Set(1)))
+
+    val future2 = client.createPartitions(Map("topic1" -> NewPartitions.increaseTo(5)).asJava).all()
+    future2.get()
+
+    assertTrue("topic1 should not be in broker 1 after increasing partition count",
+      ensureTopicNotInBrokers("topic1", Set(1)))
+
+    client.close()
+  }
+
+  @Test
+  def testDataNodeElectionWithoutPreferredControllers(): Unit = {
+    val brokerConfigs = Seq((0, false), (1, false), (2, false))
+    createBrokersWithPreferredControllers(brokerConfigs, false)
+    // no broker can be elected as controller
+    ensureControllersInBrokers(Seq.empty, 5000L)
+  }
+
+  @Test
+  def testPreferredControllerElection(): Unit = {
+    val brokerConfigs = Seq((0, false), (1, true), (2, false))
+    createBrokersWithPreferredControllers(brokerConfigs, false)
+    // only broker 1 can be elected since it is the only preferred controller node
+    ensureControllersInBrokers(Seq(1))
+  }
+
+
+  @Test
+  def testDataControllerResign(): Unit = {
+    val brokerConfigs = Seq((0, false), (1, true), (2, false))
+    createBrokersWithPreferredControllers(brokerConfigs, true)
+
+    // broker 1 should be elected since it is the only preferred controller node
+    ensureControllersInBrokers(Seq(1))
+    brokers(1).shutdown()
+
+    // broker 0 and broker 2 can become controller when broker 1 is offline
+    ensureControllersInBrokers(Seq(0, 2))
+    brokers(1).startup()
+    // broker 1 regains controllership
+    ensureControllersInBrokers(Seq(1))
+  }
+
+  @Test
+  def testDynamicAllowPreferredControllerFallback(): Unit = {
+    val brokerConfigs = Seq((0, false), (1, false), (2, false))
+    createBrokersWithPreferredControllers(brokerConfigs, false)
+
+    // non preferred controller nodes cannot be elected as the controller if fallback is not allowed
+    ensureControllersInBrokers(Seq.empty, 5000L)
+    setAllowPreferredControllerFallback(true)
+    // controller can be now elected among non preferred controller nodes
+    TestUtils.waitUntilControllerElected(zkClient)
+  }
+
+  private def ensureControllersInBrokers(brokerIds: Seq[Int], timeout: Long = 15000L): Unit = {
+    val (controllerId, _) = TestUtils.computeUntilTrue(zkClient.getControllerId, waitTime = timeout) {
+      case controller =>
+        controller.isDefined && (brokerIds.isEmpty || brokerIds.contains(controller))
+    }
+    if (brokerIds.isEmpty) {
+      assertTrue("there should not be any controller", controllerId.isEmpty)
+    } else {
+      assertTrue(s"Controller should be elected in $brokerIds",
+        brokerIds.contains(controllerId.getOrElse(fail(s"Controller not elected after $timeout ms"))))
+    }
+  }
+
+  private def ensureTopicNotInBrokers(topic: String, brokerIds: Set[Int]): Boolean = {
+    val topicAssignment = zkClient.getReplicaAssignmentForTopics(Set(topic))
+    topicAssignment.map(_._2).flatten.toSet.intersect(brokerIds).isEmpty
+  }
+
+  /**
+    * @param brokerConfigs: a list of (brokerid, preferredController) configs
+    * @param allowFallback: "allow.preferred.controller.fallback" config
+    */
+  private def createBrokersWithPreferredControllers(brokerConfigs: Seq[(Int, Boolean)],  allowFallback: Boolean): Unit = {
+    brokers = brokerConfigs.map {
+      case (id, preferredController) =>
+        val props: Properties = createBrokerConfig(id, zkConnect)
+        props.put(KafkaConfig.PreferredControllerProp, preferredController.toString)
+        props.put(KafkaConfig.AllowPreferredControllerFallbackProp, allowFallback.toString)
+        createServer(fromProps(props))
+    }
+  }
+
+  private def setAllowPreferredControllerFallback(allowFallback: Boolean): Unit = {
+    adminZkClient.changeBrokerConfig(None,
+      propsWith((KafkaConfig.AllowPreferredControllerFallbackProp, allowFallback.toString)))
+
+    TestUtils.waitUntilTrue(() => {
+        brokers.forall(_.config.allowPreferredControllerFallback == allowFallback)
+      },
+      s"fail to set ${KafkaConfig.AllowPreferredControllerFallbackProp} to ${allowFallback}", 5000)
+  }
+}


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =

This Patch separates Kafka Controller Node from non-controller (data) Node.
Summary of changes:
1)Add “preferred.controller” broker config (its type is boolean) to indicate whether a broker is used as a preferred controller node.
2)Add “allow.preferred.controller.fallback” broker config that determines whether a non-preferred controller node (data node) is allowed to become controller in the absence of preferred controller nodes. If “allow.preferred.controller.fallback” is set to “false”, a data node never tries to become controller, and only preferred controller nodes can be elected as controller. If “allow.preferred.controller.fallback” is set to “true”, a data node tries to elect itself as controller only in the absence of preferred controller node and a data node controller resigns as controller when it detects any live preferred controller.
3)Add ActivePreferredControllerCount metric to track whether the current broker is preferred controller node and is elected as Kafka controller
4)Add StandbyPreferredControllerCount metric to track whether the current broker is preferred controller node and is not elected as controller.

EXIT_CRITERIA = MANUAL [""]

