### PR TITLE
Add enableBatchingInPassthrough config to test passthrough mirroring feature with mixed message format

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -101,7 +101,7 @@
     <module name="MethodLength"/>
     <module name="ParameterNumber">
       <!-- default is 8 -->
-      <property name="max" value="13"/>
+      <property name="max" value="14"/>
     </module>
     <module name="ClassDataAbstractionCoupling">
       <!-- default is 7 -->

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.record.TimestampType;
+
+/**
+ * In case of passthrough, value contains the message batch while the key is null
+ * @param <K> null
+ * @param <V> batch of messages
+ */
+public class PassThroughConsumerRecord<K, V> extends ConsumerRecord<K, V> {
+    private final byte magic;
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, K key, V value, byte magic) {
+        super(topic, partition, offset, key, value);
+        this.magic = magic;
+    }
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, long timestamp,
+        TimestampType timestampType, long checksum, int serializedKeySize, int serializedValueSize, K key, V value,
+        byte magic) {
+        super(topic, partition, offset, timestamp, timestampType, checksum, serializedKeySize, serializedValueSize, key,
+            value);
+        this.magic = magic;
+    }
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, long timestamp,
+        TimestampType timestampType, Long checksum, int serializedKeySize, int serializedValueSize, K key, V value,
+        Headers headers, byte magic) {
+        super(topic, partition, offset, timestamp, timestampType, checksum, serializedKeySize, serializedValueSize, key,
+            value, headers);
+        this.magic = magic;
+    }
+
+    public byte magic() {
+        return magic;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
@@ -19,7 +19,11 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.record.TimestampType;
 
-
+/**
+ * In case of passthrough, value contains the message batch while the key is null
+ * @param <K> null
+ * @param <V> batch of messages
+ */
 public class PassThroughConsumerRecord<K, V> extends ConsumerRecord<K, V> {
     private final byte magic;
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/PassThroughConsumerRecord.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.record.TimestampType;
+
+
+public class PassThroughConsumerRecord<K, V> extends ConsumerRecord<K, V> {
+    private final byte magic;
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, K key, V value, byte magic) {
+        super(topic, partition, offset, key, value);
+        this.magic = magic;
+    }
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, long timestamp,
+        TimestampType timestampType, long checksum, int serializedKeySize, int serializedValueSize, K key, V value,
+        byte magic) {
+        super(topic, partition, offset, timestamp, timestampType, checksum, serializedKeySize, serializedValueSize, key,
+            value);
+        this.magic = magic;
+    }
+
+    public PassThroughConsumerRecord(String topic, int partition, long offset, long timestamp,
+        TimestampType timestampType, Long checksum, int serializedKeySize, int serializedValueSize, K key, V value,
+        Headers headers, byte magic) {
+        super(topic, partition, offset, timestamp, timestampType, checksum, serializedKeySize, serializedValueSize, key,
+            value, headers);
+        this.magic = magic;
+    }
+
+    public byte magic() {
+        return magic;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.PassThroughConsumerRecord;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
@@ -1152,6 +1153,13 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 (enableShallowIteration ? ((AbstractLegacyRecordBatch) record).outerRecord().buffer() : record.value());
             byte[] valueByteArray = valueBytes == null ? null : Utils.toArray(valueBytes);
             V value = valueBytes == null ? null : this.valueDeserializer.deserialize(partition.topic(), headers, valueByteArray);
+            if (enableShallowIteration) {
+                return new PassThroughConsumerRecord<>(partition.topic(), partition.partition(), offset, timestamp,
+                    timestampType, record.checksumOrNull(),
+                    keyByteArray == null ? ConsumerRecord.NULL_SIZE : keyByteArray.length,
+                    valueByteArray == null ? ConsumerRecord.NULL_SIZE : valueByteArray.length, key, value, headers,
+                    batch.magic());
+            }
             return new ConsumerRecord<>(partition.topic(), partition.partition(), offset,
                                         timestamp, timestampType, record.checksumOrNull(),
                                         keyByteArray == null ? ConsumerRecord.NULL_SIZE : keyByteArray.length,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.PassThroughConsumerRecord;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
@@ -1147,6 +1148,13 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 (enableShallowIteration ? ((AbstractLegacyRecordBatch) record).outerRecord().buffer() : record.value());
             byte[] valueByteArray = valueBytes == null ? null : Utils.toArray(valueBytes);
             V value = valueBytes == null ? null : this.valueDeserializer.deserialize(partition.topic(), headers, valueByteArray);
+            if (enableShallowIteration) {
+                return new PassThroughConsumerRecord<>(partition.topic(), partition.partition(), offset, timestamp,
+                    timestampType, record.checksumOrNull(),
+                    keyByteArray == null ? ConsumerRecord.NULL_SIZE : keyByteArray.length,
+                    valueByteArray == null ? ConsumerRecord.NULL_SIZE : valueByteArray.length, key, value, headers,
+                    batch.magic());
+            }
             return new ConsumerRecord<>(partition.topic(), partition.partition(), offset,
                                         timestamp, timestampType, record.checksumOrNull(),
                                         keyByteArray == null ? ConsumerRecord.NULL_SIZE : keyByteArray.length,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -242,6 +242,11 @@ public class ProducerConfig extends AbstractConfig {
     private static final String ALLOW_AUTO_CREATE_TOPICS_DOC = "The client-side (producer) permission to allow auto-topic creation. Both the client-side and the broker-side should enable auto-topic creation in order for a topic to be automatically created";
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
+    /** <code>enable.passthrough.batching</code> */
+    public static final String ENABLE_PASSTHROUGH_BATCHING_CONFIG = "enable.passthrough.batching";
+    private static final String ENABLE_PASSTHROUGH_BATCHING_DOC = "The client-side (producer) permission to enable record batching in passthrough mode";
+    public static final boolean DEFAULT_ENABLE_PASSTHROUGH_BATCHING = true;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Collections.emptyList(), new ConfigDef.NonNullValidator(), Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
                                 .define(BUFFER_MEMORY_CONFIG, Type.LONG, 32 * 1024 * 1024L, atLeast(0L), Importance.HIGH, BUFFER_MEMORY_DOC)
@@ -372,7 +377,10 @@ public class ProducerConfig extends AbstractConfig {
                                         Type.BOOLEAN,
                                         DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
                                         Importance.MEDIUM,
-                                        ALLOW_AUTO_CREATE_TOPICS_DOC);
+                                        ALLOW_AUTO_CREATE_TOPICS_DOC)
+                                .define(ENABLE_PASSTHROUGH_BATCHING_CONFIG,
+                                        Type.BOOLEAN, DEFAULT_ENABLE_PASSTHROUGH_BATCHING,
+                                        Importance.MEDIUM, ENABLE_PASSTHROUGH_BATCHING_DOC);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -69,6 +69,8 @@ import org.slf4j.Logger;
  */
 public final class RecordAccumulator {
 
+    private static final String PASS_THROUGH_MAGIC_VALUE = "__passThroughMagicValue";
+
     private final Logger log;
     private volatile boolean closed;
     private final AtomicInteger flushesInProgress;
@@ -220,6 +222,20 @@ public final class RecordAccumulator {
                 if (appendResult != null) {
                     // Somebody else found us a batch, return the one we waited for! Hopefully this doesn't happen often...
                     return appendResult;
+                }
+
+                // HOTFIX for enabling mirroring data with passthrough compression with mixed message format
+                // In PassThrough mode, KMM will set a header with key = "__passThroughMagicValue" and value = magic byte of the message.
+                // This code enables passthrough were source is in 0.10 format and destination is in 2.0 format (not the other way round).
+                if (compression.equals(CompressionType.PASSTHROUGH)) {
+                    for (Header header : headers) {
+                        if (header.key().equals(PASS_THROUGH_MAGIC_VALUE)) {
+                            byte srcMagicValue = header.value()[0];
+                            if (maxUsableMagic > srcMagicValue) {
+                                maxUsableMagic = srcMagicValue;
+                            }
+                        }
+                    }
                 }
 
                 MemoryRecordsBuilder recordsBuilder = recordsBuilder(buffer, maxUsableMagic);

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -445,6 +445,20 @@ public class MemoryRecords extends AbstractRecords {
     }
 
     public static MemoryRecordsBuilder builder(ByteBuffer buffer,
+                                                byte magic,
+                                                CompressionType compressionType,
+                                                TimestampType timestampType,
+                                                long baseOffset,
+                                                boolean enableBatchingInPassthrough) {
+        long logAppendTime = RecordBatch.NO_TIMESTAMP;
+        if (timestampType == TimestampType.LOG_APPEND_TIME)
+            logAppendTime = System.currentTimeMillis();
+        return builder(buffer, magic, compressionType, timestampType, baseOffset, logAppendTime,
+                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false,
+                RecordBatch.NO_PARTITION_LEADER_EPOCH, enableBatchingInPassthrough);
+    }
+
+    public static MemoryRecordsBuilder builder(ByteBuffer buffer,
                                                byte magic,
                                                CompressionType compressionType,
                                                TimestampType timestampType,
@@ -496,6 +510,22 @@ public class MemoryRecords extends AbstractRecords {
     }
 
     public static MemoryRecordsBuilder builder(ByteBuffer buffer,
+                                                byte magic,
+                                                CompressionType compressionType,
+                                                TimestampType timestampType,
+                                                long baseOffset,
+                                                long logAppendTime,
+                                                long producerId,
+                                                short producerEpoch,
+                                                int baseSequence,
+                                                boolean isTransactional,
+                                                int partitionLeaderEpoch,
+                                                boolean enableBatchingInPassthrough) {
+        return builder(buffer, magic, compressionType, timestampType, baseOffset,
+              logAppendTime, producerId, producerEpoch, baseSequence, isTransactional, false, partitionLeaderEpoch, enableBatchingInPassthrough);
+    }
+
+    public static MemoryRecordsBuilder builder(ByteBuffer buffer,
                                                byte magic,
                                                CompressionType compressionType,
                                                TimestampType timestampType,
@@ -510,6 +540,24 @@ public class MemoryRecords extends AbstractRecords {
         return new MemoryRecordsBuilder(buffer, magic, compressionType, timestampType, baseOffset,
                 logAppendTime, producerId, producerEpoch, baseSequence, isTransactional, isControlBatch, partitionLeaderEpoch,
                 buffer.remaining());
+    }
+
+    public static MemoryRecordsBuilder builder(ByteBuffer buffer,
+                                                byte magic,
+                                                CompressionType compressionType,
+                                                TimestampType timestampType,
+                                                long baseOffset,
+                                                long logAppendTime,
+                                                long producerId,
+                                                short producerEpoch,
+                                                int baseSequence,
+                                                boolean isTransactional,
+                                                boolean isControlBatch,
+                                                int partitionLeaderEpoch,
+                                                boolean enableBatchingInPassthrough) {
+        return new MemoryRecordsBuilder(buffer, magic, compressionType, timestampType, baseOffset,
+                logAppendTime, producerId, producerEpoch, baseSequence, isTransactional, isControlBatch, partitionLeaderEpoch,
+                buffer.remaining(), enableBatchingInPassthrough);
     }
 
     public static MemoryRecords withRecords(CompressionType compressionType, SimpleRecord... records) {

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -87,6 +87,8 @@ public class MemoryRecordsBuilder {
     private MemoryRecords builtRecords;
     private boolean aborted = false;
 
+    private boolean enableBatchingInPassthrough = true;
+
     public MemoryRecordsBuilder(ByteBufferOutputStream bufferStream,
                                 byte magic,
                                 CompressionType compressionType,
@@ -140,6 +142,61 @@ public class MemoryRecordsBuilder {
         this.appendStream = new DataOutputStream(compressionType.wrapForOutput(this.bufferStream, magic));
     }
 
+    public MemoryRecordsBuilder(ByteBufferOutputStream bufferStream,
+        byte magic,
+        CompressionType compressionType,
+        TimestampType timestampType,
+        long baseOffset,
+        long logAppendTime,
+        long producerId,
+        short producerEpoch,
+        int baseSequence,
+        boolean isTransactional,
+        boolean isControlBatch,
+        int partitionLeaderEpoch,
+        int writeLimit,
+        boolean enableBatchingInPassthrough) {
+        if (magic > RecordBatch.MAGIC_VALUE_V0 && timestampType == TimestampType.NO_TIMESTAMP_TYPE)
+            throw new IllegalArgumentException("TimestampType must be set for magic >= 0");
+        if (magic < RecordBatch.MAGIC_VALUE_V2) {
+            if (isTransactional)
+                throw new IllegalArgumentException("Transactional records are not supported for magic " + magic);
+            if (isControlBatch)
+                throw new IllegalArgumentException("Control records are not supported for magic " + magic);
+        }
+
+        this.magic = magic;
+        this.timestampType = timestampType;
+        this.baseOffset = baseOffset;
+        this.logAppendTime = logAppendTime;
+        this.numRecords = 0;
+        this.uncompressedRecordsSizeInBytes = 0;
+        this.actualCompressionRatio = 1;
+        this.maxTimestamp = RecordBatch.NO_TIMESTAMP;
+        this.producerId = producerId;
+        this.producerEpoch = producerEpoch;
+        this.baseSequence = baseSequence;
+        this.isTransactional = isTransactional;
+        this.isControlBatch = isControlBatch;
+        this.partitionLeaderEpoch = partitionLeaderEpoch;
+        this.writeLimit = writeLimit;
+        this.initialPosition = bufferStream.position();
+
+        if (compressionType == CompressionType.PASSTHROUGH) {
+            usePassthrough = true;
+            this.compressionType = CompressionType.NONE;
+        } else {
+            this.compressionType = compressionType;
+        }
+
+        this.batchHeaderSizeInBytes = usePassthrough ? 0 : AbstractRecords.recordBatchHeaderSizeInBytes(magic, this.compressionType);
+
+        bufferStream.position(initialPosition + batchHeaderSizeInBytes);
+        this.bufferStream = bufferStream;
+        this.appendStream = new DataOutputStream(compressionType.wrapForOutput(this.bufferStream, magic));
+        this.enableBatchingInPassthrough = enableBatchingInPassthrough;
+    }
+
     /**
      * Construct a new builder.
      *
@@ -175,7 +232,26 @@ public class MemoryRecordsBuilder {
                                 int writeLimit) {
         this(new ByteBufferOutputStream(buffer), magic, compressionType, timestampType, baseOffset, logAppendTime,
                 producerId, producerEpoch, baseSequence, isTransactional, isControlBatch, partitionLeaderEpoch,
-                writeLimit);
+                writeLimit, true);
+    }
+
+    public MemoryRecordsBuilder(ByteBuffer buffer,
+                                byte magic,
+                                CompressionType compressionType,
+                                TimestampType timestampType,
+                                long baseOffset,
+                                long logAppendTime,
+                                long producerId,
+                                short producerEpoch,
+                                int baseSequence,
+                                boolean isTransactional,
+                                boolean isControlBatch,
+                                int partitionLeaderEpoch,
+                                int writeLimit,
+                                boolean enableBatchingInPassthrough) {
+        this(new ByteBufferOutputStream(buffer), magic, compressionType, timestampType, baseOffset, logAppendTime,
+                producerId, producerEpoch, baseSequence, isTransactional, isControlBatch, partitionLeaderEpoch,
+                writeLimit, enableBatchingInPassthrough);
     }
 
     public ByteBuffer buffer() {
@@ -792,8 +868,13 @@ public class MemoryRecordsBuilder {
 
         // For passthrough V2, ensure one producerBatch only has one DefaultRecordBatch, and since
         // in this case, DefaultRecordBatch is the value part of a DefaultRecord, so we only allow one record
-        if (magic >= RecordBatch.MAGIC_VALUE_V2 && usePassthrough)
+        // For passthrough V1, ideally we can append multiple passthrough records to the same batch, it
+        // will not work when we are migrating from V1 to V2 message format as we cannot append V1 and V2 messages
+        // in the same batch.
+        // If enableBatchingInPassthrough is false, turn off batching in passthrough mode.
+        if (usePassthrough && !enableBatchingInPassthrough) {
             return false;
+        }
 
         final int recordSize;
         if (magic < RecordBatch.MAGIC_VALUE_V2) {

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -792,8 +792,12 @@ public class MemoryRecordsBuilder {
 
         // For passthrough V2, ensure one producerBatch only has one DefaultRecordBatch, and since
         // in this case, DefaultRecordBatch is the value part of a DefaultRecord, so we only allow one record
-        if (magic >= RecordBatch.MAGIC_VALUE_V2 && usePassthrough)
+        // For passthrough V1, ideally we can append multiple passthrough records to the same batch, it
+        // will not work when we are migrating from V1 to V2 message format as we cannot append V1 and V2 messages
+        // in the same batch.
+        if (usePassthrough) {
             return false;
+        }
 
         final int recordSize;
         if (magic < RecordBatch.MAGIC_VALUE_V2) {

--- a/core/src/main/scala/kafka/consumer/BaseConsumerRecord.scala
+++ b/core/src/main/scala/kafka/consumer/BaseConsumerRecord.scala
@@ -30,4 +30,5 @@ case class BaseConsumerRecord(topic: String,
                               timestampType: TimestampType = TimestampType.NO_TIMESTAMP_TYPE,
                               key: Array[Byte],
                               value: Array[Byte],
-                              headers: Headers = new RecordHeaders())
+                              headers: Headers = new RecordHeaders(),
+                              magic: Byte = -1)

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -28,13 +28,15 @@ import joptsimple.OptionParser
 import kafka.consumer.BaseConsumerRecord
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils.{CommandLineUtils, CoreUtils, Logging, Whitelist}
-import org.apache.kafka.clients.consumer.{CommitFailedException, Consumer, ConsumerConfig, ConsumerRebalanceListener, ConsumerRecord, KafkaConsumer, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer.{CommitFailedException, Consumer, ConsumerConfig, ConsumerRebalanceListener, ConsumerRecord, KafkaConsumer, OffsetAndMetadata, PassThroughConsumerRecord}
 import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.errors.WakeupException
+import org.apache.kafka.common.header.Headers
+import org.apache.kafka.common.header.internals.{RecordHeader, RecordHeaders}
 import org.apache.kafka.common.record.RecordBatch
 
 import scala.collection.JavaConverters._
@@ -69,6 +71,22 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
   private var offsetCommitIntervalMs = 0
   private var abortOnSendFailure: Boolean = true
   @volatile private var exitingOnSendFailure: Boolean = false
+  private var passThroughEnabled: Boolean = false
+  private val PASS_THROUGH_MAGIC_VALUE = "__passThroughMagicValue";
+
+  val recordHeadersV1: Headers = {
+    val magicValueV1 = Array[Byte] {
+      RecordBatch.MAGIC_VALUE_V1
+    }
+    new RecordHeaders().add(new RecordHeader(PASS_THROUGH_MAGIC_VALUE, magicValueV1))
+  }
+
+  val recordHeadersV2: Headers = {
+    val magicValueV2 = Array[Byte] {
+      RecordBatch.MAGIC_VALUE_V2
+    }
+    new RecordHeaders().add(new RecordHeader(PASS_THROUGH_MAGIC_VALUE, magicValueV2))
+  }
 
   // If a message send failed after retries are exhausted. The offset of the messages will also be removed from
   // the unacked offset list to avoid offset commit being stuck on that offset. In this case, the offset of that
@@ -214,6 +232,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       producerProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
       producerProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
       if (options.has(passthroughCompressionOpt)) {
+        passThroughEnabled = true
         consumerProps.setProperty("enable.shallow.iterator", "true")
         producerProps.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "passthrough")
       }
@@ -253,7 +272,11 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
           else
             CoreUtils.createObject[MirrorMakerMessageHandler](customMessageHandlerClass)
         } else {
-          defaultMirrorMakerMessageHandler
+          if (passThroughEnabled) {
+              passThroughMirrorMakerMessageHandler
+          } else  {
+              defaultMirrorMakerMessageHandler
+          }
         }
       }
     } catch {
@@ -362,6 +385,17 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
         record.value,
         record.headers)
 
+    private def toBaseConsumerRecordWithPassThrough(record: PassThroughConsumerRecord[Array[Byte], Array[Byte]]): BaseConsumerRecord =
+      BaseConsumerRecord(record.topic,
+        record.partition,
+        record.offset,
+        record.timestamp,
+        record.timestampType,
+        record.key,
+        record.value,
+        record.headers,
+        record.magic)
+
     override def run() {
       info("Starting mirror maker thread " + threadName)
       try {
@@ -377,7 +411,13 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
               } else {
                 trace("Sending message with null value and offset %d.".format(data.offset))
               }
-              val records = messageHandler.handle(toBaseConsumerRecord(data))
+              val records = {
+                if (passThroughEnabled) {
+                  messageHandler.handle(toBaseConsumerRecordWithPassThrough(data.asInstanceOf[PassThroughConsumerRecord[Array[Byte], Array[Byte]]]))
+                } else {
+                  messageHandler.handle(toBaseConsumerRecord(data))
+                }
+              }
               records.asScala.foreach(producer.send)
               maybeFlushAndCommitOffsets()
             }
@@ -584,6 +624,20 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
     override def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]] = {
       val timestamp: java.lang.Long = if (record.timestamp == RecordBatch.NO_TIMESTAMP) null else record.timestamp
       Collections.singletonList(new ProducerRecord(record.topic, null, timestamp, record.key, record.value, record.headers))
+    }
+  }
+
+  private[tools] object passThroughMirrorMakerMessageHandler extends MirrorMakerMessageHandler {
+    override def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]] = {
+      val timestamp: java.lang.Long = if (record.timestamp == RecordBatch.NO_TIMESTAMP) null else record.timestamp
+      // It is assumed that we don't have message format V0 anymore at Linkedin
+      if (record.magic.equals(RecordBatch.MAGIC_VALUE_V1)) {
+        Collections.singletonList(new ProducerRecord(record.topic, null, timestamp, record.key, record.value, recordHeadersV1))
+      } else if (record.magic.equals(RecordBatch.MAGIC_VALUE_V2)) {
+        Collections.singletonList(new ProducerRecord(record.topic, null, timestamp, record.key, record.value, recordHeadersV2))
+      } else {
+        throw new IllegalArgumentException("Record Batch with magic value : " + record.magic + ", is not supported in PassThrough mode")
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -633,8 +633,10 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       // It is assumed that we don't have message format V0 anymore at Linkedin
       if (record.magic.equals(RecordBatch.MAGIC_VALUE_V1)) {
         Collections.singletonList(new ProducerRecord(record.topic, null, timestamp, record.key, record.value, recordHeadersV1))
-      } else {
+      } else if (record.magic.equals(RecordBatch.MAGIC_VALUE_V2)) {
         Collections.singletonList(new ProducerRecord(record.topic, null, timestamp, record.key, record.value, recordHeadersV2))
+      } else {
+        throw new IllegalArgumentException("Record Batch with magic value : " + record.magic + ", is not supported in PassThrough mode")
       }
     }
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -83,7 +83,7 @@ versions += [
   snappy: "1.1.7.2",
   zkclient: "0.10",
   zookeeper: "3.4.13",
-  conscrypt: "2.2.1"
+  conscrypt: "2.1.0"
 ]
 
 libs += [
@@ -141,5 +141,5 @@ libs += [
   zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper",
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
   mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
-  conscrypt: "org.conscrypt:conscrypt-openjdk-uber:$versions.conscrypt"
+  conscrypt: "org.conscrypt:conscrypt-openjdk:$versions.conscrypt:" + osdetector.classifier
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -83,7 +83,7 @@ versions += [
   snappy: "1.1.7.2",
   zkclient: "0.10",
   zookeeper: "3.4.13",
-  conscrypt: "2.1.0"
+  conscrypt: "2.2.1"
 ]
 
 libs += [
@@ -141,5 +141,5 @@ libs += [
   zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper",
   jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
   mavenArtifact: "org.apache.maven:maven-artifact:$versions.mavenArtifact",
-  conscrypt: "org.conscrypt:conscrypt-openjdk:$versions.conscrypt:" + osdetector.classifier
+  conscrypt: "org.conscrypt:conscrypt-openjdk-uber:$versions.conscrypt"
 ]


### PR DESCRIPTION
This is to add back PR #70 https://github.com/linkedin/kafka/pull/70 to make mirroring work with mixed message format. (V1 at source and V2 at destination.)

With a config `enableBatchingInPassthrough` to turn off batching during mixed msg format and turn on batching when source and destination clusters are in same format. 

Background: we are doing message format bump version bump in kafka clusters. And for BMM-passthrough enabled clusters, we need this PR so the bump can work with mixed message format versions. PR #70 was added and reverted due to performance issues in BMM after deployment. We decide to add back the patch, test in BMM cert environment to verify if it is the non-batching that caused the performance downgrade and see how to move forward from this condition. 

And here is our testing plan:

1. PR commit with enableBatchingInPassthrough == true. So batching is still enabled, and we test performance with source and destination both in V1. 
2. Upgrade destination cluster to V2 and test performance. Should be the same as step 1 and works fine.
3. Set enableBatchingInPassthrough to false to turn off batching. Upgrade source cluster to V2.
4. If all good, (performance is expected to be low in step 3 because we turned off batching in mixed msg format time). We set it to false again to enable batching and see how the V2->V2 is working. (Wait a while and make sure no more V1 messages after step 3.)
