### PR TITLE
[LI-HOTFIX] Avoid assigning replicas to the preferred controllers or maintenance brokers

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -880,7 +880,11 @@ class KafkaController(val config: KafkaConfig,
     //    between the moment this broker started and right now when it becomes controller again.
     loadMinIsrForTopics(controllerContext.allTopics)
 
+    // scan partitions of all topics and ensure they don't lie on partitionUnassignableBrokerIds
+    // the controllerContext.partitionAssignments is still not initialized yet
+    // thus every single partition will be checked inside rearrangePartitionReplicaAssignmentForNewPartitions
     rearrangePartitionReplicaAssignmentForNewPartitions(controllerContext.allTopics.toSet)
+
     registerPartitionModificationsHandlers(controllerContext.allTopics.toSeq)
     getReplicaAssignmentPolicyCompliant(controllerContext.allTopics.toSet).foreach {
       case (topicPartition, replicaAssignment) =>

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -53,7 +53,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
                   topicConfig: Properties = new Properties,
                   rackAwareMode: RackAwareMode = RackAwareMode.Enforced): Unit = {
     val brokerMetadatas = getBrokerMetadatas(rackAwareMode)
-    val noNewPartitionBrokerIds = getMaintenanceBrokerList()
+    val noNewPartitionBrokerIds = getMaintenanceBrokerList() ++ zkClient.getPreferredControllerList
     val replicaAssignment = assignReplicasToAvailableBrokers(brokerMetadatas, noNewPartitionBrokerIds.toSet, partitions, replicationFactor)
     createTopicWithAssignment(topic, topicConfig, replicaAssignment)
   }
@@ -235,7 +235,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
                     numPartitions: Int = 1,
                     replicaAssignment: Option[Map[Int, Seq[Int]]] = None,
                     validateOnly: Boolean = false): Map[Int, Seq[Int]] = {
-    val noNewPartitionBrokerIds = getMaintenanceBrokerList()
+    val noNewPartitionBrokerIds = getMaintenanceBrokerList() ++ zkClient.getPreferredControllerList
     addPartitions(topic, existingAssignment, allBrokers, numPartitions, replicaAssignment, validateOnly, noNewPartitionBrokerIds.toSet)
   }
 

--- a/core/src/test/scala/unit/kafka/server/PreferredControllerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/PreferredControllerTest.scala
@@ -33,7 +33,6 @@ import org.scalatest.Assertions.fail
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
-import scala.collection.immutable
 
 class PreferredControllerTest extends ZooKeeperTestHarness {
 
@@ -70,33 +69,6 @@ class PreferredControllerTest extends ZooKeeperTestHarness {
       ensureTopicNotInBrokers("topic1", Set(1)))
 
     client.close()
-  }
-
-  @Test
-  def testPartitionCreatedByAdminZkClientShouldNotBeAssignedToPreferredControllers(): Unit = {
-    val brokerConfigs = Seq((0, false), (1, true), (2, false))
-    createBrokersWithPreferredControllers(brokerConfigs, true)
-
-    TestUtils.waitUntilControllerElected(zkClient)
-    // create topic using admin client
-    val topic = "topic1"
-    TestUtils.createTopic(zkClient, topic, 3, 2, brokers)
-
-    assertTrue("topic1 should not be in broker 1", ensureTopicNotInBrokers("topic1", Set(1)))
-
-    val existingAssignment = zkClient.getFullReplicaAssignmentForTopics(immutable.Set(topic)).map {
-      case (topicPartition, assignment) => topicPartition.partition -> assignment
-    }
-    val allBrokers = adminZkClient.getBrokerMetadatas()
-    val newPartitionsCount = 5
-    adminZkClient.addPartitions(topic, existingAssignment, allBrokers, 5)
-    (0 until newPartitionsCount).map { i =>
-      TestUtils.waitUntilMetadataIsPropagated(brokers, topic, i)
-      i -> TestUtils.waitUntilLeaderIsElectedOrChanged(zkClient, topic, i)
-    }
-
-    assertTrue("topic1 should not be in broker 1 after increasing partition count",
-      ensureTopicNotInBrokers("topic1", Set(1)))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/PreferredControllerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/PreferredControllerTest.scala
@@ -77,7 +77,6 @@ class PreferredControllerTest extends ZooKeeperTestHarness {
     val brokerConfigs = Seq((0, false), (1, true), (2, false))
     createBrokersWithPreferredControllers(brokerConfigs, true)
 
-    val brokerList = TestUtils.bootstrapServers(brokers, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))
     TestUtils.waitUntilControllerElected(zkClient)
     // create topic using admin client
     val topic = "topic1"


### PR DESCRIPTION
If we expand partitions using the AdminZkClient, currently there is no logic to avoid assigning replicas to preferred controllers.
This PR fixes the issue in the following two places: 
1. It avoids assignment of replicas to preferred controllers and maintenance brokers within the AdminZkClient
2. In case someone is using an non-patched client and still assigns replicas to preferred controllers, the KafkaController will call rearrangePartitionReplicaAssignmentForNewPartitions to remove the preferred controllers from the assignment.

Testing Stretegy:
An unit test is added to ensure the problem doesn't happen again.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
