### PR TITLE
[LI-HOTFIX] Ignoring the flaky test shouldListMovingPartitionsThroughApi

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -19,7 +19,7 @@ import kafka.utils.TestUtils._
 import kafka.utils.{Logging, TestUtils}
 import kafka.zk.{ReassignPartitionsZNode, ZkVersion, ZooKeeperTestHarness}
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
-import org.junit.{After, Before, Test}
+import org.junit.{After, Before, Ignore, Test}
 import kafka.admin.ReplicationQuotaUtils._
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AlterConfigOp, ConfigEntry, NewPartitionReassignment, NewPartitions, PartitionReassignment, AdminClient => JAdminClient}
 import org.apache.kafka.common.{TopicPartition, TopicPartitionReplica}
@@ -798,6 +798,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     assertEquals(Seq(100, 101), zkClient.getReplicasForPartition(tp0))
   }
 
+  @Ignore
   @Test
   def shouldListMovingPartitionsThroughApi(): Unit = {
     startBrokers(Seq(100, 101))


### PR DESCRIPTION
TICKET = KAFKA-9253
LI_DESCRIPTION = The test shouldListMovingPartitionsThroughApi failed in the CI workflow https://github.com/linkedin/kafka/actions/runs/464971264, and it has a race condition.
When a ListPartitionReassignment request is processed, the partition reassignment has already
been completed, and thus the ListPartitionReassignmentResponse does not contain data for that
partition (tp2 in the test), which further causes a NullPointerException.

EXIT_CRITERIA = When the fix for the flaky test is committed in upstream and picked up in this repo

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
