### PR TITLE
[LI-HOTFIX] Ignore the failed test ClusterConnectionStatesTest#testMu…

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ClusterConnectionStatesTest {
@@ -264,6 +265,7 @@ public class ClusterConnectionStatesTest {
         assertSame(currAddress, connectionStates.currentAddress(nodeId1));
     }
 
+    @Ignore
     @Test
     public void testMultipleIPsWithUseAll() throws UnknownHostException {
         assertTrue(ClientUtils.resolve(hostTwoIps, ClientDnsLookup.USE_ALL_DNS_IPS).size() > 1);


### PR DESCRIPTION
…ltipleIPsWithUseAll

TICKET = N/A
LI_DESCRIPTION = The test fails since the domain kafka.apache.org used to return 3 IPs and is now
only returning 2 IPs. Furthermore, the upstream fix identified below cannot be cleanly cherry
picked.
EXIT_CRITERIA = when the following commit 131d4753cf is picked from upstream:
KAFKA-12193: Re-resolve IPs after a client disconnects #9902

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
