### PR TITLE
[LI-HOTFIX] Remove KafkaZkClient#setOrCreatePartitionReassignment and add AdminZkClient#addPartitions

### DIFF
--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -251,10 +251,10 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
   def addPartitions(topic: String,
                     existingAssignment: Map[Int, Seq[Int]],
                     allBrokers: Seq[BrokerMetadata],
-                    numPartitions: Int = 1,
-                    replicaAssignment: Option[Map[Int, Seq[Int]]] = None,
-                    validateOnly: Boolean = false,
-                    noNewPartitionBrokerIds: Set[Int] = Set.empty[Int]): Map[Int, Seq[Int]] = {
+                    numPartitions: Int,
+                    replicaAssignment: Option[Map[Int, Seq[Int]]],
+                    validateOnly: Boolean,
+                    noNewPartitionBrokerIds: Set[Int]): Map[Int, Seq[Int]] = {
     val existingAssignmentPartition0 = existingAssignment.getOrElse(0,
       throw new AdminOperationException(
         s"Unexpected existing replica assignment for topic '$topic', partition id 0 is missing. " +

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -213,6 +213,30 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
   }
 
   /**
+   * Add partitions to existing topic with optional replica assignment and no constraints on whether brokers can be
+   * assigned new replicas.
+   *
+   * This method ensures that the API consistency is maintained with the upstream Kafka -- i.e. Originally this API
+   * exists in Apache Kafka 2.3, but has been removed from LinkedIn Kafka 2.3.
+   *
+   * @param topic Topic for adding partitions to
+   * @param existingAssignment A map from partition id to its assigned replicas
+   * @param allBrokers All brokers in the cluster
+   * @param numPartitions Number of partitions to be set
+   * @param replicaAssignment Manual replica assignment, or none
+   * @param validateOnly If true, validate the parameters without actually adding the partitions
+   * @return the updated replica assignment
+   */
+  def addPartitions(topic: String,
+                    existingAssignment: Map[Int, Seq[Int]],
+                    allBrokers: Seq[BrokerMetadata],
+                    numPartitions: Int = 1,
+                    replicaAssignment: Option[Map[Int, Seq[Int]]] = None,
+                    validateOnly: Boolean = false): Map[Int, Seq[Int]] = {
+    addPartitions(topic, existingAssignment, allBrokers, numPartitions, replicaAssignment, validateOnly, Set.empty[Int])
+  }
+
+  /**
   * Add partitions to existing topic with optional replica assignment
   *
   * @param topic Topic for adding partitions to

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -875,10 +875,6 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
     }
   }
 
-  def setOrCreatePartitionReassignment(reassignment: collection.Map[TopicPartition, Seq[Int]]): Unit = {
-    setOrCreatePartitionReassignment(reassignment, ZkVersion.MatchAnyVersion)
-  }
-
   /**
    * Sets or creates the partition reassignment znode with the given reassignment depending on whether it already
    * exists or not.


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
1) Remove "KafkaZkClient#setOrCreatePartitionReassignment(reassignment: collection.Map[TopicPartition, Seq[Int]]): Unit" function, which has been temporarily added to preserve the dependency of Cruise Control on this API. Since Cruise Control no longer depends on this API (see https://github.com/linkedin/cruise-control/commit/df52a906f5f6f6b75f5fe69bca61473f9c6dc6d1#diff-ab474ca3213f2c014b31470c9e344f36L91), the corresponding EXIT CRITERIA is satisfied and we can remove this API.
2) Add "AdminZkClient#addPartitions(topic: String, existingAssignment: Map[Int, Seq[Int]], allBrokers: Seq[BrokerMetadata], numPartitions: Int = 1, replicaAssignment: Option[Map[Int, Seq[Int]]] = None, validateOnly: Boolean = false): Map[Int, Seq[Int]]". This method ensures that the API consistency is maintained with the upstream Kafka -- i.e. Originally this API exists in Apache Kafka 2.3, but has been removed from LinkedIn Kafka 2.3.

EXIT_CRITERIA = TICKET [KAFKA-8527]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
