### PR TITLE
[LI-HOTFIX] revert sticky metadata fetch hotfix

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -147,9 +147,6 @@ public class CommonClientConfigs {
                                                            + "consumer's session stays active and to facilitate rebalancing when new consumers join or leave the group. "
                                                            + "The value must be set lower than <code>session.timeout.ms</code>, but typically should be set no higher "
                                                            + "than 1/3 of that value. It can be adjusted even lower to control the expected time for normal rebalances.";
-    public static final String ENABLE_STICKY_METADATA_FETCH_CONFIG = "enable.sticky.metadata.fetch";
-    public static final String ENABLE_STICKY_METADATA_FETCH_DOC = "Fetch metadata from the least loaded broker if false. Otherwise fetch metadata "
-                                                         + "from the same broker until it is disconnected.";
 
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -115,8 +115,6 @@ public class NetworkClient implements KafkaClient {
 
     private final Time time;
 
-    private boolean enableStickyMetadataFetch = true;
-
     /**
      * True if we should send an ApiVersionRequest when first connecting to a broker.
      */
@@ -273,10 +271,6 @@ public class NetworkClient implements KafkaClient {
         this.log = logContext.logger(NetworkClient.class);
         this.clientDnsLookup = clientDnsLookup;
         this.state = new AtomicReference<>(State.ACTIVE);
-    }
-
-    public void setEnableStickyMetadataFetch(boolean enableStickyMetadataFetch) {
-        this.enableStickyMetadataFetch = enableStickyMetadataFetch;
     }
 
     /**
@@ -576,12 +570,6 @@ public class NetworkClient implements KafkaClient {
         handleInitiateApiVersionRequests(updatedNow);
         handleTimedOutRequests(responses, updatedNow);
         completeResponses(responses);
-
-        // We changed the metadataUpdater.maybeUpdate() such that it will keep sending MetadataRequest
-        // to the same broker instead choosing the least loaded node. If we don't try to send metadata here, it is possible that
-        // another request is sent to the broker before the next networkClient.poll(). This can cause starvation
-        // for the MetadataRequest and consumer's metadata may be stale for a long time.
-        metadataUpdater.maybeUpdate(updatedNow);
 
         return responses;
     }
@@ -994,8 +982,6 @@ public class NetworkClient implements KafkaClient {
 
         /* the current cluster metadata */
         private final Metadata metadata;
-        // Consumer needs to keep fetching metadata from the same node until that node goes down
-        private Node nodeToFetchMetadata;
 
         // Defined if there is a request in progress, null otherwise
         private Integer inProgressRequestVersion;
@@ -1003,7 +989,6 @@ public class NetworkClient implements KafkaClient {
         DefaultMetadataUpdater(Metadata metadata) {
             this.metadata = metadata;
             this.inProgressRequestVersion = null;
-            this.nodeToFetchMetadata = null;
         }
 
         @Override
@@ -1033,15 +1018,13 @@ public class NetworkClient implements KafkaClient {
 
             // Beware that the behavior of this method and the computation of timeouts for poll() are
             // highly dependent on the behavior of leastLoadedNode.
-            if (!enableStickyMetadataFetch || nodeToFetchMetadata == null || !connectionStates.isReady(nodeToFetchMetadata.idString(), now))
-                nodeToFetchMetadata = leastLoadedNode(now);
-
-            if (nodeToFetchMetadata == null) {
+            Node node = leastLoadedNode(now);
+            if (node == null) {
                 log.debug("Give up sending metadata request since no node is available");
                 return reconnectBackoffMs;
             }
 
-            return maybeUpdate(now, nodeToFetchMetadata);
+            return maybeUpdate(now, node);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -524,11 +524,6 @@ public class ConsumerConfig extends AbstractConfig {
                                         CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
                                         Importance.MEDIUM,
                                         CommonClientConfigs.SECURITY_PROTOCOL_DOC)
-                                .define(CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_CONFIG,
-                                        Type.BOOLEAN,
-                                        true,
-                                        Importance.MEDIUM,
-                                        CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -762,7 +762,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     apiVersions,
                     throttleTimeSensor,
                     logContext);
-            netClient.setEnableStickyMetadataFetch(config.getBoolean(CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_CONFIG));
             this.client = new ConsumerNetworkClient(
                     logContext,
                     netClient,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -373,11 +373,6 @@ public class ProducerConfig extends AbstractConfig {
                                         null,
                                         Importance.LOW,
                                         SECURITY_PROVIDERS_DOC)
-                                .define(CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_CONFIG,
-                                        Type.BOOLEAN,
-                                        false,
-                                        Importance.MEDIUM,
-                                        CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport()
                                 .define(ENABLE_IDEMPOTENCE_CONFIG,


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
revert LI HOTFIX "Consumer should fetch metadata from the same broker until it is disconnected from that broker".
since sticky metadata request is no longer needed.
The original hotfix was introduced as a short term fix util the actual issue was found, and we no longer need this hotfix now.

EXIT_CRITERIA = MANUAL ["after the original fix has been removed"]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
