### PR TITLE
[LI-HOTFIX] Backport - Allowing skipping metadata cache update when topic partition is unassigned (#166)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -299,6 +299,14 @@ public class ConsumerConfig extends AbstractConfig {
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
     // LinkedIn Hotfixes
+    /** <code>skip.metadata.cache.update.upon.unassign</code> */
+    public static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN = "linkedin.skip.metadata.cache.update.upon.unassign";
+    private static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN_DOC = "Skip metadata cache update if the new " +
+            "partition assignment passed to the <code>assign</code> method is a subset of the current assignment since " +
+            "the consumer instance should already have metadata for assigned partitions.";
+    public static final boolean DEFAULT_SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN = false;
+
+    // LinkedIn Hotfixes
 
     public static final String LEAST_LOADED_NODE_ALGORITHM_CONFIG = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_CONFIG;
     public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
@@ -532,6 +540,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
                                         Importance.MEDIUM,
                                         ALLOW_AUTO_CREATE_TOPICS_DOC)
+                                .define(SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN,
+                                        Type.BOOLEAN,
+                                        DEFAULT_SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN,
+                                        Importance.LOW,
+                                        SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN_DOC)
                                 // security support
                                 .define(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
                                         Type.STRING,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -60,7 +60,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
-
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collection;
@@ -594,6 +593,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
     // to keep from repeatedly scanning subscriptions in poll(), cache the result during metadata updates
     private boolean cachedSubscriptionHashAllFetchPositions;
+    private final boolean skipMetadataCacheUpdateUponUnassignment;
 
     /**
      * A consumer is instantiated by providing a set of key-value pairs as configuration. Valid configuration strings
@@ -827,6 +827,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     isolationLevel,
                     apiVersions);
 
+            this.skipMetadataCacheUpdateUponUnassignment = config.getBoolean(ConsumerConfig.SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN);
             config.logUnused();
             AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics, time.milliseconds());
             log.debug("Kafka consumer initialized");
@@ -856,6 +857,30 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                   int defaultApiTimeoutMs,
                   List<PartitionAssignor> assignors,
                   String groupId) {
+        this(logContext, clientId, coordinator, keyDeserializer, valueDeserializer, fetcher, interceptors, time, client,
+                metrics, subscriptions, metadata, retryBackoffMs, requestTimeoutMs, defaultApiTimeoutMs, assignors, groupId,
+                false);
+    }
+
+    // visible for testing
+    KafkaConsumer(LogContext logContext,
+                  String clientId,
+                  ConsumerCoordinator coordinator,
+                  Deserializer<K> keyDeserializer,
+                  Deserializer<V> valueDeserializer,
+                  Fetcher<K, V> fetcher,
+                  ConsumerInterceptors<K, V> interceptors,
+                  Time time,
+                  ConsumerNetworkClient client,
+                  Metrics metrics,
+                  SubscriptionState subscriptions,
+                  ConsumerMetadata metadata,
+                  long retryBackoffMs,
+                  long requestTimeoutMs,
+                  int defaultApiTimeoutMs,
+                  List<PartitionAssignor> assignors,
+                  String groupId,
+                  boolean skipMetadataCacheUpdateUponUnassignment) {
         this.log = logContext.logger(getClass());
         this.clientId = clientId;
         this.coordinator = coordinator;
@@ -873,6 +898,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         this.defaultApiTimeoutMs = defaultApiTimeoutMs;
         this.assignors = assignors;
         this.groupId = groupId;
+        this.skipMetadataCacheUpdateUponUnassignment = skipMetadataCacheUpdateUponUnassignment;
     }
 
     private static Metrics buildMetrics(ConsumerConfig config, Time time, String clientId) {
@@ -1122,8 +1148,12 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     this.coordinator.maybeAutoCommitOffsetsAsync(time.milliseconds());
 
                 log.info("Subscribed to partition(s): {}", Utils.join(partitions, ", "));
-                if (this.subscriptions.assignFromUser(new HashSet<>(partitions)))
-                    metadata.requestUpdateForNewTopics();
+                boolean skipMetadataCacheUpdate = this.skipMetadataCacheUpdateUponUnassignment && this.subscriptions.areAllAssigned(partitions);
+                if (this.subscriptions.assignFromUser(new HashSet<>(partitions))) {
+                    if (!skipMetadataCacheUpdate) {
+                        metadata.requestUpdateForNewTopics();
+                    }
+                }
             }
         } finally {
             release();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -601,6 +601,10 @@ public class SubscriptionState {
         return assignment.contains(tp);
     }
 
+    public synchronized boolean areAllAssigned(Collection<TopicPartition> tps) {
+        return assignment.containsAll(tps);
+    }
+
     public synchronized boolean isPaused(TopicPartition tp) {
         TopicPartitionState assignedOrNull = assignedStateOrNull(tp);
         return assignedOrNull != null && assignedOrNull.isPaused();

--- a/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.internals;
 
+import java.util.Collection;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.ArrayList;
@@ -83,6 +84,10 @@ public class PartitionStates<S> {
 
     public boolean contains(TopicPartition topicPartition) {
         return map.containsKey(topicPartition);
+    }
+
+    public boolean containsAll(Collection<TopicPartition> topicPartitions) {
+        return map.keySet().containsAll(topicPartitions);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -125,9 +125,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doCallRealMethod;
 
 public class KafkaConsumerTest {
     private final String topic = "test";
@@ -599,6 +600,40 @@ public class KafkaConsumerTest {
         // lookup committed offset and find nothing
         client.prepareResponseFrom(offsetResponse(Collections.singletonMap(tp0, -1L), Errors.NONE), coordinator);
         consumer.poll(Duration.ZERO);
+    }
+
+    @Test
+    public void testSkipMetadataCacheUpdate() {
+        Time time = new MockTime();
+        SubscriptionState subscription = new SubscriptionState(new LogContext(), OffsetResetStrategy.NONE);
+        ConsumerMetadata mockConsumerMetadata = mock(ConsumerMetadata.class);
+        MockClient client = new MockClient(time, mockConsumerMetadata);
+
+        PartitionAssignor assignor = new RoundRobinAssignor();
+        boolean skipMetadataCacheUpdateUponUnassignment = false;
+
+        // Case 1: Default behavior. Metadata cache updated requested upon every topic assignment change.
+        KafkaConsumer<String, String> consumer = newConsumer(time, client, subscription, mockConsumerMetadata, assignor,
+                true, groupId, groupInstanceId, skipMetadataCacheUpdateUponUnassignment);
+        consumer.assign(Arrays.asList(tp0, tp1));
+        verify(mockConsumerMetadata, times(1)).requestUpdateForNewTopics();
+        consumer.assign(Arrays.asList(tp0, tp1, t2p0));
+        verify(mockConsumerMetadata, times(2)).requestUpdateForNewTopics();
+        consumer.assign(Arrays.asList(tp0, tp1));
+        verify(mockConsumerMetadata, times(3)).requestUpdateForNewTopics();
+
+        // Case 2: Skip metadata cache update.
+        skipMetadataCacheUpdateUponUnassignment = true;
+        subscription = new SubscriptionState(new LogContext(), OffsetResetStrategy.NONE);
+        mockConsumerMetadata = mock(ConsumerMetadata.class);
+        consumer = newConsumer(time, client, subscription, mockConsumerMetadata, assignor,
+                true, groupId, groupInstanceId, skipMetadataCacheUpdateUponUnassignment);
+        consumer.assign(Arrays.asList(tp0, tp1));
+        verify(mockConsumerMetadata, times(1)).requestUpdateForNewTopics();
+        consumer.assign(Arrays.asList(tp0, tp1, t2p0));
+        verify(mockConsumerMetadata, times(2)).requestUpdateForNewTopics();
+        consumer.assign(Arrays.asList(tp0, tp1)); // Not trigger metadata cache update in this case
+        verify(mockConsumerMetadata, times(2)).requestUpdateForNewTopics();
     }
 
     @Test
@@ -1869,6 +1904,18 @@ public class KafkaConsumerTest {
                                                       boolean autoCommitEnabled,
                                                       String groupId,
                                                       Optional<String> groupInstanceId) {
+        return newConsumer(time, client, subscription, metadata, assignor, autoCommitEnabled, groupId, groupInstanceId, false);
+    }
+
+    private KafkaConsumer<String, String> newConsumer(Time time,
+                                                      KafkaClient client,
+                                                      SubscriptionState subscription,
+                                                      ConsumerMetadata metadata,
+                                                      PartitionAssignor assignor,
+                                                      boolean autoCommitEnabled,
+                                                      String groupId,
+                                                      Optional<String> groupInstanceId,
+                                                      boolean skipMetadataCacheUpdateUponUnassignment) {
         String clientId = "mock-consumer";
         String metricGroupPrefix = "consumer";
         long retryBackoffMs = 100;
@@ -1957,7 +2004,8 @@ public class KafkaConsumerTest {
                 requestTimeoutMs,
                 defaultApiTimeoutMs,
                 assignors,
-                groupId);
+                groupId,
+                skipMetadataCacheUpdateUponUnassignment);
     }
 
     private static class FetchInfo {


### PR DESCRIPTION
TICKET = KAFKA-12854
LI_DESCRIPTION =
Introduce a config to allow skipping metadata cache update when a topic partition is un-assigned from
the current consumer consuming assignment. The purpose is to reduce the rate of metadata requests sent
from consumer instances to Kafka server when there are a significant number of consumer instances. See
the description section of LIKAFKA-36680 for more context.
EXIT_CRITERIA = TICKET [KAFKA-12854]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behavior change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
