### PR TITLE
Cache the serialized payload of the Struct object

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/StructSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/StructSend.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.protocol.types.Struct;
+
+
+/**
+ * A size delimited Send that consists of a 4 byte network-ordered size N followed by N bytes of content
+ */
+public class StructSend extends ByteBufferSend {
+
+    public StructSend(String destination, Struct header, Struct body) {
+        super(destination, serializeSizeDelimit(header, body));
+    }
+
+    private static ByteBuffer[] serializeSizeDelimit(Struct header, Struct body) {
+        ByteBuffer headerBuffer = header.getSerialized();
+        if (headerBuffer == null) {
+            headerBuffer = ByteBuffer.allocate(header.sizeOf());
+            header.writeTo(headerBuffer);
+        }
+
+        ByteBuffer bodyBuffer = body.getSerialized();
+        if (bodyBuffer == null) {
+            bodyBuffer = ByteBuffer.allocate(body.sizeOf());
+            body.writeTo(bodyBuffer);
+        }
+
+        headerBuffer.rewind();
+        bodyBuffer.rewind();
+        return sizeDelimit(headerBuffer, bodyBuffer);
+    }
+
+    private static ByteBuffer[] sizeDelimit(ByteBuffer headerBuffer, ByteBuffer bodyBuffer) {
+        return new ByteBuffer[] {
+            // Possible INT_OVERFLOW? Ignoring for now since header is presumed to be very small.
+            sizeBuffer(headerBuffer.remaining() + bodyBuffer.remaining()),
+            headerBuffer,
+            bodyBuffer
+        };
+    }
+
+    private static ByteBuffer sizeBuffer(int size) {
+        ByteBuffer sizeBuffer = ByteBuffer.allocate(4);
+        sizeBuffer.putInt(size);
+        sizeBuffer.rewind();
+        return sizeBuffer;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 public class Struct {
     private final Schema schema;
     private final Object[] values;
+    private volatile ByteBuffer serialized = null;
 
     Struct(Schema schema, Object[] values) {
         this.schema = schema;
@@ -37,6 +38,26 @@ public class Struct {
     public Struct(Schema schema) {
         this.schema = schema;
         this.values = new Object[this.schema.numFields()];
+    }
+
+    /**
+     * Returns the serialized byte buffer
+     */
+    public ByteBuffer getSerialized() {
+        if (serialized == null) {
+            return null;
+        }
+        return serialized.duplicate();
+    }
+
+    /**
+     * Sets the serialized byte buffer
+     */
+    public void setSerialized(ByteBuffer serialized) {
+        if (serialized == null) {
+            throw new NullPointerException("The input serialized byte buffer cannot be null");
+        }
+        this.serialized = serialized;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -17,8 +17,8 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.apache.kafka.common.network.NetworkSend;
 import org.apache.kafka.common.network.Send;
+import org.apache.kafka.common.network.StructSend;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -93,7 +93,7 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
     }
 
     public Send toSend(String destination, RequestHeader header) {
-        return new NetworkSend(destination, serialize(header));
+        return new StructSend(destination, header.toStruct(), toStruct());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -16,8 +16,8 @@
  */
 package org.apache.kafka.common.requests;
 
-import org.apache.kafka.common.network.NetworkSend;
 import org.apache.kafka.common.network.Send;
+import org.apache.kafka.common.network.StructSend;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -31,7 +31,7 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
     public static final int DEFAULT_THROTTLE_TIME = 0;
 
     protected Send toSend(String destination, ResponseHeader header, short apiVersion) {
-        return new NetworkSend(destination, serialize(apiVersion, header));
+        return new StructSend(destination, header.toStruct(), toStruct(apiVersion));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -362,7 +362,7 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
 
     // LIKAFKA-18349 - Cache the UpdateMetadataRequest struct to reduce memory usage
     private Struct struct = null;
-    private Lock structLock = new ReentrantLock();
+    private final Lock structLock = new ReentrantLock();
 
     private UpdateMetadataRequest(short version, int controllerId, int controllerEpoch, long brokerEpoch,
                                   Map<TopicPartition, PartitionState> partitionStates, Set<Broker> liveBrokers) {
@@ -507,6 +507,10 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
                     brokersData.add(brokerData);
                 }
                 struct.set(LIVE_BROKERS, brokersData.toArray());
+                // Cache the serialized payload
+                ByteBuffer buffer = ByteBuffer.allocate(struct.sizeOf());
+                struct.writeTo(buffer);
+                struct.setSerialized(buffer);
                 this.struct = struct;
             }
             return struct;

--- a/clients/src/test/java/org/apache/kafka/common/memory/WeakMemoryPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/WeakMemoryPoolTest.java
@@ -45,6 +45,8 @@ public class WeakMemoryPoolTest {
 
     @Test
     public void testAllocationMemorySize() {
+        // Start from clean state to avoid flakiness
+        System.gc();
         WeakMemoryPool pool = new WeakMemoryPool();
         long freeMemory = Runtime.getRuntime().freeMemory();
         ByteBuffer buffer1 = pool.tryAllocate(FORTY_MEGABYTES + 1);


### PR DESCRIPTION
This PR has the following changes:
1. New implementation of Send called StructSend which can send Structs.
2. AbstractRequest and AbstractResponse will be using StructSend (that is, the struct send will be applicable to all types of requests).
3. The caching of the serialized payload is only done for UpdateMetadataRequest which is causing Kafka controller scalability issue.