### PR TITLE
Add a backwards compatible constructor signature in KafkaServer

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -101,6 +101,11 @@ object KafkaServer {
  */
 class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNamePrefix: Option[String] = None,
                   kafkaMetricsReporters: Seq[KafkaMetricsReporter] = List(), actions: KafkaActions = NoOpKafkaActions) extends Logging with KafkaMetricsGroup {
+  /** Constructor signature that is backwards compatible */
+  def this(config: KafkaConfig, time: Time, threadNamePrefix: Option[String], kafkaMetricsReporters: Seq[KafkaMetricsReporter]) {
+    this(config, time, threadNamePrefix, kafkaMetricsReporters, NoOpKafkaActions)
+  }
+
   private val startupComplete = new AtomicBoolean(false)
   private val isShuttingDown = new AtomicBoolean(false)
   private val isStartingUp = new AtomicBoolean(false)


### PR DESCRIPTION
A constructor argument was added to `KafkaServer` in PR #156. Even though Scala has default arguments, any Java code that's referring to the previous constructor must be retooled to work with the new argument. This includes direct ctor  calls and reflection ctor calls. Without a backwards compatible constructor, which is added in this PR, the test code in MPs such as linkedin-kafka-clients and kafka-server MP fails to build. Adding a delegate constructor is the easiest way to fix issue.