### PR TITLE
Replace java.util.stream.* api usages with non-functional old style code in Metadata request/response

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.common.requests;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.MetadataRequestData.MetadataRequestTopic;
@@ -23,12 +28,6 @@ import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
-
-import java.nio.ByteBuffer;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class MetadataRequest extends AbstractRequest {
 
@@ -53,7 +52,9 @@ public class MetadataRequest extends AbstractRequest {
             if (topics == null)
                 data.setTopics(null);
             else {
-                topics.forEach(topic -> data.topics().add(new MetadataRequestTopic().setName(topic)));
+                for (String topic: topics) {
+                    data.topics().add(new MetadataRequestTopic().setName(topic));
+                }
             }
 
             data.setAllowAutoTopicCreation(allowAutoTopicCreation);
@@ -79,10 +80,11 @@ public class MetadataRequest extends AbstractRequest {
         }
 
         public List<String> topics() {
-            return data.topics()
-                .stream()
-                .map(MetadataRequestTopic::name)
-                .collect(Collectors.toList());
+            List<String> topicList = new ArrayList<>();
+            for (MetadataRequestData.MetadataRequestTopic mdTopic: data.topics()) {
+                topicList.add(mdTopic.name());
+            }
+            return topicList;
         }
 
         @Override
@@ -162,11 +164,13 @@ public class MetadataRequest extends AbstractRequest {
     public List<String> topics() {
         if (isAllTopics()) //In version 0, we return null for empty topic list
             return null;
-        else
-            return data.topics()
-                .stream()
-                .map(MetadataRequestTopic::name)
-                .collect(Collectors.toList());
+        else {
+            List<String> topics = new ArrayList<>(data.topics().size());
+            for (MetadataRequestTopic topic: data.topics()) {
+                topics.add(topic.name());
+            }
+            return topics;
+        }
     }
 
     public boolean allowAutoTopicCreation() {
@@ -178,9 +182,11 @@ public class MetadataRequest extends AbstractRequest {
     }
 
     public static List<MetadataRequestTopic> convertToMetadataRequestTopic(final Collection<String> topics) {
-        return topics.stream().map(topic -> new MetadataRequestTopic()
-            .setName(topic))
-            .collect(Collectors.toList());
+        List<MetadataRequestTopic> metadataRequestTopicList = new ArrayList<>(topics.size());
+        for (String topicName: topics) {
+            metadataRequestTopicList.add(new MetadataRequestTopic().setName(topicName));
+        }
+        return metadataRequestTopicList;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -79,8 +79,12 @@ public class MetadataRequest extends AbstractRequest {
             return data.topics() == null;
         }
 
+        // Used for testing only
         public List<String> topics() {
-            List<String> topicList = new ArrayList<>();
+            if (data.topics() == null) {
+                return Collections.emptyList();
+            }
+            List<String> topicList = new ArrayList<>(data.topics().size());
             for (MetadataRequestData.MetadataRequestTopic mdTopic: data.topics()) {
                 topicList.add(mdTopic.name());
             }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -17,16 +17,8 @@
 
 package kafka.server
 
-import java.lang.{Byte => JByte}
-import java.lang.{Long => JLong}
-import java.nio.ByteBuffer
-import java.util
-import java.util.{Collections, Optional}
-import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
-import java.util.concurrent.atomic.AtomicInteger
 import kafka.admin.{AdminUtils, RackAwareMode}
-import kafka.api.ElectLeadersRequestOps
-import kafka.api.{ApiVersion, KAFKA_0_11_0_IV0, KAFKA_2_3_IV0}
+import kafka.api.{ApiVersion, ElectLeadersRequestOps, KAFKA_0_11_0_IV0, KAFKA_2_3_IV0}
 import kafka.cluster.Partition
 import kafka.common.OffsetAndMetadata
 import kafka.controller.{KafkaController, ReplicaAssignment}
@@ -39,25 +31,24 @@ import kafka.security.authorizer.AuthorizerUtils
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
 import kafka.utils.{CoreUtils, LiDecomposedControlRequestUtils, Logging}
 import kafka.zk.{AdminZkClient, KafkaZkClient}
-import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
-import org.apache.kafka.common.acl.{AclBinding, AclOperation}
+import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.common.acl.AclOperation._
+import org.apache.kafka.common.acl.{AclBinding, AclOperation}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.FatalExitError
 import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, isInternal}
-import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic
-import org.apache.kafka.common.message.{AlterPartitionReassignmentsResponseData, ApiVersionsResponseData, CreateTopicsResponseData, DeleteGroupsResponseData, DeleteTopicsResponseData, DescribeGroupsResponseData, ExpireDelegationTokenResponseData, FindCoordinatorResponseData, HeartbeatResponseData, InitProducerIdResponseData, JoinGroupResponseData, LeaveGroupResponseData, LiCombinedControlResponseData, ListGroupsResponseData, ListPartitionReassignmentsResponseData, OffsetCommitRequestData, OffsetCommitResponseData, OffsetDeleteResponseData, RenewDelegationTokenResponseData, SaslAuthenticateResponseData, SaslHandshakeResponseData, StopReplicaResponseData, SyncGroupResponseData, UpdateMetadataResponseData}
-import org.apache.kafka.common.message.CreateTopicsResponseData.{CreatableTopicResult, CreatableTopicResultCollection}
-import org.apache.kafka.common.message.DeleteGroupsResponseData.{DeletableGroupResult, DeletableGroupResultCollection}
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.{ReassignablePartitionResponse, ReassignableTopicResponse}
 import org.apache.kafka.common.message.ApiVersionsResponseData.{ApiVersionsResponseKey, ApiVersionsResponseKeyCollection}
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic
+import org.apache.kafka.common.message.CreateTopicsResponseData.{CreatableTopicResult, CreatableTopicResultCollection}
+import org.apache.kafka.common.message.DeleteGroupsResponseData.{DeletableGroupResult, DeletableGroupResultCollection}
 import org.apache.kafka.common.message.DeleteTopicsResponseData.{DeletableTopicResult, DeletableTopicResultCollection}
-import org.apache.kafka.common.message.ElectLeadersResponseData.PartitionResult
-import org.apache.kafka.common.message.ElectLeadersResponseData.ReplicaElectionResult
+import org.apache.kafka.common.message.ElectLeadersResponseData.{PartitionResult, ReplicaElectionResult}
 import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse
 import org.apache.kafka.common.message.LiCombinedControlResponseData.StopReplicaPartitionError
+import org.apache.kafka.common.message._
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.{ListenerName, Send}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
@@ -79,9 +70,15 @@ import org.apache.kafka.common.utils.{LiCombinedControlTransformer, Time, Utils}
 import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.server.authorizer._
 
-import scala.compat.java8.OptionConverters._
+import java.lang.{Byte => JByte, Long => JLong}
+import java.nio.ByteBuffer
+import java.util
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.{Collections, Optional}
 import scala.collection.JavaConverters._
 import scala.collection.{Map, Seq, Set, immutable, mutable}
+import scala.compat.java8.OptionConverters._
 import scala.util.{Failure, Success, Try}
 
 
@@ -1209,10 +1206,18 @@ class KafkaApis(val requestChannel: RequestChannel,
     trace("Sending topic metadata %s and brokers %s for correlation id %d to client %s".format(completeTopicMetadata.mkString(","),
       brokers.mkString(","), request.header.correlationId, request.header.clientId))
 
+    val brokersJava: java.util.List[Node] = new util.ArrayList[Node](brokers.length)
+      for (b <- brokers) {
+        val n = b.getNode(request.context.listenerName)
+        if (n != null && n.isDefined) {
+          brokersJava.add(n.get)
+        }
+      }
+
     sendResponseMaybeThrottle(request, requestThrottleMs =>
        MetadataResponse.prepareResponse(
          requestThrottleMs,
-         brokers.flatMap(_.getNode(request.context.listenerName)).asJava,
+         brokersJava,
          clusterId,
          metadataCache.getControllerId.getOrElse(MetadataResponse.NO_CONTROLLER_ID),
          completeTopicMetadata.asJava,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1206,7 +1206,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     trace("Sending topic metadata %s and brokers %s for correlation id %d to client %s".format(completeTopicMetadata.mkString(","),
       brokers.mkString(","), request.header.correlationId, request.header.clientId))
 
-    val brokersJava: java.util.List[Node] = new util.ArrayList[Node](brokers.length)
+    val brokersJava: java.util.List[Node] = new java.util.ArrayList[Node](brokers.length)
       for (b <- brokers) {
         val n = b.getNode(request.context.listenerName)
         if (n != null && n.isDefined) {

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -128,16 +128,10 @@ class MetadataCache(brokerId: Int) extends Logging {
       Option(result)
   }
 
-  private def getAliveEndpoint(snapshot: MetadataSnapshot, brokerId: Int, listenerName: ListenerName): Option[Node] = {
+  private def getAliveEndpoint(snapshot: MetadataSnapshot, brokerId: Int, listenerName: ListenerName): Option[Node] =
     // Returns None if broker is not alive or if the broker does not have a listener named `listenerName`.
     // Since listeners can be added dynamically, a broker with a missing listener could be a transient error.
-    val listenerMap = snapshot.aliveNodes.get(brokerId)
-    if (listenerMap.isDefined && listenerMap.get.contains(listenerName)) {
-      listenerMap.get.get(listenerName)
-    } else {
-      None
-    }
-  }
+    snapshot.aliveNodes.get(brokerId).flatMap(_.get(listenerName))
 
   // errorUnavailableEndpoints exists to support v0 MetadataResponses
   def getTopicMetadata(topics: Set[String], listenerName: ListenerName, errorUnavailableEndpoints: Boolean = false,

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -60,15 +60,12 @@ class MetadataCache(brokerId: Int) extends Logging {
   // filterUnavailableEndpoints exists to support v0 MetadataResponses
   private def getEndpoints(snapshot: MetadataSnapshot, brokers: Iterable[java.lang.Integer], listenerName: ListenerName, filterUnavailableEndpoints: Boolean): Seq[Node] = {
     val result = new mutable.ArrayBuffer[Node](math.min(snapshot.aliveBrokers.size, brokers.size))
-    for (brokerId <- brokers) {
-      val endpoint = getAliveEndpoint(snapshot, brokerId, listenerName)
-      if (endpoint.isDefined) {
-        result += endpoint.get
-      } else {
-        if (!filterUnavailableEndpoints) {
-          result += new Node(brokerId, "", -1)
-        }
+    brokers.foreach { brokerId =>
+      val endpoint = getAliveEndpoint(snapshot, brokerId, listenerName) match {
+        case None => if (!filterUnavailableEndpoints) Some(new Node(brokerId, "", -1)) else None
+        case Some(node) => Some(node)
       }
+      endpoint.foreach(result +=)
     }
     result
   }

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -17,23 +17,24 @@
 
 package kafka.server
 
-import java.util.{Collections, Optional}
-import java.util.concurrent.locks.ReentrantReadWriteLock
-
-import scala.collection.{Seq, Set, mutable}
-import scala.collection.JavaConverters._
-import kafka.cluster.{Broker, EndPoint}
 import kafka.api._
+import kafka.cluster.{Broker, EndPoint}
 import kafka.controller.StateChangeLogger
 import kafka.utils.CoreUtils._
 import kafka.utils.Logging
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataPartitionState
-import org.apache.kafka.common.{Cluster, Node, PartitionInfo, TopicPartition}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{MetadataResponse, UpdateMetadataRequest}
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.common.{Cluster, Node, PartitionInfo, TopicPartition}
+
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import java.util.{Collections, Optional}
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.{Seq, Set, mutable}
 
 
 /**
@@ -59,12 +60,15 @@ class MetadataCache(brokerId: Int) extends Logging {
   // filterUnavailableEndpoints exists to support v0 MetadataResponses
   private def getEndpoints(snapshot: MetadataSnapshot, brokers: Iterable[java.lang.Integer], listenerName: ListenerName, filterUnavailableEndpoints: Boolean): Seq[Node] = {
     val result = new mutable.ArrayBuffer[Node](math.min(snapshot.aliveBrokers.size, brokers.size))
-    brokers.foreach { brokerId =>
-      val endpoint = getAliveEndpoint(snapshot, brokerId, listenerName) match {
-        case None => if (!filterUnavailableEndpoints) Some(new Node(brokerId, "", -1)) else None
-        case Some(node) => Some(node)
+    for (brokerId <- brokers) {
+      val endpoint = getAliveEndpoint(snapshot, brokerId, listenerName)
+      if (endpoint != null && endpoint.isDefined) {
+        result += endpoint.get
+      } else {
+        if (!filterUnavailableEndpoints) {
+          result += new Node(brokerId, "", -1)
+        }
       }
-      endpoint.foreach(result +=)
     }
     result
   }
@@ -74,9 +78,12 @@ class MetadataCache(brokerId: Int) extends Logging {
   // Otherwise, return LEADER_NOT_AVAILABLE for broker unavailable and missing listener (Metadata response v5 and below).
   private def getPartitionMetadata(snapshot: MetadataSnapshot, topic: String, listenerName: ListenerName, errorUnavailableEndpoints: Boolean,
                                    errorUnavailableListeners: Boolean): Option[Iterable[MetadataResponse.PartitionMetadata]] = {
-    snapshot.partitionStates.get(topic).map { partitions =>
-      partitions.map { case (partitionId, partitionState) =>
-        val topicPartition = new TopicPartition(topic, partitionId.toInt)
+    val result = new ArrayBuffer[MetadataResponse.PartitionMetadata]
+    for (partitionsMap <- snapshot.partitionStates.get(topic)) {
+      for (partitionEntry <- partitionsMap) {
+        val partitionId = partitionEntry._1.toInt
+        val partitionState = partitionEntry._2
+        val topicPartition = new TopicPartition(topic, partitionId)
         val leaderBrokerId = partitionState.leader
         val leaderEpoch = partitionState.leaderEpoch
         val maybeLeader = getAliveEndpoint(snapshot, leaderBrokerId, listenerName)
@@ -95,7 +102,7 @@ class MetadataCache(brokerId: Int) extends Logging {
               debug(s"Error while fetching metadata for $topicPartition: listener $listenerName not found on leader $leaderBrokerId")
               if (errorUnavailableListeners) Errors.LISTENER_NOT_FOUND else Errors.LEADER_NOT_AVAILABLE
             }
-            new MetadataResponse.PartitionMetadata(error, partitionId.toInt, Node.noNode(),
+            result += new MetadataResponse.PartitionMetadata(error, partitionId, Node.noNode(),
               Optional.empty(), replicaInfo.asJava, isrInfo.asJava,
               offlineReplicaInfo.asJava)
 
@@ -104,20 +111,24 @@ class MetadataCache(brokerId: Int) extends Logging {
               debug(s"Error while fetching metadata for $topicPartition: replica information not available for " +
                 s"following brokers ${replicas.filterNot(replicaInfo.map(_.id).contains).mkString(",")}")
 
-              new MetadataResponse.PartitionMetadata(Errors.REPLICA_NOT_AVAILABLE, partitionId.toInt, leader,
+              result += new MetadataResponse.PartitionMetadata(Errors.REPLICA_NOT_AVAILABLE, partitionId, leader,
                 Optional.empty(), replicaInfo.asJava, isrInfo.asJava, offlineReplicaInfo.asJava)
             } else if (isrInfo.size < isr.size) {
               debug(s"Error while fetching metadata for $topicPartition: in sync replica information not available for " +
                 s"following brokers ${isr.filterNot(isrInfo.map(_.id).contains).mkString(",")}")
-              new MetadataResponse.PartitionMetadata(Errors.REPLICA_NOT_AVAILABLE, partitionId.toInt, leader,
+              result += new MetadataResponse.PartitionMetadata(Errors.REPLICA_NOT_AVAILABLE, partitionId, leader,
                 Optional.empty(), replicaInfo.asJava, isrInfo.asJava, offlineReplicaInfo.asJava)
             } else {
-              new MetadataResponse.PartitionMetadata(Errors.NONE, partitionId.toInt, leader, Optional.of(leaderEpoch),
+              result += new MetadataResponse.PartitionMetadata(Errors.NONE, partitionId, leader, Optional.of(leaderEpoch),
                 replicaInfo.asJava, isrInfo.asJava, offlineReplicaInfo.asJava)
             }
         }
       }
     }
+    if (result.isEmpty)
+      None
+    else
+      Option(result)
   }
 
   private def getAliveEndpoint(snapshot: MetadataSnapshot, brokerId: Int, listenerName: ListenerName): Option[Node] =
@@ -129,11 +140,14 @@ class MetadataCache(brokerId: Int) extends Logging {
   def getTopicMetadata(topics: Set[String], listenerName: ListenerName, errorUnavailableEndpoints: Boolean = false,
                        errorUnavailableListeners: Boolean = false): Seq[MetadataResponse.TopicMetadata] = {
     val snapshot = metadataSnapshot
-    topics.toSeq.flatMap { topic =>
-      getPartitionMetadata(snapshot, topic, listenerName, errorUnavailableEndpoints, errorUnavailableListeners).map { partitionMetadata =>
-        new MetadataResponse.TopicMetadata(Errors.NONE, topic, Topic.isInternal(topic), partitionMetadata.toBuffer.asJava)
+    val topicMetadata = new ArrayBuffer[MetadataResponse.TopicMetadata]
+    for (t <- topics) {
+      val partitionsMetadata = getPartitionMetadata(snapshot, t, listenerName, errorUnavailableEndpoints, errorUnavailableListeners)
+      for (partitionMetadata <- partitionsMetadata) {
+        topicMetadata += new MetadataResponse.TopicMetadata(Errors.NONE, t, Topic.isInternal(t), partitionMetadata.toBuffer.asJava)
       }
     }
+    topicMetadata
   }
 
   def getAllTopics(): Set[String] = {

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -154,6 +154,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <Or>
             <Package name="org.apache.kafka.jmh.cache.generated"/>
             <Package name="org.apache.kafka.jmh.common.generated"/>
+            <Package name="org.apache.kafka.jmh.common.requests.generated"/>
             <Package name="org.apache.kafka.jmh.record.generated"/>
             <Package name="org.apache.kafka.jmh.partition.generated"/>
             <Package name="org.apache.kafka.jmh.producer.generated"/>

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/requests/MetadataRequestResponseBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/requests/MetadataRequestResponseBenchmark.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.jmh.common.requests;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+public class MetadataRequestResponseBenchmark {
+    @State(Scope.Thread)
+    public static class BenchState {
+
+        public void populateBrokerNodeList(int numNodes) {
+            brokerNodeList = new ArrayList<>();
+            for (int i = 0; i < numNodes; i++) {
+                brokerNodeList.add(new Node(i, "localhost", 2194));
+            }
+        }
+
+        public void populateTopicMetadataList(int maxTopics, int maxPartitionsPerTopic) {
+            topicMetadataList = new ArrayList<>();
+            for (int topicCount = 0; topicCount < maxTopics; topicCount++) {
+                String topic = "topic-" + topicCount;
+                List<MetadataResponse.PartitionMetadata> topicPartitionMetadata = new ArrayList<>();
+                for (int i = 0; i < maxPartitionsPerTopic; i++) {
+                    List<Node> replicas =
+                        Arrays.asList(new Node(1000, "localhost", 9999), new Node(1001, "localhost", 9999),
+                            new Node(1002, "localhost", 9999));
+                    List<Node> isr = Arrays.asList(replicas.get(1), replicas.get(2));
+                    topicPartitionMetadata.add(
+                        new MetadataResponse.PartitionMetadata(Errors.NONE, i, replicas.get(0), Optional.empty(),
+                            replicas, isr, Collections.emptyList()));
+                }
+                topicMetadataList.add(
+                    new MetadataResponse.TopicMetadata(Errors.NONE, topic, false, topicPartitionMetadata));
+            }
+        }
+
+        @Setup(Level.Iteration)
+        public void setUp() {
+            populateBrokerNodeList(10);
+            populateTopicMetadataList(20, 8);
+        }
+
+        public List<Node> brokerNodeList;
+        public List<MetadataResponse.TopicMetadata> topicMetadataList;
+        public String clusterId = "XYZ";
+        int controllerId = 290230;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void responseConstructor(Blackhole blackhole, BenchState state) {
+        blackhole.consume(MetadataResponse.prepareResponse(state.brokerNodeList, state.clusterId, state.controllerId,
+            state.topicMetadataList));
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/MetadataCacheBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/MetadataCacheBenchmark.java
@@ -1,14 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.kafka.jmh.server;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import kafka.server.MetadataCache;
-import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.message.UpdateMetadataRequestData;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -29,6 +43,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import scala.collection.JavaConverters;
 
+
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -38,97 +53,92 @@ import scala.collection.JavaConverters;
 @Threads(1)
 public class MetadataCacheBenchmark {
 
-  @State(Scope.Thread)
-  public static class BenchState {
+    @State(Scope.Thread)
+    public static class BenchState {
 
-    @Setup(Level.Iteration)
-    public void setUp() {
-      UpdateMetadataRequest request = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion(),
-          2, 1, 0, 0, getPartitionStates(),
-          getUpdateMetadataBroker()).build();
-      metadataCache.updateMetadata(15, request);
-    }
-
-    private List<UpdateMetadataRequestData.UpdateMetadataBroker> getUpdateMetadataBroker() {
-      List<UpdateMetadataRequestData.UpdateMetadataBroker> result = new LinkedList<>();
-      for (int i = 0; i < 5; i++) {
-        result.add(new UpdateMetadataRequestData.UpdateMetadataBroker()
-            .setId(i)
-            .setEndpoints(getEndPoints(i))
-            .setRack("rack1"));
-      }
-      return result;
-    }
-
-    private List<UpdateMetadataRequestData.UpdateMetadataEndpoint> getEndPoints(int brokerId) {
-      return new LinkedList<UpdateMetadataRequestData.UpdateMetadataEndpoint>() {
-        {
-          add(new UpdateMetadataRequestData.UpdateMetadataEndpoint()
-              .setHost("host-" + brokerId)
-              .setPort(9092)
-              .setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)
-              .setListener(ListenerName.forSecurityProtocol(org.apache.kafka.common.security.auth.SecurityProtocol.PLAINTEXT).value())
-          );
+        @Setup(Level.Iteration)
+        public void setUp() {
+            UpdateMetadataRequest request =
+                new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion(), 2, 1, 0, 0,
+                    getPartitionStates(), getUpdateMetadataBroker()).build();
+            metadataCache.updateMetadata(15, request);
         }
-        {
-          add(new UpdateMetadataRequestData.UpdateMetadataEndpoint()
-              .setHost("host-" + brokerId)
-              .setPort(9093)
-              .setSecurityProtocol(SecurityProtocol.SSL.id)
-              .setListener(ListenerName.forSecurityProtocol(org.apache.kafka.common.security.auth.SecurityProtocol.SSL).value())
-          );
+
+        private List<UpdateMetadataRequestData.UpdateMetadataBroker> getUpdateMetadataBroker() {
+            List<UpdateMetadataRequestData.UpdateMetadataBroker> result = new LinkedList<>();
+            for (int i = 0; i < 5; i++) {
+                result.add(new UpdateMetadataRequestData.UpdateMetadataBroker().setId(i)
+                    .setEndpoints(getEndPoints(i))
+                    .setRack("rack1"));
+            }
+            return result;
         }
-      };
+
+        private List<UpdateMetadataRequestData.UpdateMetadataEndpoint> getEndPoints(int brokerId) {
+            return new LinkedList<UpdateMetadataRequestData.UpdateMetadataEndpoint>() {
+                {
+                    add(new UpdateMetadataRequestData.UpdateMetadataEndpoint().setHost("host-" + brokerId)
+                        .setPort(9092)
+                        .setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)
+                        .setListener(ListenerName.forSecurityProtocol(
+                            org.apache.kafka.common.security.auth.SecurityProtocol.PLAINTEXT).value()));
+                }
+
+                {
+                    add(new UpdateMetadataRequestData.UpdateMetadataEndpoint().setHost("host-" + brokerId)
+                        .setPort(9093)
+                        .setSecurityProtocol(SecurityProtocol.SSL.id)
+                        .setListener(
+                            ListenerName.forSecurityProtocol(org.apache.kafka.common.security.auth.SecurityProtocol.SSL)
+                                .value()));
+                }
+            };
+        }
+
+        private List<UpdateMetadataRequestData.UpdateMetadataPartitionState> getPartitionStates() {
+            List<UpdateMetadataRequestData.UpdateMetadataPartitionState> result = new LinkedList<>();
+            int controllerEpoch = 1;
+            int zkVersion = 3;
+
+            result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState().setTopicName(topicName)
+                .setPartitionIndex(0)
+                .setControllerEpoch(controllerEpoch)
+                .setLeader(0)
+                .setLeaderEpoch(0)
+                .setIsr(Arrays.asList(0, 1, 3))
+                .setZkVersion(zkVersion)
+                .setReplicas(Arrays.asList(0, 1, 3)));
+            result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState().setTopicName(topicName)
+                .setPartitionIndex(1)
+                .setControllerEpoch(controllerEpoch)
+                .setLeader(1)
+                .setLeaderEpoch(1)
+                .setIsr(Arrays.asList(1, 0))
+                .setZkVersion(zkVersion)
+                .setReplicas(Arrays.asList(1, 2, 0, 4)));
+            result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState().setTopicName(topic1Name)
+                .setPartitionIndex(0)
+                .setControllerEpoch(controllerEpoch)
+                .setLeader(2)
+                .setLeaderEpoch(2)
+                .setIsr(Arrays.asList(2, 1))
+                .setZkVersion(zkVersion)
+                .setReplicas(Arrays.asList(2, 1, 3)));
+            return result;
+        }
+
+        public final int brokerId = 1;
+        public final MetadataCache metadataCache = new MetadataCache(brokerId);
+        public final String topicName = "topic";
+        public final String topic1Name = "topic1";
+        public final ListenerName listenerName = ListenerName.normalised("PLAINTEXT");
+        public final scala.collection.Set<String> topicScalaSetInQuery =
+            JavaConverters.<String>asScalaSet(Collections.singleton(topicName));
     }
 
-    private List<UpdateMetadataRequestData.UpdateMetadataPartitionState> getPartitionStates() {
-      List<UpdateMetadataRequestData.UpdateMetadataPartitionState> result = new LinkedList<>();
-      int controllerEpoch = 1;
-      int zkVersion = 3;
-
-      result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState()
-        .setTopicName(topicName)
-          .setPartitionIndex(0)
-          .setControllerEpoch(controllerEpoch)
-          .setLeader(0)
-          .setLeaderEpoch(0)
-          .setIsr(Arrays.asList(0, 1, 3))
-          .setZkVersion(zkVersion)
-          .setReplicas(Arrays.asList(0, 1, 3))
-      );
-      result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState()
-          .setTopicName(topicName)
-          .setPartitionIndex(1)
-          .setControllerEpoch(controllerEpoch)
-          .setLeader(1)
-          .setLeaderEpoch(1)
-          .setIsr(Arrays.asList(1, 0))
-          .setZkVersion(zkVersion)
-          .setReplicas(Arrays.asList(1, 2, 0, 4))
-      );
-      result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState()
-          .setTopicName(topic1Name)
-          .setPartitionIndex(0)
-          .setControllerEpoch(controllerEpoch)
-          .setLeader(2)
-          .setLeaderEpoch(2)
-          .setIsr(Arrays.asList(2, 1))
-          .setZkVersion(zkVersion)
-          .setReplicas(Arrays.asList(2, 1, 3))
-      );
-      return result;
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void benchmarkGetTopicMetadata(BenchState state, Blackhole blackhole) {
+        state.metadataCache.getTopicMetadata(state.topicScalaSetInQuery, state.listenerName, false, false);
     }
-
-    public final int brokerId = 1;
-    public final MetadataCache metadataCache = new MetadataCache(brokerId);
-    public final String topicName = "topic";
-    public final String topic1Name = "topic1";
-    public final ListenerName listenerName = ListenerName.normalised("PLAINTEXT");
-    public final scala.collection.Set<String> topicScalaSetInQuery = JavaConverters.<String>asScalaSet(Collections.singleton(topicName));
-  }
-  @Benchmark
-  @BenchmarkMode(Mode.Throughput)
-  public void benchmarkGetTopicMetadata(BenchState state, Blackhole blackhole) {
-    state.metadataCache.getTopicMetadata(state.topicScalaSetInQuery, state.listenerName, false, false);
-  }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/MetadataCacheBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/MetadataCacheBenchmark.java
@@ -1,0 +1,134 @@
+package org.apache.kafka.jmh.server;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import kafka.server.MetadataCache;
+import org.apache.kafka.common.Endpoint;
+import org.apache.kafka.common.message.UpdateMetadataRequestData;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.requests.UpdateMetadataRequest;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import scala.collection.JavaConverters;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10, time = 60, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 60, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+public class MetadataCacheBenchmark {
+
+  @State(Scope.Thread)
+  public static class BenchState {
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+      UpdateMetadataRequest request = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion(),
+          2, 1, 0, 0, getPartitionStates(),
+          getUpdateMetadataBroker()).build();
+      metadataCache.updateMetadata(15, request);
+    }
+
+    private List<UpdateMetadataRequestData.UpdateMetadataBroker> getUpdateMetadataBroker() {
+      List<UpdateMetadataRequestData.UpdateMetadataBroker> result = new LinkedList<>();
+      for (int i = 0; i < 5; i++) {
+        result.add(new UpdateMetadataRequestData.UpdateMetadataBroker()
+            .setId(i)
+            .setEndpoints(getEndPoints(i))
+            .setRack("rack1"));
+      }
+      return result;
+    }
+
+    private List<UpdateMetadataRequestData.UpdateMetadataEndpoint> getEndPoints(int brokerId) {
+      return new LinkedList<UpdateMetadataRequestData.UpdateMetadataEndpoint>() {
+        {
+          add(new UpdateMetadataRequestData.UpdateMetadataEndpoint()
+              .setHost("host-" + brokerId)
+              .setPort(9092)
+              .setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)
+              .setListener(ListenerName.forSecurityProtocol(org.apache.kafka.common.security.auth.SecurityProtocol.PLAINTEXT).value())
+          );
+        }
+        {
+          add(new UpdateMetadataRequestData.UpdateMetadataEndpoint()
+              .setHost("host-" + brokerId)
+              .setPort(9093)
+              .setSecurityProtocol(SecurityProtocol.SSL.id)
+              .setListener(ListenerName.forSecurityProtocol(org.apache.kafka.common.security.auth.SecurityProtocol.SSL).value())
+          );
+        }
+      };
+    }
+
+    private List<UpdateMetadataRequestData.UpdateMetadataPartitionState> getPartitionStates() {
+      List<UpdateMetadataRequestData.UpdateMetadataPartitionState> result = new LinkedList<>();
+      int controllerEpoch = 1;
+      int zkVersion = 3;
+
+      result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState()
+        .setTopicName(topicName)
+          .setPartitionIndex(0)
+          .setControllerEpoch(controllerEpoch)
+          .setLeader(0)
+          .setLeaderEpoch(0)
+          .setIsr(Arrays.asList(0, 1, 3))
+          .setZkVersion(zkVersion)
+          .setReplicas(Arrays.asList(0, 1, 3))
+      );
+      result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState()
+          .setTopicName(topicName)
+          .setPartitionIndex(1)
+          .setControllerEpoch(controllerEpoch)
+          .setLeader(1)
+          .setLeaderEpoch(1)
+          .setIsr(Arrays.asList(1, 0))
+          .setZkVersion(zkVersion)
+          .setReplicas(Arrays.asList(1, 2, 0, 4))
+      );
+      result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState()
+          .setTopicName(topic1Name)
+          .setPartitionIndex(0)
+          .setControllerEpoch(controllerEpoch)
+          .setLeader(2)
+          .setLeaderEpoch(2)
+          .setIsr(Arrays.asList(2, 1))
+          .setZkVersion(zkVersion)
+          .setReplicas(Arrays.asList(2, 1, 3))
+      );
+      return result;
+    }
+
+    public final int brokerId = 1;
+    public final MetadataCache metadataCache = new MetadataCache(brokerId);
+    public final String topicName = "topic";
+    public final String topic1Name = "topic1";
+    public final ListenerName listenerName = ListenerName.normalised("PLAINTEXT");
+    public final scala.collection.Set<String> topicScalaSetInQuery = JavaConverters.<String>asScalaSet(Collections.singleton(topicName));
+  }
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  public void benchmarkGetTopicMetadata(BenchState state, Blackhole blackhole) {
+    state.metadataCache.getTopicMetadata(state.topicScalaSetInQuery, state.listenerName, false, false);
+  }
+}


### PR DESCRIPTION
### Changes
* Replace java.util.stream.* api usages with non-functional old style code in 
** `MetadataRequest`
** `MetadataResponse` 
** `MetadataCache`
* Added a JMH benchmark code for `MetadataResponse.prepareResponse` codepath.

### Test: 
The benchmark shows ~3x improvement in GC allocation rates:

**Baseline**
```MetadataRequestResponseBenchmark.responseConstructor:·gc.alloc.rate.norm               thrpt   10  175272.420 ±    0.012    B/op```

**Test**
```MetadataRequestResponseBenchmark.responseConstructor:·gc.alloc.rate.norm               thrpt   10  56216.185 ±   0.004    B/op```


Minor (< 1%) improvements in `MetadataCache` GC allocation rates:

**Baseline**
```
MetadataCacheBenchmark.benchmarkGetTopicMetadata:·gc.alloc.rate.norm               thrpt   10  2648.000 ±  0.001    B/op
MetadataCacheBenchmark.benchmarkGetTopicMetadata:·gc.time                          thrpt   10  5053.000               ms
```

**Test**
```
MetadataCacheBenchmark.benchmarkGetTopicMetadata:·gc.alloc.rate.norm               thrpt   10  2232.001 ±  0.001    B/op
MetadataCacheBenchmark.benchmarkGetTopicMetadata:·gc.time                          thrpt   10  4625.000               ms
```
