### PR TITLE
[LI-HOTFIX] passthrough performance improvement in Log.append

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1049,6 +1049,75 @@ class Log(@volatile private var _dir: File,
   }
 
   /**
+   *  Append records to the active segment of the log.
+   *
+   * This method accepts a MemoryRecords with a buffer that contains one or more valid MemoryRecords and calls
+   * appendSingleBatch for each individually. This allows multiple batches to be aggregated in a single
+   * record_set, but still be processed without forcing offset assignment.
+   *
+   * @param records The log records to append
+   * @param origin Declares the origin of the append which affects required validations
+   * @param interBrokerProtocolVersion Inter-broker message protocol version
+   * @param assignOffsets Should the log assign offsets to this message set or blindly apply what it is given
+   * @param leaderEpoch The partition's leader epoch which will be applied to messages when offsets are assigned on the leader
+   * @throws KafkaStorageException If the append fails due to an I/O error.
+   * @throws OffsetsOutOfOrderException If out of order offsets found in 'records'
+   * @throws UnexpectedAppendOffsetException If the first or last offset in append is less than next offset
+   * @return Information about the appended messages including the first and last offset.
+   */
+  private def append(records: MemoryRecords,
+                                origin: AppendOrigin,
+                                interBrokerProtocolVersion: ApiVersion,
+                                assignOffsets: Boolean,
+                                leaderEpoch: Int): LogAppendInfo = {
+    val batches = records.batches()
+
+    if (batches.asScala.isEmpty) {
+      return analyzeAndValidateRecords(records, origin)
+    }
+    val remainingBytes = records.buffer().duplicate()
+    batches.asScala.map(b => {
+      // Create the current record set using only the first batch
+      val batchSize = b.sizeInBytes()
+      val batchBuffer = remainingBytes.slice()
+      batchBuffer.limit(batchSize)
+      val batchRecords = MemoryRecords.readableRecords(batchBuffer)
+
+      // Advance the position in remaining bytes
+      remainingBytes.position(remainingBytes.position() + batchSize)
+
+      // Append the single record batch to the log
+      appendSingleBatch(batchRecords, origin, interBrokerProtocolVersion, assignOffsets, leaderEpoch)
+    }).reduceLeft((info1, info2) => {
+      // Don't assume that the max timestamp is always in the later batch
+      var maxTimestamp = info1.maxTimestamp
+      var offsetofMaxTimestamp = info1.offsetOfMaxTimestamp
+      if (info2.maxTimestamp > info1.maxTimestamp) {
+        maxTimestamp = info2.maxTimestamp
+        offsetofMaxTimestamp = info2.offsetOfMaxTimestamp
+      }
+      var combinedRecordConversionStats = info1.recordConversionStats
+      combinedRecordConversionStats.add(info2.recordConversionStats)
+
+      // Combine the LogAppendInfo to maintain an overall result to return
+      LogAppendInfo(
+        info1.firstOffset,
+        info2.lastOffset,
+        maxTimestamp,
+        offsetofMaxTimestamp,
+        info1.logAppendTime,
+        info1.logStartOffset,
+        combinedRecordConversionStats,
+        info1.sourceCodec,
+        info1.targetCodec,
+        info1.shallowCount + info2.shallowCount,
+        info1.validBytes + info2.validBytes,
+        info1.offsetsMonotonic && info2.offsetsMonotonic,
+        info1.lastOffsetOfFirstBatch
+      )
+    })
+  }
+  /**
    * Append this message set to the active segment of the log, rolling over to a fresh segment if necessary.
    *
    * This method will generally be responsible for assigning offsets to the messages,
@@ -1064,7 +1133,7 @@ class Log(@volatile private var _dir: File,
    * @throws UnexpectedAppendOffsetException If the first or last offset in append is less than next offset
    * @return Information about the appended messages including the first and last offset.
    */
-  private def append(records: MemoryRecords,
+  private def appendSingleBatch(records: MemoryRecords,
                      origin: AppendOrigin,
                      interBrokerProtocolVersion: ApiVersion,
                      assignOffsets: Boolean,

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -107,6 +107,9 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       config.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
       config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp, "false")
       config.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false")
+      // Set up CreateTopicPolicy to be included in test.
+      config.setProperty(KafkaConfig.DefaultReplicationFactorProp, "1");
+      config.setProperty(KafkaConfig.CreateTopicPolicyClassNameProp, "kafka.server.LiCreateTopicPolicy")
       // We set this in order to test that we don't expose sensitive data via describe configs. This will already be
       // set for subclasses with security enabled and we don't want to overwrite it.
       if (!config.containsKey(KafkaConfig.SslTruststorePasswordProp))


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION = LIKAFKA-9737 Broker-side changes for pass-through solution

EXIT_CRITERIA = MANUAL ["If we no longer need pass-through support in Kafka. Only known user is KMM for venice; BrooklinMM has not enabled this everywhere."]

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
