### PR TITLE
[LI-HOTFIX] add configuration to control least loaded node logic in clients (backport)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -109,6 +109,13 @@ public class CommonClientConfigs {
                                                          + "retries are exhausted.";
 
 
+    public static final String LEAST_LOADED_NODE_ALGORITHM_CONFIG = "linkedin.least.loaded.node.algorithm";
+    public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = "when clients look for the least loaded (from the client point of view) node to route requests to "
+                                                                 + "(usually metadata requests) - which algorithm to use. values are in class org.apache.kafka.clients "
+                                                                 + "and are currently VANILLA (picks node with least expected latency) and AT_LEAST_THREE (random out "
+                                                                 + "of 3 lowest-expected-latency nodes)";
+    public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = LeastLoadedNodeAlgorithm.VANILLA.name();
+
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/LeastLoadedNodeAlgorithm.java
+++ b/clients/src/main/java/org/apache/kafka/clients/LeastLoadedNodeAlgorithm.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+/**
+ * algorithms for selecting the least loaded node in a kafka cluster
+ * from a client's point of view. used for selecting nodes to query for metadata
+ * (for example)
+ */
+public enum LeastLoadedNodeAlgorithm {
+  /**
+   * default upstream kafka selection algorithm.
+   * attempts to minimize latency, but may result in stickiness
+   * and hammering of dedicated controllers and brokers down
+   * for maintenance
+   */
+  VANILLA,
+  /**
+   * selects a random broker out of 3 candidates. candidates are preferably
+   * brokers with existing connections, but new connections will be initiated
+   * to get the candidate pool up to 3.
+   */
+  AT_LEAST_THREE,
+  /**
+   * selects a random broker out of all nodes except those for which the number
+   * of requests in flight is already at max.
+   * NOTE - this is expected to result in a lot of open sockets per client
+   * (worst case being one per broker)
+   */
+  RANDOM,
+  /**
+   * designed by an esteemed kafka SRE, this algorithm selects a broker out
+   * of the top 15 brokers EXCEPT the top 5 (so random broker out of brokers
+   * 5 to 15 in the best candidates structure). the idea is that the top 5
+   * may be dedicated controllers and/or brokers in maintenance mode, both
+   * of which we want to avoid hitting from clients
+   */
+  RANDOM_BETWEEN_5_TO_15
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -19,10 +19,12 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.LeastLoadedNodeAlgorithm;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.EnumValueValidator;
 import org.apache.kafka.common.metrics.Sensor;
 
 import java.util.Map;
@@ -109,6 +111,12 @@ public class AdminClientConfig extends AbstractConfig {
 
     public static final String RETRIES_CONFIG = CommonClientConfigs.RETRIES_CONFIG;
 
+    // LinkedIn Hotfixes
+
+    public static final String LEAST_LOADED_NODE_ALGORITHM_CONFIG = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_CONFIG;
+    public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
+    public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                                         Type.LIST,
@@ -186,6 +194,12 @@ public class AdminClientConfig extends AbstractConfig {
                                         DEFAULT_SECURITY_PROTOCOL,
                                         Importance.MEDIUM,
                                         SECURITY_PROTOCOL_DOC)
+                                .define(LEAST_LOADED_NODE_ALGORITHM_CONFIG,
+                                       Type.STRING,
+                                       DEFAULT_LEAST_LOADED_NODE_ALGORITHM,
+                                       new EnumValueValidator<>(LeastLoadedNodeAlgorithm.class),
+                                       Importance.MEDIUM,
+                                       LEAST_LOADED_NODE_ALGORITHM_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.LeastLoadedNodeAlgorithm;
 import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.StaleMetadataException;
 import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResult;
@@ -357,6 +358,9 @@ public class KafkaAdminClient extends AdminClient {
         Selector selector = null;
         ApiVersions apiVersions = new ApiVersions();
         LogContext logContext = createLogContext(clientId);
+        LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm = LeastLoadedNodeAlgorithm.valueOf(
+            config.getString(AdminClientConfig.LEAST_LOADED_NODE_ALGORITHM_CONFIG)
+        );
 
         try {
             // Since we only request node information, it's safe to pass true for allowAutoTopicCreation (and it
@@ -397,7 +401,8 @@ public class KafkaAdminClient extends AdminClient {
                 time,
                 true,
                 apiVersions,
-                logContext);
+                logContext,
+                leastLoadedNodeAlgorithm);
             return new KafkaAdminClient(config, clientId, time, metadataManager, metrics, networkClient,
                 timeoutProcessorFactory, logContext);
         } catch (Throwable exc) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -18,10 +18,12 @@ package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.LeastLoadedNodeAlgorithm;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.EnumValueValidator;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -295,6 +297,14 @@ public class ConsumerConfig extends AbstractConfig {
             " broker allows for it using `auto.create.topics.enable` broker configuration. This configuration must" +
             " be set to `false` when using brokers older than 0.11.0";
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
+
+    // LinkedIn Hotfixes
+
+    public static final String LEAST_LOADED_NODE_ALGORITHM_CONFIG = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_CONFIG;
+    public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
+    public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
+
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                                         Type.LIST,
@@ -528,6 +538,12 @@ public class ConsumerConfig extends AbstractConfig {
                                         CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
                                         Importance.MEDIUM,
                                         CommonClientConfigs.SECURITY_PROTOCOL_DOC)
+                                .define(LEAST_LOADED_NODE_ALGORITHM_CONFIG,
+                                        Type.STRING,
+                                        DEFAULT_LEAST_LOADED_NODE_ALGORITHM,
+                                        new EnumValueValidator<>(LeastLoadedNodeAlgorithm.class),
+                                        Importance.MEDIUM,
+                                        LEAST_LOADED_NODE_ALGORITHM_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientUtils;
+import org.apache.kafka.clients.LeastLoadedNodeAlgorithm;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerCoordinator;
@@ -746,6 +747,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             int heartbeatIntervalMs = config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG);
 
             ApiVersions apiVersions = new ApiVersions();
+
+            LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm = LeastLoadedNodeAlgorithm.valueOf(
+                config.getString(ConsumerConfig.LEAST_LOADED_NODE_ALGORITHM_CONFIG)
+            );
+
             NetworkClient netClient = new NetworkClient(
                     new Selector(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder, logContext),
                     this.metadata,
@@ -761,7 +767,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     true,
                     apiVersions,
                     throttleTimeSensor,
-                    logContext);
+                    logContext,
+                    leastLoadedNodeAlgorithm);
+
             this.client = new ConsumerNetworkClient(
                     logContext,
                     netClient,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.KafkaClient;
+import org.apache.kafka.clients.LeastLoadedNodeAlgorithm;
 import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -444,6 +445,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(producerConfig, time);
         ProducerMetrics metricsRegistry = new ProducerMetrics(this.metrics);
         Sensor throttleTimeSensor = Sender.throttleTimeSensor(metricsRegistry.senderMetrics);
+        LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm = LeastLoadedNodeAlgorithm.valueOf(
+            producerConfig.getString(ProducerConfig.LEAST_LOADED_NODE_ALGORITHM_CONFIG)
+        );
         KafkaClient client = kafkaClient != null ? kafkaClient : new NetworkClient(
                 new Selector(producerConfig.getLong(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
                         this.metrics, time, "producer", channelBuilder, logContext),
@@ -460,7 +464,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 true,
                 apiVersions,
                 throttleTimeSensor,
-                logContext);
+                logContext,
+                leastLoadedNodeAlgorithm);
         int retries = configureRetries(producerConfig, transactionManager != null, log);
         short acks = configureAcks(producerConfig, transactionManager != null, log);
         return new Sender(logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -18,12 +18,14 @@ package org.apache.kafka.clients.producer;
 
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.LeastLoadedNodeAlgorithm;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.clients.producer.internals.ProducerMetadata;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.EnumValueValidator;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -255,6 +257,12 @@ public class ProducerConfig extends AbstractConfig {
     private static final String ALLOW_AUTO_CREATE_TOPICS_DOC = "The client-side (producer) permission to allow auto-topic creation. Both the client-side and the broker-side should enable auto-topic creation in order for a topic to be automatically created";
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
+    // LinkedIn Hotfixes
+
+    public static final String LEAST_LOADED_NODE_ALGORITHM_CONFIG = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_CONFIG;
+    public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
+    public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Collections.emptyList(), new ConfigDef.NonNullValidator(), Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
                                 .define(CLIENT_DNS_LOOKUP_CONFIG,
@@ -388,7 +396,13 @@ public class ProducerConfig extends AbstractConfig {
                                         Type.BOOLEAN,
                                         DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
                                         Importance.MEDIUM,
-                                        ALLOW_AUTO_CREATE_TOPICS_DOC);
+                                        ALLOW_AUTO_CREATE_TOPICS_DOC)
+                                .define(LEAST_LOADED_NODE_ALGORITHM_CONFIG,
+                                        Type.STRING,
+                                        DEFAULT_LEAST_LOADED_NODE_ALGORITHM,
+                                        new EnumValueValidator<>(LeastLoadedNodeAlgorithm.class),
+                                        Importance.MEDIUM,
+                                        LEAST_LOADED_NODE_ALGORITHM_DOC);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/config/EnumValueValidator.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/EnumValueValidator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.config;
+
+import java.util.Arrays;
+
+
+/**
+ * validates that a given input string is a legal enum value
+ * @param <E> the enum class
+ */
+public class EnumValueValidator<E extends Enum<?>> implements ConfigDef.Validator {
+    private final Class<E> enumClass;
+
+    public EnumValueValidator(Class<E> enumClass) {
+        this.enumClass = enumClass;
+    }
+
+    @Override
+    public void ensureValid(String name, Object value) {
+        if (value == null) {
+            //allow nulls
+            return;
+        }
+        String valueStr = (String) value;
+        E[] legalValues = enumClass.getEnumConstants();
+        for  (E legal : legalValues) {
+            //case sensitive on purpose
+            if (legal.name().equals(valueStr)) {
+                return;
+            }
+        }
+        throw new ConfigException("value \"" + valueStr + "\" for " + name + " is not one of " + Arrays.toString(legalValues));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.PriorityQueue;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -575,6 +576,53 @@ public class NetworkClientTest {
         assertTrue(client.canConnect(node, time.milliseconds()));
         client.disconnect(node.idString());
         assertTrue(client.canConnect(node, time.milliseconds()));
+    }
+
+    @Test
+    public void testLeastLoadedNodePrioritization() {
+        Node nodeA = new Node(1, "1", 666);
+        Node nodeB = new Node(2, "2", 666);
+        Node nodeC = new Node(3, "3", 666);
+
+        NetworkClient.CandidateNode candA = new NetworkClient.CandidateNode(nodeA, NetworkClient.NodeState.HAS_CAPACITY, 7);
+        NetworkClient.CandidateNode candB = new NetworkClient.CandidateNode(nodeB, NetworkClient.NodeState.HAS_CAPACITY, 7);
+        assertEquals(0, candA.compareTo(candB));
+        assertEquals(0, candB.compareTo(candA));
+
+        assertTrue(
+                new NetworkClient.CandidateNode(nodeA, NetworkClient.NodeState.HAS_CAPACITY, 8).compareTo(
+                        new NetworkClient.CandidateNode(nodeB, NetworkClient.NodeState.HAS_CAPACITY, 5)
+                ) < 0);
+
+        assertTrue(
+                new NetworkClient.CandidateNode(nodeA, NetworkClient.NodeState.HAS_CAPACITY, 1).compareTo(
+                        new NetworkClient.CandidateNode(nodeB, NetworkClient.NodeState.HAS_CAPACITY, 9)
+                ) > 0);
+
+        assertTrue(
+                new NetworkClient.CandidateNode(nodeA, NetworkClient.NodeState.CONNECTING, 1).compareTo(
+                        new NetworkClient.CandidateNode(nodeB, NetworkClient.NodeState.HAS_CAPACITY, 666)
+                ) < 0);
+
+        assertTrue(
+                new NetworkClient.CandidateNode(nodeA, NetworkClient.NodeState.CONNECTABLE, 0).compareTo(
+                        new NetworkClient.CandidateNode(nodeB, NetworkClient.NodeState.CONNECTING, Integer.MAX_VALUE)
+                ) < 0);
+
+        PriorityQueue<NetworkClient.CandidateNode> queue = new PriorityQueue<>();
+
+        queue.add(new NetworkClient.CandidateNode(nodeA, NetworkClient.NodeState.HAS_CAPACITY, 4));
+        queue.add(new NetworkClient.CandidateNode(nodeB, NetworkClient.NodeState.HAS_CAPACITY, 1));
+        queue.add(new NetworkClient.CandidateNode(nodeC, NetworkClient.NodeState.CONNECTING, 0)); //worst
+
+        assertEquals(3, queue.poll().node.id());
+
+        queue.clear();
+        queue.add(new NetworkClient.CandidateNode(nodeA, NetworkClient.NodeState.CONNECTABLE, -1000)); //worst
+        queue.add(new NetworkClient.CandidateNode(nodeB, NetworkClient.NodeState.CONNECTING, 7));
+        queue.add(new NetworkClient.CandidateNode(nodeC, NetworkClient.NodeState.HAS_CAPACITY, 0));
+
+        assertEquals(1, queue.poll().node.id());
     }
 
     private void awaitInFlightApiVersionRequest() throws Exception {


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION = vanilla logic can lead to clients being sticky to the same broker, which can cause issues. added new mode to spread out the MD requests a bit more.
EXIT_CRITERIA = N/A

Co-authored-by: Radai Rosenblatt <rrosenbl@rrosenbl-mn1.linkedin.biz>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
