### PR TITLE
[DRAFT] Coalesce controller requests in controller request queue

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractControlRequest.java
@@ -47,7 +47,6 @@ public abstract class AbstractControlRequest extends AbstractRequest {
             this.brokerEpoch = brokerEpoch;
             this.maxBrokerEpoch = maxBrokerEpoch;
         }
-
     }
 
     public int controllerId() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
@@ -168,7 +168,7 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
 
         public boolean merge(LeaderAndIsrRequest.Builder other) {
             if (other.maxBrokerEpoch == maxBrokerEpoch && other.brokerEpoch == brokerEpoch && other.controllerEpoch == controllerEpoch) {
-                liveLeaders.addAll(other.liveLeaders);
+                other.liveLeaders.forEach(node -> liveLeaders.add(node));
                 other.partitionStates.forEach((k, v) -> partitionStates.merge(k, v,
                     (state, otherState) -> new PartitionState(otherState.basePartitionState, state.isNew || otherState.isNew)));
                 return true;

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -199,8 +199,8 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
     }
 
     public static class Builder extends AbstractControlRequest.Builder<UpdateMetadataRequest> {
-        private final Map<TopicPartition, PartitionState> partitionStates;
-        private final Set<Broker> liveBrokers;
+        private Map<TopicPartition, PartitionState> partitionStates;
+        private Set<Broker> liveBrokers;
         private Lock buildLock = new ReentrantLock();
 
 
@@ -261,6 +261,16 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
             //   append(", liveBrokers=").append(Utils.join(liveBrokers, ", ")).
             //   append(")");
             return bld.toString();
+        }
+
+        public boolean merge(UpdateMetadataRequest.Builder other) {
+            if (other.maxBrokerEpoch == maxBrokerEpoch && other.brokerEpoch == brokerEpoch && other.controllerEpoch == controllerEpoch) {
+                liveBrokers = other.liveBrokers;
+                partitionStates = other.partitionStates;
+                return true;
+            } else {
+                return other.maxBrokerEpoch < maxBrokerEpoch || other.brokerEpoch < brokerEpoch || other.controllerEpoch < controllerEpoch;
+            }
         }
     }
 

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -62,6 +62,7 @@ object Defaults {
   val ProducerBatchDecompressionEnable = true
   val PreferredController = false
   val AllowPreferredControllerFallback = true
+  val UpdateMetadataRequestCacheThreshold = 5000
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassName = ""
@@ -301,6 +302,7 @@ object KafkaConfig {
   val ProducerBatchDecompressionEnableProp = "producer.batch.decompression.enable"
   val PreferredControllerProp = "preferred.controller"
   val AllowPreferredControllerFallbackProp = "allow.preferred.controller.fallback"
+  val UpdateMetadataRequestCacheThreshold = "update.metadata.request.cache.threshold"
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameProp = "authorizer.class.name"
@@ -558,6 +560,8 @@ object KafkaConfig {
   val AllowPreferredControllerFallbackDoc = "Specifies whether a non-preferred controller node (broker) is allowed to become the controller." +
   " This configuration is expected to be configured at cluster level via dynamic broker configuration to provide a consistent configuration among all brokers." +
   " If AllowPreferredControllerFallback is dynamically set to false and there is no preferred controllers, the non-preferred active controller does not resign."
+  val UpdateMetadataRequestCacheThresholdDoc = "Specifies the number of partitions included in a single UpdateMetadataRequest that will trigger caching the request." +
+    " If a single UpdateMetadataRequest has more partitions than the specified threshold, we will cache the request to reduce memory pressure in controller."
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameDoc = "The authorizer class that should be used for authorization"
   /** ********* Socket Server Configuration ***********/
@@ -937,6 +941,7 @@ object KafkaConfig {
       .define(ProducerBatchDecompressionEnableProp, BOOLEAN, Defaults.ProducerBatchDecompressionEnable, LOW, ProducerBatchDecompressionEnableDoc)
       .define(PreferredControllerProp, BOOLEAN, Defaults.PreferredController, HIGH, PreferredControllerDoc)
       .define(AllowPreferredControllerFallbackProp, BOOLEAN, Defaults.AllowPreferredControllerFallback, HIGH, AllowPreferredControllerFallbackDoc)
+      .define(UpdateMetadataRequestCacheThreshold, INT, Defaults.UpdateMetadataRequestCacheThreshold, LOW, UpdateMetadataRequestCacheThresholdDoc)
 
       /************* Authorizer Configuration ***********/
       .define(AuthorizerClassNameProp, STRING, Defaults.AuthorizerClassName, LOW, AuthorizerClassNameDoc)
@@ -1245,6 +1250,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
 
   var preferredController = getBoolean(KafkaConfig.PreferredControllerProp)
   def allowPreferredControllerFallback: Boolean = getBoolean(KafkaConfig.AllowPreferredControllerFallbackProp)
+  val updateMetadataRequestCacheThreshold = getInt(KafkaConfig.UpdateMetadataRequestCacheThreshold);
 
   def getNumReplicaAlterLogDirsThreads: Int = {
     val numThreads: Integer = Option(getInt(KafkaConfig.NumReplicaAlterLogDirsThreadsProp)).getOrElse(logDirs.size)


### PR DESCRIPTION
### **This is a draft PR opened to collect early feedback before polishing the implementation. Please don't merge this PR!** 

Recently we encounter the under min ISR issue caused by partition reassignment tasks generating too many small controller requests in the controller request send queue, leading to the broker unable to keep up in processing the requests and thus generate a huge backlog in the controller request queue. This PR explores an approach to coalesce the requests in the controller request queue by keeping track of the queue items that can be coalesced together without breaking the ordering guarantees. Here is the detail explanation of the approach:

```
  * The controller request is either merged with another request in the queue of the same type or enqueued as a
   * separate item without breaking the guarantees listed below:
   * U = UpdateMetadataRequest
   * L = LeaderAndIsrRequest
   * S = StopReplicaRequest
   *
   * 1. U enqueued after L/S should be seen by the broker after L/S. Otherwise the broker may see the updated metadata
   *    before the changes are taken.
   * 2. S enqueued after L should be seen by the broker after L. Otherwise the broker may re-create an already deleted
   *    replica.
   * 3. L enqueued after S should be seen by the broker after S. Otherwise the broker may miss to create a replica.
   *
   * In this class, apart from have a single request queue, we also maintain the currently opened
   * LeaderAndIsrRequestItem (LI) and UpdateMetadataRequestItem (UI) in the queue, which are eligible of merging with
   * the items being put into the queue. With this structure, we can coalesce the following patterns:
   * - Adjacent UpdateMetadataRequests:       U  U  U    =>   U
   *                                              (UI)      (UI)
   *
   * - Adjacent LeaderAndIsrRequests:         L  L  L    =>   L
   *                                              (LI)      (LI)
   *
   * - Adjacent (U, L) pairs:     U   L   U   L   U   L  =>   U   L
   *                                            (UI) (LI)   (UI) (LI)
   *
   *
   * Caveats:
   * - StopReplicaRequest acts like a barrier meaning that coalescing is not allowed across S. For example,
   *   "U L S U L => S U L" is not allowed, otherwise guarantee 1) and 3) are broken.
   *
   * - Two requests can be merged only if they have the same (brokerEpoch, maxBrokerEpoch, controllerEpoch) because
   *   otherwise we may mistakenly convert a stale request into a non-stale request.
   *
   * - For S/L enqueued after U, it is not a requirement to make sure they are seen by the broker after U
   *   because reordering S/L and U in this case will only cause delay for the broker on learning about the changes
   *   made by S/L, which is always the case since the U reflecting changes made by S/L always comes after S/L.
   *   Moreover, with the coalescing pattern describe above, we will end up minimizing that delay. For example,
   *   "U L U U L" will be coalesced into "U L", not "U U U L" so the U reflecting changes made by L will be delayed
   *   only by one request.
```

The upside of this approach is that we can batch the request more aggressively and reduce the controller request queue size significantly when we have a lot of partition reassignment tasks going on.

However, the changes made in this PR also introduce some overhead:
- A config is added to determine whether a UpdateMetadataRequest is cacheable. Only the UpdateMetadataRequests with a lot of partitions involved are cacheable and these cacheable requests are not eligible for coalescing.
- The request send queue now is protected by a single lock, which may perform worst in terms of enqueue/dequeue throughput than before because previously we were using LinkedBlockingQueue, which has separate locks to protect the head and the tail. However, given that this queue has only a single writer and a single reader, I don't think the impact will be dramatic.