### PR TITLE
[LI-HOTFIX] Exclude partition info in MetadataResponse for the listTopics() API

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1508,7 +1508,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             AbstractRequest.Builder createRequest(int timeoutMs) {
-                return MetadataRequest.Builder.allTopics();
+                return MetadataRequest.Builder.allTopicsOnly();
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -34,6 +34,8 @@ public class MetadataRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<MetadataRequest> {
         private static final MetadataRequestData ALL_TOPICS_REQUEST_DATA = new MetadataRequestData().
             setTopics(null).setAllowAutoTopicCreation(true);
+        private static final MetadataRequestData ALL_TOPICS_ONLY_REQUEST_DATA = new MetadataRequestData().
+                setTopics(null).setAllowAutoTopicCreation(false).setExcludePartitions(true);
 
         private final MetadataRequestData data;
 
@@ -69,6 +71,10 @@ public class MetadataRequest extends AbstractRequest {
             // This never causes auto-creation, but we set the boolean to true because that is the default value when
             // deserializing V2 and older. This way, the value is consistent after serialization and deserialization.
             return new Builder(ALL_TOPICS_REQUEST_DATA);
+        }
+
+        public static Builder allTopicsOnly() {
+            return new Builder(ALL_TOPICS_ONLY_REQUEST_DATA);
         }
 
         public boolean emptyTopicList() {
@@ -179,6 +185,10 @@ public class MetadataRequest extends AbstractRequest {
 
     public boolean allowAutoTopicCreation() {
         return data.allowAutoTopicCreation();
+    }
+
+    public boolean excludePartitions() {
+        return data.excludePartitions();
     }
 
     public static MetadataRequest parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -264,6 +264,15 @@ public class MetadataResponse extends AbstractResponse {
             this(error, topic, isInternal, partitionMetadata, 0);
         }
 
+        private static final List<PartitionMetadata> EMPTY_PARTITION_METADATA = new ArrayList<>();
+
+        public TopicMetadata(Errors error,
+                             String topic,
+                             boolean isInternal) {
+            this(error, topic, isInternal, EMPTY_PARTITION_METADATA, 0);
+        }
+
+
         public Errors error() {
             return error;
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.requests;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -264,7 +265,7 @@ public class MetadataResponse extends AbstractResponse {
             this(error, topic, isInternal, partitionMetadata, 0);
         }
 
-        private static final List<PartitionMetadata> EMPTY_PARTITION_METADATA = new ArrayList<>();
+        private static final List<PartitionMetadata> EMPTY_PARTITION_METADATA = Collections.emptyList();
 
         public TopicMetadata(Errors error,
                              String topic,

--- a/clients/src/main/resources/common/message/MetadataRequest.json
+++ b/clients/src/main/resources/common/message/MetadataRequest.json
@@ -41,6 +41,8 @@
     { "name": "IncludeClusterAuthorizedOperations", "type": "bool", "versions": "8+",
       "about": "Whether to include cluster authorized operations." },
     { "name": "IncludeTopicAuthorizedOperations", "type": "bool", "versions": "8+",
-      "about": "Whether to include topic authorized operations." }
+      "about": "Whether to include topic authorized operations." },
+    { "name": "ExcludePartitions", "type": "bool", "versions": "9+", "default": "false",
+      "about": "Whether to exclude partitions in the MetadataResponse." }
   ]
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1169,10 +1169,9 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (authorizedTopics.isEmpty)
         Seq.empty[MetadataResponse.TopicMetadata]
       else if (metadataRequest.excludePartitions()) {
-        val topicsOnlyMetadata = new ArrayBuffer[MetadataResponse.TopicMetadata]
-        val emptyPartitionMetadata = new util.ArrayList[MetadataResponse.PartitionMetadata]()
+        val topicsOnlyMetadata = new ArrayBuffer[MetadataResponse.TopicMetadata](authorizedTopics.size)
         for (t <- authorizedTopics) {
-          topicsOnlyMetadata += new MetadataResponse.TopicMetadata(Errors.NONE, t, Topic.isInternal(t), emptyPartitionMetadata)
+          topicsOnlyMetadata += new MetadataResponse.TopicMetadata(Errors.NONE, t, Topic.isInternal(t))
         }
         topicsOnlyMetadata
       } else {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -37,7 +37,7 @@ import org.apache.kafka.common.acl.AclOperation._
 import org.apache.kafka.common.acl.{AclBinding, AclOperation}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors._
-import org.apache.kafka.common.internals.FatalExitError
+import org.apache.kafka.common.internals.{FatalExitError, Topic}
 import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, isInternal}
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.{ReassignablePartitionResponse, ReassignableTopicResponse}
 import org.apache.kafka.common.message.ApiVersionsResponseData.{ApiVersionsResponseKey, ApiVersionsResponseKeyCollection}
@@ -77,6 +77,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Collections, Optional}
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Map, Seq, Set, immutable, mutable}
 import scala.compat.java8.OptionConverters._
 import scala.util.{Failure, Success, Try}
@@ -1167,7 +1168,14 @@ class KafkaApis(val requestChannel: RequestChannel,
     var topicMetadata =
       if (authorizedTopics.isEmpty)
         Seq.empty[MetadataResponse.TopicMetadata]
-      else {
+      else if (metadataRequest.excludePartitions()) {
+        val topicsOnlyMetadata = new ArrayBuffer[MetadataResponse.TopicMetadata]
+        val emptyPartitionMetadata = new util.ArrayList[MetadataResponse.PartitionMetadata]()
+        for (t <- authorizedTopics) {
+          topicsOnlyMetadata += new MetadataResponse.TopicMetadata(Errors.NONE, t, Topic.isInternal(t), emptyPartitionMetadata)
+        }
+        topicsOnlyMetadata
+      } else {
         // If the metadata request is fetching metadata for all topics, auto topic creation is NOT allowed. This is an
         // internal hotfix for issue KAFKA-10606
         val allowAutoTopicCreation = (!metadataRequest.isAllTopics) && metadataRequest.allowAutoTopicCreation


### PR DESCRIPTION
TICKET = LIKAFKA-37320
LI_DESCRIPTION = Making the listTopics() API more light-weight so that a kafka broker would only return the topic names in the MetadataResponse. The partitions and replicas info would not be included in the MetadataResponse for the listTopics() API.

EXIT_CRITERIA = When this change is merged in upstream and the corresponding change is pulled into a future release.


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
