### PR TITLE
[LI-HOTFIX] Clearing the ZkReplicaStateMachine request batch state up…

### DIFF
--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -97,7 +97,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
                             stateChangeLogger: StateChangeLogger,
                             controllerContext: ControllerContext,
                             zkClient: KafkaZkClient,
-                            controllerBrokerRequestBatch: ControllerBrokerRequestBatch)
+                            val controllerBrokerRequestBatch: ControllerBrokerRequestBatch)
   extends ReplicaStateMachine(controllerContext) with Logging {
 
   private val controllerId = config.brokerId
@@ -114,6 +114,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
       } catch {
         case e: ControllerMovedException =>
           error(s"Controller moved to another broker when moving some replicas to $targetState state", e)
+          reset()
           throw e
         case e: Throwable => error(s"Error while moving some replicas to $targetState state", e)
       }
@@ -431,6 +432,16 @@ class ZkReplicaStateMachine(config: KafkaConfig,
     stateChangeLogger.withControllerEpoch(controllerContext.epoch)
       .error(s"Controller $controllerId epoch ${controllerContext.epoch} initiated state change of replica ${replica.replica} " +
         s"for partition ${replica.topicPartition} from $currState to $targetState failed", t)
+  }
+
+
+  private def reset(): Unit = {
+    controllerBrokerRequestBatch.clear()
+  }
+
+  override def shutdown(): Unit = {
+    reset()
+    super.shutdown()
   }
 }
 

--- a/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
@@ -25,6 +25,7 @@ import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.log4j.Logger
 import org.junit.{After, Test}
@@ -94,5 +95,51 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
       }
     }, "Failed to find controller")
 
+  }
+
+  @Test
+  def testTopicDeletionOnResignedController(): Unit = {
+    val initialController = servers.find(_.kafkaController.isActive).map(_.kafkaController).getOrElse {
+      fail("Could not find controller")
+    }
+    val initialEpoch = initialController.epoch
+
+    createTopic(topic, 1, 1)
+
+    // halt the initial controller so that it won't detect a controllership switch
+    val latch = new CountDownLatch(1)
+    val haltControllerEvent = new MockEvent(ControllerState.BrokerChange) {
+      override def process(): Unit = {
+        latch.await()
+      }
+    }
+    initialController.eventManager.put(haltControllerEvent)
+
+    // delete the controller znode so that a new controller can be elected
+    zkClient.deleteController(initialController.controllerContext.epochZkVersion)
+    // wait until a new controller has been elected
+    TestUtils.waitUntilTrue(() => {
+      servers.exists { server =>
+        server.kafkaController.isActive && server.kafkaController.epoch > initialEpoch
+      }
+    }, "Failed to find controller")
+
+    // enqueue a topic for deletion, and verify that the ControllerMovedException will be triggered
+    var receivedControllerMovedException = false
+    try {
+      initialController.topicDeletionManager.enqueueTopicsForDeletion(Set(topic))
+    } catch {
+      case _: ControllerMovedException => {
+        receivedControllerMovedException = true
+      }
+    }
+    assertTrue("The ControllerMovedException is never received", receivedControllerMovedException)
+    latch.countDown()
+
+    // verify that the replicaStateMachine's controllerBrokerRequestBatch is empty
+    val controllerBrokerRequestBatch = initialController.replicaStateMachine.asInstanceOf[ZkReplicaStateMachine].controllerBrokerRequestBatch
+    assertTrue(controllerBrokerRequestBatch.stopReplicaRequestMap.isEmpty)
+    assertTrue(controllerBrokerRequestBatch.updateMetadataRequestPartitionInfoMap.isEmpty)
+    assertTrue(controllerBrokerRequestBatch.leaderAndIsrRequestMap.isEmpty)
   }
 }


### PR DESCRIPTION
…on ControllerMovedException

TICKET = KAFKA-12315
LI_DESCRIPTION = Clearing the ZkReplicaStateMachine request batch state upon
ControllerMovedException so that when a node becomes the controller again, it
has a clean state and can operate normally. More details can be found at
KAFKA-12315.

EXIT_CRITERIA = When KAFKA-12315 is resolved and the commit is pulled in from upstream

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
