### PR TITLE
[LI-HOTFIX] Add broker info log when getting UNKNOWN_TOPIC_OR_PARTITION error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
@@ -81,7 +81,8 @@ public class ManualMetadataUpdater implements MetadataUpdater {
     }
 
     @Override
-    public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse response) {
+    public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse response,
+        String destination) {
         // Do nothing
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -76,7 +76,8 @@ public interface MetadataUpdater extends Closeable {
      * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
      * requests with special handling for completed receives of such requests.
      */
-    void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse);
+    void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse,
+        String destination);
 
     /**
      * Schedules an update of the current cluster metadata info. A subsequent call to `maybeUpdate` would trigger the

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -854,7 +854,7 @@ public class NetworkClient implements KafkaClient {
                     parseResponse(req.header.apiKey(), responseStruct, req.header.apiVersion());
             maybeThrottle(body, req.header.apiVersion(), req.destination, now);
             if (req.isInternalRequest && body instanceof MetadataResponse)
-                metadataUpdater.handleCompletedMetadataResponse(req.header, now, (MetadataResponse) body);
+                metadataUpdater.handleCompletedMetadataResponse(req.header, now, (MetadataResponse) body, req.destination);
             else if (req.isInternalRequest && body instanceof ApiVersionsResponse)
                 handleApiVersionsResponse(responses, req, now, (ApiVersionsResponse) body);
             else
@@ -1047,7 +1047,7 @@ public class NetworkClient implements KafkaClient {
         }
 
         @Override
-        public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse response) {
+        public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse response, String destination) {
             // If any partition has leader with missing listeners, log up to ten of these partitions
             // for diagnosing broker configuration issues.
             // This could be a transient issue if listeners were added dynamically to brokers.
@@ -1065,7 +1065,8 @@ public class NetworkClient implements KafkaClient {
             // Check if any topic's metadata failed to get updated
             Map<String, Errors> errors = response.errors();
             if (!errors.isEmpty())
-                log.warn("Error while fetching metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
+                log.warn("Error while fetching metadata with from source {} with correlation id {} : {}", destination,
+                    requestHeader.correlationId(), errors);
 
             // Don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being
             // created which means we will get errors and no nodes until it exists

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -110,7 +110,8 @@ public class AdminMetadataManager {
         }
 
         @Override
-        public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse) {
+        public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse,
+            String destination) {
             // Do nothing
         }
 


### PR DESCRIPTION
Description: backporting the [fix](https://github.com/linkedin/kafka/pull/112) to add additional logs in NetworkClient for broker metadata info like leader id and epoch during metadata fetch failure with UNKNOWN_TOPIC_OR_PARTITION error. This helps debug Venice issue outlined here: https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-33540
Testing: N/A, since this is log only.