### PR TITLE
Caching the body of the UpdateMetadataRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkSend.java
@@ -27,8 +27,24 @@ public class NetworkSend extends ByteBufferSend {
         super(destination, sizeDelimit(buffer));
     }
 
+    public NetworkSend(String destination, ByteBuffer[] buffers) {
+        super(destination, sizeDelimit(buffers));
+    }
+
     private static ByteBuffer[] sizeDelimit(ByteBuffer buffer) {
         return new ByteBuffer[] {sizeBuffer(buffer.remaining()), buffer};
+    }
+
+    private static ByteBuffer[] sizeDelimit(ByteBuffer[] buffers) {
+        int totalRemaining = 0;
+        for (ByteBuffer byteBuffer: buffers) {
+            totalRemaining += byteBuffer.remaining();
+        }
+
+        ByteBuffer[] result = new ByteBuffer[buffers.length + 1];
+        result[0] = sizeBuffer(totalRemaining);
+        System.arraycopy(buffers, 0, result, 1, buffers.length);
+        return result;
     }
 
     private static ByteBuffer sizeBuffer(int size) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 public abstract class AbstractRequest extends AbstractRequestResponse {
-    private ByteBuffer bodyBuffer;
+    private byte[] bodyBuffer;
     public static abstract class Builder<T extends AbstractRequest> {
         private final ApiKeys apiKey;
         private final short oldestAllowedVersion;
@@ -97,10 +97,9 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
         // value and a header containing a different correlation id.
         ByteBuffer headerBuffer = serializeStruct(header.toStruct());
         if (bodyBuffer == null) {
-            bodyBuffer = serializeStruct(toStruct());
+            bodyBuffer = serializeStruct(toStruct()).array();
         }
-        bodyBuffer.rewind();
-        return new NetworkSend(destination, new ByteBuffer[]{headerBuffer, bodyBuffer});
+        return new NetworkSend(destination, new ByteBuffer[]{headerBuffer, ByteBuffer.wrap(bodyBuffer)});
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -93,7 +93,7 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
     }
 
     public Send toSend(String destination, RequestHeader header) {
-        // For UpdateMetadataRequest, the same object will be called many times, each time with a different destination
+        // For UpdateMetadataRequest, the toSend method on the same object will be called many times, each time with a different destination
         // value and a header containing a different correlation id.
         ByteBuffer headerBuffer = serializeStruct(header.toStruct());
         if (bodyBuffer == null) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequestResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequestResponse.java
@@ -31,4 +31,11 @@ public abstract class AbstractRequestResponse {
         buffer.rewind();
         return buffer;
     }
+
+    public static ByteBuffer serializeStruct(Struct struct) {
+        ByteBuffer buffer = ByteBuffer.allocate(struct.sizeOf());
+        struct.writeTo(buffer);
+        buffer.rewind();
+        return buffer;
+    }
 }

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -524,13 +524,26 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
       }
     }
 
-    val maxBrokerEpoch = controllerContext.maxBrokerEpoch
-    updateMetadataRequestBrokerSet.intersect(controllerContext.liveOrShuttingDownBrokerIds).foreach { broker =>
-      val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(broker)
+    if (updateMetadataRequestVersion >= 6) {
+      // We should only create one copy UpdateMetadataRequest that should apply to all brokers.
+      // The goal is to reduce memory footprint on the controller.
+      val maxBrokerEpoch = controllerContext.maxBrokerEpoch
       val updateMetadataRequest = new UpdateMetadataRequest.Builder(updateMetadataRequestVersion, controllerId, controllerEpoch,
-        brokerEpoch, maxBrokerEpoch, partitionStates.asJava, liveBrokers.asJava)
-      sendRequest(broker, updateMetadataRequest)
+        AbstractControlRequest.UNKNOWN_BROKER_EPOCH, maxBrokerEpoch, partitionStates.asJava, liveBrokers.asJava)
+
+      updateMetadataRequestBrokerSet.intersect(controllerContext.liveOrShuttingDownBrokerIds).foreach { broker =>
+        val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(broker)
+        sendRequest(broker, updateMetadataRequest)
+      }
+    } else {
+      updateMetadataRequestBrokerSet.intersect(controllerContext.liveOrShuttingDownBrokerIds).foreach { broker =>
+        val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(broker)
+        val updateMetadataRequest = new UpdateMetadataRequest.Builder(updateMetadataRequestVersion, controllerId, controllerEpoch,
+          brokerEpoch, AbstractControlRequest.UNKNOWN_BROKER_EPOCH, partitionStates.asJava, liveBrokers.asJava)
+        sendRequest(broker, updateMetadataRequest)
+      }
     }
+
 
     updateMetadataRequestBrokerSet.clear()
     updateMetadataRequestPartitionInfoMap.clear()


### PR DESCRIPTION
To reduce memory footprint on the controller, this PR caches the body of the UpdateMetadataRequest, so that the requests sent to all brokers will reuse the same buffer.

After this change, all the integration tests under the project "core"
can still pass.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
