### PR TITLE
Add log brokerid for admin client listTopics failure (#131)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1442,6 +1442,14 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             void handleResponse(AbstractResponse abstractResponse) {
                 MetadataResponse response = (MetadataResponse) abstractResponse;
+
+                // Check if any topic's metadata failed to get updated
+                Map<String, Errors> errors = response.errors();
+                if (!errors.isEmpty()) {
+                    String destination = this.curNode().idString();
+                    log.warn("Error while fetching metadata with from source {} with errors : {}", destination, errors);
+                }
+
                 Map<String, TopicListing> topicListing = new HashMap<>();
                 for (MetadataResponse.TopicMetadata topicMetadata : response.topicMetadata()) {
                     String topicName = topicMetadata.topic();


### PR DESCRIPTION
Backporting `KafkaAdminClient#listTopics` log to 2.3-li-1 branch.
[LI-HOTFIX] Add log brokerid for admin client listTopics failure (#131)
TICKET = N/A
LI_DESCRIPTION = VENG-7361
In VENG-7361, sometimes KafkaAdminClient#listTopics will time out. This patch adds logs to help show the broker that served the listTopic request, which can help us understand the timeout.
EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
