### PR TITLE
[LI-HOTFIX] Cleaning up fetcher threads in ReplicaManagerTest

### DIFF
--- a/.github/workflows/build-and-test-on-pr-events.yml
+++ b/.github/workflows/build-and-test-on-pr-events.yml
@@ -45,11 +45,13 @@ jobs:
         run: ./gradlew cleanTest checkstyleMain checkstyleTest :clients:unitTest :core:unitTest --no-daemon -PxmlFindBugsReport=true
       - name: Archive client test output
         uses: actions/upload-artifact@v2
+        if: ${{ always() }}
         with:
           name: client-test-output
           path: client/build/reports/testOutput
       - name: Archive core test output
         uses: actions/upload-artifact@v2
+        if: ${{ always() }}
         with:
           name: core-test-output
           path: core/build/reports/testOutput

--- a/.github/workflows/build-and-test-on-pr-events.yml
+++ b/.github/workflows/build-and-test-on-pr-events.yml
@@ -42,4 +42,4 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle and run all unit tests
         # exclude the streams test and connect test
-        run: ./gradlew cleanTest checkstyleMain checkstyleTest :clients:unitTest :core:unitTest --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
+        run: ./gradlew cleanTest checkstyleMain checkstyleTest :clients:unitTest :core:unitTest --no-daemon -PxmlFindBugsReport=true

--- a/.github/workflows/build-and-test-on-pr-events.yml
+++ b/.github/workflows/build-and-test-on-pr-events.yml
@@ -43,3 +43,14 @@ jobs:
       - name: Build with Gradle and run all unit tests
         # exclude the streams test and connect test
         run: ./gradlew cleanTest checkstyleMain checkstyleTest :clients:unitTest :core:unitTest --no-daemon -PxmlFindBugsReport=true
+      - name: Archive client test output
+        uses: actions/upload-artifact@v2
+        with:
+          name: client-test-output
+          path: client/build/reports/testOutput
+      - name: Archive core test output
+        uses: actions/upload-artifact@v2
+        with:
+          name: core-test-output
+          path: core/build/reports/testOutput
+

--- a/core/src/main/scala/kafka/server/AsyncReplicaFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AsyncReplicaFetcherManager.scala
@@ -34,7 +34,7 @@ class AsyncReplicaFetcherManager(brokerConfig: KafkaConfig,
 
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): FetcherEventManager = {
     val prefix = threadNamePrefix.map(tp => s"$tp:").getOrElse("")
-    val threadName = s"${prefix}ReplicaFetcherThread-$fetcherId-${sourceBroker.id}"
+    val threadName = s"${prefix}AsyncReplicaFetcherThread-$fetcherId-${sourceBroker.id}"
     val fetcherEventBus = new FetcherEventBus(time)
     val replicaFetcher = new AsyncReplicaFetcher(threadName, fetcherId, sourceBroker, brokerConfig, failedPartitions, replicaManager,
       metrics, time, quotaManager, fetcherEventBus)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
@@ -35,6 +35,11 @@ class ReplicaFetcherManager(brokerConfig: KafkaConfig,
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaFetcherThread = {
     val prefix = threadNamePrefix.map(tp => s"$tp:").getOrElse("")
     val threadName = s"${prefix}ReplicaFetcherThread-$fetcherId-${sourceBroker.id}"
+    try {
+      throw new Exception("test message")
+    } catch {
+      case e:Exception => e.printStackTrace()
+    }
     new ReplicaFetcherThread(threadName, fetcherId, sourceBroker, brokerConfig, failedPartitions, replicaManager,
       metrics, time, quotaManager)
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -81,6 +81,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
   @After
   def tearDown(): Unit = {
     metrics.close()
+    TestUtils.assertNoNonDaemonThreads(this.getClass.getName)
   }
 
   @Test
@@ -119,6 +120,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
     // Trigger sending of ISR notifications.
     rm.maybePropagateIsrChanges()
     EasyMock.verify(kafkaZkClient)
+    rm.shutdown(false)
   }
 
   @Test
@@ -856,6 +858,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
 
     // Truncation should have happened once
     EasyMock.verify(mockLogMgr)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -894,6 +897,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
     val preferredReadReplica: Option[Int] = replicaManager.findPreferredReadReplica(
       tp0, metadata, Request.OrdinaryConsumerId, 1L, System.currentTimeMillis)
     assertFalse(preferredReadReplica.isDefined)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -945,6 +949,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
 
     // But only leader will compute preferred replica
     assertTrue(consumerResult.assertFired.preferredReadReplica.isEmpty)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -996,6 +1001,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
 
     // Returns a preferred replica (should just be the leader, which is None)
     assertFalse(consumerResult.assertFired.preferredReadReplica.isDefined)
+    replicaManager.shutdown(false)
   }
 
   @Test(expected = classOf[ClassNotFoundException])
@@ -1030,6 +1036,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
       topicPartition, leaderEpoch + leaderEpochIncrement, followerBrokerId,
       leaderBrokerId, countDownLatch, expectTruncation = true, props)
     assertFalse(replicaManager.replicaSelectorOpt.isDefined)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -1068,6 +1075,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
     fetchResult = sendConsumerFetch(replicaManager, tp0, partitionData, None)
     assertNotNull(fetchResult.get)
     assertEquals(Errors.NOT_LEADER_FOR_PARTITION, fetchResult.get.error)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -1116,6 +1124,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
 
     assertNotNull(fetchResult.get)
     assertEquals(Errors.NOT_LEADER_FOR_PARTITION, fetchResult.get.error)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -1165,6 +1174,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
 
     assertNotNull(fetchResult.get)
     assertEquals(Errors.FENCED_LEADER_EPOCH, fetchResult.get.error)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -1202,6 +1212,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
     fetchResult = sendConsumerFetch(replicaManager, tp0, partitionData, Some(clientMetadata))
     assertNotNull(fetchResult.get)
     assertEquals(Errors.NONE, fetchResult.get.error)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -1245,6 +1256,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
     replicaManager.stopReplica(tp0, deletePartition = true)
     assertNotNull(fetchResult.get)
     assertEquals(Errors.NOT_LEADER_FOR_PARTITION, fetchResult.get.error)
+    replicaManager.shutdown(false)
   }
 
   @Test
@@ -1279,6 +1291,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
     replicaManager.stopReplica(tp0, deletePartition = true)
     assertNotNull(produceResult.get)
     assertEquals(Errors.NOT_LEADER_FOR_PARTITION, produceResult.get.error)
+    replicaManager.shutdown(false)
   }
 
   private def sendProducerAppend(replicaManager: ReplicaManager,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -73,6 +73,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
 
   @Before
   def setUp(): Unit = {
+    TestUtils.assertNoNonDaemonThreads(this.getClass.getName)
     kafkaZkClient = EasyMock.createMock(classOf[KafkaZkClient])
     EasyMock.expect(kafkaZkClient.getEntityConfigs(EasyMock.anyString(), EasyMock.anyString())).andReturn(new Properties()).anyTimes()
     EasyMock.replay(kafkaZkClient)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1028,8 +1028,13 @@ object TestUtils extends Logging {
   // Note: Call this method in the test itself, rather than the @After method.
   // Because of the assert, if assertNoNonDaemonThreads fails, nothing after would be executed.
   def assertNoNonDaemonThreads(threadNamePrefix: String): Unit = {
-    val threadCount = Thread.getAllStackTraces.keySet.asScala.count { t =>
-      !t.isDaemon && t.isAlive && t.getName.startsWith(threadNamePrefix)
+    val threadCount = Thread.getAllStackTraces.keySet.asScala.count { t => {
+      val result = !t.isDaemon && t.isAlive && t.getName.startsWith(threadNamePrefix)
+      if (result) {
+        throw new IllegalStateException("found non-daemon thread " + t.getName)
+      }
+      result
+    }
     }
     assertEquals(0, threadCount)
   }


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
At the end of the ReplicaManagerTest.testIllegalRequiredAcks test,
there is logic to verify that there are no non-daemon threads with
TestUtils.assertNoNonDaemonThreads(this.getClass.getName)

However, some other test in the same class could have left some
non-daemon threads running, which will cause the test above to fail.

This PR ensures that each test method closes the fetcher threads
it may have created. Also, validation is added to the tearDown
method to ensure no non-daemon threads are left running by each test method.

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
