### PR TITLE
[LI-CHERRY-PICK][dca1bf1] Fix LazyTimeIndex & LazyOffsetIndex concurrency

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -38,8 +38,8 @@ import scala.math.ceil
  * @param baseOffset the base offset of the segment that this index is corresponding to.
  * @param maxIndexSize The maximum index size in bytes.
  */
-abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Long,
-                                   val maxIndexSize: Int = -1, val writable: Boolean) extends Closeable {
+abstract class AbstractIndex(@volatile var file: File, val baseOffset: Long, val maxIndexSize: Int = -1,
+                             val writable: Boolean) extends Closeable {
   import AbstractIndex._
 
   // Length of the index file
@@ -144,11 +144,11 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
    * The maximum number of entries this index can hold
    */
   @volatile
-  private[this] var _maxEntries = mmap.limit() / entrySize
+  private[this] var _maxEntries: Int = mmap.limit() / entrySize
 
   /** The number of entries in this index */
   @volatile
-  protected var _entries = mmap.position() / entrySize
+  protected var _entries: Int = mmap.position() / entrySize
 
   /**
    * True iff there are no more slots available in this index
@@ -246,7 +246,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
   /**
    * The number of bytes actually used by this index
    */
-  def sizeInBytes = entrySize * _entries
+  def sizeInBytes: Int = entrySize * _entries
 
   /** Close the index */
   def close() {
@@ -429,7 +429,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
 }
 
 object AbstractIndex extends Logging {
-  override val loggerName: String = classOf[AbstractIndex[_, _]].getName
+  override val loggerName: String = classOf[AbstractIndex].getName
 }
 
 object IndexSearchType extends Enumeration {

--- a/core/src/main/scala/kafka/log/LazyIndex.scala
+++ b/core/src/main/scala/kafka/log/LazyIndex.scala
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.log
+
+import java.io.{File, IOException}
+import java.nio.file.Files
+import java.util.concurrent.locks.ReentrantLock
+
+import LazyIndex._
+import kafka.utils.CoreUtils.inLock
+import kafka.utils.threadsafe
+import org.apache.kafka.common.utils.Utils
+
+/**
+  * A wrapper over an `AbstractIndex` instance that provides a mechanism to defer loading (i.e. memory mapping) the
+  * underlying index until it is accessed for the first time via the `get` method.
+  *
+  * This is an important optimization with regards to broker start-up and shutdown time if it has a large number of segments.
+  * It prevents illegal accesses to the underlying index after closing the index, which might otherwise lead to memory
+  * leaks due to recreation of underlying memory mapped object.
+  *
+  * Finally, this wrapper ensures that redundant disk accesses and memory mapped operations are avoided upon attempts to
+  * delete or rename the file that backs this index.
+  *
+  * @param loadIndex A function that takes a `File` pointing to an index and returns a loaded `AbstractIndex` instance.
+  */
+@threadsafe
+class LazyIndex[T <: AbstractIndex] private (@volatile private var indexWrapper: IndexWrapper, loadIndex: File => T) {
+  // A closed index does not allow accessing its indices to prevent side effects.
+  @volatile private var isClosed: Boolean = false
+  private val lock = new ReentrantLock()
+
+  def file: File = indexWrapper.file
+
+  def file_=(f: File): Unit = {
+    inLock(lock) {
+      indexWrapper.file = f
+    }
+  }
+
+  def get: T = {
+    if (isClosed)
+      throw new IllegalStateException(s"Attempt to access the closed Index (file=$file).")
+    indexWrapper match {
+      case indexValue: IndexValue[T] => indexValue.index
+      case _: IndexFile =>
+        inLock(lock) {
+          indexWrapper match {
+            case indexValue: IndexValue[T] => indexValue.index
+            case indexFile: IndexFile =>
+              val indexValue = new IndexValue(loadIndex(indexFile.file))
+              indexWrapper = indexValue
+              indexValue.index
+          }
+        }
+    }
+  }
+
+  /**
+   * Close this index file.
+   * Note: This will be a no-op if the index has already been closed.
+   */
+  def close(): Unit = {
+    if (!isClosed) {
+      inLock(lock) {
+        indexWrapper match {
+          case indexValue: IndexValue[T] => indexValue.index.close()
+          case _: IndexFile => // no-op
+        }
+      }
+      isClosed = true
+    }
+  }
+
+  /**
+   * Delete the index file that backs this index if exists.
+   * This method ensures that if the index file has already been closed, it will not be recreated as a side effect.
+   *
+   * @throws IOException if deletion fails due to an I/O error
+   * @return `true` if the file was deleted by this method; `false` if the file could not be deleted because it did
+   *         not exist
+   */
+  def deleteIfExists(): Boolean = {
+    if (isClosed)
+      Files.deleteIfExists(file.toPath)
+    else
+      get.deleteIfExists()
+  }
+
+  /**
+   * Rename the file that backs this index if the index has ever been initialized or file already exists.
+   *
+   * @throws IOException if rename fails for defined index or existing file.
+   */
+  def renameTo(f: File) {
+    try {
+      if (file.exists)
+        Utils.atomicMoveWithFallback(file.toPath, f.toPath)
+      else {
+        inLock(lock) {
+          indexWrapper match {
+            case indexValue: IndexValue[T] => Utils.atomicMoveWithFallback(file.toPath, f.toPath)
+            case _: IndexFile => // no-op
+          }
+        }
+      }
+    } finally file = f
+  }
+}
+
+object LazyIndex {
+
+  def forOffset(file: File, baseOffset: Long, maxIndexSize: Int = -1, writable: Boolean = true): LazyIndex[OffsetIndex] =
+    new LazyIndex(new IndexFile(file), file => new OffsetIndex(file, baseOffset, maxIndexSize, writable))
+
+  def forTime(file: File, baseOffset: Long, maxIndexSize: Int = -1, writable: Boolean = true): LazyIndex[TimeIndex] =
+    new LazyIndex(new IndexFile(file), file => new TimeIndex(file, baseOffset, maxIndexSize, writable))
+
+  private sealed trait IndexWrapper {
+    def file: File
+    def file_=(f: File)
+  }
+
+  private class IndexFile(@volatile var file: File) extends IndexWrapper
+
+  private class IndexValue[T <: AbstractIndex](val index: T) extends IndexWrapper {
+    override def file: File = index.file
+    override def file_=(f: File): Unit = index.file = f
+  }
+
+}
+

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -53,8 +53,8 @@ import scala.math._
  */
 @nonthreadsafe
 class LogSegment private[log] (val log: FileRecords,
-                               val lazyOffsetIndex: LazyOffsetIndex,
-                               val lazyTimeIndex: LazyTimeIndex,
+                               val lazyOffsetIndex: LazyIndex[OffsetIndex],
+                               val lazyTimeIndex: LazyIndex[TimeIndex],
                                val txnIndex: TransactionIndex,
                                val baseOffset: Long,
                                val indexIntervalBytes: Int,
@@ -670,8 +670,8 @@ object LogSegment {
     val maxIndexSize = config.maxIndexSize
     new LogSegment(
       FileRecords.open(Log.logFile(dir, baseOffset, fileSuffix), fileAlreadyExists, initFileSize, preallocate),
-      new LazyOffsetIndex(Log.offsetIndexFile(dir, baseOffset, fileSuffix), baseOffset = baseOffset, maxIndexSize = maxIndexSize),
-      new LazyTimeIndex(Log.timeIndexFile(dir, baseOffset, fileSuffix), baseOffset = baseOffset, maxIndexSize = maxIndexSize),
+      LazyIndex.forOffset(Log.offsetIndexFile(dir, baseOffset, fileSuffix), baseOffset = baseOffset, maxIndexSize = maxIndexSize),
+      LazyIndex.forTime(Log.timeIndexFile(dir, baseOffset, fileSuffix), baseOffset = baseOffset, maxIndexSize = maxIndexSize),
       new TransactionIndex(baseOffset, Log.transactionIndexFile(dir, baseOffset, fileSuffix)),
       baseOffset,
       indexIntervalBytes = config.indexInterval,

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -17,14 +17,12 @@
 
 package kafka.log
 
-import java.io.{File, IOException}
+import java.io.File
 import java.nio.ByteBuffer
-import java.nio.file.Files
 
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.Logging
 import org.apache.kafka.common.errors.InvalidOffsetException
-import org.apache.kafka.common.utils.Utils
 
 /**
  * An index that maps offsets to physical file locations for a particular log segment. This index may be sparse:
@@ -53,7 +51,7 @@ import org.apache.kafka.common.utils.Utils
  */
 // Avoid shadowing mutable `file` in AbstractIndex
 class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writable: Boolean = true)
-    extends AbstractIndex[Long, Int](_file, baseOffset, maxIndexSize, writable) {
+    extends AbstractIndex(_file, baseOffset, maxIndexSize, writable) {
   import OffsetIndex._
 
   override def entrySize = 8
@@ -209,87 +207,4 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
 
 object OffsetIndex extends Logging {
   override val loggerName: String = classOf[OffsetIndex].getName
-}
-
-
-
-/**
-  * A thin wrapper on top of the raw OffsetIndex object to avoid initialization on construction. This defers the OffsetIndex
-  * initialization to the time it gets accessed so the cost of the heavy memory mapped operation gets amortized over time.
-  * Likewise, the OffsetIndex initialization can be further postponed by accessing the index lazily.
-  *
-  * Combining with skipping sanity check for safely flushed segments, the startup time of a broker can be reduced, especially
-  * for the the broker with a lot of log segments. Similarly, the broker shutdown time can be reduced by closing the
-  * index lazily, which closes it only if it has been accessed before -- i.e. already has a corresponding memory map.
-  * It prevents illegal accesses to the underlying index after closing the index, which might otherwise lead to memory
-  * leaks due to recreation of underlying memory mapped object.
-  *
-  * Finally, this wrapper ensures that redundant disk accesses and memory mapped operations are avoided upon attempts to
-  * delete or rename the file that backs this offset index.
-  */
-class LazyOffsetIndex(@volatile private var _file: File, baseOffset: Long, maxIndexSize: Int = -1, writable: Boolean = true) {
-  @volatile private var offsetIndex: Option[OffsetIndex] = None
-  // A closed offset index does not allow accessing its indices to prevent side effects.
-  @volatile private var isClosed: Boolean = false
-
-  def file: File = {
-    if (offsetIndex.isDefined)
-      offsetIndex.get.file
-    else
-      _file
-  }
-
-  def file_=(f: File) {
-    if (offsetIndex.isDefined)
-      offsetIndex.get.file = f
-    else
-      _file = f
-  }
-
-  def get: OffsetIndex = {
-    if (isClosed)
-      throw new IllegalStateException(s"Attempt to access the closed OffsetIndex (file=${_file}, baseOffset=${baseOffset}, " +
-                                      s"maxIndexSize=${maxIndexSize}, writable=${writable}.")
-    if (offsetIndex.isEmpty)
-      offsetIndex = Some(new OffsetIndex(_file, baseOffset, maxIndexSize, writable))
-    offsetIndex.get
-  }
-
-  /**
-   * Close this index file.
-   * Note: This will be a no-op if the index has already been closed.
-   */
-  def close(): Unit = {
-    if (!isClosed) {
-      offsetIndex.foreach(_.close())
-      isClosed = true
-    }
-  }
-
-  /**
-   * Delete the index file that backs this offset if exists.
-   * This method ensures that if the index file has already been closed, it will not be recreated as a side effect.
-   *
-   * @throws IOException if deletion fails due to an I/O error
-   * @return `true` if the file was deleted by this method; `false` if the file could not be deleted because it did
-   *         not exist
-   */
-  def deleteIfExists(): Boolean = {
-    if (isClosed)
-      Files.deleteIfExists(file.toPath)
-    else
-      get.deleteIfExists()
-  }
-
-  /**
-   * Rename the file that backs this offset index if the index has ever been initialized or file already exists.
-   *
-   * @throws IOException if rename fails for defined index or existing file.
-   */
-  def renameTo(f: File) {
-    try {
-      if (offsetIndex.isDefined || file.exists)
-        Utils.atomicMoveWithFallback(file.toPath, f.toPath)
-    } finally file = f
-  }
 }

--- a/core/src/test/scala/unit/kafka/log/LogUtils.scala
+++ b/core/src/test/scala/unit/kafka/log/LogUtils.scala
@@ -31,8 +31,8 @@ object LogUtils {
                     indexIntervalBytes: Int = 10,
                     time: Time = Time.SYSTEM): LogSegment = {
     val ms = FileRecords.open(Log.logFile(logDir, offset))
-    val idx = new LazyOffsetIndex(Log.offsetIndexFile(logDir, offset), offset, maxIndexSize = 1000)
-    val timeIdx = new LazyTimeIndex(Log.timeIndexFile(logDir, offset), offset, maxIndexSize = 1500)
+    val idx = LazyIndex.forOffset(Log.offsetIndexFile(logDir, offset), offset, maxIndexSize = 1000)
+    val timeIdx = LazyIndex.forTime(Log.timeIndexFile(logDir, offset), offset, maxIndexSize = 1500)
     val txnIndex = new TransactionIndex(offset, Log.transactionIndexFile(logDir, offset))
 
     new LogSegment(ms, idx, timeIdx, txnIndex, offset, indexIntervalBytes, 0, time)


### PR DESCRIPTION
TICKET = KAFKA-9156
LI_DESCRIPTION =
This patch fixes BufferOverflow exceptions due to concurrent accesses to indices.

EXIT_CRITERIA = HASH [dca1bf1]
ORIGINAL_DESCRIPTION =
Race condition in concurrent  `get` method invocation of lazy indexes might lead
to multiple `OffsetIndex`/`TimeIndex` objects being concurrently created. When
that happens position of `MappedByteBuffer` in `AbstractIndex` is advanced to
the last entry which in turn leads to a critical `BufferOverflowException` being
thrown whenever leader or replica tries to append a record to the segment.

Moreover, `file_=` setter is seemingly also vulnerable to the race, since multiple
threads can attempt to set a new file reference as well as create new
Time/OffsetIndex objects at the same time. This might lead to the discrepant
File references being held by e.g. LazyTimeIndex and its TimeIndex counterpart.

This patch attempts to fix the issue by making sure that index objects are
atomically constructed when loaded lazily via `get` method. Additionally, `file`
reference modifications are also made atomic and thread safe.

Note that the `Lazy*Index` mutation operations are executed with a lock held by
the callers, but `get` can be called without a lock (e.g. from `Log.read`).

Reviewers: Jun Rao <junrao@gmail.com>, Jason Gustafson <jason@confluent.io>, Shilin Lu, Ismael Juma <ismael@juma.me.uk>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
