### PR TITLE
[LI-HOTFIX] revert sticky metadata fetch hotfix

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -108,9 +108,6 @@ public class CommonClientConfigs {
                                                          + "elapses the client will resend the request if necessary or fail the request if "
                                                          + "retries are exhausted.";
 
-    public static final String ENABLE_STICKY_METADATA_FETCH_CONFIG = "enable.sticky.metadata.fetch";
-    public static final String ENABLE_STICKY_METADATA_FETCH_DOC = "Fetch metadata from the least loaded broker if false. Otherwise fetch metadata "
-                                                         + "from the same broker until it is disconnected.";
 
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -110,8 +110,6 @@ public class NetworkClient implements KafkaClient {
 
     private final Time time;
 
-    private boolean enableStickyMetadataFetch = true;
-
     /**
      * True if we should send an ApiVersionRequest when first connecting to a broker.
      */
@@ -268,10 +266,6 @@ public class NetworkClient implements KafkaClient {
         this.log = logContext.logger(NetworkClient.class);
         this.clientDnsLookup = clientDnsLookup;
         this.state = new AtomicReference<>(State.ACTIVE);
-    }
-
-    public void setEnableStickyMetadataFetch(boolean enableStickyMetadataFetch) {
-        this.enableStickyMetadataFetch = enableStickyMetadataFetch;
     }
 
     /**
@@ -557,12 +551,6 @@ public class NetworkClient implements KafkaClient {
         handleInitiateApiVersionRequests(updatedNow);
         handleTimedOutRequests(responses, updatedNow);
         completeResponses(responses);
-
-        // We changed the metadataUpdater.maybeUpdate() such that it will keep sending MetadataRequest
-        // to the same broker instead choosing the least loaded node. If we don't try to send metadata here, it is possible that
-        // another request is sent to the broker before the next networkClient.poll(). This can cause starvation
-        // for the MetadataRequest and consumer's metadata may be stale for a long time.
-        metadataUpdater.maybeUpdate(updatedNow);
 
         return responses;
     }
@@ -971,8 +959,6 @@ public class NetworkClient implements KafkaClient {
 
         /* the current cluster metadata */
         private final Metadata metadata;
-        // Consumer needs to keep fetching metadata from the same node until that node goes down
-        private Node nodeToFetchMetadata;
 
         // Defined if there is a request in progress, null otherwise
         private Integer inProgressRequestVersion;
@@ -980,7 +966,6 @@ public class NetworkClient implements KafkaClient {
         DefaultMetadataUpdater(Metadata metadata) {
             this.metadata = metadata;
             this.inProgressRequestVersion = null;
-            this.nodeToFetchMetadata = null;
         }
 
         @Override
@@ -1011,15 +996,13 @@ public class NetworkClient implements KafkaClient {
 
             // Beware that the behavior of this method and the computation of timeouts for poll() are
             // highly dependent on the behavior of leastLoadedNode.
-            if (!enableStickyMetadataFetch || nodeToFetchMetadata == null || !connectionStates.isReady(nodeToFetchMetadata.idString(), now))
-                nodeToFetchMetadata = leastLoadedNode(now);
-
-            if (nodeToFetchMetadata == null) {
+            Node node = leastLoadedNode(now);
+            if (node == null) {
                 log.debug("Give up sending metadata request since no node is available");
                 return reconnectBackoffMs;
             }
 
-            return maybeUpdate(now, nodeToFetchMetadata);
+            return maybeUpdate(now, node);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -528,11 +528,6 @@ public class ConsumerConfig extends AbstractConfig {
                                         CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
                                         Importance.MEDIUM,
                                         CommonClientConfigs.SECURITY_PROTOCOL_DOC)
-                                .define(CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_CONFIG,
-                                        Type.BOOLEAN,
-                                        true,
-                                        Importance.MEDIUM,
-                                        CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -19,7 +19,6 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientUtils;
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerCoordinator;
@@ -763,7 +762,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     apiVersions,
                     throttleTimeSensor,
                     logContext);
-            netClient.setEnableStickyMetadataFetch(config.getBoolean(CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_CONFIG));
             this.client = new ConsumerNetworkClient(
                     logContext,
                     netClient,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -361,11 +361,6 @@ public class ProducerConfig extends AbstractConfig {
                                         CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
                                         Importance.MEDIUM,
                                         CommonClientConfigs.SECURITY_PROTOCOL_DOC)
-                                .define(CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_CONFIG,
-                                        Type.BOOLEAN,
-                                        false,
-                                        Importance.MEDIUM,
-                                        CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport()
                                 .define(ENABLE_IDEMPOTENCE_CONFIG,


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
revert LI HOTFIX "Consumer should fetch metadata from the same broker until it is disconnected from that broker".
since sticky metadata request is no longer needed.
The original hotfix was introduced as a short term fix util the actual issue was found, and we no longer need this hotfix now.

EXIT_CRITERIA = MANUAL ["after the original fix has been removed"]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
