### PR TITLE
[LI-HOTFIX] Add a Github Actions workflow to trigger build and test upon PR and push

### DIFF
--- a/.github/workflows/build-and-test-on-pr-events.yml
+++ b/.github/workflows/build-and-test-on-pr-events.yml
@@ -26,7 +26,7 @@ on:
       # Push events on the 2.4-li-dev-* branch
       - '2.4-li-dev-*'
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:
@@ -50,4 +50,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # exclude the streams test and connect test
-        run: ./gradlew cleanTest :clients:test :core:test --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
+        run: ./gradlew cleanTest :clients:unitTest :core:unitTest --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed

--- a/.github/workflows/build-and-test-on-pr-events.yml
+++ b/.github/workflows/build-and-test-on-pr-events.yml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+name: Pull Request Build and Test Workflow
+
+# Run this workflow every time a new pull request is created in the repository
+on:
+  push:
+    branches:
+      # Push events on the 2.4-li branch
+      - '2.4-li'
+      # Push events on the 2.4-li-dev-* branch
+      - '2.4-li-dev-*'
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  build:
+    # Name the Job
+    name: Build Pull Request
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
+          fetch-depth: 0
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Gradle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # exclude the streams test and connect test
+        run: ./gradlew cleanTest :clients:test :core:test --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed

--- a/.github/workflows/build-and-test-on-pr-events.yml
+++ b/.github/workflows/build-and-test-on-pr-events.yml
@@ -19,12 +19,6 @@ name: Pull Request Build and Test Workflow
 
 # Run this workflow every time a new pull request is created in the repository
 on:
-  push:
-    branches:
-      # Push events on the 2.4-li branch
-      - '2.4-li'
-      # Push events on the 2.4-li-dev-* branch
-      - '2.4-li-dev-*'
   pull_request:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
Add a Github Actions workflow to trigger build and test upon the below conditions.

- Create/open a new pull request
- Re-open a pull request
- Edited/updated a pull request
- Synchronized a pull request
- Push to the 2.4-li branch
- Push to 2.4-li-dev-* branch(es)

`Test`: Created a PR to my own forked repo and observed that this workflow was triggered ([link](https://github.com/Lincong/kafka/actions))

TICKET = N/A
LI_DESCRIPTION = LIKAFKA-34202
EXIT_CRITERIA = N/A