### PR TITLE
Cache the UpdateMetadataRequest when using the latest inter broker protocol version

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkSend.java
@@ -27,8 +27,24 @@ public class NetworkSend extends ByteBufferSend {
         super(destination, sizeDelimit(buffer));
     }
 
+    public NetworkSend(String destination, ByteBuffer[] buffers) {
+        super(destination, sizeDelimit(buffers));
+    }
+
     private static ByteBuffer[] sizeDelimit(ByteBuffer buffer) {
         return new ByteBuffer[] {sizeBuffer(buffer.remaining()), buffer};
+    }
+
+    private static ByteBuffer[] sizeDelimit(ByteBuffer[] buffers) {
+        int totalRemaining = 0;
+        for (ByteBuffer byteBuffer: buffers) {
+            totalRemaining += byteBuffer.remaining();
+        }
+
+        ByteBuffer[] result = new ByteBuffer[buffers.length + 1];
+        result[0] = sizeBuffer(totalRemaining);
+        System.arraycopy(buffers, 0, result, 1, buffers.length);
+        return result;
     }
 
     private static ByteBuffer sizeBuffer(int size) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 public abstract class AbstractRequest extends AbstractRequestResponse {
-
+    private byte[] bodyBuffer;
     public static abstract class Builder<T extends AbstractRequest> {
         private final ApiKeys apiKey;
         private final short oldestAllowedVersion;
@@ -93,7 +93,13 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
     }
 
     public Send toSend(String destination, RequestHeader header) {
-        return new NetworkSend(destination, serialize(header));
+        // For UpdateMetadataRequest, the toSend method on the same object will be called many times, each time with a different destination
+        // value and a header containing a different correlation id.
+        ByteBuffer headerBuffer = serializeStruct(header.toStruct());
+        if (bodyBuffer == null) {
+            bodyBuffer = serializeStruct(toStruct()).array();
+        }
+        return new NetworkSend(destination, new ByteBuffer[]{headerBuffer, ByteBuffer.wrap(bodyBuffer)});
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequestResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequestResponse.java
@@ -31,4 +31,11 @@ public abstract class AbstractRequestResponse {
         buffer.rewind();
         return buffer;
     }
+
+    public static ByteBuffer serializeStruct(Struct struct) {
+        ByteBuffer buffer = ByteBuffer.allocate(struct.sizeOf());
+        struct.writeTo(buffer);
+        buffer.rewind();
+        return buffer;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -47,7 +47,7 @@ import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
 import static org.apache.kafka.common.protocol.types.Type.INT32;
 
 public class UpdateMetadataRequest extends AbstractControlRequest {
-    private ReentrantLock bobyBufferLock = new ReentrantLock();
+    private final ReentrantLock bodyBufferLock = new ReentrantLock();
     private byte[] bodyBuffer;
 
     private static final Field.ComplexArray TOPIC_STATES = new Field.ComplexArray("topic_states", "Topic states");
@@ -457,13 +457,13 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
         // For UpdateMetadataRequest, the toSend method on the same object will be called many times, each time with a different destination
         // value and a header containing a different correlation id.
         ByteBuffer headerBuffer = serializeStruct(header.toStruct());
-        bobyBufferLock.lock();
+        bodyBufferLock.lock();
         try {
             if (bodyBuffer == null) {
                 bodyBuffer = serializeStruct(toStruct()).array();
             }
         } finally {
-            bobyBufferLock.unlock();
+            bodyBufferLock.unlock();
         }
         return new NetworkSend(destination, new ByteBuffer[]{headerBuffer, ByteBuffer.wrap(bodyBuffer)});
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -22,6 +22,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.network.NetworkSend;
+import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Field;
@@ -45,6 +47,9 @@ import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
 import static org.apache.kafka.common.protocol.types.Type.INT32;
 
 public class UpdateMetadataRequest extends AbstractControlRequest {
+    private ReentrantLock bobyBufferLock = new ReentrantLock();
+    private byte[] bodyBuffer;
+
     private static final Field.ComplexArray TOPIC_STATES = new Field.ComplexArray("topic_states", "Topic states");
     private static final Field.ComplexArray PARTITION_STATES = new Field.ComplexArray("partition_states", "Partition states");
     private static final Field.ComplexArray LIVE_BROKERS = new Field.ComplexArray("live_brokers", "Live brokers");
@@ -445,6 +450,22 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
         }
         this.partitionStates = partitionStates;
         this.liveBrokers = liveBrokers;
+    }
+
+    @Override
+    public Send toSend(String destination, RequestHeader header) {
+        // For UpdateMetadataRequest, the toSend method on the same object will be called many times, each time with a different destination
+        // value and a header containing a different correlation id.
+        ByteBuffer headerBuffer = serializeStruct(header.toStruct());
+        bobyBufferLock.lock();
+        try {
+            if (bodyBuffer == null) {
+                bodyBuffer = serializeStruct(toStruct()).array();
+            }
+        } finally {
+            bobyBufferLock.unlock();
+        }
+       return new NetworkSend(destination, new ByteBuffer[]{headerBuffer, ByteBuffer.wrap(bodyBuffer)});
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -465,7 +465,7 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
         } finally {
             bobyBufferLock.unlock();
         }
-       return new NetworkSend(destination, new ByteBuffer[]{headerBuffer, ByteBuffer.wrap(bodyBuffer)});
+        return new NetworkSend(destination, new ByteBuffer[]{headerBuffer, ByteBuffer.wrap(bodyBuffer)});
     }
 
     @Override

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -524,13 +524,26 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
       }
     }
 
-    val maxBrokerEpoch = controllerContext.maxBrokerEpoch
-    updateMetadataRequestBrokerSet.intersect(controllerContext.liveOrShuttingDownBrokerIds).foreach { broker =>
-      val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(broker)
+    if (updateMetadataRequestVersion >= 6) {
+      // We should only create one copy UpdateMetadataRequest that should apply to all brokers.
+      // The goal is to reduce memory footprint on the controller.
+      val maxBrokerEpoch = controllerContext.maxBrokerEpoch
       val updateMetadataRequest = new UpdateMetadataRequest.Builder(updateMetadataRequestVersion, controllerId, controllerEpoch,
-        brokerEpoch, maxBrokerEpoch, partitionStates.asJava, liveBrokers.asJava)
-      sendRequest(broker, updateMetadataRequest)
+        AbstractControlRequest.UNKNOWN_BROKER_EPOCH, maxBrokerEpoch, partitionStates.asJava, liveBrokers.asJava)
+
+      updateMetadataRequestBrokerSet.intersect(controllerContext.liveOrShuttingDownBrokerIds).foreach { broker =>
+        val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(broker)
+        sendRequest(broker, updateMetadataRequest)
+      }
+    } else {
+      updateMetadataRequestBrokerSet.intersect(controllerContext.liveOrShuttingDownBrokerIds).foreach { broker =>
+        val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(broker)
+        val updateMetadataRequest = new UpdateMetadataRequest.Builder(updateMetadataRequestVersion, controllerId, controllerEpoch,
+          brokerEpoch, AbstractControlRequest.UNKNOWN_BROKER_EPOCH, partitionStates.asJava, liveBrokers.asJava)
+        sendRequest(broker, updateMetadataRequest)
+      }
     }
+
 
     updateMetadataRequestBrokerSet.clear()
     updateMetadataRequestPartitionInfoMap.clear()

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -532,7 +532,6 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
         AbstractControlRequest.UNKNOWN_BROKER_EPOCH, maxBrokerEpoch, partitionStates.asJava, liveBrokers.asJava)
 
       updateMetadataRequestBrokerSet.intersect(controllerContext.liveOrShuttingDownBrokerIds).foreach { broker =>
-        val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(broker)
         sendRequest(broker, updateMetadataRequest)
       }
     } else {


### PR DESCRIPTION
To reduce the memory footprint on the controller, this PR caches the body of the UpdateMetadataRequest such that all the requests sent to many brokers can share the same
underlying bytes array.

All the tests in the "core" subprojects are still passing after this PR.
To test this change, I added some additional logs to compare the behaviors before and after.
Before this change, when a controller is elected, it sends out UpdateMetadataRequest by allocating bytes for the header and body repeatedly:
```
2020/03/17 03:18:43.914 INFO [AbstractRequest] [Controller-28772-to-broker-27051-send-thread] [kafka-server] [] allocating 15 bytes for header, 3639063 bytes for body
...
...
2020/03/17 03:18:44.205 INFO [AbstractRequest] [Controller-28772-to-broker-11992-send-thread] [kafka-server] [] allocating 15 bytes for header, 3639063 bytes for body
```

After this change, for a given round of UpdateMetadataRequest, the controller would allocate bytes for the header many times, but only once for the body
```
2020/03/18 18:55:56.503 WARN [AbstractRequest] [Controller-28772-to-broker-27051-send-thread] [kafka-server] [] In caching code, allocating 15 bytes for header, 2322938 bytes for body
2020/03/18 18:55:56.504 WARN [AbstractRequest] [Controller-28772-to-broker-5700-send-thread] [kafka-server] [] In caching code, allocating 15 bytes for header, 
2020/03/18 18:55:56.504 WARN [AbstractRequest] [Controller-28772-to-broker-27104-send-thread] [kafka-server] [] In caching code, allocating 15 bytes for header, 
2020/03/18 18:55:56.504 WARN [AbstractRequest] [Controller-28772-to-broker-27119-send-thread] [kafka-server] [] In caching code, allocating 15 bytes for header, 
...
...
2020/03/18 18:55:56.509 WARN [AbstractRequest] [Controller-28772-to-broker-5742-send-thread] [kafka-server] [] In caching code, allocating 15 bytes for header,
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
