### PR TITLE
Add a logline to include connection ID when describing a request and response pair

### DIFF
--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -82,6 +82,7 @@ object Observer {
         requestDesc += " null"
       } else {
         requestDesc += (" header: " + request.header)
+        requestDesc += (" connection ID: " + request.context.connectionId)
         requestDesc += (" from service with principal: " +
           request.session.sanitizedUser +
           " IP address: " + request.session.clientAddress)


### PR DESCRIPTION
The method `Observer.describeRequestAndResponse` is used to generate request/response information to log when the observer throws an exception. The generated request/response information will be logged together with the exception thrown by the observer.
Logging the connection ID along with the exception will help us understand how the value of connection ID plays a part in the exception and help us root cause the problem.