### PR TITLE
[LI-HOTFIX] Merge controller requests 1/4: adding the new LiCombinedControl RPC

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ControlledShutdownRequestData;
 import org.apache.kafka.common.message.ControlledShutdownResponseData;
+import org.apache.kafka.common.message.LiCombinedControlRequestData;
+import org.apache.kafka.common.message.LiCombinedControlResponseData;
 import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData;
 import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckResponseData;
 import org.apache.kafka.common.message.CreateDelegationTokenRequestData;
@@ -211,7 +213,9 @@ public enum ApiKeys {
     OFFSET_DELETE(47, "OffsetDelete", OffsetDeleteRequestData.SCHEMAS, OffsetDeleteResponseData.SCHEMAS),
 
     // LinkedIn API keys for APIs not yet upstreamed.
-    LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK(1000, "LiControlledShutdownSkipSafetyCheck", true, LiControlledShutdownSkipSafetyCheckRequestData.SCHEMAS, LiControlledShutdownSkipSafetyCheckResponseData.SCHEMAS);
+    LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK(1000, "LiControlledShutdownSkipSafetyCheck", true, LiControlledShutdownSkipSafetyCheckRequestData.SCHEMAS, LiControlledShutdownSkipSafetyCheckResponseData.SCHEMAS),
+
+    LI_COMBINED_CONTROL(1001, "LiCombinedControl", true, LiCombinedControlRequestData.SCHEMAS, LiCombinedControlResponseData.SCHEMAS);
 
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -241,6 +241,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return new OffsetDeleteRequest(struct, apiVersion);
             case LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK:
                 return new LiControlledShutdownSkipSafetyCheckRequest(struct, apiVersion);
+            case LI_COMBINED_CONTROL:
+                return new LiCombinedControlRequest(struct, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -178,6 +178,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return new OffsetDeleteResponse(struct, version);
             case LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK:
                 return new LiControlledShutdownSkipSafetyCheckResponse(struct, version);
+            case LI_COMBINED_CONTROL:
+                return new LiCombinedControlResponse(struct, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.message.LiCombinedControlRequestData;
+import org.apache.kafka.common.message.LiCombinedControlResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.utils.FlattenedIterator;
+import org.apache.kafka.common.utils.Utils;
+
+
+public class LiCombinedControlRequest extends AbstractControlRequest {
+    public static class Builder extends AbstractControlRequest.Builder<LiCombinedControlRequest> {
+        // fields from the LeaderAndISRRequest
+        private final List<LiCombinedControlRequestData.LeaderAndIsrPartitionState> leaderAndIsrPartitionStates;
+        private final Collection<Node> leaderAndIsrLiveLeaders;
+
+        // fields from the UpdateMetadataRequest
+        private final List<LiCombinedControlRequestData.UpdateMetadataPartitionState> updateMetadataPartitionStates;
+        private final List<LiCombinedControlRequestData.UpdateMetadataBroker> updateMetadataLiveBrokers;
+
+        // fields from the StopReplicaRequest
+        private final List<LiCombinedControlRequestData.StopReplicaPartitionState> stopReplicaPartitions;
+
+        public Builder(short version, int controllerId, int controllerEpoch,
+            List<LiCombinedControlRequestData.LeaderAndIsrPartitionState> leaderAndIsrPartitionStates, Collection<Node> leaderAndIsrLiveLeaders,
+            List<LiCombinedControlRequestData.UpdateMetadataPartitionState> updateMetadataPartitionStates, List<LiCombinedControlRequestData.UpdateMetadataBroker> updateMetadataLiveBrokers,
+            List<LiCombinedControlRequestData.StopReplicaPartitionState> stopReplicaPartitions) {
+            // Since we've moved the maxBrokerEpoch down to the partition level
+            // the request level maxBrokerEpoch will always be -1
+            super(ApiKeys.LI_COMBINED_CONTROL, version, controllerId, controllerEpoch, -1, -1);
+            this.leaderAndIsrPartitionStates = leaderAndIsrPartitionStates;
+            this.leaderAndIsrLiveLeaders = leaderAndIsrLiveLeaders;
+            this.updateMetadataPartitionStates = updateMetadataPartitionStates;
+            this.updateMetadataLiveBrokers = updateMetadataLiveBrokers;
+            this.stopReplicaPartitions = stopReplicaPartitions;
+        }
+
+        @Override
+        public LiCombinedControlRequest build(short version) {
+            LiCombinedControlRequestData data = new LiCombinedControlRequestData()
+                .setControllerId(controllerId)
+                .setControllerEpoch(controllerEpoch);
+
+            // setting the LeaderAndIsr fields
+            List<LiCombinedControlRequestData.LeaderAndIsrLiveLeader> leaders = leaderAndIsrLiveLeaders.stream()
+                .map(n -> new LiCombinedControlRequestData.LeaderAndIsrLiveLeader().setBrokerId(n.id())
+                    .setHostName(n.host())
+                    .setPort(n.port()))
+                .collect(Collectors.toList());
+            data.setLiveLeaders(leaders);
+
+            Map<String, LiCombinedControlRequestData.LeaderAndIsrTopicState> leaderAndIsrTopicStateMap =
+                groupByLeaderAndIsrTopic(leaderAndIsrPartitionStates);
+            data.setLeaderAndIsrTopicStates(new ArrayList<>(leaderAndIsrTopicStateMap.values()));
+
+            // setting the UpdateMetadata fields
+            data.setLiveBrokers(updateMetadataLiveBrokers);
+
+            Map<String, LiCombinedControlRequestData.UpdateMetadataTopicState> updateMetadataTopicStateMap =
+                groupByUpdateMetadataTopic(updateMetadataPartitionStates);
+            data.setUpdateMetadataTopicStates(new ArrayList<>(updateMetadataTopicStateMap.values()));
+
+            // setting the StopReplica fields
+            data.setStopReplicaPartitionStates(stopReplicaPartitions);
+
+            return new LiCombinedControlRequest(data, version);
+        }
+
+        private static Map<String, LiCombinedControlRequestData.LeaderAndIsrTopicState> groupByLeaderAndIsrTopic(List<LiCombinedControlRequestData.LeaderAndIsrPartitionState> partitionStates) {
+            Map<String, LiCombinedControlRequestData.LeaderAndIsrTopicState> topicStates = new HashMap<>();
+            // We don't null out the topic name in LeaderAndIsrRequestPartition since it's ignored by
+            // the generated code if version > 0
+            for (LiCombinedControlRequestData.LeaderAndIsrPartitionState partition : partitionStates) {
+                LiCombinedControlRequestData.LeaderAndIsrTopicState topicState = topicStates.computeIfAbsent(partition.topicName(),
+                    t -> new LiCombinedControlRequestData.LeaderAndIsrTopicState().setTopicName(partition.topicName()));
+                topicState.partitionStates().add(partition);
+            }
+            return topicStates;
+        }
+
+        private static Map<String, LiCombinedControlRequestData.UpdateMetadataTopicState> groupByUpdateMetadataTopic(List<LiCombinedControlRequestData.UpdateMetadataPartitionState> partitionStates) {
+            Map<String, LiCombinedControlRequestData.UpdateMetadataTopicState> topicStates = new HashMap<>();
+            for (LiCombinedControlRequestData.UpdateMetadataPartitionState partition : partitionStates) {
+                // We don't null out the topic name in UpdateMetadataTopicState since it's ignored by the generated
+                // code if version > 0
+                LiCombinedControlRequestData.UpdateMetadataTopicState topicState = topicStates.computeIfAbsent(partition.topicName(),
+                    t -> new LiCombinedControlRequestData.UpdateMetadataTopicState().setTopicName(partition.topicName()));
+                topicState.partitionStates().add(partition);
+            }
+            return topicStates;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder bld = new StringBuilder();
+            // HOTFIX: LIKAFKA-24478
+            // large cluster with large metadata can create really large string
+            // potentially causing OOM, thus we don't print out the UpdateMetadata PartitionStates
+            bld.append("(type=LiCombinedControlRequest")
+                .append(", controllerId=").append(controllerId)
+                .append(", controllerEpoch=").append(controllerEpoch)
+                .append(", brokerEpoch=").append(brokerEpoch)
+                .append(", maxBrokerEpoch=").append(maxBrokerEpoch).append("\n")
+                .append("leaderAndIsrPartitionStates=\n");
+            for (LiCombinedControlRequestData.LeaderAndIsrPartitionState leaderAndIsrPartitionState : leaderAndIsrPartitionStates) {
+                bld.append("\t" + leaderAndIsrPartitionState + "\n");
+            }
+            bld.append("leaderAndIsrLiveLeaders=\n");
+
+            bld.append("\t" + Utils.join(leaderAndIsrLiveLeaders, ", ") + "\n");
+
+            bld.append("updateMetadataLiveBrokers=\n");
+            for (LiCombinedControlRequestData.UpdateMetadataBroker broker: updateMetadataLiveBrokers) {
+                bld.append("\t" + broker + "\n");
+            }
+
+            bld.append("stopReplicaPartitions=\n");
+            for (LiCombinedControlRequestData.StopReplicaPartitionState partitionState: stopReplicaPartitions) {
+                bld.append("\t" + partitionState + "\n");
+            }
+
+            return bld.toString();
+        }
+
+        /**
+         * visible for test only
+         */
+        public List<LiCombinedControlRequestData.LeaderAndIsrPartitionState> leaderAndIsrPartitionStates() {
+            return leaderAndIsrPartitionStates;
+        }
+
+        /**
+         * visible for test only
+         */
+        public List<LiCombinedControlRequestData.UpdateMetadataPartitionState> updateMetadataPartitionStates() {
+            return updateMetadataPartitionStates;
+        }
+
+        /**
+         * visible for test only
+         */
+        public List<LiCombinedControlRequestData.StopReplicaPartitionState> stopReplicaPartitionStates() {
+            return stopReplicaPartitions;
+        }
+    }
+
+    private final LiCombinedControlRequestData data;
+
+    LiCombinedControlRequest(LiCombinedControlRequestData data, short version) {
+        super(ApiKeys.LI_COMBINED_CONTROL, version);
+        this.data = data;
+        // Do this from the constructor to make it thread-safe (even though it's only needed when some methods are called)
+        normalizeLeaderAndIsr();
+        normalizeUpdateMetadata();
+    }
+
+    private void normalizeLeaderAndIsr() {
+        for (LiCombinedControlRequestData.LeaderAndIsrTopicState topicState : data.leaderAndIsrTopicStates()) {
+            for (LiCombinedControlRequestData.LeaderAndIsrPartitionState partitionState : topicState.partitionStates()) {
+                // Set the topic name so that we can always present the ungrouped view to callers
+                partitionState.setTopicName(topicState.topicName());
+            }
+        }
+    }
+
+    private void normalizeUpdateMetadata() {
+        for (LiCombinedControlRequestData.UpdateMetadataTopicState topicState : data.updateMetadataTopicStates()) {
+            for (LiCombinedControlRequestData.UpdateMetadataPartitionState partitionState : topicState.partitionStates()) {
+                // Set the topic name so that we can always present the ungrouped view to callers
+                partitionState.setTopicName(topicState.topicName());
+            }
+        }
+    }
+
+    public LiCombinedControlRequest(Struct struct, short version) {
+        this(new LiCombinedControlRequestData(struct, version), version);
+    }
+
+    @Override
+    protected Struct toStruct() {
+        return data.toStruct(version());
+    }
+
+    @Override
+    public LiCombinedControlResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiCombinedControlResponseData responseData = new LiCombinedControlResponseData();
+        Errors error = Errors.forException(e);
+
+        // below we populate the error code to all the error fields and the partition error fields
+        // 1. populate LeaderAndIsr error code
+        responseData.setLeaderAndIsrErrorCode(error.code());
+        List<LiCombinedControlResponseData.LeaderAndIsrPartitionError> leaderAndIsrPartitionErrors = new ArrayList<>();
+        for (LiCombinedControlRequestData.LeaderAndIsrPartitionState partition : leaderAndIsrPartitionStates()) {
+            leaderAndIsrPartitionErrors.add(new LiCombinedControlResponseData.LeaderAndIsrPartitionError()
+                .setTopicName(partition.topicName())
+                .setPartitionIndex(partition.partitionIndex())
+                .setErrorCode(error.code()));
+        }
+        responseData.setLeaderAndIsrPartitionErrors(leaderAndIsrPartitionErrors);
+
+        // 2. populate the UpdateMetadata error code
+        responseData.setUpdateMetadataErrorCode(error.code());
+
+        // 3. populate the StopReplica error code
+        responseData.setStopReplicaErrorCode(error.code());
+        List<LiCombinedControlResponseData.StopReplicaPartitionError> stopReplicaPartitions = new ArrayList<>();
+        for (LiCombinedControlRequestData.StopReplicaPartitionState tp : stopReplicaPartitions()) {
+            stopReplicaPartitions.add(new LiCombinedControlResponseData.StopReplicaPartitionError()
+                .setTopicName(tp.topicName())
+                .setPartitionIndex(tp.partitionIndex())
+                .setErrorCode(error.code()));
+        }
+        responseData.setStopReplicaPartitionErrors(stopReplicaPartitions);
+
+        return new LiCombinedControlResponse(responseData);
+    }
+
+    private List<LiCombinedControlRequestData.StopReplicaPartitionState> stopReplicaPartitions() {
+        return data.stopReplicaPartitionStates();
+    }
+
+    @Override
+    public int controllerId() {
+        return data.controllerId();
+    }
+
+    @Override
+    public int controllerEpoch() {
+        return data.controllerEpoch();
+    }
+
+    @Override
+    public long brokerEpoch() {
+        return -1; // the broker epoch field is no longer used
+    }
+
+    @Override
+    public long maxBrokerEpoch() {
+        return -1;
+    }
+
+    public Iterable<LiCombinedControlRequestData.LeaderAndIsrPartitionState> leaderAndIsrPartitionStates() {
+        return () -> new FlattenedIterator<>(data.leaderAndIsrTopicStates().iterator(),
+            topicState -> topicState.partitionStates().iterator());
+    }
+
+    public List<LiCombinedControlRequestData.LeaderAndIsrLiveLeader> liveLeaders() {
+        return Collections.unmodifiableList(data.liveLeaders());
+    }
+
+    public Iterable<LiCombinedControlRequestData.UpdateMetadataPartitionState> updateMetadataPartitionStates() {
+        return () -> new FlattenedIterator<>(data.updateMetadataTopicStates().iterator(),
+            topicState -> topicState.partitionStates().iterator());
+    }
+
+    public List<LiCombinedControlRequestData.UpdateMetadataBroker> liveBrokers() {
+        return data.liveBrokers();
+    }
+
+    public List<LiCombinedControlRequestData.StopReplicaPartitionState> stopReplicaPartitionStates() {
+        return data.stopReplicaPartitionStates();
+    }
+
+    public static LiCombinedControlRequest parse(ByteBuffer buffer, short version) {
+        return new LiCombinedControlRequest(ApiKeys.LI_COMBINED_CONTROL.parseRequest(version, buffer), version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlResponse.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.message.LiCombinedControlResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+
+
+public class LiCombinedControlResponse extends AbstractResponse {
+    private final LiCombinedControlResponseData data;
+    public LiCombinedControlResponse(LiCombinedControlResponseData data) {
+        this.data = data;
+    }
+
+    public LiCombinedControlResponse(Struct struct, short version) {
+        this.data = new LiCombinedControlResponseData(struct, version);
+    }
+
+    public List<LiCombinedControlResponseData.LeaderAndIsrPartitionError> leaderAndIsrPartitionErrors() {
+        return data.leaderAndIsrPartitionErrors();
+    }
+
+    public List<LiCombinedControlResponseData.StopReplicaPartitionError> stopReplicaPartitionErrors() {
+        return data.stopReplicaPartitionErrors();
+    }
+
+    public short leaderAndIsrErrorCode() {
+        return data.leaderAndIsrErrorCode();
+    }
+
+    private Errors leaderAndIsrError() {
+        return Errors.forCode(data.leaderAndIsrErrorCode());
+    }
+
+    public short updateMetadataErrorCode() {
+        return data.updateMetadataErrorCode();
+    }
+
+    private Errors updateMetadataError() {
+        return Errors.forCode(data.updateMetadataErrorCode());
+    }
+
+    public short stopReplicaErrorCode() {
+        return data.stopReplicaErrorCode();
+    }
+
+    private Errors stopReplicaError() {
+        return Errors.forCode(data.stopReplicaErrorCode());
+    }
+
+    public Errors error() {
+        // To be backward compatible with the existing API, which can only return one error,
+        // we give the following priorities LeaderAndIsr error > Stop Replica error > UpdateMetadata error
+        Errors leaderAndIsrError = leaderAndIsrError();
+        if (leaderAndIsrError != Errors.NONE) {
+            return leaderAndIsrError;
+        }
+
+        Errors stopReplicaError = stopReplicaError();
+        if (stopReplicaError != Errors.NONE) {
+            return stopReplicaError;
+        }
+
+        Errors updateMetadataError = updateMetadataError();
+        if (updateMetadataError != Errors.NONE) {
+            return updateMetadataError;
+        }
+
+        return Errors.NONE;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Errors leaderAndIsrError = leaderAndIsrError();
+        Map<Errors, Integer> leaderAndIsrErrorCount;
+        if (leaderAndIsrError != Errors.NONE) {
+            // Minor optimization since the top-level error applies to all partitions
+            leaderAndIsrErrorCount = Collections.singletonMap(leaderAndIsrError, data.leaderAndIsrPartitionErrors().size());
+        } else {
+            leaderAndIsrErrorCount = errorCounts(data.leaderAndIsrPartitionErrors().stream().map(l -> Errors.forCode(l.errorCode())).collect(Collectors.toList()));
+        }
+
+        Map<Errors, Integer> updateMetadataErrorCount = errorCounts(updateMetadataError());
+
+        Map<Errors, Integer> stopReplicaErrorCount;
+        if (data.stopReplicaErrorCode() != Errors.NONE.code()) {
+            // Minor optimization since the top-level error applies to all partitions
+            stopReplicaErrorCount = Collections.singletonMap(error(), data.stopReplicaPartitionErrors().size());
+        } else {
+            stopReplicaErrorCount = errorCounts(data.stopReplicaPartitionErrors().stream().map(p -> Errors.forCode(p.errorCode())).collect(Collectors.toList()));
+        }
+
+        // merge the several count maps into one result
+        Map<Errors, Integer> combinedErrorCount = mergeMaps(leaderAndIsrErrorCount, updateMetadataErrorCount);
+        combinedErrorCount = mergeMaps(combinedErrorCount, stopReplicaErrorCount);
+
+        return combinedErrorCount;
+    }
+
+    private static Map<Errors, Integer> mergeMaps(Map<Errors, Integer> m1, Map<Errors, Integer> m2) {
+        Map<Errors, Integer> result = new HashMap<>(m1);
+        m2.forEach((k, v) -> result.merge(k, v, (v1, v2) -> v1 + v2));
+        return result;
+    }
+
+    @Override
+    protected Struct toStruct(short version) {
+        return data.toStruct(version);
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+
+}

--- a/clients/src/main/resources/common/message/LiCombinedControlRequest.json
+++ b/clients/src/main/resources/common/message/LiCombinedControlRequest.json
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1001,
+  "type": "request",
+  "name": "LiCombinedControlRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ControllerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
+      "about": "The current controller ID." },
+    { "name": "ControllerEpoch", "type": "int32", "versions": "0+",
+      "about": "The current controller epoch." },
+    // fields from the LeaderAndIsr
+    { "name": "LeaderAndIsrTopicStates", "type": "[]LeaderAndIsrTopicState", "versions": "0+",
+      "about": "Each topic.", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "PartitionStates", "type": "[]LeaderAndIsrPartitionState", "versions": "0+",
+        "about": "The state of each partition" }
+    ]},
+    { "name": "LiveLeaders", "type": "[]LeaderAndIsrLiveLeader", "versions": "0+",
+      "about": "The current live leaders. An empty list means there is no LeaderAndIsr info in this combined request.", "fields": [
+      { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
+        "about": "The leader's broker ID." },
+      { "name": "HostName", "type": "string", "versions": "0+",
+        "about": "The leader's hostname." },
+      { "name": "Port", "type": "int32", "versions": "0+",
+        "about": "The leader's port." }
+    ]},
+    // fields from the UpdateMetadata
+    { "name": "UpdateMetadataTopicStates", "type": "[]UpdateMetadataTopicState", "versions": "0+",
+      "about": "In newer versions of this RPC, each topic that we would like to update.", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "PartitionStates", "type": "[]UpdateMetadataPartitionState", "versions": "0+",
+        "about": "The partition that we would like to update." }
+    ]},
+    { "name": "LiveBrokers", "type": "[]UpdateMetadataBroker", "versions": "0+",
+      "about": "The current live brokers. An empty list means there is no UpdateMetadata info in tihs combined request",
+      "fields": [
+      { "name": "Id", "type": "int32", "versions": "0+", "entityType": "brokerId",
+        "about": "The broker id." },
+      { "name": "Endpoints", "type": "[]UpdateMetadataEndpoint", "versions": "0+", "ignorable": true,
+        "about": "The broker endpoints.", "fields": [
+        { "name": "Port", "type": "int32", "versions": "0+",
+          "about": "The port of this endpoint" },
+        { "name": "Host", "type": "string", "versions": "0+",
+          "about": "The hostname of this endpoint" },
+        { "name": "Listener", "type": "string", "versions": "0+", "ignorable": true,
+          "about": "The listener name." },
+        { "name": "SecurityProtocol", "type": "int16", "versions": "0+",
+          "about": "The security protocol type." }
+      ]},
+      { "name": "Rack", "type": "string", "versions": "0+", "nullableVersions": "0+", "ignorable": true,
+        "about": "The rack which this broker belongs to." }
+    ]},
+    // fields from the StopReplica
+    { "name": "StopReplicaPartitionStates", "type": "[]StopReplicaPartitionState", "versions": "0+",
+      "about": "The topics to stop."}
+  ],
+  "commonStructs": [
+    { "name": "StopReplicaPartitionState", "versions": "0+", "fields": [
+        { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+          "about": "The topic name." },
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition indexes." },
+        { "name": "DeletePartitions", "type": "bool", "versions": "0+",
+          "about": "Whether these partitions should be deleted." },
+        { "name": "MaxBrokerEpoch", "type": "int64", "versions": "0+",
+          "about": "The max broker epoch." }
+        ]
+    },
+    { "name": "LeaderAndIsrPartitionState", "versions": "0+", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0", "entityType": "topicName", "ignorable": true,
+        "about": "The topic name.  This is only present in v0." },
+      { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        "about": "The partition index." },
+      { "name": "ControllerEpoch", "type": "int32", "versions": "0+",
+        "about": "The controller epoch." },
+      { "name": "MaxBrokerEpoch", "type": "int64", "versions": "0+",
+        "about": "The max broker epoch." },
+      { "name": "Leader", "type": "int32", "versions": "0+", "entityType": "brokerId",
+        "about": "The broker ID of the leader." },
+      { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+        "about": "The leader epoch." },
+      { "name": "Isr", "type": "[]int32", "versions": "0+",
+        "about": "The in-sync replica IDs." },
+      { "name": "ZkVersion", "type": "int32", "versions": "0+",
+        "about": "The ZooKeeper version." },
+      { "name": "Replicas", "type": "[]int32", "versions": "0+",
+        "about": "The replica IDs." },
+      { "name": "AddingReplicas", "type": "[]int32", "versions": "0+", "ignorable": true,
+        "about": "The replica IDs that we are adding this partition to, or null if no replicas are being added." },
+      { "name": "RemovingReplicas", "type": "[]int32", "versions": "0+", "ignorable": true,
+        "about": "The replica IDs that we are removing this partition from, or null if no replicas are being removed." },
+      { "name": "IsNew", "type": "bool", "versions": "0+", "default": "false", "ignorable": true,
+        "about": "Whether the replica should have existed on the broker or not." }
+    ]},
+    { "name": "UpdateMetadataPartitionState", "versions": "0+", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0", "entityType": "topicName", "ignorable": true,
+        "about": "In older versions of this RPC, the topic name." },
+      { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        "about": "The partition index." },
+      { "name": "ControllerEpoch", "type": "int32", "versions": "0+",
+        "about": "The controller epoch." },
+      { "name": "Leader", "type": "int32", "versions": "0+", "entityType": "brokerId",
+        "about": "The ID of the broker which is the current partition leader." },
+      { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
+        "about": "The leader epoch of this partition." },
+      { "name": "Isr", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
+        "about": "The brokers which are in the ISR for this partition." },
+      { "name": "ZkVersion", "type": "int32", "versions": "0+",
+        "about": "The Zookeeper version." },
+      { "name": "Replicas", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
+        "about": "All the replicas of this partition." },
+      { "name": "OfflineReplicas", "type": "[]int32", "versions": "0+", "entityType": "brokerId", "ignorable": true,
+        "about": "The replicas of this partition which are offline." }
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/LiCombinedControlResponse.json
+++ b/clients/src/main/resources/common/message/LiCombinedControlResponse.json
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1001,
+  "type": "response",
+  "name": "LiCombinedControlResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    // fields from the LeaderAndIsr response
+    { "name": "LeaderAndIsrErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "LeaderAndIsrPartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "0+",
+      "about": "Each partition.", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        "about": "The partition index." },
+      { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        "about": "The partition error code, or 0 if there was no error." }
+    ]},
+    // fields from the UpdateMetadata response
+    { "name": "UpdateMetadataErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    // fields from the StopReplica response
+    { "name": "StopReplicaErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code, or 0 if there was no top-level error." },
+    { "name": "StopReplicaPartitionErrors", "type": "[]StopReplicaPartitionError", "versions": "0+",
+      "about": "The responses for each partition.", "fields": [
+      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        "about": "The partition index." },
+      { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        "about": "The partition error code, or 0 if there was no partition error." }
+    ]}
+  ]
+}

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -84,7 +84,7 @@ class ControllerChannelManager(controllerContext: ControllerContext,
   }
 
   def initBrokerResponseSensors(): Unit = {
-    Array(ApiKeys.STOP_REPLICA, ApiKeys.LEADER_AND_ISR, ApiKeys.UPDATE_METADATA).foreach { k: ApiKeys =>
+    Array(ApiKeys.STOP_REPLICA, ApiKeys.LEADER_AND_ISR, ApiKeys.UPDATE_METADATA, ApiKeys.LI_COMBINED_CONTROL).foreach { k: ApiKeys =>
       brokerResponseSensors.put(k, new BrokerResponseTimeStats(k))
     }
   }

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -512,6 +512,11 @@ class RequestQuotaTest extends BaseRequestTest {
               .setBrokerEpoch(6431),
             ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK.latestVersion)
 
+        case ApiKeys.LI_COMBINED_CONTROL =>
+          new LiCombinedControlRequest.Builder(ApiKeys.LI_COMBINED_CONTROL.latestVersion, brokerId, 0, new util.ArrayList[LiCombinedControlRequestData.LeaderAndIsrPartitionState](),
+            new util.ArrayList[Node](), new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataPartitionState](), new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataBroker](),
+            new util.ArrayList[LiCombinedControlRequestData.StopReplicaPartitionState]())
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
This PR is the 1st to implement the feature of control request merging laid out in the design doc
https://docs.google.com/document/d/1PZAOwpw09tVDeuSP0OBVhB6dbgz7C7dQU6bRkePQ8qg/edit

Specifically, I'm adding a new RPC request and response called LiCombinedControl, which can be used to incorporate info from all the 3 types of controller requests, i.e. LeaderAndIsr, UpdateMetadata, and StopReplica requests.

EXIT_CRITERIA = It's unclear whether this feature should be put in upstream apache kafka yet. If we decide to put this change in upstream, the exit criteria will be when it gets merged in upstream and pulled in a part of a release.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
