### PR TITLE
Allow customized client name passed to ApiVersionsRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -63,6 +63,9 @@ public class CommonClientConfigs {
     public static final String CLIENT_ID_CONFIG = "client.id";
     public static final String CLIENT_ID_DOC = "An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.";
 
+    public static final String CUSTOMIZED_CLIENT_NAME_CONFIG = "customized.client.name";
+    public static final String CUSTOMIZED_CLIENT_NAME_DOC = "A name string to indicate client type. The purpose of this is to be able to track/analyze clients type beyond just client id";
+
     public static final String CLIENT_RACK_CONFIG = "client.rack";
     public static final String CLIENT_RACK_DOC = "A rack identifier for this client. This can be any string value which indicates where this client is physically located. It corresponds with the broker config 'broker.rack'";
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -160,6 +160,9 @@ public class ConsumerConfig extends AbstractConfig {
      */
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
 
+    /** <code>customized.client.name</code> */
+    public static final String CUSTOMIZED_CLIENT_NAME_CONFIG = CommonClientConfigs.CUSTOMIZED_CLIENT_NAME_CONFIG;
+
     /**
      * <code>client.rack</code>
      */
@@ -345,6 +348,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         "",
                                         Importance.LOW,
                                         CommonClientConfigs.CLIENT_ID_DOC)
+                                .define(CUSTOMIZED_CLIENT_NAME_CONFIG,
+                                        Type.STRING,
+                                        "linkedin-kafka-oss-consumer-java",
+                                        Importance.LOW,
+                                        CommonClientConfigs.CUSTOMIZED_CLIENT_NAME_DOC)
                                 .define(CLIENT_RACK_CONFIG,
                                         Type.STRING,
                                         "",

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -761,7 +761,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     true,
                     apiVersions,
                     throttleTimeSensor,
-                    logContext);
+                    logContext,
+                    config.getString(ConsumerConfig.CUSTOMIZED_CLIENT_NAME_CONFIG));
             netClient.setEnableStickyMetadataFetch(config.getBoolean(CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_CONFIG));
             this.client = new ConsumerNetworkClient(
                     logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -469,7 +469,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 true,
                 apiVersions,
                 throttleTimeSensor,
-                logContext);
+                logContext,
+                producerConfig.getString(ProducerConfig.CUSTOMIZED_CLIENT_NAME_CONFIG));
         int retries = configureRetries(producerConfig, transactionManager != null, log);
         short acks = configureAcks(producerConfig, transactionManager != null, log);
         return new Sender(logContext,
@@ -930,7 +931,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             }
             RecordAccumulator.RecordAppendResult result = accumulator.append(tp, timestamp, serializedKey,
                     serializedValue, headers, interceptCallback, remainingWaitMs, true);
-            
+
             if (result.abortForNewBatch) {
                 int prevPartition = partition;
                 partitioner.onNewBatch(record.topic(), cluster, prevPartition);
@@ -945,7 +946,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 result = accumulator.append(tp, timestamp, serializedKey,
                     serializedValue, headers, interceptCallback, remainingWaitMs, false);
             }
-            
+
             if (transactionManager != null && transactionManager.isTransactional())
                 transactionManager.maybeAddPartitionToTransaction(tp);
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -130,6 +130,9 @@ public class ProducerConfig extends AbstractConfig {
     /** <code>client.id</code> */
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
 
+    /** <code>customized.client.name</code> */
+    public static final String CUSTOMIZED_CLIENT_NAME_CONFIG = CommonClientConfigs.CUSTOMIZED_CLIENT_NAME_CONFIG;
+
     /** <code>send.buffer.bytes</code> */
     public static final String SEND_BUFFER_CONFIG = CommonClientConfigs.SEND_BUFFER_CONFIG;
 
@@ -285,6 +288,7 @@ public class ProducerConfig extends AbstractConfig {
                                 .define(LINGER_MS_CONFIG, Type.LONG, 0, atLeast(0), Importance.MEDIUM, LINGER_MS_DOC)
                                 .define(DELIVERY_TIMEOUT_MS_CONFIG, Type.INT, Integer.MAX_VALUE, atLeast(0), Importance.MEDIUM, DELIVERY_TIMEOUT_MS_DOC)
                                 .define(CLIENT_ID_CONFIG, Type.STRING, "", Importance.MEDIUM, CommonClientConfigs.CLIENT_ID_DOC)
+                                .define(CUSTOMIZED_CLIENT_NAME_CONFIG, Type.STRING, "linkedin-kafka-oss-producer-java", Importance.LOW, CommonClientConfigs.CUSTOMIZED_CLIENT_NAME_DOC)
                                 .define(SEND_BUFFER_CONFIG, Type.INT, 128 * 1024, atLeast(CommonClientConfigs.SEND_BUFFER_LOWER_BOUND), Importance.MEDIUM, CommonClientConfigs.SEND_BUFFER_DOC)
                                 .define(RECEIVE_BUFFER_CONFIG, Type.INT, 32 * 1024, atLeast(CommonClientConfigs.RECEIVE_BUFFER_LOWER_BOUND), Importance.MEDIUM, CommonClientConfigs.RECEIVE_BUFFER_DOC)
                                 .define(MAX_REQUEST_SIZE_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -31,7 +31,8 @@ import java.nio.ByteBuffer;
 public class ApiVersionsRequest extends AbstractRequest {
 
     public static class Builder extends AbstractRequest.Builder<ApiVersionsRequest> {
-        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
+        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "linkedin-kafka-oss-java";
+        private static String customizedClientName = null;
 
         private static final ApiVersionsRequestData DATA = new ApiVersionsRequestData()
             .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
@@ -41,13 +42,30 @@ public class ApiVersionsRequest extends AbstractRequest {
             super(ApiKeys.API_VERSIONS);
         }
 
+        public Builder(String clientName) {
+            super(ApiKeys.API_VERSIONS);
+            customizedClientName = clientName;
+        }
+
         public Builder(short version) {
             super(ApiKeys.API_VERSIONS, version);
         }
 
+        public Builder(short version, String clientName) {
+            super(ApiKeys.API_VERSIONS, version);
+            customizedClientName = clientName;
+        }
+
         @Override
         public ApiVersionsRequest build(short version) {
-            return new ApiVersionsRequest(DATA, version);
+            if (customizedClientName == null) {
+                return new ApiVersionsRequest(DATA, version);
+            } else {
+                ApiVersionsRequestData customizedData = new ApiVersionsRequestData()
+                    .setClientSoftwareName(customizedClientName)
+                    .setClientSoftwareVersion(AppInfoParser.getVersion());
+                return new ApiVersionsRequest(customizedData, version);
+            }
         }
 
         @Override

--- a/core/src/main/scala/kafka/server/FetcherEventManager.scala
+++ b/core/src/main/scala/kafka/server/FetcherEventManager.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.server
 
 

--- a/core/src/main/scala/kafka/server/FetcherState.scala
+++ b/core/src/main/scala/kafka/server/FetcherState.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.server
 
 sealed abstract class FetcherState {

--- a/core/src/test/scala/integration/kafka/server/FetcherEventManagerTest.scala
+++ b/core/src/test/scala/integration/kafka/server/FetcherEventManagerTest.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package integration.kafka.server
 
 import kafka.cluster.BrokerEndPoint

--- a/core/src/test/scala/unit/kafka/server/FetcherEventBusTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetcherEventBusTest.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package unit.kafka.server
 
 import java.util.Date


### PR DESCRIPTION
This patch includes the following:
1. Change DEFAULT_CLIENT_SOFTWARE_NAME to linkedin-kafka-java.
2. Add config to pass customized client name from producer/consumer to ApiVersionsRequest.
3. Add license info in files missing it.

Starting from kafka 2.4, brokers are able to collect clients' version and name, see [KIP-511](https://cwiki.apache.org/confluence/display/KAFKA/KIP-511%3A+Collect+and+Expose+Client%27s+Name+and+Version+in+the+Brokers) for more details. 

With kafka 2.4 and linkedin-kafka-clients 10, we should make this name unique so that in future when collecting user metrics, we can distinguish supported clients from those using unsupported clients. 
