### PR TITLE
[LI-HOTFIX] kafka-run-class.sh SCALA_VERSION should match gradle.properties

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -48,7 +48,7 @@ should_include_file() {
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
-  SCALA_VERSION=2.12.8
+  SCALA_VERSION=2.11.12
 fi
 
 if [ -z "$SCALA_BINARY_VERSION" ]; then


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
This is a follow-up to an earlier hotfix 2a9a7d3d2992f11f05ff4c147abd7f8d46935336 which added bintray support to LinkedIn Kafka Github. The Scala version in the run script needs to be updated.

EXIT_CRITERIA = MANUAL [""]