### PR TITLE
[HOTFIX] Allocate correct size for ArrayList when parsing UpdateMetadataRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -285,11 +285,11 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
 
             if (struct.hasField(OFFLINE_REPLICAS)) {
                 Object[] offlineReplicasArray = struct.get(OFFLINE_REPLICAS);
-                offlineReplicas = new ArrayList<>(offlineReplicasArray.length);
+                this.offlineReplicas = new ArrayList<>(offlineReplicasArray.length);
                 for (Object r : offlineReplicasArray)
                     offlineReplicas.add((Integer) r);
             } else {
-                offlineReplicas = Collections.emptyList();
+                this.offlineReplicas = Collections.emptyList();
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.requests;
 
+import java.util.Collections;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.kafka.common.TopicPartition;
@@ -282,11 +283,13 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
 
             this.basePartitionState = new BasePartitionState(controllerEpoch, leader, leaderEpoch, isr, zkVersion, replicas);
 
-            this.offlineReplicas = new ArrayList<>();
             if (struct.hasField(OFFLINE_REPLICAS)) {
                 Object[] offlineReplicasArray = struct.get(OFFLINE_REPLICAS);
+                offlineReplicas = new ArrayList<>(offlineReplicasArray.length);
                 for (Object r : offlineReplicasArray)
                     offlineReplicas.add((Integer) r);
+            } else {
+                offlineReplicas = Collections.emptyList();
             }
         }
 
@@ -392,9 +395,10 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
             }
         }
 
-        Set<Broker> liveBrokers = new HashSet<>();
+        Object[] liveBrokersArray = struct.get(LIVE_BROKERS);
+        Set<Broker> liveBrokers = new HashSet<>(liveBrokersArray.length);
 
-        for (Object brokerDataObj : struct.get(LIVE_BROKERS)) {
+        for (Object brokerDataObj : liveBrokersArray) {
             Struct brokerData = (Struct) brokerDataObj;
             int brokerId = brokerData.get(BROKER_ID);
 
@@ -407,8 +411,9 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
                 endPoints.add(new EndPoint(host, port, securityProtocol, ListenerName.forSecurityProtocol(securityProtocol)));
                 liveBrokers.add(new Broker(brokerId, endPoints, null));
             } else { // V1, V2 or V3
-                List<EndPoint> endPoints = new ArrayList<>();
-                for (Object endPointDataObj : brokerData.get(ENDPOINTS)) {
+                Object[] endPointsArray = brokerData.get(ENDPOINTS);
+                List<EndPoint> endPoints = new ArrayList<>(endPointsArray.length);
+                for (Object endPointDataObj : endPointsArray) {
                     Struct endPointData = (Struct) endPointDataObj;
                     int port = endPointData.get(PORT);
                     String host = endPointData.get(HOST);


### PR DESCRIPTION
During one of the GCNs, the heapdump revealed noted a lot of sparse object arrays. One of them was the `ArrayList<EndPoint>` object allocated every time an `UpdateMetadataRequest` is parsed in the broker. The `ArrayList<OfflineReplicas>` object is usually small or empty in most of the `UpdateMetadataRequests`. Hence, these data structures should be allocated appropriately as well. 
This patch improves upon the existing parsing code by allocating the `ArrayList` to the correct size. 
