### PR TITLE
[LI-HOTFIX] Avoid excessive info logs in the client side for incremental fetch and print out more informative logs for throttling

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -381,7 +381,7 @@ public class FetchSessionHandler {
     public boolean handleResponse(FetchResponse response) {
         if (response.error() != Errors.NONE) {
             if (response.error() == Errors.FETCH_SESSION_ID_NOT_FOUND) {
-                log.warn("Node {} was unable to process the fetch request with {}: {}. "
+                log.debug("Node {} was unable to process the fetch request with {}: {}. "
                         + "This normally indicates the session has been evicted in the server side cache",
                     node, nextMetadata, response.error());
                 nextMetadata = FetchMetadata.INITIAL;

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -380,11 +380,14 @@ public class FetchSessionHandler {
      */
     public boolean handleResponse(FetchResponse response) {
         if (response.error() != Errors.NONE) {
-            log.debug("Node {} was unable to process the fetch request with {}: {}.",
-                node, nextMetadata, response.error());
             if (response.error() == Errors.FETCH_SESSION_ID_NOT_FOUND) {
+                log.warn("Node {} was unable to process the fetch request with {}: {}. "
+                        + "This normally indicates the session has been evicted in the server side cache",
+                    node, nextMetadata, response.error());
                 nextMetadata = FetchMetadata.INITIAL;
             } else {
+                log.warn("Node {} was unable to process the fetch request with {}: {}.",
+                    node, nextMetadata, response.error());
                 nextMetadata = nextMetadata.nextCloseExisting();
             }
             return false;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -283,6 +283,9 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                                                 fetchTarget.id());
                                         return;
                                     }
+
+                                    handler.maybeLogThrottledFetch(response, resp.requestHeader().apiVersion());
+
                                     if (!handler.handleResponse(response)) {
                                         return;
                                     }


### PR DESCRIPTION
TICKET = KAFKA-8921

LI_DESCRIPTION =  

Currently in FetchSessionHandler::handleResponse, the following info log
will get printed out excessively when the session is evicted from the
server-side cache even though there is nothing wrong with the fetch
request and client cannot do much to improve it.
```
Node xxx was unable to process the fetch request with (sessionId=xxx,
epoch=xxx): FETCH_SESSION_ID_NOT_FOUND.
```

Moreover, when the fetch request gets throttled, the following info logs
will also get printed out, which are very misleading.
```
Node xxx sent an invalid full fetch response with ...
Node xxx sent an invalid incremental fetch response with ...
```

We should avoid logging these things in INFO level and print out more
informative logs for throttling.

 

EXIT_CRITERIA = MANUAL ["When the hotfix is pushed to apache/kafka"]