### PR TITLE
[LI-HOTFIX] add 2 more algorithms for least loaded node selection

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/LeastLoadedNodeAlgorithm.java
+++ b/clients/src/main/java/org/apache/kafka/clients/LeastLoadedNodeAlgorithm.java
@@ -24,15 +24,30 @@ package org.apache.kafka.clients;
 public enum LeastLoadedNodeAlgorithm {
   /**
    * default upstream kafka selection algorithm.
-   * attempts to minimize latency, but may resuult in stickiness
+   * attempts to minimize latency, but may result in stickiness
    * and hammering of dedicated controllers and brokers down
    * for maintenance
    */
   VANILLA,
   /**
-   * selects a random broker out of 3 candidates. candidates are preferrably
+   * selects a random broker out of 3 candidates. candidates are preferably
    * brokers with existing connections, but new connections will be initiated
    * to get the candidate pool up to 3.
    */
-  AT_LEAST_THREE
+  AT_LEAST_THREE,
+  /**
+   * selects a random broker out of all nodes except those for which the number
+   * of requests in flight is already at max.
+   * NOTE - this is expected to result in a lot of open sockets per client
+   * (worst case being one per broker)
+   */
+  RANDOM,
+  /**
+   * designed by an esteemed kafka SRE, this algorithm selects a broker out
+   * of the top 15 brokers EXCEPT the top 5 (so random broker out of brokers
+   * 5 to 15 in the best candidates structure). the idea is that the top 5
+   * may be dedicated controllers and/or brokers in maintenance mode, both
+   * of which we want to avoid hitting from clients
+   */
+  RANDOM_BETWEEN_5_TO_15
 }

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -848,6 +848,10 @@ public class NetworkClient implements KafkaClient {
                 return vanillaLeastLoadedNode(now, nodes);
             case AT_LEAST_THREE:
                 return atLeastThreeLeastLoadedNode(now, nodes);
+            case RANDOM:
+                return randomLeastLoadedNode(now, nodes);
+            case RANDOM_BETWEEN_5_TO_15:
+                return haskinsLeastLoadedNode(now, nodes);
             default:
                 throw new IllegalStateException("unhandled selection algorithm " + algo);
         }
@@ -978,6 +982,85 @@ public class NetworkClient implements KafkaClient {
 
         int chosen = randOffset.nextInt(pool.size());
         CandidateNode[] finalists = pool.toArray(new CandidateNode[0]);
+        Node chosenNode = finalists[chosen].node;
+        log.trace("Least loaded node selected {} out of a pool of {}", chosenNode.idString(), pool.size());
+        return chosenNode;
+    }
+
+    private Node randomLeastLoadedNode(long now, List<Node> nodes) {
+        int offset = this.randOffset.nextInt(nodes.size());
+        for (int i = 0; i < nodes.size(); i++) {
+            int idx = (offset + i) % nodes.size();
+            Node node = nodes.get(idx);
+            if (canSendRequest(node.idString(), now)) {
+                log.trace("Found random least loaded node {} connected with spare capacity", node);
+                return node;
+            } else if (connectionStates.isPreparingConnection(node.idString())) {
+                log.trace("Found random least loaded connecting node {}", node);
+                return node;
+            } else if (canConnect(node, now)) {
+                log.trace("Found random least loaded connecting node {} with no active connection", node);
+                return node;
+            } else {
+                log.trace("Removing node {} from least loaded node selection since it is neither ready " +
+                    "for sending or connecting", node);
+            }
+        }
+        log.trace("Least loaded node random selection failed to find an available node");
+        return null;
+    }
+
+    private Node haskinsLeastLoadedNode(long now, List<Node> nodes) {
+
+        PriorityQueue<CandidateNode> pool = new PriorityQueue<>(16);
+
+        //scan over nodes starting at a random location to compensate for our early loop
+        //termination clause
+        int offset = this.randOffset.nextInt(nodes.size());
+        for (int i = 0; i < nodes.size(); i++) {
+            int idx = (offset + i) % nodes.size();
+            Node node = nodes.get(idx);
+            String id = node.idString();
+            if (canSendRequest(node.idString(), now)) {
+                int currInflight = this.inFlightRequests.count(node.idString());
+                pool.add(new CandidateNode(node, NodeState.HAS_CAPACITY, currInflight));
+            } else if (connectionStates.isPreparingConnection(node.idString())) {
+                pool.add(new CandidateNode(node, NodeState.CONNECTING, 0));
+            } else if (canConnect(node, now)) {
+                pool.add(new CandidateNode(node, NodeState.CONNECTABLE, 0));
+            } else {
+                log.trace("Removing node {} from least loaded node selection since it is neither ready " +
+                    "for sending or connecting", node);
+                continue;
+            }
+
+            if (pool.size() >= 15) {
+                if (pool.size() > 15) {
+                    pool.poll(); //remove "worst" node leaving 15
+                }
+                CandidateNode worstCandidate = pool.peek();
+                if (NodeState.HAS_CAPACITY.equals(worstCandidate.state) && worstCandidate.weight == 0) {
+                    //early loop termination - we have 15 candidates with live sockets and 0 in-flight
+                    break;
+                }
+            }
+        }
+
+        if (pool.isEmpty()) {
+            log.trace("Least loaded node selection failed to find an available node (empty pool)");
+            return null;
+        }
+
+        CandidateNode[] finalists = pool.toArray(new CandidateNode[0]);
+        int numCandidates = finalists.length;
+        int chosen;
+        if (numCandidates >= 7) {
+            //ignore the top 5
+            chosen = 5 + randOffset.nextInt(numCandidates - 5);
+        } else {
+            //dont have enough candidates to ignore anything
+            chosen = randOffset.nextInt(numCandidates);
+        }
         Node chosenNode = finalists[chosen].node;
         log.trace("Least loaded node selected {} out of a pool of {}", chosenNode.idString(), pool.size());
         return chosenNode;
@@ -1355,6 +1438,7 @@ public class NetworkClient implements KafkaClient {
                 log.trace("Ignoring empty metadata response with correlation id {}.", requestHeader.correlationId());
                 this.metadata.failedUpdate(now);
             } else {
+                log.trace("Updating cached metadata from source {} with {} brokers", destination, response.brokersById().size());
                 this.metadata.update(inProgressRequestVersion, response, now);
             }
 


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION = vanilla logic can lead to clients being sticky to the same broker, which can cause issues. added new mode to spread out the MD requests a bit more.
EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
