### PR TITLE
[LI-HOTFIX] Improve shutdown performance via lazy accessing the offset and time indices.

### DIFF
--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -501,13 +501,13 @@ class LogSegment private[log] (val log: FileRecords,
   }
 
   /**
-   * Change the suffix for the index and log file for this log segment
+   * Change the suffix for the index and log files for this log segment
    * IOException from this method should be handled by the caller
    */
   def changeFileSuffixes(oldSuffix: String, newSuffix: String) {
     log.renameTo(new File(CoreUtils.replaceSuffix(log.file.getPath, oldSuffix, newSuffix)))
-    offsetIndex.renameTo(new File(CoreUtils.replaceSuffix(lazyOffsetIndex.file.getPath, oldSuffix, newSuffix)))
-    timeIndex.renameTo(new File(CoreUtils.replaceSuffix(lazyTimeIndex.file.getPath, oldSuffix, newSuffix)))
+    lazyOffsetIndex.renameTo(new File(CoreUtils.replaceSuffix(lazyOffsetIndex.file.getPath, oldSuffix, newSuffix)))
+    lazyTimeIndex.renameTo(new File(CoreUtils.replaceSuffix(lazyTimeIndex.file.getPath, oldSuffix, newSuffix)))
     txnIndex.renameTo(new File(CoreUtils.replaceSuffix(txnIndex.file.getPath, oldSuffix, newSuffix)))
   }
 
@@ -601,8 +601,8 @@ class LogSegment private[log] (val log: FileRecords,
     if (_maxTimestampSoFar.nonEmpty || _offsetOfMaxTimestampSoFar.nonEmpty) {
       CoreUtils.swallow(timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestampSoFar, skipFullCheck = true), this)
     }
-    CoreUtils.swallow(lazyOffsetIndex.getLazy.foreach(_.close()), this)
-    CoreUtils.swallow(lazyTimeIndex.getLazy.foreach(_.close()), this)
+    CoreUtils.swallow(lazyOffsetIndex.close(), this)
+    CoreUtils.swallow(lazyTimeIndex.close(), this)
     CoreUtils.swallow(log.close(), this)
     CoreUtils.swallow(txnIndex.close(), this)
   }
@@ -611,8 +611,8 @@ class LogSegment private[log] (val log: FileRecords,
     * Close file handlers used by the log segment but don't write to disk. This is used when the disk may have failed
     */
   def closeHandlers() {
-    CoreUtils.swallow(lazyOffsetIndex.getLazy.foreach(_.closeHandler()), this)
-    CoreUtils.swallow(lazyTimeIndex.getLazy.foreach(_.closeHandler()), this)
+    CoreUtils.swallow(lazyOffsetIndex.close(), this)
+    CoreUtils.swallow(lazyTimeIndex.close(), this)
     CoreUtils.swallow(log.closeHandlers(), this)
     CoreUtils.swallow(txnIndex.close(), this)
   }
@@ -635,8 +635,8 @@ class LogSegment private[log] (val log: FileRecords,
 
     CoreUtils.tryAll(Seq(
       () => delete(log.deleteIfExists _, "log", log.file, logIfMissing = true),
-      () => delete(offsetIndex.deleteIfExists _, "offset index", lazyOffsetIndex.file, logIfMissing = true),
-      () => delete(timeIndex.deleteIfExists _, "time index", lazyTimeIndex.file, logIfMissing = true),
+      () => delete(lazyOffsetIndex.deleteIfExists _, "offset index", lazyOffsetIndex.file, logIfMissing = true),
+      () => delete(lazyTimeIndex.deleteIfExists _, "time index", lazyTimeIndex.file, logIfMissing = true),
       () => delete(txnIndex.deleteIfExists _, "transaction index", txnIndex.file, logIfMissing = false)
     ))
   }

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -601,8 +601,8 @@ class LogSegment private[log] (val log: FileRecords,
     if (_maxTimestampSoFar.nonEmpty || _offsetOfMaxTimestampSoFar.nonEmpty) {
       CoreUtils.swallow(timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestampSoFar, skipFullCheck = true), this)
     }
-    CoreUtils.swallow(offsetIndex.close(), this)
-    CoreUtils.swallow(timeIndex.close(), this)
+    CoreUtils.swallow(lazyOffsetIndex.getLazy.foreach(_.close()), this)
+    CoreUtils.swallow(lazyTimeIndex.getLazy.foreach(_.close()), this)
     CoreUtils.swallow(log.close(), this)
     CoreUtils.swallow(txnIndex.close(), this)
   }
@@ -611,8 +611,8 @@ class LogSegment private[log] (val log: FileRecords,
     * Close file handlers used by the log segment but don't write to disk. This is used when the disk may have failed
     */
   def closeHandlers() {
-    CoreUtils.swallow(offsetIndex.closeHandler(), this)
-    CoreUtils.swallow(timeIndex.closeHandler(), this)
+    CoreUtils.swallow(lazyOffsetIndex.getLazy.foreach(_.closeHandler()), this)
+    CoreUtils.swallow(lazyTimeIndex.getLazy.foreach(_.closeHandler()), this)
     CoreUtils.swallow(log.closeHandlers(), this)
     CoreUtils.swallow(txnIndex.close(), this)
   }

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -17,12 +17,14 @@
 
 package kafka.log
 
-import java.io.File
+import java.io.{File, IOException}
 import java.nio.ByteBuffer
+import java.nio.file.Files
 
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.Logging
 import org.apache.kafka.common.errors.InvalidOffsetException
+import org.apache.kafka.common.utils.Utils
 
 /**
  * An index that maps offsets to physical file locations for a particular log segment. This index may be sparse:
@@ -214,12 +216,18 @@ object OffsetIndex extends Logging {
   * Likewise, the OffsetIndex initialization can be further postponed by accessing the index lazily.
   *
   * Combining with skipping sanity check for safely flushed segments, the startup time of a broker can be reduced, especially
-  * for the the broker with a lot of log segments. Similarly, the broker shutdown time can be reduced by accessing the
-  * index lazily, and closing it only if it has been accessed before -- i.e. already has a corresponding memory map.
+  * for the the broker with a lot of log segments. Similarly, the broker shutdown time can be reduced by closing the
+  * index lazily, which closes it only if it has been accessed before -- i.e. already has a corresponding memory map.
+  * It prevents illegal accesses to the underlying index after closing the index, which might otherwise lead to memory
+  * leaks due to recreation of underlying memory mapped object.
   *
+  * Finally, this wrapper ensures that redundant disk accesses and memory mapped operations are avoided upon attempts to
+  * delete or rename the file that backs this offset index.
   */
 class LazyOffsetIndex(@volatile private var _file: File, baseOffset: Long, maxIndexSize: Int = -1, writable: Boolean = true) {
   @volatile private var offsetIndex: Option[OffsetIndex] = None
+  // A closed offset index does not allow accessing its indices to prevent side effects.
+  @volatile private var isClosed: Boolean = false
 
   def file: File = {
     if (offsetIndex.isDefined)
@@ -236,12 +244,49 @@ class LazyOffsetIndex(@volatile private var _file: File, baseOffset: Long, maxIn
   }
 
   def get: OffsetIndex = {
+    if (isClosed)
+      throw new IllegalStateException(s"Attempt to access the closed OffsetIndex (file=${_file}, baseOffset=${baseOffset}, " +
+                                      s"maxIndexSize=${maxIndexSize}, writable=${writable}.")
     if (offsetIndex.isEmpty)
       offsetIndex = Some(new OffsetIndex(_file, baseOffset, maxIndexSize, writable))
     offsetIndex.get
   }
 
-  def getLazy: Option[OffsetIndex] = {
-    offsetIndex
+  /**
+   * Close this index file.
+   * Note: This will be a no-op if the index has already been closed.
+   */
+  def close(): Unit = {
+    if (!isClosed) {
+      offsetIndex.foreach(_.close())
+      isClosed = true
+    }
+  }
+
+  /**
+   * Delete the index file that backs this offset if exists.
+   * This method ensures that if the index file has already been closed, it will not be recreated as a side effect.
+   *
+   * @throws IOException if deletion fails due to an I/O error
+   * @return `true` if the file was deleted by this method; `false` if the file could not be deleted because it did
+   *         not exist
+   */
+  def deleteIfExists(): Boolean = {
+    if (isClosed)
+      Files.deleteIfExists(file.toPath)
+    else
+      get.deleteIfExists()
+  }
+
+  /**
+   * Rename the file that backs this offset index if the index has ever been initialized or file already exists.
+   *
+   * @throws IOException if rename fails for defined index or existing file.
+   */
+  def renameTo(f: File) {
+    try {
+      if (offsetIndex.isDefined || file.exists)
+        Utils.atomicMoveWithFallback(file.toPath, f.toPath)
+    } finally file = f
   }
 }

--- a/core/src/main/scala/kafka/log/TimeIndex.scala
+++ b/core/src/main/scala/kafka/log/TimeIndex.scala
@@ -17,13 +17,15 @@
 
 package kafka.log
 
-import java.io.File
+import java.io.{File, IOException}
 import java.nio.ByteBuffer
+import java.nio.file.Files
 
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.Logging
 import org.apache.kafka.common.errors.InvalidOffsetException
 import org.apache.kafka.common.record.RecordBatch
+import org.apache.kafka.common.utils.Utils
 
 /**
  * An index that maps from the timestamp to the logical offsets of the messages in a segment. This index might be
@@ -233,15 +235,20 @@ object TimeIndex extends Logging {
 /**
   * A thin wrapper on top of the raw TimeIndex object to avoid initialization on construction. This defers the TimeIndex
   * initialization to the time it gets accessed so the cost of the heavy memory mapped operation gets amortized over time.
-  * Likewise, the TimeIndex initialization can be further postponed by accessing the index lazily.
   *
   * Combining with skipping sanity check for safely flushed segments, the startup time of a broker can be reduced, especially
-  * for the the broker with a lot of log segments. Similarly, the broker shutdown time can be reduced by accessing the
-  * index lazily, and closing it only if it has been accessed before -- i.e. already has a corresponding memory map.
+  * for the the broker with a lot of log segments. Similarly, the broker shutdown time can be reduced by closing the
+  * index lazily, which closes it only if it has been accessed before -- i.e. already has a corresponding memory map.
+  * It prevents illegal accesses to the underlying index after closing the index, which might otherwise lead to memory
+  * leaks due to recreation of underlying memory mapped object.
   *
+  * Finally, this wrapper ensures that redundant disk accesses and memory mapped operations are avoided upon attempts to
+  * delete or rename the file that backs this time index.
   */
 class LazyTimeIndex(@volatile private var _file: File, baseOffset: Long, maxIndexSize: Int = -1, writable: Boolean = true) {
   @volatile private var timeIndex: Option[TimeIndex] = None
+  // A closed index does not allow accessing its indices to prevent side effects.
+  @volatile private var isClosed: Boolean = false
 
   def file: File = {
     if (timeIndex.isDefined)
@@ -258,12 +265,49 @@ class LazyTimeIndex(@volatile private var _file: File, baseOffset: Long, maxInde
   }
 
   def get: TimeIndex = {
+    if (isClosed)
+      throw new IllegalStateException(s"Attempt to access the closed TimeIndex (file=${_file}, baseOffset=${baseOffset}, " +
+                                      s"maxIndexSize=${maxIndexSize}, writable=${writable}.")
     if (timeIndex.isEmpty)
       timeIndex = Some(new TimeIndex(_file, baseOffset, maxIndexSize, writable))
     timeIndex.get
   }
 
-  def getLazy: Option[TimeIndex] = {
-    timeIndex
+  /**
+   * Close this index file.
+   * Note: This will be a no-op if the index has already been closed.
+   */
+  def close(): Unit = {
+    if (!isClosed) {
+      timeIndex.foreach(_.close())
+      isClosed = true
+    }
+  }
+
+  /**
+   * Delete the index file that backs this offset if exists.
+   * This method ensures that if the index file has already been closed, it will not be recreated as a side effect.
+   *
+   * @throws IOException if deletion fails due to an I/O error
+   * @return `true` if the file was deleted by this method; `false` if the file could not be deleted because it did
+   *         not exist
+   */
+  def deleteIfExists(): Boolean = {
+    if (isClosed)
+      Files.deleteIfExists(file.toPath)
+    else
+      get.deleteIfExists()
+  }
+
+  /**
+   * Rename the file that backs this time index if the index has ever been initialized or file already exists.
+   *
+   * @throws IOException if rename fails for defined index or existing file.
+   */
+  def renameTo(f: File) {
+    try {
+      if (timeIndex.isDefined || file.exists)
+        Utils.atomicMoveWithFallback(file.toPath, f.toPath)
+    } finally file = f
   }
 }

--- a/core/src/main/scala/kafka/log/TimeIndex.scala
+++ b/core/src/main/scala/kafka/log/TimeIndex.scala
@@ -233,9 +233,11 @@ object TimeIndex extends Logging {
 /**
   * A thin wrapper on top of the raw TimeIndex object to avoid initialization on construction. This defers the TimeIndex
   * initialization to the time it gets accessed so the cost of the heavy memory mapped operation gets amortized over time.
+  * Likewise, the TimeIndex initialization can be further postponed by accessing the index lazily.
   *
   * Combining with skipping sanity check for safely flushed segments, the startup time of a broker can be reduced, especially
-  * for the the broker with a lot of log segments
+  * for the the broker with a lot of log segments. Similarly, the broker shutdown time can be reduced by accessing the
+  * index lazily, and closing it only if it has been accessed before -- i.e. already has a corresponding memory map.
   *
   */
 class LazyTimeIndex(@volatile private var _file: File, baseOffset: Long, maxIndexSize: Int = -1, writable: Boolean = true) {
@@ -259,5 +261,9 @@ class LazyTimeIndex(@volatile private var _file: File, baseOffset: Long, maxInde
     if (timeIndex.isEmpty)
       timeIndex = Some(new TimeIndex(_file, baseOffset, maxIndexSize, writable))
     timeIndex.get
+  }
+
+  def getLazy: Option[TimeIndex] = {
+    timeIndex
   }
 }

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.{MockTime, Time, Utils}
 import org.junit.Assert._
-import org.junit.{After, Before, Test}
+import org.junit.{After, Assert, Before, Test}
 
 import scala.collection.JavaConverters._
 import scala.collection._
@@ -154,6 +154,35 @@ class LogSegmentTest {
     }
   }
 
+  /**
+   * This tests the scenario, where the caller attempts to access the offsets of a closed segment.
+   *
+   * Accessing underlying indices of a closed segment would lead to memory leaks due to recreation of the underlying
+   * memory mapped objects.
+   */
+  @Test
+  def testIndexAccessAfterClosingSegment() {
+    val seg = createSegment(0, time = new MockTime)
+    // Accessing the indices while the segment is legal.
+    seg.offsetIndex
+    seg.timeIndex
+
+    // Accessing the indices while the segment is closed is disallowed.
+    seg.close()
+    try {
+      seg.offsetIndex
+      Assert.fail("Expected IllegalStateException due to accessing OffsetIndex of a closed segment.")
+    } catch {
+      case _: IllegalStateException => //expected
+    }
+    try {
+      seg.timeIndex
+      Assert.fail("Expected IllegalStateException due to accessing TimeIndex of a closed segment.")
+    } catch {
+      case _: IllegalStateException => //expected
+    }
+  }
+
   @Test
   def testTruncateEmptySegment() {
     // This tests the scenario in which the follower truncates to an empty segment. In this
@@ -163,11 +192,13 @@ class LogSegmentTest {
     val maxSegmentMs = 300000
     val time = new MockTime
     val seg = createSegment(0, time = time)
+    val timeIndexSizeInBytes = seg.timeIndex.sizeInBytes
+    val offsetIndexSizeInBytes = seg.offsetIndex.sizeInBytes
     seg.close()
 
     val reopened = createSegment(0, time = time)
-    assertEquals(0, seg.timeIndex.sizeInBytes)
-    assertEquals(0, seg.offsetIndex.sizeInBytes)
+    assertEquals(0, timeIndexSizeInBytes)
+    assertEquals(0, offsetIndexSizeInBytes)
 
     time.sleep(500)
     reopened.truncateTo(57)
@@ -280,11 +311,24 @@ class LogSegmentTest {
     val seg = createSegment(40)
     val logFile = seg.log.file
     val indexFile = seg.lazyOffsetIndex.file
+    val timeIndexFile = seg.lazyTimeIndex.file
+    // Ensure that files for offset and time indices have not been created redundantly.
+    assertFalse(seg.lazyOffsetIndex.file.exists)
+    assertFalse(seg.lazyTimeIndex.file.exists)
     seg.changeFileSuffixes("", ".deleted")
+    // Ensure that attempt to change suffixes for non-existing offset and time indices do not create new files.
+    assertFalse(seg.lazyOffsetIndex.file.exists)
+    assertFalse(seg.lazyTimeIndex.file.exists)
+    // Ensure that file names are updated accordingly.
     assertEquals(logFile.getAbsolutePath + ".deleted", seg.log.file.getAbsolutePath)
     assertEquals(indexFile.getAbsolutePath + ".deleted", seg.lazyOffsetIndex.file.getAbsolutePath)
     assertTrue(seg.log.file.exists)
+    // Ensure lazy creation of offset index file upon accessing it.
+    seg.lazyOffsetIndex.get
     assertTrue(seg.lazyOffsetIndex.file.exists)
+    // Ensure lazy creation of time index file upon accessing it.
+    seg.lazyTimeIndex.get
+    assertTrue(seg.lazyTimeIndex.file.exists)
   }
 
   /**


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION = KAFKA-7283 enabled lazy mmap on index files by initializing indices on-demand rather than performing costly disk/memory operations when creating all indices on broker startup. This helped reducing the startup time of brokers. However, segment indices are still created on closing segments, regardless of whether they needs to be closed or not.

This patch:
  * Improves shutdown performance via lazy accessing the offset and time indices.
  * Eliminates redundant disk accesses and memory mapped operations while deleting or renaming files that back segment indices.
  * Prevents illegal accesses to underlying indices of a closed segment, which would lead to memory leaks due to recreation of the underlying memory mapped objects.

EXIT_CRITERIA = MANUAL [""]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
