### PR TITLE
Add KafkaActions interface to invoke environment-dependent actions

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaActions.scala
+++ b/core/src/main/scala/kafka/server/KafkaActions.scala
@@ -1,7 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.server
 
 import org.apache.kafka.common.requests.ControlledShutdownResponse
 
+/** A general-purpose interface to abstract out environment-dependent functionality away from the core Kafka logic.
+ *  The interface prevents leaking the derived class dependencies in to the core Kafka packages.  */
 trait KafkaActions {
   /** Notify the controlled shutdown status.
    * @param safeToShutdown Whether this broker has determined that it's safe to shutdown.
@@ -10,3 +29,8 @@ trait KafkaActions {
    * */
   def notifyControlledShutdownStatus(safeToShutdown: Boolean, prevControlledShutdownResponse: ControlledShutdownResponse, remainingRetries: Long): Unit
 }
+
+object NoOpKafkaActions extends KafkaActions {
+  override def notifyControlledShutdownStatus(safeToShutdown: Boolean, prevControlledShutdownResponse: ControlledShutdownResponse, remainingRetries: Long): Unit = ()
+}
+

--- a/core/src/main/scala/kafka/server/KafkaActions.scala
+++ b/core/src/main/scala/kafka/server/KafkaActions.scala
@@ -1,0 +1,12 @@
+package kafka.server
+
+import org.apache.kafka.common.requests.ControlledShutdownResponse
+
+trait KafkaActions {
+  /** Notify the controlled shutdown status.
+   * @param safeToShutdown Whether this broker has determined that it's safe to shutdown.
+   * @param prevControlledShutdownResponse The ControlledShutdownResponse that prevented a successful shutdown in this iteration
+   * @param remainingRetries The remaining retries (possibly zero)
+   * */
+  def notifyControlledShutdownStatus(safeToShutdown: Boolean, prevControlledShutdownResponse: ControlledShutdownResponse, remainingRetries: Long): Unit
+}

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -521,6 +521,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
         while (!shutdownSucceeded && remainingRetries > 0) {
           remainingRetries = remainingRetries - 1
+          shutdownResponse = null
 
           // 1. Find the controller and establish a connection to it.
 
@@ -553,7 +554,6 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
           // 2. issue a controlled shutdown to the controller
           if (prevController != null) {
             try {
-
               if (!NetworkClientUtils.awaitReady(networkClient, node(prevController), time, socketTimeoutMs))
                 throw new SocketTimeoutException(s"Failed to connect within $socketTimeoutMs ms")
 
@@ -603,7 +603,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
             warn("Retrying controlled shutdown after the previous attempt failed...")
           }
           /** In case {@link KafkaController.safeToShutdown} reported that it's not safe to shutdown,
-           * the delegate KafkaAction will invoke Cruise-Control to demote this broker. */
+           * the delegate KafkaAction will invoke Cruise-Control to demote this broker in Azure environment only. */
           kafkaActions.notifyControlledShutdownStatus(shutdownSucceeded, shutdownResponse, remainingRetries)
         }
       }


### PR DESCRIPTION
While handling a `ControlledShutdownRequest`, the controller might deny a broker's shutdown request if the safety check is not satisfied thereby not draining the leaderships away from the shutting down broker as it would have done otherwise. The safety checks ensures the minimum number of replicas in the ISR among other things. The safety check may not be satisfied for a long time if the cluster is unhealthy or it's taking a really long time to catchup. Therefore, retrying `ControlledShutdownRequest` does not guarantee traffic draining.

However, in Azure environment, a [reboot MaintenanceEvent](https://docs.microsoft.com/en-us/azure/virtual-machines/maintenance-notifications) gives only 15 minutes heads up. At the end of the 15 minutes, the broker VM will shut down. This gives a 15 minutes window to drain the leaderships (of the healthy partitions) away from the broker via some external mechanism (e.g., CruiseControl [DemoteBrokerPlan](https://github.com/linkedin/cruise-control/blob/master/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/detector/DemoteBrokerPlan.java)). 

This PR adds a "hook" interface `KafkaActions` to implement such a environment-dependent action in the broker's logic.