### PR TITLE
Add OneAboveMinIsr sensor.

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -180,6 +180,15 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
+  def oneAboveMinIsr: Boolean = {
+    leaderReplicaIfLocal match {
+      case Some(leaderReplica) =>
+        inSyncReplicas.size == leaderReplica.log.get.config.minInSyncReplicas + 1
+      case None =>
+        false
+    }
+  }
+
   /**
     * Create the future replica if 1) the current replica is not in the given log directory and 2) the future replica
     * does not exist. This method assumes that the current replica has already been created.

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -180,7 +180,7 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  def oneAboveMinIsr: Boolean = {
+  def isOneAboveMinIsr: Boolean = {
     leaderReplicaIfLocal match {
       case Some(leaderReplica) =>
         inSyncReplicas.size == leaderReplica.log.get.config.minInSyncReplicas + 1

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -255,7 +255,7 @@ class ReplicaManager(val config: KafkaConfig,
   val oneAboveMinIsrPartitionCount = newGauge(
     "OneAboveMinIsrPartitionCount",
     new Gauge[Int] {
-      def value = leaderPartitionsIterator.count(_.oneAboveMinIsr)
+      def value = leaderPartitionsIterator.count(_.isOneAboveMinIsr)
     }
   )
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -252,6 +252,12 @@ class ReplicaManager(val config: KafkaConfig,
       def value = leaderPartitionsIterator.count(_.isAtMinIsr)
     }
   )
+  val oneAboveMinIsrPartitionCount = newGauge(
+    "OneAboveMinIsrPartitionCount",
+    new Gauge[Int] {
+      def value = leaderPartitionsIterator.count(_.oneAboveMinIsr)
+    }
+  )
 
   val recompressionCount = newGauge(
     "recompressionCount",


### PR DESCRIPTION
The patch adds a new gauge sensor to reflect the number of partition having (minISR + 1) in-sync replicas.
This will be helpful in determining whether it is safe to shut down a broker during a rolling deployment.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
