### PR TITLE
[LI-HOTFIX] Remove BytesInTotal/MessagesInTotal metrics

### DIFF
--- a/core/src/main/scala/kafka/metrics/KafkaMetricsGroup.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaMetricsGroup.scala
@@ -71,9 +71,6 @@ trait KafkaMetricsGroup extends Logging {
   def newMeter(name: String, eventType: String, timeUnit: TimeUnit, tags: scala.collection.Map[String, String] = Map.empty) =
     Metrics.defaultRegistry().newMeter(metricName(name, tags), eventType, timeUnit)
 
-  def newCounter(name: String, tags: scala.collection.Map[String, String] = Map.empty) =
-    Metrics.defaultRegistry().newCounter(metricName(name, tags))
-
   def newHistogram(name: String, biased: Boolean = true, tags: scala.collection.Map[String, String] = Map.empty) =
     Metrics.defaultRegistry().newHistogram(metricName(name, tags), biased)
 

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -23,7 +23,7 @@ import kafka.metrics.KafkaMetricsGroup
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.yammer.metrics.core.{Counter, Meter}
+import com.yammer.metrics.core.Meter
 import org.apache.kafka.common.internals.FatalExitError
 import org.apache.kafka.common.utils.{KafkaThread, Time}
 
@@ -176,35 +176,6 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
       meter()
   }
 
-  case class CounterWrapper(metricType: String) {
-    @volatile private var lazyCounter: Counter = _
-    private val counterLock = new Object
-
-    def counter(): Counter = {
-      var counter = lazyCounter
-      if (counter == null) {
-        counterLock synchronized {
-          counter = lazyCounter
-          if (counter == null) {
-            counter = newCounter(metricType, tags)
-            lazyCounter = counter
-          }
-        }
-      }
-      counter
-    }
-
-    def close(): Unit = counterLock synchronized {
-      if (lazyCounter != null) {
-        removeMetric(metricType, tags)
-        lazyCounter = null
-      }
-    }
-
-    if (tags.isEmpty) // greedily initialize the general topic metrics
-    counter()
-  }
-
   // an internal map for "lazy initialization" of certain metrics
   private val metricTypeMap = new Pool[String, MeterWrapper]()
   metricTypeMap.putAll(Map(
@@ -228,23 +199,12 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
     metricTypeMap.put(BrokerTopicStats.ReplicationBytesOutPerSec, MeterWrapper(BrokerTopicStats.ReplicationBytesOutPerSec, "bytes"))
   }
 
-  private val counterMetricTypeMap = new Pool[String, CounterWrapper]()
-  counterMetricTypeMap.putAll(Map(
-    BrokerTopicStats.MessagesInTotal-> CounterWrapper(BrokerTopicStats.MessagesInTotal),
-    BrokerTopicStats.BytesInTotal -> CounterWrapper(BrokerTopicStats.BytesInTotal)
-  ).asJava)
   // used for testing only
   def metricMap: Map[String, MeterWrapper] = metricTypeMap.toMap
 
-  def counterMetricMap: Map[String, CounterWrapper] = counterMetricTypeMap.toMap
-
   def messagesInRate = metricTypeMap.get(BrokerTopicStats.MessagesInPerSec).meter()
 
-  def messagesInTotal = counterMetricTypeMap.get(BrokerTopicStats.MessagesInTotal).counter()
-
   def bytesInRate = metricTypeMap.get(BrokerTopicStats.BytesInPerSec).meter()
-
-  def bytesInTotal = counterMetricTypeMap.get(BrokerTopicStats.BytesInTotal).counter()
 
   def bytesOutRate = metricTypeMap.get(BrokerTopicStats.BytesOutPerSec).meter()
 
@@ -284,18 +244,12 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
       meter.close()
   }
 
-  def close(): Unit = {
-    metricTypeMap.values.foreach(_.close())
-    removeMetric(BrokerTopicStats.MessagesInTotal, tags)
-    removeMetric(BrokerTopicStats.BytesInTotal, tags)
-  }
+  def close(): Unit = metricTypeMap.values.foreach(_.close())
 }
 
 object BrokerTopicStats {
   val MessagesInPerSec = "MessagesInPerSec"
-  val MessagesInTotal = "MessagesInTotal"
   val BytesInPerSec = "BytesInPerSec"
-  val BytesInTotal = "BytesInTotal"
   val BytesOutPerSec = "BytesOutPerSec"
   val BytesRejectedPerSec = "BytesRejectedPerSec"
   val ReplicationBytesInPerSec = "ReplicationBytesInPerSec"

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -838,16 +838,9 @@ class ReplicaManager(val config: KafkaConfig,
 
           // update stats for successfully appended bytes and messages as bytesInRate and messageInRate
           brokerTopicStats.topicStats(topicPartition.topic).bytesInRate.mark(records.sizeInBytes)
-          brokerTopicStats.topicStats(topicPartition.topic).bytesInTotal.inc(records.sizeInBytes)
-
           brokerTopicStats.allTopicsStats.bytesInRate.mark(records.sizeInBytes)
-          brokerTopicStats.allTopicsStats.bytesInTotal.inc(records.sizeInBytes)
-
           brokerTopicStats.topicStats(topicPartition.topic).messagesInRate.mark(numAppendedMessages)
-          brokerTopicStats.topicStats(topicPartition.topic).messagesInTotal.inc(numAppendedMessages)
-
           brokerTopicStats.allTopicsStats.messagesInRate.mark(numAppendedMessages)
-          brokerTopicStats.allTopicsStats.messagesInTotal.inc(numAppendedMessages)
 
           trace(s"${records.sizeInBytes} written to log $topicPartition beginning at offset " +
             s"${info.firstOffset.getOrElse(-1)} and ending at offset ${info.lastOffset}")

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -83,8 +83,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
 
     // The broker metrics for all topics should be greedily registered
     assertTrue("General topic metrics don't exist", topicMetrics(None).nonEmpty)
-    assertEquals(servers.head.brokerTopicStats.allTopicsStats.metricMap.size +
-      servers.head.brokerTopicStats.allTopicsStats.counterMetricMap.size, topicMetrics(None).size)
+    assertEquals(servers.head.brokerTopicStats.allTopicsStats.metricMap.size, topicMetrics(None).size)
     // topic metrics should be lazily registered
     assertTrue("Topic metrics aren't lazily registered", topicMetricGroups(topic).isEmpty)
     TestUtils.generateAndProduceMessages(servers, topic, nMessages)


### PR DESCRIPTION
This effectively reverts commit da0cee0
"[LI-HOTFIX] Add counters (#59)" (https://github.com/linkedin/kafka/pull/59/files)

Such cumulation counters may not be helpful in terms of monitoring
as they are reset after restart/redeploy unless we'd like to monitor
"the cumulation of bytes/messages in since the broker restart".

TICKET = N/A
LI_DESCRIPTION = LIKAFKA-36927
EXIT_CRITERIA =
Can be removed if commit da0cee0 "[LI-HOTFIX] Add counters (#59)" is not cherry-picked