### PR TITLE
[LI-HOTFIX] catch throwable instead of exception from user callback o…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -229,8 +229,8 @@ public final class ProducerBatch {
                     if (thunk.callback != null)
                         thunk.callback.onCompletion(null, exception);
                 }
-            } catch (Exception e) {
-                log.error("Error executing user-provided callback on message for topic-partition '{}'", topicPartition, e);
+            } catch (Throwable t) {
+                log.error("Error executing user-provided callback on message for topic-partition '{}'", topicPartition, t);
             }
         }
 


### PR DESCRIPTION
…n completeFutureAndFireCallbacks

TICKET = KAFKA-10806
LI_DESCRIPTION =  When kafka producer tries to complete/abort a batch,  producer invokes user callback. However, "completeFutureAndFireCallbacks" only captures exceptions from user callback not all throwables.  An uncaught throwable can prevent the batch from being freed.

EXIT_CRITERIA = TICKET [KAFKA-10806]
