### PR TITLE
[LI-HOTFIX] Add broker info log when getting UNKNOWN_TOPIC_OR_PARTITION error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
@@ -77,7 +77,7 @@ public class ManualMetadataUpdater implements MetadataUpdater {
     }
 
     @Override
-    public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response) {
+    public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response, String source) {
         // Do nothing
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
@@ -77,7 +77,8 @@ public class ManualMetadataUpdater implements MetadataUpdater {
     }
 
     @Override
-    public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response, String source) {
+    public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response,
+        String destination) {
         // Do nothing
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -83,7 +83,8 @@ public interface MetadataUpdater extends Closeable {
      * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
      * requests with special handling for completed receives of such requests.
      */
-    void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse, String source);
+    void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse,
+        String destination);
 
     /**
      * Close this updater.

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -83,7 +83,7 @@ public interface MetadataUpdater extends Closeable {
      * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
      * requests with special handling for completed receives of such requests.
      */
-    void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse);
+    void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse, String source);
 
     /**
      * Close this updater.

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1094,8 +1094,19 @@ public class NetworkClient implements KafkaClient {
 
             // Check if any topic's metadata failed to get updated
             Map<String, Errors> errors = response.errors();
-            if (!errors.isEmpty())
+            if (!errors.isEmpty()) {
                 log.warn("Error while fetching metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
+                // Print additional debugging information such as leader id and epoch for partitions fail metadata fetch
+                // with UNKNOWN_TOPIC_OR_PARTITION error
+                if (errors.containsKey(Errors.UNKNOWN_TOPIC_OR_PARTITION)) {
+                    List<MetadataResponse.PartitionMetadata> partitionMetadataList = response.topicMetadata().stream()
+                        .flatMap(topicMetadata -> topicMetadata.partitionMetadata().stream()
+                            .filter(partitionMetadata -> partitionMetadata.error() == Errors.UNKNOWN_TOPIC_OR_PARTITION))
+                        .collect(Collectors.toList());
+                    log.warn("Unable to fetch metadata with correlation id {} for topic partitions with these metadata"
+                        + " {}", requestHeader.correlationId(), partitionMetadataList);
+                }
+            }
 
             // Don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being
             // created which means we will get errors and no nodes until it exists

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1096,16 +1096,6 @@ public class NetworkClient implements KafkaClient {
             Map<String, Errors> errors = response.errors();
             if (!errors.isEmpty()) {
                 log.warn("Error while fetching metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
-                // Print additional debugging information such as leader id and epoch for partitions fail metadata fetch
-                // with UNKNOWN_TOPIC_OR_PARTITION error
-                if (errors.containsValue(Errors.UNKNOWN_TOPIC_OR_PARTITION)) {
-                    List<MetadataResponse.PartitionMetadata> partitionMetadataList = response.topicMetadata().stream()
-                        .flatMap(topicMetadata -> topicMetadata.partitionMetadata().stream()
-                            .filter(partitionMetadata -> partitionMetadata.error() == Errors.UNKNOWN_TOPIC_OR_PARTITION))
-                        .collect(Collectors.toList());
-                    log.warn("Unable to fetch metadata from source {} with correlation id {} for topic partitions with these metadata"
-                        + " {}", source, requestHeader.correlationId(), partitionMetadataList);
-                }
             }
 
             // Don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -863,9 +863,9 @@ public class NetworkClient implements KafkaClient {
             AbstractResponse body = AbstractResponse.
                     parseResponse(req.header.apiKey(), responseStruct, req.header.apiVersion());
             maybeThrottle(body, req.header.apiVersion(), req.destination, now);
-            if (req.isInternalRequest && body instanceof MetadataResponse) {
-                metadataUpdater.handleSuccessfulResponse(req.header, now, (MetadataResponse) body, source);
-            } else if (req.isInternalRequest && body instanceof ApiVersionsResponse)
+            if (req.isInternalRequest && body instanceof MetadataResponse)
+                metadataUpdater.handleSuccessfulResponse(req.header, now, (MetadataResponse) body, req.destination);
+            else if (req.isInternalRequest && body instanceof ApiVersionsResponse)
                 handleApiVersionsResponse(responses, req, now, (ApiVersionsResponse) body);
             else
                 responses.add(req.completed(body, now));
@@ -1077,7 +1077,7 @@ public class NetworkClient implements KafkaClient {
         }
 
         @Override
-        public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response, String source) {
+        public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response, String destination) {
             // If any partition has leader with missing listeners, log up to ten of these partitions
             // for diagnosing broker configuration issues.
             // This could be a transient issue if listeners were added dynamically to brokers.
@@ -1095,7 +1095,8 @@ public class NetworkClient implements KafkaClient {
             // Check if any topic's metadata failed to get updated
             Map<String, Errors> errors = response.errors();
             if (!errors.isEmpty()) {
-                log.warn("Error while fetching metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
+                log.warn("Error while fetching metadata with from source {} with correlation id {} : {}", destination,
+                    requestHeader.correlationId(), errors);
             }
 
             // Don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -864,8 +864,7 @@ public class NetworkClient implements KafkaClient {
                     parseResponse(req.header.apiKey(), responseStruct, req.header.apiVersion());
             maybeThrottle(body, req.header.apiVersion(), req.destination, now);
             if (req.isInternalRequest && body instanceof MetadataResponse) {
-                ((MetadataResponse) body).setSource(source);
-                metadataUpdater.handleSuccessfulResponse(req.header, now, (MetadataResponse) body);
+                metadataUpdater.handleSuccessfulResponse(req.header, now, (MetadataResponse) body, source);
             } else if (req.isInternalRequest && body instanceof ApiVersionsResponse)
                 handleApiVersionsResponse(responses, req, now, (ApiVersionsResponse) body);
             else
@@ -1078,7 +1077,7 @@ public class NetworkClient implements KafkaClient {
         }
 
         @Override
-        public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response) {
+        public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response, String source) {
             // If any partition has leader with missing listeners, log up to ten of these partitions
             // for diagnosing broker configuration issues.
             // This could be a transient issue if listeners were added dynamically to brokers.
@@ -1105,7 +1104,7 @@ public class NetworkClient implements KafkaClient {
                             .filter(partitionMetadata -> partitionMetadata.error() == Errors.UNKNOWN_TOPIC_OR_PARTITION))
                         .collect(Collectors.toList());
                     log.warn("Unable to fetch metadata from source {} with correlation id {} for topic partitions with these metadata"
-                        + " {}", response.source(), requestHeader.correlationId(), partitionMetadataList);
+                        + " {}", source, requestHeader.correlationId(), partitionMetadataList);
                 }
             }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -112,7 +112,8 @@ public class AdminMetadataManager {
         }
 
         @Override
-        public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse) {
+        public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse,
+            String source) {
             // Do nothing
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -113,7 +113,7 @@ public class AdminMetadataManager {
 
         @Override
         public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse,
-            String source) {
+            String destination) {
             // Do nothing
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -60,6 +60,7 @@ public class MetadataResponse extends AbstractResponse {
     private final MetadataResponseData data;
     private volatile Holder holder;
     private final boolean hasReliableLeaderEpochs;
+    private volatile String source;
 
     public MetadataResponse(MetadataResponseData data) {
         this(data, true);
@@ -224,6 +225,21 @@ public class MetadataResponse extends AbstractResponse {
         return this.data.clusterId();
     }
 
+    /**
+     * The source broker id of the broker that returned this metadata response
+     * @return broker id
+     */
+    public String source() {
+        return this.source;
+    }
+
+    /**
+     * Set the source broker id
+     * @param source broker id
+     */
+    public void setSource(String source) {
+        this.source = source;
+    }
     /**
      * Check whether the leader epochs returned from the response can be relied on
      * for epoch validation in Fetch, ListOffsets, and OffsetsForLeaderEpoch requests.

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -226,21 +226,6 @@ public class MetadataResponse extends AbstractResponse {
     }
 
     /**
-     * The source broker id of the broker that returned this metadata response
-     * @return broker id
-     */
-    public String source() {
-        return this.source;
-    }
-
-    /**
-     * Set the source broker id
-     * @param source broker id
-     */
-    public void setSource(String source) {
-        this.source = source;
-    }
-    /**
      * Check whether the leader epochs returned from the response can be relied on
      * for epoch validation in Fetch, ListOffsets, and OffsetsForLeaderEpoch requests.
      * If not, then the client will not retain the leader epochs and hence will not

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -60,7 +60,6 @@ public class MetadataResponse extends AbstractResponse {
     private final MetadataResponseData data;
     private volatile Holder holder;
     private final boolean hasReliableLeaderEpochs;
-    private volatile String source;
 
     public MetadataResponse(MetadataResponseData data) {
         this(data, true);


### PR DESCRIPTION
Description: add additional logs in `NetworkClient` for broker metadata info like leader id and epoch during metadata fetch failure with UNKNOWN_TOPIC_OR_PARTITION error. This helps debug Venice issue outlined here: https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-33540
Testing: N/A, since this is log only.