### PR TITLE
[LI-HOTFIX] Enable stack traces for ApiExceptions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/ApiException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ApiException.java
@@ -41,11 +41,4 @@ public class ApiException extends KafkaException {
     public ApiException() {
         super();
     }
-
-    /* avoid the expensive and useless stack trace for api exceptions */
-    @Override
-    public Throwable fillInStackTrace() {
-        return this;
-    }
-
 }


### PR DESCRIPTION
TICKET = KAFKA-7016
LI_DESCRIPTION = The current code base has the stack trace of ApiExceptions disabled.
However, the stack trace can provide valuable information for troubleshooting.
Although getting the stack trace may be expensive, exceptions should happen rarely,
and thus it's better to pay the cost when they do happen.

EXIT_CRITERIA = When KAFKA-7016 is resolved and the changes are pulled in.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
