### PR TITLE
[LI-HOTFIX] fix DynamicConfig and DynamicBrokerConfig cross reference…

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfig.scala
@@ -57,6 +57,9 @@ object DynamicConfig {
       s"This property can be only set dynamically. It is suggested that the limit be kept above 1MB/s for accurate behaviour."
     val MaintenanceBrokerListDoc = "A list containing maintenance broker Ids, separated by comma"
 
+    //cluster level only configs
+    val ClusterLevelConfigs = Set(MaintenanceBrokerListProp)
+
     //Definitions
     private val brokerConfigDef = new ConfigDef()
       //round minimum value down, to make it easier for users.
@@ -67,8 +70,6 @@ object DynamicConfig {
     DynamicBrokerConfig.addDynamicConfigs(brokerConfigDef)
     val nonDynamicProps = KafkaConfig.configNames.toSet -- brokerConfigDef.names.asScala
 
-    //cluster level only configs
-    val ClusterLevelConfigs = Set(MaintenanceBrokerListProp)
     def typeOf(key: String): ConfigDef.Type = {
       val configKey: ConfigDef.ConfigKey = brokerConfigDef.configKeys().get(key)
       if (configKey == null)


### PR DESCRIPTION
… issue

TICKET =
LI_DESCRIPTION =
DynamicBrokerConfig holds a reference to DynamicConfig.Broker.ClusterLevelConfigs.
During DynamicConfig object initialization, DynamicBrokerConfig object is created if it was not created before.

kafka-configs.sh script (ConfigCommand.scala) tries to create DynamicConfig object directly, which in turns creates DynamicBrokerConfig object.
This fix makes sure that
when initializing DynamicBrokerConfig object, DynamicConfig.Broker.ClusterLevelConfigs should have already been defined.

EXIT_CRITERIA = MANUAL [""]
