### PR TITLE
[LI-HOTFIX] Skip shutdown safety check at epoch already checked

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1335,13 +1335,14 @@ class KafkaController(val config: KafkaConfig,
 
       // See which replicas are known alive and not pending shutdown for this partition
       val liveBrokerIds = controllerContext.liveBrokerIds
-      val liveReplicasInIsr = controllerContext.partitionLeadershipInfo(partition).leaderAndIsr.isr.count({ replicaBrokerId =>
+      val isr = controllerContext.partitionLeadershipInfo(partition).leaderAndIsr.isr
+      val remainingLiveReplicasInIsr = isr.filter(replicaId => replicaId != id).count({ replicaBrokerId =>
         liveBrokerIds.contains(replicaBrokerId)
       })
 
       // Consider this topic-partition at-risk if removing one broker will result in the ISR shrinking below minISR
-      debug(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Broker $id is a replica and the ISR contains $liveReplicasInIsr live replicas.")
-      liveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
+      debug(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Removing broker $id will leave $remainingLiveReplicasInIsr live replicas in the ISR.")
+      remainingLiveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
     }
 
     atRiskPartitions.isEmpty

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1319,6 +1319,13 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def safeToShutdown(id: Int, brokerEpoch: Long): Boolean = {
+    // First, check whether or not the broker requesting shutdown has already been told that it is OK to shut down
+    // at this epoch.
+    if (controllerContext.shuttingDownBrokerIds.contains(id)
+      && controllerContext.shuttingDownBrokerIds(id) >= brokerEpoch) {
+      return true
+    }
+
     // If a topic doesn't have min.insync.replicas configured, default to 1
     val defaultMinISRPropertyValue = 1
 

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -167,7 +167,7 @@ object Defaults {
   val ControlledShutdownRetryBackoffMs = 5000
   val ControlledShutdownEnable = true
   val ControlledShutdownSafetyCheckEnable = false
-  val ControlledShutdownSafetyCheckRedundancyFactor = 2
+  val ControlledShutdownSafetyCheckRedundancyFactor = 1
 
   /** ********* Group coordinator configuration ***********/
   val GroupMinSessionTimeoutMs = 6000
@@ -776,7 +776,7 @@ object KafkaConfig {
   val ControlledShutdownRetryBackoffMsDoc = "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying."
   val ControlledShutdownEnableDoc = "Enable controlled shutdown of the server"
   val ControlledShutdownSafetyCheckEnableDoc = s"Perform a safety check in the controller before allowing a controlled shutdown to begin. The controller will try to confirm that allowing the broker requesting shutdown to shut down will not result in any partitions going offline by shrinking the ISR below min.in.sync.replicas. This only works if $ControlledShutdownEnableProp is true."
-  val ControlledShutdownSafetyCheckRedundancyFactorDoc = s"If $ControlledShutdownSafetyCheckEnableProp is enabled, this configures the required redundancy for the safety check. If there are fewer than min.insync.replicas + $ControlledShutdownSafetyCheckRedundancyFactorProp replicas in the ISR, shutdown will not be allowed."
+  val ControlledShutdownSafetyCheckRedundancyFactorDoc = s"If $ControlledShutdownSafetyCheckEnableProp is enabled, this configures the required redundancy for the safety check. Shutdown will only be allowed if removing the broker will leave min.insync.replicas + $ControlledShutdownSafetyCheckRedundancyFactorProp replicas in the ISR."
   /** ********* Group coordinator configuration ***********/
   val GroupMinSessionTimeoutMsDoc = "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources."
   val GroupMaxSessionTimeoutMsDoc = "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures."


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
In c337e4752 (PR #103) a shutdown safety check was introduced. In
testing this in a large cluster, we found a problem. If the controller
sees that brokerId 1 is safe to shut down at brokerEpoch 99, it will
add that broker to `controllerContext.shuttingDownBrokerIds`. But it
might still not allow shutdown because some leadership transitions
must happen first.

In the process of performing those leadership transitions, brokerId 1
may receive StopReplica, which would cause it to leave the
ISR. Subsequent ControlledShutdownRequest attempts would then fail the
`safeToShutdown` safety check, so the broker would never be allowed to
shut down.

This patch just adjust the implementation of `safeToShutdown`
slightly. Now, if the controller has said that a broker is safe to
shut down at a given epoch, it will always allow that shutdown for
that epoch without performing any additional checks. This allows the
full controlled shutdown process to complete which in a large, busy
cluster may take several rounds of `ControlledShutdownRequest`.

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
