### PR TITLE
[LI-HOTFIX] Make partition count increase requests consider brokers under maintenance

### DIFF
--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -235,7 +235,8 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
                     numPartitions: Int = 1,
                     replicaAssignment: Option[Map[Int, Seq[Int]]] = None,
                     validateOnly: Boolean = false): Map[Int, Seq[Int]] = {
-    addPartitions(topic, existingAssignment, allBrokers, numPartitions, replicaAssignment, validateOnly, Set.empty[Int])
+    val noNewPartitionBrokerIds = getMaintenanceBrokerList()
+    addPartitions(topic, existingAssignment, allBrokers, numPartitions, replicaAssignment, validateOnly, noNewPartitionBrokerIds.toSet)
   }
 
   /**


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
Currently a request to increase partition count initiated via AdminZkClient may
assign replicas to brokers under maintenance. Given the definition of a broker
under-maintenance, this is unexpected. Hence, the partition increase request
should take brokers under-maintenance into account.

Note that (1) topic creation and (2) partition count increase via AdminZkClient
has also been ignoring the preferred controllers. As a result, preferred controllers
may end up with partitions if AdminZkClient is used to perform these operations.
This PR does not address that.

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
