### PR TITLE
[LI-HOTFIX] Event based fetcher part 2/3: adding the FetcherEventBus and FetcherEventManager 

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractAsyncFetcher.scala
+++ b/core/src/main/scala/kafka/server/AbstractAsyncFetcher.scala
@@ -29,12 +29,12 @@ import kafka.metrics.KafkaMetricsGroup
 import kafka.server.AbstractFetcherThread.ResultWithPartitions
 import kafka.utils.{DelayedItem, Logging, Pool}
 import org.apache.kafka.common.errors._
-import org.apache.kafka.common.internals.PartitionStates
+import org.apache.kafka.common.internals.{KafkaFutureImpl, PartitionStates}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.{FileRecords, MemoryRecords, Records}
 import org.apache.kafka.common.requests.EpochEndOffset._
 import org.apache.kafka.common.requests.{EpochEndOffset, FetchRequest, FetchResponse, OffsetsForLeaderEpochRequest}
-import org.apache.kafka.common.{InvalidRecordException, KafkaFuture, TopicPartition}
+import org.apache.kafka.common.{InvalidRecordException, TopicPartition}
 
 import scala.collection.JavaConverters._
 import scala.collection.{Map, Seq, Set, mutable}
@@ -51,17 +51,17 @@ sealed trait FetcherEvent extends Comparable[FetcherEvent] {
 }
 
 // TODO: merge the AddPartitions and RemovePartitions into a single event
-case class AddPartitions(initialFetchStates: Map[TopicPartition, OffsetAndEpoch], future: KafkaFuture[Void]) extends FetcherEvent {
+case class AddPartitions(initialFetchStates: Map[TopicPartition, OffsetAndEpoch], future: KafkaFutureImpl[Void]) extends FetcherEvent {
   override def priority = 2
   override def state = FetcherState.AddPartitions
 }
 
-case class RemovePartitions(topicPartitions: Set[TopicPartition], future: KafkaFuture[Void]) extends FetcherEvent {
+case class RemovePartitions(topicPartitions: Set[TopicPartition], future: KafkaFutureImpl[Void]) extends FetcherEvent {
   override def priority = 2
   override def state = FetcherState.RemovePartitions
 }
 
-case class GetPartitionCount(future: KafkaFuture[Int]) extends FetcherEvent {
+case class GetPartitionCount(future: KafkaFutureImpl[Int]) extends FetcherEvent {
   override def priority = 2
   override def state = FetcherState.GetPartitionCount
 }

--- a/core/src/main/scala/kafka/server/AbstractAsyncFetcher.scala
+++ b/core/src/main/scala/kafka/server/AbstractAsyncFetcher.scala
@@ -46,7 +46,7 @@ sealed trait FetcherEvent extends Comparable[FetcherEvent] {
   def state: FetcherState
   override def compareTo(other: FetcherEvent): Int = {
     // an event with a higher proirity value should be dequeued first in a PriorityQueue
-    other.priority - this.priority
+    other.priority.compareTo(this.priority)
   }
 }
 

--- a/core/src/main/scala/kafka/server/FetcherEventBus.scala
+++ b/core/src/main/scala/kafka/server/FetcherEventBus.scala
@@ -8,6 +8,14 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import scala.util.control.Breaks.{break, breakable}
 
+/**
+ * The FetcherEventBus supports queued events and delayed events.
+ * Queued events are inserted via the {@link #put} method, and delayed events
+ * are inserted via the {@link #schedule} method.
+ * Events are polled via the {@link #getNextEvent} method, which returns
+ * either a queued event or a scheduled event.
+ * @param time
+ */
 class FetcherEventBus(time: Time) {
   private val eventLock = new ReentrantLock()
   private val newEventCondition = eventLock.newCondition()

--- a/core/src/main/scala/kafka/server/FetcherEventBus.scala
+++ b/core/src/main/scala/kafka/server/FetcherEventBus.scala
@@ -1,0 +1,83 @@
+package kafka.server
+
+import kafka.utils.CoreUtils.inLock
+import org.apache.kafka.common.utils.Time
+
+import java.util.PriorityQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import scala.util.control.Breaks.{break, breakable}
+
+class FetcherEventBus(time: Time) {
+  private val eventLock = new ReentrantLock()
+  private val newEventCondition = eventLock.newCondition()
+
+  private val queue = new PriorityQueue[QueuedFetcherEvent]
+  private val scheduler = new SimpleScheduler[DelayedFetcherEvent]
+  @volatile private var shutdownInitialized = false
+
+  def size() = {
+    queue.size()
+  }
+
+  /**
+   * close should be called in a thread different from the one calling getNextEvent()
+   */
+  def close(): Unit = {
+    shutdownInitialized = true
+    inLock(eventLock) {
+      newEventCondition.signalAll()
+    }
+  }
+
+  def put(event: FetcherEvent): Unit = {
+    inLock(eventLock) {
+      queue.add(new QueuedFetcherEvent(event, time.milliseconds()))
+      newEventCondition.signalAll()
+    }
+  }
+
+  def schedule(delayedEvent: DelayedFetcherEvent): Unit = {
+    inLock(eventLock) {
+      scheduler.schedule(delayedEvent)
+      newEventCondition.signalAll()
+    }
+  }
+
+  /**
+   * There are 3 cases when the getNextEvent() method is called
+   * 1. There is at least one delayed event that has become current. If so, we return the delayed event with the earliest
+   * due time.
+   * 2. There is at least one event in the queue. If so, we return the event with the highest priority from the queue.
+   * 3. There are neither delayed events that have become current, nor queued events. We block until the earliest delayed
+   * event becomes current. A special case is that there are no delayed events at all, under which we would block
+   * indefinitely until being explicitly waken up by a new delayed or queued event.
+   *
+   * @return Either a QueuedFetcherEvent or a DelayedFetcherEvent that has become current. A special case is that the
+   *         FetcherEventBus is shutdown before an event can be polled, under which null will be returned.
+   */
+  def getNextEvent(): Either[QueuedFetcherEvent, DelayedFetcherEvent] = {
+    inLock(eventLock) {
+      var result : Either[QueuedFetcherEvent, DelayedFetcherEvent] = null
+
+      breakable {
+        while (!shutdownInitialized) {
+          val (delayedFetcherEvent, delayMs) = scheduler.peek()
+          if (delayedFetcherEvent.nonEmpty) {
+            scheduler.poll()
+            result = Right(delayedFetcherEvent.get)
+            break
+          } else if (!queue.isEmpty) {
+            result = Left(queue.poll())
+            break
+          } else {
+            newEventCondition.await(delayMs, TimeUnit.MILLISECONDS)
+          }
+        }
+      }
+
+      result
+    }
+  }
+
+}

--- a/core/src/main/scala/kafka/server/FetcherEventManager.scala
+++ b/core/src/main/scala/kafka/server/FetcherEventManager.scala
@@ -82,7 +82,14 @@ class SimpleScheduler[T <: DelayedItem] {
   }
 }
 
-// TODO: add locks to the addPartitions, removePartitions, getPartitionsCount methods
+/**
+ * The FetcherEventManager can spawn a FetcherEventThread, whose main job is to take events from a
+ * FetcherEventBus and executes them in a FetcherEventProcessor.
+ * @param name
+ * @param fetcherEventBus
+ * @param processor
+ * @param time
+ */
 class FetcherEventManager(name: String,
                           fetcherEventBus: FetcherEventBus,
                           processor: FetcherEventProcessor,

--- a/core/src/main/scala/kafka/server/FetcherEventManager.scala
+++ b/core/src/main/scala/kafka/server/FetcherEventManager.scala
@@ -1,0 +1,199 @@
+package kafka.server
+
+
+import com.yammer.metrics.core.Gauge
+import kafka.cluster.BrokerEndPoint
+import kafka.metrics.{KafkaMetricsGroup, KafkaTimer}
+import kafka.utils.CoreUtils.inLock
+import kafka.utils.{DelayedItem, ShutdownableThread}
+import org.apache.kafka.common.internals.KafkaFutureImpl
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{KafkaFuture, TopicPartition}
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import java.util.{Comparator, PriorityQueue}
+import scala.collection.{Map, Set}
+import scala.util.control.Breaks.break
+
+trait FetcherEventProcessor {
+  def process(event: FetcherEvent)
+  def fetcherStats: AsyncFetcherStats
+  def fetcherLagStats : AsyncFetcherLagStats
+  def sourceBroker: BrokerEndPoint
+  def close(): Unit
+}
+
+
+class QueuedFetcherEvent(val event: FetcherEvent,
+                         val enqueueTimeMs: Long) extends Comparable[QueuedFetcherEvent] {
+  override def compareTo(other: QueuedFetcherEvent): Int = event.compareTo(other.event)
+}
+
+object FetcherEventManager {
+  val EventQueueTimeMetricName = "EventQueueTimeMs"
+  val EventQueueSizeMetricName = "EventQueueSize"
+}
+
+/**
+ * The SimpleScheduler is not thread safe
+ */
+class SimpleScheduler[T <: DelayedItem] {
+  private val delayedQueue = new PriorityQueue[T](new Comparator[T]() {
+    override def compare(t1: T, t2: T): Int = {
+      // here we use natural ordering so that events with the earliest due time can be checked first
+      t1.compareTo(t2)
+    }
+  })
+
+  def schedule(item: T) : Unit = {
+    delayedQueue.add(item)
+  }
+
+  /**
+   * peek can be used to get the earliest item that has become current.
+   * There are 3 cases when peek() is called
+   * 1. There are no items whatsoever.  peek would return (None, Long.MaxValue) to indicate that the caller needs to wait
+   *    indefinitely until an item is inserted.
+   * 2. There are items, and yet none has become current. peek would return (None, delay) where delay represents
+   *    the time to wait before the earliest item becomes current.
+   * 3. Some item has become current. peek would return (Some(item), 0L)
+   */
+  def peek(): (Option[T], Long) = {
+    if (delayedQueue.isEmpty) {
+      (None, Long.MaxValue)
+    } else {
+      val delayedEvent = delayedQueue.peek()
+      val delayMs = delayedEvent.getDelay(TimeUnit.MILLISECONDS)
+      if (delayMs == 0) {
+        (Some(delayedQueue.peek()), 0L)
+      } else {
+        (None, delayMs)
+      }
+    }
+  }
+
+  /**
+   * poll() unconditionally removes the earliest item
+   * If there are no items, poll() has no effect.
+   */
+  def poll(): Unit = {
+    delayedQueue.poll()
+  }
+}
+
+// TODO: add locks to the addPartitions, removePartitions, getPartitionsCount methods
+class FetcherEventManager(name: String,
+                          fetcherEventBus: FetcherEventBus,
+                          processor: FetcherEventProcessor,
+                          time: Time) extends KafkaMetricsGroup {
+
+  import FetcherEventManager._
+
+  val rateAndTimeMetrics: Map[FetcherState, KafkaTimer] = FetcherState.values.flatMap { state =>
+    state.rateAndTimeMetricName.map { metricName =>
+      state -> new KafkaTimer(newTimer(metricName, TimeUnit.MILLISECONDS, TimeUnit.SECONDS))
+    }
+  }.toMap
+
+  @volatile private var _state: FetcherState = FetcherState.Idle
+  private[server] val thread = new FetcherEventThread(name)
+
+  def fetcherStats: AsyncFetcherStats = processor.fetcherStats
+  def fetcherLagStats : AsyncFetcherLagStats = processor.fetcherLagStats
+  def sourceBroker: BrokerEndPoint = processor.sourceBroker
+  def isThreadFailed: Boolean = thread.isThreadFailed
+
+  private val eventQueueTimeHist = newHistogram(EventQueueTimeMetricName)
+
+  newGauge(
+    EventQueueSizeMetricName,
+    new Gauge[Int] {
+      def value: Int = {
+        fetcherEventBus.size()
+      }
+    }
+  )
+
+  def state: FetcherState = _state
+
+  def start(): Unit = {
+    fetcherEventBus.put(TruncateAndFetch)
+    thread.start()
+  }
+
+  def addPartitions(initialFetchStates: Map[TopicPartition, OffsetAndEpoch]): KafkaFuture[Void] = {
+    val future = new KafkaFutureImpl[Void] {}
+    fetcherEventBus.put(AddPartitions(initialFetchStates, future))
+    future
+  }
+
+  def removePartitions(topicPartitions: Set[TopicPartition]): KafkaFuture[Void] = {
+    val future = new KafkaFutureImpl[Void] {}
+    fetcherEventBus.put(RemovePartitions(topicPartitions, future))
+    future
+  }
+
+  def getPartitionsCount(): KafkaFuture[Int] = {
+    val future = new KafkaFutureImpl[Int]{}
+    fetcherEventBus.put(GetPartitionCount(future))
+    future
+  }
+
+  def close(): Unit = {
+    try {
+      thread.initiateShutdown()
+      fetcherEventBus.close()
+      thread.awaitShutdown()
+    } finally {
+      removeMetric(EventQueueTimeMetricName)
+      removeMetric(EventQueueSizeMetricName)
+    }
+
+    processor.close()
+  }
+
+
+  class FetcherEventThread(name: String) extends ShutdownableThread(name = name, isInterruptible = false) {
+    logIdent = s"[FetcherEventThread fetcherId=$name] "
+
+
+    /**
+     * This method is repeatedly invoked until the thread shuts down or this method throws an exception
+     */
+    override def doWork(): Unit = {
+      val nextEvent = fetcherEventBus.getNextEvent()
+      if (nextEvent == null) {
+        // a null value will be returned when the fetcherEventBus has started shutting down
+        return
+      }
+
+      val (fetcherEvent, optionalEnqueueTime) = nextEvent match {
+        case Left(dequeued: QueuedFetcherEvent) =>
+          (dequeued.event, Some(dequeued.enqueueTimeMs))
+
+        case Right(delayedFetcherEvent: DelayedFetcherEvent) => {
+          (delayedFetcherEvent.fetcherEvent, None)
+        }
+      }
+
+      _state = fetcherEvent.state
+      optionalEnqueueTime match {
+        case Some(enqueueTimeMs) => {
+          eventQueueTimeHist.update(time.milliseconds() - enqueueTimeMs)
+        }
+        case None =>
+      }
+
+      try {
+        rateAndTimeMetrics(state).time {
+          processor.process(fetcherEvent)
+        }
+      } catch {
+        case e: Exception => error(s"Uncaught error processing event $fetcherEvent", e)
+      }
+
+      _state = FetcherState.Idle
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/FetcherEventManager.scala
+++ b/core/src/main/scala/kafka/server/FetcherEventManager.scala
@@ -136,7 +136,7 @@ class FetcherEventManager(name: String,
 
       try {
         rateAndTimeMetrics(state).time {
-          processor.process(nextEvent.event)
+          processor.process(fetcherEvent)
         }
       } catch {
         case e: Exception => error(s"Uncaught error processing event $fetcherEvent", e)

--- a/core/src/main/scala/kafka/server/FetcherState.scala
+++ b/core/src/main/scala/kafka/server/FetcherState.scala
@@ -1,0 +1,35 @@
+package kafka.server
+
+sealed abstract class FetcherState {
+  def value: Byte
+
+  def rateAndTimeMetricName: Option[String] =
+    if (hasRateAndTimeMetric) Some(s"${toString}RateAndTimeMs") else None
+
+  protected def hasRateAndTimeMetric: Boolean = true
+}
+
+object FetcherState {
+  case object Idle extends FetcherState {
+    def value = 0
+    override protected def hasRateAndTimeMetric: Boolean = false
+  }
+
+  case object AddPartitions extends FetcherState {
+    def value = 1
+  }
+
+  case object RemovePartitions extends FetcherState {
+    def value = 2
+  }
+
+  case object GetPartitionCount extends FetcherState {
+    def value = 3
+  }
+
+  case object TruncateAndFetch extends FetcherState {
+    def value = 4
+  }
+
+  val values: Seq[FetcherState] = Seq(Idle, AddPartitions, RemovePartitions, GetPartitionCount, TruncateAndFetch)
+}

--- a/core/src/test/scala/integration/kafka/server/FetcherEventManagerTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetcherEventManagerTest.scala
@@ -2,6 +2,7 @@ package integration.kafka.server
 
 import kafka.cluster.BrokerEndPoint
 import kafka.server._
+import org.apache.kafka.common.internals.KafkaFutureImpl
 import org.apache.kafka.common.utils.Time
 import org.easymock.EasyMock.{createMock, expect, replay, verify}
 import org.junit.Assert.assertEquals
@@ -40,13 +41,13 @@ class FetcherEventManagerTest {
         event match {
           case AddPartitions(initialFetchStates, future) =>
             addPartitionsProcessed += 1
-            future.complete(null)
+            future.asInstanceOf[KafkaFutureImpl[Void]].complete(null)
           case RemovePartitions(topicPartitions, future) =>
             removePartitionsProcessed += 1
-            future.complete(null)
+            future.asInstanceOf[KafkaFutureImpl[Void]].complete(null)
           case GetPartitionCount(future) =>
             getPartitionsProcessed += 1
-            future.complete(1)
+            future.asInstanceOf[KafkaFutureImpl[Int]].complete(1)
           case TruncateAndFetch =>
             truncateAndFetchProcessed += 1
         }

--- a/core/src/test/scala/integration/kafka/server/FetcherEventManagerTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetcherEventManagerTest.scala
@@ -1,0 +1,82 @@
+package integration.kafka.server
+
+import kafka.cluster.BrokerEndPoint
+import kafka.server._
+import org.apache.kafka.common.utils.Time
+import org.easymock.EasyMock.{createMock, expect, replay, verify}
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FetcherEventManagerTest {
+
+  @Test
+  def testInitialState(): Unit = {
+    val time = Time.SYSTEM
+    val fetcherEventBus: FetcherEventBus = createMock(classOf[FetcherEventBus])
+    expect(fetcherEventBus.put(TruncateAndFetch)).andVoid()
+    expect(fetcherEventBus.close()).andVoid()
+    replay(fetcherEventBus)
+
+    val processor : FetcherEventProcessor = createMock(classOf[FetcherEventProcessor])
+    val fetcherEventManager = new FetcherEventManager("thread-1", fetcherEventBus, processor, time)
+
+    fetcherEventManager.start()
+    fetcherEventManager.close()
+
+    verify(fetcherEventBus)
+  }
+
+  @Test
+  def testEventExecution(): Unit = {
+    val time = Time.SYSTEM
+    val fetcherEventBus = new FetcherEventBus(time)
+
+    @volatile var addPartitionsProcessed = 0
+    @volatile var removePartitionsProcessed = 0
+    @volatile var getPartitionsProcessed = 0
+    @volatile var truncateAndFetchProcessed = 0
+    val processor : FetcherEventProcessor = new FetcherEventProcessor {
+      override def process(event: FetcherEvent): Unit = {
+        event match {
+          case AddPartitions(initialFetchStates, future) =>
+            addPartitionsProcessed += 1
+            future.complete(null)
+          case RemovePartitions(topicPartitions, future) =>
+            removePartitionsProcessed += 1
+            future.complete(null)
+          case GetPartitionCount(future) =>
+            getPartitionsProcessed += 1
+            future.complete(1)
+          case TruncateAndFetch =>
+            truncateAndFetchProcessed += 1
+        }
+
+      }
+
+      override def fetcherStats: AsyncFetcherStats = ???
+
+      override def fetcherLagStats: AsyncFetcherLagStats = ???
+
+      override def sourceBroker: BrokerEndPoint = ???
+
+      override def close(): Unit = {}
+    }
+
+    val fetcherEventManager = new FetcherEventManager("thread-1", fetcherEventBus, processor, time)
+    val addPartitionsFuture = fetcherEventManager.addPartitions(Map.empty)
+    val removePartitionsFuture = fetcherEventManager.removePartitions(Set.empty)
+    val getPartitionCountFuture = fetcherEventManager.getPartitionsCount()
+
+    fetcherEventManager.start()
+    addPartitionsFuture.get()
+    removePartitionsFuture.get()
+    getPartitionCountFuture.get()
+
+    assertEquals(1, addPartitionsProcessed)
+    assertEquals(1, removePartitionsProcessed)
+    assertEquals(1, getPartitionsProcessed)
+    fetcherEventManager.close()
+  }
+
+}
+

--- a/core/src/test/scala/unit/kafka/server/FetcherEventBusTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetcherEventBusTest.scala
@@ -71,6 +71,29 @@ class FetcherEventBusTest {
     assertEquals(expectedSequence, actualSequence)
   }
 
+  @Test
+  def testQueuedEventsWithSamePriority(): Unit = {
+    // Two queued events with the same priority should be polled
+    // according to their sequence numbers in a FIFO manner
+    val fetcherEventBus = new FetcherEventBus(new MockTime())
+
+    val task1 = AddPartitions(Map.empty, null)
+    fetcherEventBus.put(task1)
+
+    val task2 = AddPartitions(Map.empty, null)
+    fetcherEventBus.put(task2)
+
+    val expectedSequence = Seq(task1, task2)
+
+    val actualSequence = ArrayBuffer[FetcherEvent]()
+
+    for (_ <- 0 until 2) {
+      actualSequence += fetcherEventBus.getNextEvent().event
+    }
+
+    assertEquals(expectedSequence, actualSequence)
+  }
+
   class MockCondition extends Condition {
     override def await(): Unit = ???
 

--- a/core/src/test/scala/unit/kafka/server/FetcherEventBusTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetcherEventBusTest.scala
@@ -1,0 +1,182 @@
+package unit.kafka.server
+
+import kafka.server
+import kafka.server.{AddPartitions, DelayedFetcherEvent, FetcherEvent, FetcherEventBus, QueuedFetcherEvent, RemovePartitions, TruncateAndFetch}
+import kafka.utils.MockTime
+import org.apache.kafka.common.utils.Time
+import org.junit.Assert.{assertEquals, assertTrue, fail}
+import org.junit.Test
+
+import java.util.concurrent.{CountDownLatch, Executors}
+import scala.collection.Map
+import scala.collection.mutable.ArrayBuffer
+
+
+class FetcherEventBusTest {
+  @Test
+  def testGetWhileEmpty(): Unit = {
+    // test the getNextEvent method while the fetcherEventBus is empty
+    val fetcherEventBus = new FetcherEventBus(new MockTime())
+
+    val service = Executors.newSingleThreadExecutor()
+    @volatile var counter = 0
+    val runnableFinished = new CountDownLatch(1)
+    service.submit(new Runnable {
+      override def run(): Unit = {
+        // trying to call get will block indefinitely
+        fetcherEventBus.getNextEvent()
+        counter = 1
+        runnableFinished.countDown()
+      }
+    })
+
+    // sleep for 500ms, during which the runnable should still be blocked
+    Thread.sleep(500)
+    assertTrue(counter == 0)
+
+    // put a event to unblock the runnable
+    fetcherEventBus.put(AddPartitions(Map.empty, null))
+    service.shutdown()
+    runnableFinished.await()
+    assertTrue(counter == 1)
+  }
+
+  @Test
+  def testQueuedEvent(): Unit = {
+    val fetcherEventBus = new FetcherEventBus(new MockTime())
+    val addPartitions = AddPartitions(Map.empty, null)
+    fetcherEventBus.put(addPartitions)
+    fetcherEventBus.getNextEvent() match {
+      case Left(queuedFetcherEvent: QueuedFetcherEvent) =>
+        assertTrue(queuedFetcherEvent.event == addPartitions)
+      case Right(_) => fail("a QueuedFetcherEvent should have been returned")
+    }
+  }
+
+  @Test
+  def testQueuedEventsWithDifferentPriorities(): Unit = {
+    val fetcherEventBus = new FetcherEventBus(new MockTime())
+
+    val lowPriorityTask = TruncateAndFetch
+    fetcherEventBus.put(lowPriorityTask)
+
+    val highPriorityTask = AddPartitions(Map.empty, null)
+    fetcherEventBus.put(highPriorityTask)
+
+    val expectedSequence = Seq(highPriorityTask, lowPriorityTask)
+
+    val actualSequence = ArrayBuffer[FetcherEvent]()
+
+    for (_ <- 0 until 2) {
+      fetcherEventBus.getNextEvent() match {
+        case Left(queuedFetcherEvent: QueuedFetcherEvent) =>
+          actualSequence += queuedFetcherEvent.event
+        case Right(_) => fail("a QueuedFetcherEvent should have been returned")
+      }
+    }
+
+    assertEquals(expectedSequence, actualSequence)
+  }
+
+  @Test
+  def testDelayedEvent(): Unit = {
+    val time = Time.SYSTEM
+    val fetcherEventBus = new FetcherEventBus(time)
+    val addPartitions = AddPartitions(Map.empty, null)
+    val delay = 500
+    fetcherEventBus.schedule(new DelayedFetcherEvent(delay, addPartitions))
+
+    val service = Executors.newSingleThreadExecutor()
+
+    val t1 = time.milliseconds()
+    val future = service.submit(new Runnable {
+      override def run(): Unit = {
+        // trying to call get will block for at least 500ms
+        fetcherEventBus.getNextEvent() match {
+          case Left(_) => fail("a DelayedFetcherEvent should have been returned")
+          case Right(delayedFetcherEvent: DelayedFetcherEvent) => {
+            assertTrue(delayedFetcherEvent.fetcherEvent == addPartitions)
+          }
+        }
+        // verify that at least 500ms has passed
+
+        val t2 = time.milliseconds()
+        assertTrue(t2 - t1 >= delay)
+      }
+    })
+
+    future.get()
+    service.shutdown()
+  }
+
+  @Test
+  def testDelayedEventsWithDifferentDueTimes(): Unit = {
+    val time = Time.SYSTEM
+    val fetcherEventBus = new FetcherEventBus(time)
+    val secondTask = AddPartitions(Map.empty, null)
+    fetcherEventBus.schedule(new DelayedFetcherEvent(200, secondTask))
+
+    val firstTask = RemovePartitions(Set.empty, null)
+    fetcherEventBus.schedule(new DelayedFetcherEvent(100, firstTask))
+
+    val service = Executors.newSingleThreadExecutor()
+
+    val expectedSequence = Seq(firstTask, secondTask)
+
+    val actualSequence = ArrayBuffer[FetcherEvent]()
+    val future = service.submit(new Runnable {
+      override def run(): Unit = {
+        for (_ <- 0 until 2) {
+          fetcherEventBus.getNextEvent() match {
+            case Left(_) => fail("a DelayedFetcherEvent should have been returned")
+            case Right(delayedFetcherEvent: DelayedFetcherEvent) => {
+              actualSequence += delayedFetcherEvent.fetcherEvent
+            }
+          }
+        }
+      }
+    })
+
+    future.get()
+    assertEquals(expectedSequence, actualSequence)
+    service.shutdown()
+  }
+
+  @Test
+  def testBothDelayedAndQueuedEvent(): Unit = {
+    val time = Time.SYSTEM
+    val fetcherEventBus = new FetcherEventBus(time)
+
+    val queuedEvent = RemovePartitions(Set.empty, null)
+    fetcherEventBus.put(queuedEvent)
+
+    val delay = 10
+    val scheduledEvent = AddPartitions(Map.empty, null)
+    fetcherEventBus.schedule(new DelayedFetcherEvent(delay, scheduledEvent))
+
+    val service = Executors.newSingleThreadExecutor()
+
+    @volatile var receivedEvents = 0
+    val expectedEvents = 2
+    val future = service.submit(new Runnable {
+      override def run(): Unit = {
+        for (_ <- 0 until expectedEvents) {
+          fetcherEventBus.getNextEvent() match {
+            case Left(queuedFetcherEvent: QueuedFetcherEvent) => {
+              assertTrue(queuedFetcherEvent.event == queuedEvent)
+              receivedEvents += 1
+            }
+            case Right(delayedFetcherEvent: DelayedFetcherEvent) => {
+              assertTrue(delayedFetcherEvent.fetcherEvent == scheduledEvent)
+              receivedEvents += 1
+            }
+          }
+        }
+      }
+    })
+
+    future.get()
+    assertTrue(receivedEvents == expectedEvents)
+    service.shutdown()
+  }
+}


### PR DESCRIPTION
This PR adds the FetcherEventBus and FetcherEventManager to support the event-based processing model proposed in https://docs.google.com/document/d/1PZAOwpw09tVDeuSP0OBVhB6dbgz7C7dQU6bRkePQ8qg/edit#

The FetcherEventBus supports queued events and scheduled events with a delay.
The FetcherEventManager spawns a FetcherEventThread, which takes events from the FetcherEventBus and executes them into the FetcherEventProcessor (implemented via the AbstractAsyncFetcher).

This PR uses a single event TruncateAndFetch to model one iteration of the previous thread loop. This does not give the best latency for Add/Remove partition events. If the thread has just begun processing a TruncateAndFetch event when the Add/Remove partition event is enqueued, then the latter will need to wait potentially several network round-trips for the 
`OffsetsForLeaderEpochRequest` and one network round-trip for the `FetchRequest`. Besides, we haven't added a separate network thread yet. Nonetheless, this PR lays the async processing framework.
As future work, we may need to 
1. break the TruncateAndFetch into several sub-events
2. add a separate network thread
3. reduce the number of fetcher threads


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
