### PR TITLE
  [LI-HOTFIX] Allow skipping metadata cache update when topic partition is unassigned

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -288,7 +288,7 @@ public class ConsumerConfig extends AbstractConfig {
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
     /** <code>skip.metadata.cache.update.upon.unassign</code> */
-    public static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN = "skip.metadata.cache.update.upon.unassign";
+    public static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN = "linkedin.skip.metadata.cache.update.upon.unassign";
     private static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN_DOC = "Skip metadata cache update if the new " +
             "partition assignment passed to the <code>assign</code> method is a subset of the current assignment since " +
             "the consumer instance should already have metadata for assigned partitions.";

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -287,6 +287,13 @@ public class ConsumerConfig extends AbstractConfig {
             " be set to `false` when using brokers older than 0.11.0";
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
+    /** <code>skip.metadata.cache.update.upon.unassign</code> */
+    public static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN = "skip.metadata.cache.update.upon.unassign";
+    private static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN_DOC = "Skip metadata cache update if the new " +
+            "partition assignment passed to the <code>assign</code> method is a subset of the current assignment since " +
+            "the consumer instance should already have metadata for assigned partitions.";
+    public static final boolean DEFAULT_SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN = false;
+
     /**
      * <code>security.providers</code>
      */
@@ -531,6 +538,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
                                         Importance.MEDIUM,
                                         ALLOW_AUTO_CREATE_TOPICS_DOC)
+                                .define(SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN,
+                                        Type.BOOLEAN,
+                                        DEFAULT_SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN,
+                                        Importance.LOW,
+                                        SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN_DOC)
                                 // security support
                                 .define(SECURITY_PROVIDERS_CONFIG,
                                         Type.STRING,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -822,6 +822,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
             this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, metricGrpPrefix);
             this.skipMetadataCacheUpdateUponUnassignment = config.getBoolean(ConsumerConfig.SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN);
+
             config.logUnused();
             AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
             log.debug("Kafka consumer initialized");

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -62,7 +62,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
-
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collection;
@@ -596,7 +595,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
     // to keep from repeatedly scanning subscriptions in poll(), cache the result during metadata updates
     private boolean cachedSubscriptionHashAllFetchPositions;
-
     private final boolean skipMetadataCacheUpdateUponUnassignment;
 
     /**
@@ -851,7 +849,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                   long requestTimeoutMs,
                   int defaultApiTimeoutMs,
                   List<ConsumerPartitionAssignor> assignors,
-                  String groupId) {
+                  String groupId,
+                  boolean skipMetadataCacheUpdateUponUnassignment) {
         this.log = logContext.logger(getClass());
         this.clientId = clientId;
         this.coordinator = coordinator;
@@ -870,7 +869,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         this.assignors = assignors;
         this.groupId = groupId;
         this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, "consumer");
-        this.skipMetadataCacheUpdateUponUnassignment = false;
+        this.skipMetadataCacheUpdateUponUnassignment = skipMetadataCacheUpdateUponUnassignment;
     }
 
     private static String buildClientId(String configuredClientId, GroupRebalanceConfig rebalanceConfig) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -849,6 +849,29 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                   long requestTimeoutMs,
                   int defaultApiTimeoutMs,
                   List<ConsumerPartitionAssignor> assignors,
+                  String groupId) {
+        this(logContext, clientId, coordinator, keyDeserializer, valueDeserializer, fetcher, interceptors, time, client,
+                metrics, subscriptions, metadata, retryBackoffMs, requestTimeoutMs, defaultApiTimeoutMs, assignors, groupId,
+                false);
+    }
+
+    // visible for testing
+    KafkaConsumer(LogContext logContext,
+                  String clientId,
+                  ConsumerCoordinator coordinator,
+                  Deserializer<K> keyDeserializer,
+                  Deserializer<V> valueDeserializer,
+                  Fetcher<K, V> fetcher,
+                  ConsumerInterceptors<K, V> interceptors,
+                  Time time,
+                  ConsumerNetworkClient client,
+                  Metrics metrics,
+                  SubscriptionState subscriptions,
+                  ConsumerMetadata metadata,
+                  long retryBackoffMs,
+                  long requestTimeoutMs,
+                  int defaultApiTimeoutMs,
+                  List<ConsumerPartitionAssignor> assignors,
                   String groupId,
                   boolean skipMetadataCacheUpdateUponUnassignment) {
         this.log = logContext.logger(getClass());
@@ -1134,7 +1157,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     this.coordinator.maybeAutoCommitOffsetsAsync(time.milliseconds());
 
                 log.info("Subscribed to partition(s): {}", Utils.join(partitions, ", "));
-                boolean skipMetadataCacheUpdate = this.skipMetadataCacheUpdateUponUnassignment && this.subscriptions.isAllAssigned(partitions);
+                boolean skipMetadataCacheUpdate = this.skipMetadataCacheUpdateUponUnassignment && this.subscriptions.areAllAssigned(partitions);
                 if (this.subscriptions.assignFromUser(new HashSet<>(partitions))) {
                     if (!skipMetadataCacheUpdate) {
                         metadata.requestUpdateForNewTopics();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -645,6 +645,10 @@ public class SubscriptionState {
         return assignment.contains(tp);
     }
 
+    public synchronized boolean isAllAssigned(Collection<TopicPartition> tps) {
+        return assignment.containsAll(tps);
+    }
+
     public synchronized boolean isPaused(TopicPartition tp) {
         TopicPartitionState assignedOrNull = assignedStateOrNull(tp);
         return assignedOrNull != null && assignedOrNull.isPaused();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -645,7 +645,7 @@ public class SubscriptionState {
         return assignment.contains(tp);
     }
 
-    public synchronized boolean isAllAssigned(Collection<TopicPartition> tps) {
+    public synchronized boolean areAllAssigned(Collection<TopicPartition> tps) {
         return assignment.containsAll(tps);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.internals;
 
+import java.util.Collection;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.ArrayList;
@@ -83,6 +84,10 @@ public class PartitionStates<S> {
 
     public boolean contains(TopicPartition topicPartition) {
         return map.containsKey(topicPartition);
+    }
+
+    public boolean containsAll(Collection<TopicPartition> topicPartitions) {
+        return map.keySet().containsAll(topicPartitions);
     }
 
     /**


### PR DESCRIPTION
  TICKET = KAFKA-12854
  LI_DESCRIPTION = Introduce a config to allow skipping metadata cache update when a topic partition is un-assigned from the current consumer consuming assignment. The purpose is to reduce the rate of metadata requests sent from consumer instances to Kafka server when there are a significant number of consumer instances. See the description section of LIKAFKA-36680 for more context.
  EXIT_CRITERIA = TICKET [KAFKA-12854]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behavior change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
