### PR TITLE
Added support to enable passthrough mirroring data from V1 format to V2 format

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
@@ -19,7 +19,11 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.record.TimestampType;
 
-
+/**
+ * In case of passthrough, value contains the message batch while the key is null
+ * @param <K> null
+ * @param <V> batch of messages
+ */
 public class PassThroughConsumerRecord<K, V> extends ConsumerRecord<K, V> {
     private final byte magic;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.record.TimestampType;
+
+
+public class PassThroughConsumerRecord<K, V> extends ConsumerRecord<K, V> {
+    private final byte magic;
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, K key, V value, byte magic) {
+        super(topic, partition, offset, key, value);
+        this.magic = magic;
+    }
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, long timestamp,
+        TimestampType timestampType, long checksum, int serializedKeySize, int serializedValueSize, K key, V value,
+        byte magic) {
+        super(topic, partition, offset, timestamp, timestampType, checksum, serializedKeySize, serializedValueSize, key,
+            value);
+        this.magic = magic;
+    }
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, long timestamp,
+        TimestampType timestampType, Long checksum, int serializedKeySize, int serializedValueSize, K key, V value,
+        Headers headers, byte magic) {
+        super(topic, partition, offset, timestamp, timestampType, checksum, serializedKeySize, serializedValueSize, key,
+            value, headers);
+        this.magic = magic;
+    }
+
+    public byte magic() {
+        return magic;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.PassThroughConsumerRecord;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
@@ -1147,6 +1148,13 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 (enableShallowIteration ? ((AbstractLegacyRecordBatch) record).outerRecord().buffer() : record.value());
             byte[] valueByteArray = valueBytes == null ? null : Utils.toArray(valueBytes);
             V value = valueBytes == null ? null : this.valueDeserializer.deserialize(partition.topic(), headers, valueByteArray);
+            if (enableShallowIteration) {
+                return new PassThroughConsumerRecord<>(partition.topic(), partition.partition(), offset, timestamp,
+                    timestampType, record.checksumOrNull(),
+                    keyByteArray == null ? ConsumerRecord.NULL_SIZE : keyByteArray.length,
+                    valueByteArray == null ? ConsumerRecord.NULL_SIZE : valueByteArray.length, key, value, headers,
+                    batch.magic());
+            }
             return new ConsumerRecord<>(partition.topic(), partition.partition(), offset,
                                         timestamp, timestampType, record.checksumOrNull(),
                                         keyByteArray == null ? ConsumerRecord.NULL_SIZE : keyByteArray.length,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -69,6 +69,8 @@ import org.slf4j.Logger;
  */
 public final class RecordAccumulator {
 
+    private static final String PASS_THROUGH_MAGIC_VALUE = "__passThroughMagicValue";
+
     private final Logger log;
     private volatile boolean closed;
     private final AtomicInteger flushesInProgress;
@@ -220,6 +222,20 @@ public final class RecordAccumulator {
                 if (appendResult != null) {
                     // Somebody else found us a batch, return the one we waited for! Hopefully this doesn't happen often...
                     return appendResult;
+                }
+
+                // HOTFIX for enabling mirroring data with passthrough compression with mixed message format
+                // In PassThrough mode, KMM will set a header with key = "__passThroughMagicValue" and value = magic byte of the message.
+                // This code enables passthrough were source is in 0.10 format and destination is in 2.0 format (not the other way round).
+                if (compression.equals(CompressionType.PASSTHROUGH)) {
+                    for (Header header : headers) {
+                        if (header.key().equals(PASS_THROUGH_MAGIC_VALUE)) {
+                            byte srcMagicValue = header.value()[0];
+                            if (maxUsableMagic > srcMagicValue) {
+                                maxUsableMagic = srcMagicValue;
+                            }
+                        }
+                    }
                 }
 
                 MemoryRecordsBuilder recordsBuilder = recordsBuilder(buffer, maxUsableMagic);

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -792,8 +792,12 @@ public class MemoryRecordsBuilder {
 
         // For passthrough V2, ensure one producerBatch only has one DefaultRecordBatch, and since
         // in this case, DefaultRecordBatch is the value part of a DefaultRecord, so we only allow one record
-        if (magic >= RecordBatch.MAGIC_VALUE_V2 && usePassthrough)
+        // For passthrough V1, ideally we can append multiple passthrough records to the same batch, it
+        // will not work when we are migrating from V1 to V2 message format as we cannot append V1 and V2 messages
+        // in the same batch.
+        if (usePassthrough) {
             return false;
+        }
 
         final int recordSize;
         if (magic < RecordBatch.MAGIC_VALUE_V2) {

--- a/core/src/main/scala/kafka/consumer/BaseConsumerRecord.scala
+++ b/core/src/main/scala/kafka/consumer/BaseConsumerRecord.scala
@@ -30,4 +30,5 @@ case class BaseConsumerRecord(topic: String,
                               timestampType: TimestampType = TimestampType.NO_TIMESTAMP_TYPE,
                               key: Array[Byte],
                               value: Array[Byte],
-                              headers: Headers = new RecordHeaders())
+                              headers: Headers = new RecordHeaders(),
+                              magic: Byte = -1)

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -633,8 +633,10 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       // It is assumed that we don't have message format V0 anymore at Linkedin
       if (record.magic.equals(RecordBatch.MAGIC_VALUE_V1)) {
         Collections.singletonList(new ProducerRecord(record.topic, null, timestamp, record.key, record.value, recordHeadersV1))
-      } else {
+      } else if (record.magic.equals(RecordBatch.MAGIC_VALUE_V2)) {
         Collections.singletonList(new ProducerRecord(record.topic, null, timestamp, record.key, record.value, recordHeadersV2))
+      } else {
+        throw new IllegalArgumentException("Record Batch with magic value : " + record.magic + ", is not supported in PassThrough mode")
       }
     }
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -83,7 +83,7 @@ versions += [
   snappy: "1.1.7.2",
   zkclient: "0.10",
   zookeeper: "3.4.13",
-  conscrypt: "2.2.1"
+  conscrypt: "2.1.0"
 ]
 
 libs += [
@@ -141,5 +141,5 @@ libs += [
   zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper",
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
   mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
-  conscrypt: "org.conscrypt:conscrypt-openjdk-uber:$versions.conscrypt"
+  conscrypt: "org.conscrypt:conscrypt-openjdk:$versions.conscrypt:" + osdetector.classifier
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -83,7 +83,7 @@ versions += [
   snappy: "1.1.7.2",
   zkclient: "0.10",
   zookeeper: "3.4.13",
-  conscrypt: "2.1.0"
+  conscrypt: "2.2.1"
 ]
 
 libs += [
@@ -141,5 +141,5 @@ libs += [
   zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper",
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
   mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
-  conscrypt: "org.conscrypt:conscrypt-openjdk:$versions.conscrypt:" + osdetector.classifier
+  conscrypt: "org.conscrypt:conscrypt-openjdk-uber:$versions.conscrypt"
 ]


### PR DESCRIPTION
Pass through mirroring as it is today, works when the `log.message.format.version` between source and destination cluster is the same (0.10.0 to 0.10.0, 2.0 to 2.0).
When there is mixed message format between source and destination, KMM throws errors. 
This patch makes pass through mirroring work when the source is at 0.10.0 format and destination is at 2.0 format.
This patch does not address the errors/issues when the source is at 2.0 format and destination is at 0.10.0 format. 
