### PR TITLE
Move the logging trait to a companion object.

### DIFF
--- a/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
+++ b/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
@@ -37,6 +37,8 @@ class DelayedCreatePartitions(delayMs: Long,
                               responseCallback: Map[String, ApiError] => Unit)
   extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   /**
     * The operation can be completed if all of the topics that do not have an error exist and every partition has a
     * leader in the controller.

--- a/core/src/main/scala/kafka/server/DelayedDeleteRecords.scala
+++ b/core/src/main/scala/kafka/server/DelayedDeleteRecords.scala
@@ -46,6 +46,8 @@ class DelayedDeleteRecords(delayMs: Long,
                            responseCallback: Map[TopicPartition, DeleteRecordsResponse.PartitionResponse] => Unit)
   extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   // first update the acks pending variable according to the error code
   deleteRecordsStatus.foreach { case (topicPartition, status) =>
     if (status.responseStatus.error == Errors.NONE) {

--- a/core/src/main/scala/kafka/server/DelayedDeleteTopics.scala
+++ b/core/src/main/scala/kafka/server/DelayedDeleteTopics.scala
@@ -36,6 +36,8 @@ class DelayedDeleteTopics(delayMs: Long,
                           responseCallback: Map[String, Errors] => Unit)
   extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   /**
     * The operation can be completed if all of the topics not in error have been removed
     */

--- a/core/src/main/scala/kafka/server/DelayedElectLeader.scala
+++ b/core/src/main/scala/kafka/server/DelayedElectLeader.scala
@@ -34,6 +34,8 @@ class DelayedElectLeader(
   responseCallback: Map[TopicPartition, ApiError] => Unit
 ) extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   private var waitingPartitions = expectedLeaders
   private val fullResults = mutable.Map() ++= results
 

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -67,6 +67,8 @@ class DelayedFetch(delayMs: Long,
                    responseCallback: Seq[(TopicPartition, FetchPartitionData)] => Unit)
   extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   /**
    * The operation can be completed if:
    *

--- a/core/src/main/scala/kafka/server/DelayedFuture.scala
+++ b/core/src/main/scala/kafka/server/DelayedFuture.scala
@@ -34,6 +34,8 @@ class DelayedFuture[T](timeoutMs: Long,
                        responseCallback: () => Unit)
   extends DelayedOperation(timeoutMs) {
 
+  import DelayedOperation._
+
   /**
    * The operation can be completed if all the futures have completed successfully
    * or failed with exceptions.

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -30,6 +30,10 @@ import kafka.utils.timer._
 import scala.collection._
 import scala.collection.mutable.ListBuffer
 
+object DelayedOperation extends Logging {
+
+}
+
 /**
  * An operation whose processing needs to be delayed for at most the given delayMs. For example
  * a delayed produce operation could be waiting for specified number of acks; or
@@ -45,8 +49,9 @@ import scala.collection.mutable.ListBuffer
  */
 abstract class DelayedOperation(override val delayMs: Long,
                                 lockOpt: Option[Lock] = None)
-  extends TimerTask with Logging {
+  extends TimerTask {
 
+  import DelayedOperation._
   private val completed = new AtomicBoolean(false)
   private val tryCompletePending = new AtomicBoolean(false)
   // Visible for testing

--- a/core/src/main/scala/kafka/server/DelayedProduce.scala
+++ b/core/src/main/scala/kafka/server/DelayedProduce.scala
@@ -56,6 +56,8 @@ class DelayedProduce(delayMs: Long,
                      lockOpt: Option[Lock] = None)
   extends DelayedOperation(delayMs, lockOpt) {
 
+  import DelayedOperation._
+
   // first update the acks pending variable according to the error code
   produceMetadata.produceStatus.foreach { case (topicPartition, status) =>
     if (status.responseStatus.error == Errors.NONE) {

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -35,7 +35,7 @@ import scala.math.Ordered.orderingToOrdered
 import scala.collection.{mutable, _}
 import scala.collection.JavaConverters._
 
-object FetchSession extends Logging {
+object FetchSession {
   type REQ_MAP = util.Map[TopicPartition, FetchRequest.PartitionData]
   type RESP_MAP = util.LinkedHashMap[TopicPartition, FetchResponse.PartitionData[Records]]
   type CACHE_MAP = ImplicitLinkedHashCollection[CachedPartition]

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -494,7 +494,7 @@ class IncrementalFetchContext(private val time: Time,
           partitionIter.next()
         }
         debug(s"Incremental fetch context with session id ${session.id} returning " +
-            s"${partitionsToLogString(updates.keySet)}")
+          s"${partitionsToLogString(updates.keySet)}")
         new FetchResponse(Errors.NONE, updates, 0, session.id)
       }
     }


### PR DESCRIPTION
TICKET = KAFKA-10877
LI_DESCRIPTION = When Log4j2 is used in JDK11 it uses a different class from JDK 8 to determine where the logger was instantiated (which class instantiated the logger).  The StackWalker class is used to do this.  The StackWaker turns out to be very slow which causes low RHIPR on the brokers.  This cpu cost occurs even if a log message is not emitted as the logger needs to perform this initialization even to find out if a log message needs to be emitted.  If loggers are not initialized frequently then this cost is low when amortized over runtime of the broker.  This patch moves the Logging trait from some classes into companion objects.  This initializes the logger only once for each of these classes instead of every time a class is instantiated.  The larger patch of doing this move to every class which currently mixes in Logger is more complicated and will be attempted in open source.

EXIT_CRITERIA = TICKET [KAFKA-10877]