### PR TITLE
[LI-HOTFIX] Generate logs to help estimate the amount of data loss during ULE

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2158,20 +2158,24 @@ class Log(@volatile private var _dir: File,
         info(s"Truncating to $targetOffset has no effect as the largest offset in the log is ${logEndOffset - 1}")
         false
       } else {
-        info(s"Truncating to offset $targetOffset")
+        var bytesTruncated = 0L
+        val originalLogEndOffset = logEndOffset
         lock synchronized {
           checkIfMemoryMappedBufferClosed()
           if (segments.firstEntry.getValue.baseOffset > targetOffset) {
             truncateFullyAndStartAt(targetOffset)
+            bytesTruncated += logSegments.map(_.size).sum
           } else {
             val deletable = logSegments.filter(segment => segment.baseOffset > targetOffset)
-            removeAndDeleteSegments(deletable, asyncDelete = true)
-            activeSegment.truncateTo(targetOffset)
+            bytesTruncated += removeAndDeleteSegments(deletable, asyncDelete = true)
+            bytesTruncated += activeSegment.truncateTo(targetOffset)
             updateLogEndOffset(targetOffset)
             updateLogStartOffset(math.min(targetOffset, this.logStartOffset))
             leaderEpochCache.foreach(_.truncateFromEnd(targetOffset))
             loadProducerState(targetOffset, reloadFromCleanShutdown = false)
           }
+          info(s"Truncated to offset $targetOffset from the log end offset $originalLogEndOffset " +
+            s"with ${originalLogEndOffset - targetOffset} messages and $bytesTruncated bytes truncated")
           true
         }
       }
@@ -2288,8 +2292,10 @@ class Log(@volatile private var _dir: File,
    *
    * @param segments The log segments to schedule for deletion
    * @param asyncDelete Whether the segment files should be deleted asynchronously
+   * @return the total number of bytes deleted
    */
-  private def removeAndDeleteSegments(segments: Iterable[LogSegment], asyncDelete: Boolean): Unit = {
+  private def removeAndDeleteSegments(segments: Iterable[LogSegment], asyncDelete: Boolean): Long = {
+    var bytesDeleted = 0L
     lock synchronized {
       // As most callers hold an iterator into the `segments` collection and `removeAndDeleteSegment` mutates it by
       // removing the deleted segment, we should force materialization of the iterator here, so that results of the
@@ -2297,9 +2303,11 @@ class Log(@volatile private var _dir: File,
       val toDelete = segments.toList
       toDelete.foreach { segment =>
         this.segments.remove(segment.baseOffset)
+        bytesDeleted += segment.size
       }
       deleteSegmentFiles(toDelete, asyncDelete)
     }
+    bytesDeleted
   }
 
   /**

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2174,7 +2174,7 @@ class Log(@volatile private var _dir: File,
             leaderEpochCache.foreach(_.truncateFromEnd(targetOffset))
             loadProducerState(targetOffset, reloadFromCleanShutdown = false)
           }
-          info(s"Truncated to offset $targetOffset from the log end offset $originalLogEndOffset " +
+          warn(s"Truncated to offset $targetOffset from the log end offset $originalLogEndOffset " +
             s"with ${originalLogEndOffset - targetOffset} messages and $bytesTruncated bytes truncated")
           true
         }


### PR DESCRIPTION
TICKET = KAFKA-10751
LI_DESCERIPTION =
During Unclean Leader Election, there could be data loss due to truncation at the resigned leader.
This PR tries to add more logs to understand the scale of message loss during an unclean leader election.

Suppose there are 3 brokers that has replicas for a given partition:
Broker A (leader) with largest offset 9 (log end offset 10)
Broker B (follower) with largest offset 4 (log end offset 5)
Broker C (follower) with largest offset 1 (log end offset 2)

Only the leader A is in the ISR with B and C lagging behind.
Now an unclean leader election causes the leadership to be transferred to C. Broker A would need to truncate 8 messages, and Broker B 3 messages.

Case 1: if these messages have been produced with acks=0 or 1, then clients would experience 8 lost messages.
Case 2: if the client is using acks=all and the partition's minISR setting is 2, and further let's assume broker B dropped out of the ISR after receiving the message with offset 4, then only the messages with offset<=4 have been acked to the client. The truncation effectively causes the client to lose 3 messages.

Knowing the exact amount of data loss involves knowing the client's acks setting when the messages are produced, and also whether the messages have been sufficiently replicated according to the MinISR setting.
Without getting too involved, this PR reduces the requirement from getting the exact data loss numbers to getting an ESTIMATE of the data loss.
Specifically this PR adds logs during truncation to show the log end offset, number of messages truncated, and number of bytes truncated.

Testing:
I manually tested a ULE case where the resigned leader contains two more messages than the newly elected leader, and saw the following log on the resigned leader
[2020-10-29 15:43:50,154] INFO [Log partition=topic0-0, dir=/tmp/kafka-logs-0] Truncated to offset 0 from the log end offset 2 with 2 messages and 85 bytes truncated (kafka.log.Log)

The bytes truncated match the result shown by the kafka-dump-log.sh script before the truncation
Starting offset: 0
baseOffset: 0 lastOffset: 1 count: 2 baseSequence: -1 lastSequence: -1 producerId: -1 producerEpoch: -1 partitionLeaderEpoch: 12 isTransactional: false isControl: false position: 0 CreateTime: 1604010918227 size: 85 magic: 2 compresscodec: NONE crc: 324998737 isvalid: true

EXIT_CRITERIA = When KAFKA-10751 is resolved and the corresponding change is brought in from upstream