### PR TITLE
[LI-HOTFIX] Renaming the async fetcher classes to Async*

### DIFF
--- a/core/src/main/scala/kafka/server/AsyncAbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AsyncAbstractFetcherManager.scala
@@ -27,7 +27,7 @@ import org.apache.kafka.common.utils.Utils
 import scala.collection.{Map, Set, mutable}
 import scala.collection.mutable.ArrayBuffer
 
-abstract class AbstractFetcherManager[T <: FetcherEventManager](val name: String, clientId: String, numFetchers: Int)
+abstract class AsyncAbstractFetcherManager[T <: FetcherEventManager](val name: String, clientId: String, numFetchers: Int)
   extends Logging with KafkaMetricsGroup {
   // map of (source broker_id, fetcher_id per source broker) => fetcher.
   // package private for test

--- a/core/src/main/scala/kafka/server/AsyncReplicaFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AsyncReplicaFetcherManager.scala
@@ -21,13 +21,13 @@ import kafka.cluster.BrokerEndPoint
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.utils.Time
 
-class ReplicaFetcherManager(brokerConfig: KafkaConfig,
+class AsyncReplicaFetcherManager(brokerConfig: KafkaConfig,
                             protected val replicaManager: ReplicaManager,
                             metrics: Metrics,
                             time: Time,
                             threadNamePrefix: Option[String] = None,
                             quotaManager: ReplicationQuotaManager)
-      extends AbstractFetcherManager[FetcherEventManager](
+      extends AsyncAbstractFetcherManager[FetcherEventManager](
         name = "ReplicaFetcherManager on broker " + brokerConfig.brokerId,
         clientId = "Replica",
         numFetchers = brokerConfig.numReplicaFetchers) {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -265,7 +265,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         .setPartitionErrors(result.map { case (tp, error) => toStopReplicaPartition(tp, error) }.toBuffer.asJava)))
     }
 
-    CoreUtils.swallow(replicaManager.replicaFetcherManager.shutdownIdleFetcherThreads(), this)
+    CoreUtils.swallow(replicaManager.asyncReplicaFetcherManager.shutdownIdleFetcherThreads(), this)
   }
 
   def handleUpdateMetadataRequest(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -202,7 +202,7 @@ class ReplicaManager(val config: KafkaConfig,
     valueFactory = Some(tp => HostedPartition.Online(Partition(tp, time, this)))
   )
   private val replicaStateChangeLock = new Object
-  val replicaFetcherManager = createReplicaFetcherManager(metrics, time, threadNamePrefix, quotaManagers.follower)
+  val asyncReplicaFetcherManager = createAsyncReplicaFetcherManager(metrics, time, threadNamePrefix, quotaManagers.follower)
 //  val replicaAlterLogDirsManager = createReplicaAlterLogDirsManager(quotaManagers.alterLogDirs, brokerTopicStats)
   private val highWatermarkCheckPointThreadStarted = new AtomicBoolean(false)
   @volatile var highWatermarkCheckpoints: Map[String, OffsetCheckpointFile] = logManager.liveLogDirs.map(dir =>
@@ -422,7 +422,7 @@ class ReplicaManager(val config: KafkaConfig,
         val partitions = stopReplicaRequest.partitions.asScala.toSet
         controllerEpoch = stopReplicaRequest.controllerEpoch
         // First stop fetchers for all partitions, then stop the corresponding replicas
-        replicaFetcherManager.removeFetcherForPartitions(partitions)
+        asyncReplicaFetcherManager.removeFetcherForPartitions(partitions)
 //        replicaAlterLogDirsManager.removeFetcherForPartitions(partitions)
         for (topicPartition <- partitions){
           try {
@@ -1354,7 +1354,7 @@ class ReplicaManager(val config: KafkaConfig,
         }
 //        replicaAlterLogDirsManager.addFetcherForPartitions(futureReplicasAndInitialOffset)
 
-        replicaFetcherManager.shutdownIdleFetcherThreads()
+        asyncReplicaFetcherManager.shutdownIdleFetcherThreads()
 //        replicaAlterLogDirsManager.shutdownIdleFetcherThreads()
         onLeadershipChange(partitionsBecomeLeader, partitionsBecomeFollower)
         val responsePartitions = responseMap.iterator.map { case (tp, error) =>
@@ -1402,7 +1402,7 @@ class ReplicaManager(val config: KafkaConfig,
 
     try {
       // First stop fetchers for all the partitions
-      replicaFetcherManager.removeFetcherForPartitions(partitionStates.keySet.map(_.topicPartition))
+      asyncReplicaFetcherManager.removeFetcherForPartitions(partitionStates.keySet.map(_.topicPartition))
       // Update the partition information to be the leader
       partitionStates.foreach { case (partition, partitionState) =>
         try {
@@ -1521,7 +1521,7 @@ class ReplicaManager(val config: KafkaConfig,
         }
       }
 
-      replicaFetcherManager.removeFetcherForPartitions(partitionsToMakeFollower.map(_.topicPartition))
+      asyncReplicaFetcherManager.removeFetcherForPartitions(partitionsToMakeFollower.map(_.topicPartition))
       partitionsToMakeFollower.foreach { partition =>
         stateChangeLogger.trace(s"Stopped fetchers as part of become-follower request from controller $controllerId " +
           s"epoch $controllerEpoch with correlation id $correlationId for partition ${partition.topicPartition} with leader " +
@@ -1554,7 +1554,7 @@ class ReplicaManager(val config: KafkaConfig,
           partition.topicPartition -> InitialFetchState(leader, partition.getLeaderEpoch, fetchOffset)
        }.toMap
 
-        replicaFetcherManager.addFetcherForPartitions(partitionsToMakeFollowerWithLeaderAndOffset)
+        asyncReplicaFetcherManager.addFetcherForPartitions(partitionsToMakeFollowerWithLeaderAndOffset)
         partitionsToMakeFollowerWithLeaderAndOffset.foreach { case (partition, initialFetchState) =>
           stateChangeLogger.trace(s"Started fetcher to new leader as part of become-follower " +
             s"request from controller $controllerId epoch $controllerEpoch with correlation id $correlationId for " +
@@ -1682,7 +1682,7 @@ class ReplicaManager(val config: KafkaConfig,
         partition.futureLog.exists { _.parentDir == dir }
       }.toSet
 
-      replicaFetcherManager.removeFetcherForPartitions(newOfflinePartitions)
+      asyncReplicaFetcherManager.removeFetcherForPartitions(newOfflinePartitions)
 //      replicaAlterLogDirsManager.removeFetcherForPartitions(newOfflinePartitions ++ partitionsWithOfflineFutureReplica.map(_.topicPartition))
 
       partitionsWithOfflineFutureReplica.foreach(partition => partition.removeFutureLocalReplica(deleteFromLogDir = false))
@@ -1720,7 +1720,7 @@ class ReplicaManager(val config: KafkaConfig,
     removeMetrics()
     if (logDirFailureHandler != null)
       logDirFailureHandler.shutdown()
-    replicaFetcherManager.shutdown()
+    asyncReplicaFetcherManager.shutdown()
 //    replicaAlterLogDirsManager.shutdown()
     delayedFetchPurgatory.shutdown()
     delayedProducePurgatory.shutdown()
@@ -1732,8 +1732,8 @@ class ReplicaManager(val config: KafkaConfig,
     info("Shut down completely")
   }
 
-  protected def createReplicaFetcherManager(metrics: Metrics, time: Time, threadNamePrefix: Option[String], quotaManager: ReplicationQuotaManager) = {
-    new ReplicaFetcherManager(config, this, metrics, time, threadNamePrefix, quotaManager)
+  protected def createAsyncReplicaFetcherManager(metrics: Metrics, time: Time, threadNamePrefix: Option[String], quotaManager: ReplicationQuotaManager) = {
+    new AsyncReplicaFetcherManager(config, this, metrics, time, threadNamePrefix, quotaManager)
   }
 
 //  protected def createReplicaAlterLogDirsManager(quotaManager: ReplicationQuotaManager, brokerTopicStats: BrokerTopicStats) = {

--- a/core/src/test/scala/unit/kafka/server/AsyncAbstractFetcherManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AsyncAbstractFetcherManagerTest.scala
@@ -27,7 +27,7 @@ import org.junit.Assert._
 
 import scala.collection.JavaConverters._
 
-class AbstractFetcherManagerTest {
+class AsyncAbstractFetcherManagerTest {
 
   @Before
   def cleanMetricRegistry(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1424,11 +1424,11 @@ class ReplicaManagerTest {
       metadataCache, mockLogDirFailureChannel, mockProducePurgatory, mockFetchPurgatory,
       mockDeleteRecordsPurgatory, mockElectLeaderPurgatory, Option(this.getClass.getName)) {
 
-      override protected def createReplicaFetcherManager(metrics: Metrics,
+      override protected def createAsyncReplicaFetcherManager(metrics: Metrics,
                                                      time: Time,
                                                      threadNamePrefix: Option[String],
-                                                     quotaManager: ReplicationQuotaManager): ReplicaFetcherManager = {
-        new ReplicaFetcherManager(config, this, metrics, time, threadNamePrefix, quotaManager) {
+                                                     quotaManager: ReplicationQuotaManager): AsyncReplicaFetcherManager = {
+        new AsyncReplicaFetcherManager(config, this, metrics, time, threadNamePrefix, quotaManager) {
 
           override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): FetcherEventManager = {
             val fetcherEventBus = new FetcherEventBus(time)

--- a/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
@@ -17,7 +17,7 @@
 
 package kafka.utils
 
-import kafka.server.{KafkaConfig, ReplicaFetcherManager, ReplicaManager}
+import kafka.server.{KafkaConfig, AsyncReplicaFetcherManager, ReplicaManager}
 import kafka.api.LeaderAndIsr
 import kafka.controller.LeaderIsrAndControllerEpoch
 import kafka.log.{Log, LogManager}
@@ -61,7 +61,7 @@ class ReplicationUtilsTest extends ZooKeeperTestHarness {
     val replicaManager: ReplicaManager = EasyMock.createMock(classOf[ReplicaManager])
     EasyMock.expect(replicaManager.config).andReturn(configs.head)
     EasyMock.expect(replicaManager.logManager).andReturn(logManager)
-    EasyMock.expect(replicaManager.replicaFetcherManager).andReturn(EasyMock.createMock(classOf[ReplicaFetcherManager]))
+    EasyMock.expect(replicaManager.asyncReplicaFetcherManager).andReturn(EasyMock.createMock(classOf[AsyncReplicaFetcherManager]))
     EasyMock.expect(replicaManager.zkClient).andReturn(zkClient)
     EasyMock.replay(replicaManager)
 


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
I'd like to add a config to control whether the async fetcher threads feature should be enabled.
In order to do that, I'm using this PR to rename all the async fetcher classes by adding an `Async` prefix.

In a subsequent PR, I'll add the previous behavior back, including the classes for supporting lock-based fetcher threads.
EXIT_CRITERIA = N/A

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
