### PR TITLE
[LI-HOTFIX] Filter out UNKNOWN_TOPIC_OR_PARTITION from metadata response when the request is to fetch metadata for all topics

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1150,7 +1150,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     // In versions 5 and below, we returned LEADER_NOT_AVAILABLE if a matching listener was not found on the leader.
     // From version 6 onwards, we return LISTENER_NOT_FOUND to enable diagnosis of configuration errors.
     val errorUnavailableListeners = requestVersion >= 6
-    val topicMetadata =
+    var topicMetadata =
       if (authorizedTopics.isEmpty)
         Seq.empty[MetadataResponse.TopicMetadata]
       else {
@@ -1175,17 +1175,17 @@ class KafkaApis(val requestChannel: RequestChannel,
         })
     }
 
-    val completeTopicMetadata = (if (metadataRequest.isAllTopics) {
-      /*
-       * In fix of KAFKA-10606, we stopped auto topic creation on fetch all metadata, which might introduce
-       * UNKNOWN_TOPIC_OR_PARTITION.
-       * But in previous versions, UNKNOWN_TOPIC_OR_PARTITION won't happen on fetch all metadata, so we filter out
-       * those UNKNOWN_TOPIC_OR_PARTITION during fetch all metadata for backward-compatibility.
-       */
-      topicMetadata.filter(_.error().code() != Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
-    } else {
-      topicMetadata
-    }) ++ unauthorizedForCreateTopicMetadata ++ unauthorizedForDescribeTopicMetadata
+    /*
+     * In fix of KAFKA-10606, we stopped auto topic creation on fetch all metadata, which might introduce
+     * UNKNOWN_TOPIC_OR_PARTITION.
+     * But in previous versions, UNKNOWN_TOPIC_OR_PARTITION won't happen on fetch all metadata, so we filter out
+     * those UNKNOWN_TOPIC_OR_PARTITION during fetch all metadata for backward-compatibility.
+     */
+    if (metadataRequest.isAllTopics) {
+      topicMetadata = topicMetadata.filter(_.error().code() != Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
+    }
+
+    val completeTopicMetadata = topicMetadata ++ unauthorizedForCreateTopicMetadata ++ unauthorizedForDescribeTopicMetadata
 
     val brokers = metadataCache.getAliveBrokers
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1175,7 +1175,17 @@ class KafkaApis(val requestChannel: RequestChannel,
         })
     }
 
-    val completeTopicMetadata = topicMetadata ++ unauthorizedForCreateTopicMetadata ++ unauthorizedForDescribeTopicMetadata
+    val completeTopicMetadata = (if (metadataRequest.isAllTopics) {
+      /*
+       * In fix of KAFKA-10606, we stopped auto topic creation on fetch all metadata, which might introduce
+       * UNKNOWN_TOPIC_OR_PARTITION.
+       * But in previous versions, UNKNOWN_TOPIC_OR_PARTITION won't happen on fetch all metadata, so we filter out
+       * those UNKNOWN_TOPIC_OR_PARTITION during fetch all metadata for backward-compatibility.
+       */
+      topicMetadata.filter(_.error().code() != Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
+    } else {
+      topicMetadata
+    }) ++ unauthorizedForCreateTopicMetadata ++ unauthorizedForDescribeTopicMetadata
 
     val brokers = metadataCache.getAliveBrokers
 


### PR DESCRIPTION
Filter out `UNKNOWN_TOPIC_OR_PARTITION` from metadata response when the request is to fetch metadata for all topics since the request to fetch metadata for all topics should not contain any `UNKNOWN_TOPIC_OR_PARTITION` exception in its response.

TICKET = KAFKA-10606
LI_DESCRIPTION = LIKAFKA-32857
EXIT_CRITERIA = Once we cherry-pick the fix for KAFKA-10606
