### PR TITLE
Release the memory back into MemoryPool

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
@@ -146,7 +146,7 @@ public class ClientResponse {
     }
 
     private boolean usingMemoryPool() {
-        return memoryPool != null && memoryPool == MemoryPool.NONE;
+        return memoryPool != null && memoryPool != MemoryPool.NONE;
     }
 
     public void incRefCount() {

--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
@@ -16,18 +16,24 @@
  */
 package org.apache.kafka.clients;
 
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * A response from the server. Contains both the body of the response as well as the correlated request
  * metadata that was originally sent.
  */
 public class ClientResponse {
-
-    private final RequestHeader requestHeader;
+    protected static final Logger log = LoggerFactory.getLogger(ClientResponse.class);
+    protected final RequestHeader requestHeader;
     private final RequestCompletionHandler callback;
     private final String destination;
     private final long receivedTimeMs;
@@ -36,6 +42,35 @@ public class ClientResponse {
     private final UnsupportedVersionException versionMismatch;
     private final AuthenticationException authenticationException;
     private final AbstractResponse responseBody;
+    protected final MemoryPool memoryPool;
+    protected final AtomicLong refCount;
+    protected ByteBuffer responsePayload;
+    private boolean bufferReleased = false;
+
+    public ClientResponse(RequestHeader requestHeader,
+        RequestCompletionHandler callback,
+        String destination,
+        long createdTimeMs,
+        long receivedTimeMs,
+        boolean disconnected,
+        UnsupportedVersionException versionMismatch,
+        AuthenticationException authenticationException,
+        AbstractResponse responseBody,
+        MemoryPool memoryPool,
+        ByteBuffer responsePayload) {
+        this.requestHeader = requestHeader;
+        this.callback = callback;
+        this.destination = destination;
+        this.receivedTimeMs = receivedTimeMs;
+        this.latencyMs = receivedTimeMs - createdTimeMs;
+        this.disconnected = disconnected;
+        this.versionMismatch = versionMismatch;
+        this.authenticationException = authenticationException;
+        this.responseBody = responseBody;
+        this.memoryPool = memoryPool;
+        this.responsePayload = responsePayload;
+        this.refCount = new AtomicLong(0);
+    }
 
     /**
      * @param requestHeader The header of the corresponding request
@@ -57,15 +92,8 @@ public class ClientResponse {
                           UnsupportedVersionException versionMismatch,
                           AuthenticationException authenticationException,
                           AbstractResponse responseBody) {
-        this.requestHeader = requestHeader;
-        this.callback = callback;
-        this.destination = destination;
-        this.receivedTimeMs = receivedTimeMs;
-        this.latencyMs = receivedTimeMs - createdTimeMs;
-        this.disconnected = disconnected;
-        this.versionMismatch = versionMismatch;
-        this.authenticationException = authenticationException;
-        this.responseBody = responseBody;
+        this(requestHeader, callback, destination, createdTimeMs, receivedTimeMs, disconnected, versionMismatch,
+            authenticationException, responseBody, null, null);
     }
 
     public long receivedTimeMs() {
@@ -104,6 +132,45 @@ public class ClientResponse {
         return latencyMs;
     }
 
+    private void releaseBuffer() {
+        if (memoryPool != null && responsePayload != null) {
+            if (log.isTraceEnabled()) {
+                log.trace("ByteBuffer[{}] returned to memorypool. Ref Count: {}. RequestType: {}",
+                    responsePayload.position(), refCount.get(), this.requestHeader.apiKey());
+            }
+
+            memoryPool.release(responsePayload);
+            responsePayload = null;
+            bufferReleased = true;
+        }
+    }
+
+    private boolean usingMemoryPool() {
+        return memoryPool != null && memoryPool == MemoryPool.NONE;
+    }
+
+    public void incRefCount() {
+        if (bufferReleased && usingMemoryPool()) {
+            // If somebody tried to call incRefCount after buffer has been released. This shouldn't happen
+            throw new IllegalStateException(
+                "Ref count being incremented again after buffer release. This should never happen.");
+        }
+        refCount.incrementAndGet();
+    }
+
+    public void decRefCount() {
+        long value = refCount.decrementAndGet();
+        if (value < 0 && usingMemoryPool()) {
+            // Oops! This seems to be a place where we shouldn't get to.
+            // However, to save users from exceptions, who don't use pooling, don't throw an exception.
+            throw new IllegalStateException("Ref count decremented below zero. This should never happen.");
+        }
+
+        if (value == 0) {
+            releaseBuffer();
+        }
+    }
+
     public void onComplete() {
         if (callback != null)
             callback.onComplete(this);
@@ -122,5 +189,4 @@ public class ClientResponse {
                responseBody +
                ")";
     }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponseWithFinalize.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponseWithFinalize.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+
+/**
+ * This is a decorator for ClientResponse used to verify (at finalization time) that any underlying memory for this
+ * response has been returned to the pool. To be used only as a debugging aide.
+ */
+public class ClientResponseWithFinalize extends ClientResponse {
+    private final LogContext logContext;
+
+    public ClientResponseWithFinalize(RequestHeader requestHeader, RequestCompletionHandler callback,
+        String destination, long createdTimeMs, long receivedTimeMs, boolean disconnected,
+        UnsupportedVersionException versionMismatch, AuthenticationException authenticationException,
+        AbstractResponse responseBody, MemoryPool memoryPool, ByteBuffer responsePayload, LogContext logContext) {
+        super(requestHeader, callback, destination, createdTimeMs, receivedTimeMs, disconnected, versionMismatch,
+            authenticationException, responseBody, memoryPool, responsePayload);
+        this.logContext = logContext;
+    }
+
+    private Logger getLogger() {
+        if (logContext != null) {
+            return logContext.logger(ClientResponseWithFinalize.class);
+        }
+        return log;
+    }
+
+    protected void checkAndForceBufferRelease() {
+        if (memoryPool != null && responsePayload != null) {
+            getLogger().error("ByteBuffer[{}] not released. Ref Count: {}. RequestType: {}", responsePayload.position(),
+                refCount.get(), this.requestHeader.apiKey());
+            memoryPool.release(responsePayload);
+            responsePayload = null;
+        }
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        checkAndForceBufferRelease();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -158,6 +158,9 @@ public class CommonClientConfigs {
                                                                  + "of 3 lowest-expected-latency nodes)";
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = LeastLoadedNodeAlgorithm.VANILLA.name();
 
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";
+
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKey;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.network.ChannelState;
 import org.apache.kafka.common.network.NetworkReceive;
@@ -79,6 +80,8 @@ public class NetworkClient implements KafkaClient {
         CLOSED
     }
 
+    private final LogContext logContext;
+
     private final Logger log;
 
     /* the selector used to perform network i/o */
@@ -118,6 +121,8 @@ public class NetworkClient implements KafkaClient {
     private final ClientDnsLookup clientDnsLookup;
 
     private final Time time;
+
+    private boolean enableClientResponseWithFinalize = false;
 
     /**
      * True if we should send an ApiVersionRequest when first connecting to a broker.
@@ -427,6 +432,7 @@ public class NetworkClient implements KafkaClient {
         this.discoverBrokerVersions = discoverBrokerVersions;
         this.apiVersions = apiVersions;
         this.throttleTimeSensor = throttleTimeSensor;
+        this.logContext = logContext;
         this.log = logContext.logger(NetworkClient.class);
         this.clientDnsLookup = clientDnsLookup;
         this.state = new AtomicReference<>(State.ACTIVE);
@@ -434,6 +440,10 @@ public class NetworkClient implements KafkaClient {
             throw new IllegalArgumentException("must specify leastLoadedNodeAlgorithm");
         }
         this.leastLoadedNodeAlgorithm = leastLoadedNodeAlgorithm;
+    }
+
+    public void setEnableClientResponseWithFinalize(boolean enableClientResponseWithFinalize) {
+        this.enableClientResponseWithFinalize = enableClientResponseWithFinalize;
     }
 
     /**
@@ -820,6 +830,8 @@ public class NetworkClient implements KafkaClient {
         if (state.compareAndSet(State.CLOSING, State.CLOSED)) {
             this.selector.close();
             this.metadataUpdater.close();
+            this.selector.completedReceives().forEach(NetworkReceive::close);
+            this.selector.completedReceives().clear();
         } else {
             log.warn("Attempting to close NetworkClient that has already been closed.");
         }
@@ -1205,8 +1217,16 @@ public class NetworkClient implements KafkaClient {
                 metadataUpdater.handleSuccessfulResponse(req.header, now, (MetadataResponse) body, req.destination);
             else if (req.isInternalRequest && body instanceof ApiVersionsResponse)
                 handleApiVersionsResponse(responses, req, now, (ApiVersionsResponse) body);
-            else
-                responses.add(req.completed(body, now));
+            else {
+                responses.add(req.completed(body, now, receive.memoryPool(), receive.payload(), this.logContext,
+                    this.enableClientResponseWithFinalize));
+            }
+
+            // If request is an internal request such as Metadata or ApiVersion, then close the network receive
+            // Otherwise, it's ClientResponse's responsibility to release the buffer to MemoryPool via ref counting
+            if (req.isInternalRequest) {
+                receive.close();
+            }
         }
     }
 
@@ -1585,9 +1605,19 @@ public class NetworkClient implements KafkaClient {
             this.sendTimeMs = sendTimeMs;
         }
 
+        public ClientResponse completed(AbstractResponse response, long timeMs, MemoryPool memoryPool,
+            ByteBuffer responsePayload, LogContext logContext, boolean enableClientResponseWithFinalize) {
+            if (enableClientResponseWithFinalize) {
+                return new ClientResponseWithFinalize(header, callback, destination, createdTimeMs, timeMs, false, null, null, response,
+                    memoryPool, responsePayload, logContext);
+            }
+            return new ClientResponse(header, callback, destination, createdTimeMs, timeMs, false, null, null, response,
+                memoryPool, responsePayload);
+        }
+
         public ClientResponse completed(AbstractResponse response, long timeMs) {
             return new ClientResponse(header, callback, destination, createdTimeMs, timeMs,
-                    false, null, null, response);
+                false, null, null, response);
         }
 
         public ClientResponse disconnected(long timeMs, AuthenticationException authenticationException) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -560,6 +560,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         new EnumValueValidator<>(LeastLoadedNodeAlgorithm.class),
                                         Importance.MEDIUM,
                                         LEAST_LOADED_NODE_ALGORITHM_DOC)
+                                .define(CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK,
+                                        Type.BOOLEAN,
+                                        false,
+                                        Importance.MEDIUM,
+                                        CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -769,6 +769,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     logContext,
                     config.getString(ConsumerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG),
                     leastLoadedNodeAlgorithm);
+            netClient.setEnableClientResponseWithFinalize(config.getBoolean(CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK));
 
             this.client = new ConsumerNetworkClient(
                     logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -597,7 +597,9 @@ public class ConsumerNetworkClient implements Closeable {
                 future.raise(response.versionMismatch());
             } else {
                 future.complete(response);
+            }
 
+            if (response != null) {
                 // dec ref count and release the buffer to memory pool if any
                 // the fetch request buffer pool won't be release since we hold on to buffer references and add ref counts
                 this.response.decRefCount();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -597,6 +597,10 @@ public class ConsumerNetworkClient implements Closeable {
                 future.raise(response.versionMismatch());
             } else {
                 future.complete(response);
+
+                // dec ref count and release the buffer to memory pool if any
+                // the fetch request buffer pool won't be release since we hold on to buffer references and add ref counts
+                this.response.decRefCount();
             }
         }
 
@@ -608,6 +612,9 @@ public class ConsumerNetworkClient implements Closeable {
         @Override
         public void onComplete(ClientResponse response) {
             this.response = response;
+            // increment ref count to the client response in order to hold on to buffer till we are done with handler
+            // this will make sure everything except poll is released once fireCompleted call is done
+            this.response.incRefCount();
             pendingCompletion.add(this);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -606,6 +606,14 @@ public class Fetcher<K, V> implements Closeable {
         try {
             while (recordsRemaining > 0) {
                 if (nextInLineFetch == null || nextInLineFetch.isConsumed) {
+                    // The completed fetch object could be de-referenced and use the underlying buffer in
+                    // two different cases.
+                    // 1. The CompletedFetch could be a valid object containing fetched data from broker. In that case,
+                    //    the records are retrieved by fetchRecords() call below and then, underlying buffer is no
+                    //    longer needed and it's released via the Fetcher.CompletedFetch.drain() method.
+                    // 2. The CompletedFetch could be an object containing an error code from broker such as
+                    //    NOT_LEADER_FOR_PARTITION. In that case, we don't need to retrieve the records and ref count
+                    //    is decremented after initializeCompletedFetch() method.
                     CompletedFetch records = completedFetches.peek();
                     if (records == null) break;
 

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -135,11 +135,15 @@ public class NetworkReceive implements Receive {
 
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         if (buffer != null && buffer != EMPTY_BUFFER) {
             memoryPool.release(buffer);
             buffer = null;
         }
+    }
+
+    public MemoryPool memoryPool() {
+        return memoryPool;
     }
 
     public ByteBuffer payload() {

--- a/clients/src/test/java/org/apache/kafka/clients/ClientResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientResponseTest.java
@@ -21,12 +21,13 @@ import java.util.LinkedHashMap;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.requests.RequestHeader;
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 
 public class ClientResponseTest {
@@ -40,8 +41,8 @@ public class ClientResponseTest {
     public void setup() {
         RequestHeader requestHeader = new RequestHeader(ApiKeys.FETCH, (short) 1, "someclient", 1);
         NetworkClientTest.TestCallbackHandler callbackHandler = new NetworkClientTest.TestCallbackHandler();
-        FetchResponse fetchResponse = new FetchResponse(Errors.NONE, new LinkedHashMap<>(), 0, 1);
-        memoryPool = EasyMock.createMock(MemoryPool.class);
+        FetchResponse<MemoryRecords> fetchResponse = new FetchResponse<>(Errors.NONE, new LinkedHashMap<>(), 0, 1);
+        memoryPool = Mockito.mock(MemoryPool.class);
 
         clientResponseWithPool =
             new ClientResponse(requestHeader, callbackHandler, "node0", 100, 110, false, null, null, fetchResponse,
@@ -67,14 +68,12 @@ public class ClientResponseTest {
 
     @Test
     public void testClientResponseBufferRelease() {
-        memoryPool.release(EasyMock.anyObject());
-        EasyMock.expectLastCall().once();
-        EasyMock.replay(memoryPool);
+        Mockito.doNothing().when(memoryPool).release(Mockito.any());
 
         clientResponseWithPool.incRefCount();
         clientResponseWithPool.decRefCount();
 
-        EasyMock.verify(memoryPool);
+        Mockito.verify(memoryPool, Mockito.times(1)).release(Mockito.any());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientResponseTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class ClientResponseTest {
+
+    private ClientResponse clientResponseWithPool;
+    private ClientResponse clientResponse;
+    private ClientResponse clientResponseDisconnected;
+    private MemoryPool memoryPool;
+
+    @Before
+    public void setup() {
+        RequestHeader requestHeader = new RequestHeader(ApiKeys.FETCH, (short) 1, "someclient", 1);
+        NetworkClientTest.TestCallbackHandler callbackHandler = new NetworkClientTest.TestCallbackHandler();
+        FetchResponse fetchResponse = new FetchResponse(Errors.NONE, new LinkedHashMap<>(), 0, 1);
+        memoryPool = EasyMock.createMock(MemoryPool.class);
+
+        clientResponseWithPool =
+            new ClientResponse(requestHeader, callbackHandler, "node0", 100, 110, false, null, null, fetchResponse,
+                memoryPool, ByteBuffer.allocate(1));
+        clientResponse =
+            new ClientResponse(requestHeader, callbackHandler, "node0", 100, 110, false, null, null, fetchResponse,
+                MemoryPool.NONE, ByteBuffer.allocate(1));
+        clientResponseDisconnected =
+            new ClientResponse(requestHeader, callbackHandler, "node0", 100, 110, true, null, null, fetchResponse);
+    }
+
+    private void decrementRefCountBelowZero(ClientResponse clientResponse) {
+        clientResponse.decRefCount();
+    }
+
+    private void incrementRefCountAfterBufferRelease(ClientResponse clientResponse) {
+        clientResponse.incRefCount();
+        clientResponse.decRefCount();
+
+        // Buffer released now. Try incrementing the ref count again.
+        clientResponse.incRefCount();
+    }
+
+    @Test
+    public void testClientResponseBufferRelease() {
+        memoryPool.release(EasyMock.anyObject());
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(memoryPool);
+
+        clientResponseWithPool.incRefCount();
+        clientResponseWithPool.decRefCount();
+
+        EasyMock.verify(memoryPool);
+    }
+
+    @Test
+    public void testDecRefCountBelowZeroMemoryPoolNone() {
+        try {
+            decrementRefCountBelowZero(clientResponse);
+        } catch (Exception e) {
+            Assert.fail("Client response with MemoryPool.NONE should not throw.");
+        }
+    }
+
+    @Test
+    public void testDecRefCountBelowZeroDisconnected() {
+        try {
+            decrementRefCountBelowZero(clientResponseDisconnected);
+        } catch (Exception e) {
+            Assert.fail("Client response with disconnection should not throw.");
+        }
+    }
+
+    @Test
+    public void testDecRefCountBelowZeroShouldThrow() {
+        try {
+            decrementRefCountBelowZero(clientResponseWithPool);
+            Assert.fail("Decrementing ref count below zero should throw.");
+        } catch (Exception e) {
+            Assert.assertEquals(IllegalStateException.class, e.getClass());
+            Assert.assertEquals("Ref count decremented below zero. This should never happen.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testIncRefCountAfterBufferReleaseMemoryPoolNone() {
+        try {
+            incrementRefCountAfterBufferRelease(clientResponse);
+        } catch (Exception e) {
+            Assert.fail("Client response with MemoryPool.NONE should not throw.");
+        }
+    }
+
+    @Test
+    public void testIncRefCountAfterBufferReleaseDisconnected() {
+        try {
+            incrementRefCountAfterBufferRelease(clientResponseDisconnected);
+        } catch (Exception e) {
+            Assert.fail("Client response with disconnection should not throw.");
+        }
+    }
+
+    @Test
+    public void testIncRefCountAfterBufferReleaseShouldThrow() {
+        try {
+            incrementRefCountAfterBufferRelease(clientResponseWithPool);
+            Assert.fail("Incrementing ref count after releasing pool should throw.");
+        } catch (IllegalStateException e) {
+            Assert.assertEquals("Ref count being incremented again after buffer release. This should never happen.",
+                e.getMessage());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -175,6 +175,72 @@ public class NetworkClientTest {
         assertEquals(UnsupportedVersionException.class, metadataUpdater.getAndClearFailure().getClass());
     }
 
+    @Test
+    public void testCloseClearsCompletedReceives() {
+        client.ready(node, time.milliseconds());
+        awaitReady(client, node);
+        client.poll(1, time.milliseconds());
+        assertTrue("The client should be ready", client.isReady(node, time.milliseconds()));
+
+        ProduceRequest.Builder builder = ProduceRequest.Builder.forCurrentMagic((short) 1, 1000,
+            Collections.<TopicPartition, MemoryRecords>emptyMap());
+        ClientRequest request = client.newClientRequest(node.idString(), builder, time.milliseconds(), true);
+        client.send(request, time.milliseconds());
+        assertTrue(client.hasInFlightRequests());
+
+        ResponseHeader respHeader = new ResponseHeader(request.correlationId());
+        Struct resp = new Struct(ApiKeys.PRODUCE.responseSchema(ApiKeys.PRODUCE.latestVersion()));
+        resp.set("responses", new Object[0]);
+        Struct responseHeaderStruct = respHeader.toStruct();
+        int size = responseHeaderStruct.sizeOf() + resp.sizeOf();
+        ByteBuffer buffer = ByteBuffer.allocate(size);
+        responseHeaderStruct.writeTo(buffer);
+        resp.writeTo(buffer);
+        buffer.flip();
+        selector.completeReceive(new NetworkReceive(node.idString(), buffer));
+
+        // Save completed receive references for looking back after close call
+        List<NetworkReceive> completedReceives = selector.completedReceives();
+        client.close();
+
+        completedReceives.forEach(completedReceive -> assertNull(completedReceive.payload()));
+        assertTrue(selector.completedReceives().isEmpty());
+    }
+
+    @Test
+    public void testSetEnableClientResponseWithFinalize() {
+        client.ready(node, time.milliseconds());
+        client.setEnableClientResponseWithFinalize(true);
+        awaitReady(client, node);
+        client.poll(1, time.milliseconds());
+        assertTrue("The client should be ready", client.isReady(node, time.milliseconds()));
+
+        ProduceRequest.Builder builder = ProduceRequest.Builder.forCurrentMagic((short) 1, 1000,
+            Collections.<TopicPartition, MemoryRecords>emptyMap());
+        ClientRequest request = client.newClientRequest(node.idString(), builder, time.milliseconds(), true);
+        client.send(request, time.milliseconds());
+        assertTrue(client.hasInFlightRequests());
+
+        ResponseHeader respHeader = new ResponseHeader(request.correlationId());
+        Struct resp = new Struct(ApiKeys.PRODUCE.responseSchema(ApiKeys.PRODUCE.latestVersion()));
+        resp.set("responses", new Object[0]);
+        Struct responseHeaderStruct = respHeader.toStruct();
+        int size = responseHeaderStruct.sizeOf() + resp.sizeOf();
+        ByteBuffer buffer = ByteBuffer.allocate(size);
+        responseHeaderStruct.writeTo(buffer);
+        resp.writeTo(buffer);
+        buffer.flip();
+        selector.completeReceive(new NetworkReceive(node.idString(), buffer));
+
+        List<ClientResponse> responses = client.poll(1, time.milliseconds());
+        assertEquals(1, responses.size());
+
+        ClientResponse response = responses.get(0);
+        assertTrue(response instanceof ClientResponseWithFinalize);
+
+        client.setEnableClientResponseWithFinalize(false);
+    }
+
     private void checkSimpleRequestResponse(NetworkClient networkClient) {
         awaitReady(networkClient, node); // has to be before creating any request, as it may send ApiVersionsRequest and its response is mocked with correlation id 0
         ProduceRequest.Builder builder = new ProduceRequest.Builder(
@@ -203,6 +269,7 @@ public class NetworkClientTest {
         buffer.flip();
         selector.completeReceive(new NetworkReceive(node.idString(), buffer));
         List<ClientResponse> responses = networkClient.poll(1, time.milliseconds());
+
         assertEquals(1, responses.size());
         assertTrue("The handler should have executed.", handler.executed);
         assertTrue("Should have a response body.", handler.response.hasResponse());
@@ -941,7 +1008,7 @@ public class NetworkClientTest {
         assertFalse(client.isReady(node, time.milliseconds()));
     }
 
-    private static class TestCallbackHandler implements RequestCompletionHandler {
+    public static class TestCallbackHandler implements RequestCompletionHandler {
         public boolean executed = false;
         public ClientResponse response;
 

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -188,7 +188,8 @@ public class NetworkClientTest {
         client.send(request, time.milliseconds());
         assertTrue(client.hasInFlightRequests());
 
-        ResponseHeader respHeader = new ResponseHeader(request.correlationId());
+        ResponseHeader respHeader = new ResponseHeader(request.correlationId(),
+            request.apiKey().responseHeaderVersion(PRODUCE.latestVersion()));
         Struct resp = new Struct(ApiKeys.PRODUCE.responseSchema(ApiKeys.PRODUCE.latestVersion()));
         resp.set("responses", new Object[0]);
         Struct responseHeaderStruct = respHeader.toStruct();
@@ -221,7 +222,8 @@ public class NetworkClientTest {
         client.send(request, time.milliseconds());
         assertTrue(client.hasInFlightRequests());
 
-        ResponseHeader respHeader = new ResponseHeader(request.correlationId());
+        ResponseHeader respHeader = new ResponseHeader(request.correlationId(),
+            request.apiKey().responseHeaderVersion(PRODUCE.latestVersion()));
         Struct resp = new Struct(ApiKeys.PRODUCE.responseSchema(ApiKeys.PRODUCE.latestVersion()));
         resp.set("responses", new Object[0]);
         Struct responseHeaderStruct = respHeader.toStruct();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -16,9 +16,12 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientRequest;
+import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.FetchSessionHandler;
 import org.apache.kafka.clients.Metadata;
@@ -117,6 +120,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.powermock.reflect.Whitebox;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
@@ -198,6 +202,90 @@ public class FetcherTest {
             assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
         }
     }
+
+    @Test
+    public void testFetchIncrementClientResponseRefCount() {
+        Set<TopicPartition> topicPartitions = new HashSet<>();
+        topicPartitions.add(tp0);
+        topicPartitions.add(tp1);
+        subscriptions.assignFromUser(topicPartitions);
+        subscriptions.seek(tp0, 0);
+        subscriptions.seek(tp1, 0);
+
+        // normal fetch
+        assertEquals(1, fetcher.sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(topicPartitions, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        ConcurrentLinkedQueue<Object> fetches = Whitebox.getInternalState(fetcher, "completedFetches");
+        ClientResponse response = Whitebox.getInternalState(fetches.peek(), "response");
+        AtomicLong refCount = Whitebox.getInternalState(response, "refCount");
+        assertEquals(2, refCount.longValue());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetcher.fetchedRecords();
+        assertTrue(partitionRecords.containsKey(tp0));
+        assertTrue(partitionRecords.containsKey(tp1));
+
+        refCount = Whitebox.getInternalState(response, "refCount");
+        assertEquals(0, refCount.longValue());
+    }
+
+    @Test
+    public void testFetcherCloseCleanupRefCount() {
+        Set<TopicPartition> topicPartitions = new HashSet<>();
+        topicPartitions.add(tp0);
+        topicPartitions.add(tp1);
+        subscriptions.assignFromUser(topicPartitions);
+        subscriptions.seek(tp0, 0);
+        subscriptions.seek(tp1, 0);
+
+        // normal fetch
+        assertEquals(1, fetcher.sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(topicPartitions, this.records, Errors.NONE, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        ConcurrentLinkedQueue<Object> fetches = Whitebox.getInternalState(fetcher, "completedFetches");
+        ClientResponse response = Whitebox.getInternalState(fetches.peek(), "response");
+        AtomicLong refCount = Whitebox.getInternalState(response, "refCount");
+        assertEquals(2, refCount.longValue());
+
+        fetcher.close();
+        assertTrue(fetches.isEmpty());
+
+        refCount = Whitebox.getInternalState(response, "refCount");
+        assertEquals(0, refCount.longValue());
+    }
+
+    @Test
+    public void testFetchErrorDecrementsRefCount() {
+        subscriptions.assignFromUser(singleton(tp0));
+        subscriptions.seek(tp0, 0);
+
+        assertEquals(1, fetcher.sendFetches());
+        assertFalse(fetcher.hasCompletedFetches());
+
+        client.prepareResponse(fullFetchResponse(tp0, this.records, Errors.NOT_LEADER_FOR_PARTITION, 100L, 0));
+        consumerClient.poll(time.timer(0));
+        assertTrue(fetcher.hasCompletedFetches());
+
+        ConcurrentLinkedQueue<Object> fetches = Whitebox.getInternalState(fetcher, "completedFetches");
+        ClientResponse response = Whitebox.getInternalState(fetches.peek(), "response");
+        AtomicLong refCount = Whitebox.getInternalState(response, "refCount");
+        assertEquals(1, refCount.longValue());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionRecords = fetcher.fetchedRecords();
+        assertFalse(partitionRecords.containsKey(tp0));
+
+        refCount = Whitebox.getInternalState(response, "refCount");
+        assertEquals(0, refCount.longValue());
+    }
+
 
     @Test
     public void testFetchNormal() {
@@ -2392,7 +2480,7 @@ public class FetcherTest {
     private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchRecords(
             TopicPartition tp, MemoryRecords records, Errors error, long hw, long lastStableOffset, int throttleTime) {
         assertEquals(1, fetcher.sendFetches());
-        client.prepareResponse(fullFetchResponse(tp, records, error, hw, lastStableOffset, throttleTime));
+        client.prepareResponse(fullFetchResponse(singleton(tp), records, error, hw, lastStableOffset, throttleTime));
         consumerClient.poll(time.timer(0));
         return fetchedRecords();
     }
@@ -3945,13 +4033,18 @@ public class FetcherTest {
     }
 
     private FetchResponse<MemoryRecords> fullFetchResponse(TopicPartition tp, MemoryRecords records, Errors error, long hw, int throttleTime) {
-        return fullFetchResponse(tp, records, error, hw, FetchResponse.INVALID_LAST_STABLE_OFFSET, throttleTime);
+        return fullFetchResponse(singleton(tp), records, error, hw, FetchResponse.INVALID_LAST_STABLE_OFFSET, throttleTime);
     }
 
-    private FetchResponse<MemoryRecords> fullFetchResponse(TopicPartition tp, MemoryRecords records, Errors error, long hw,
+    private FetchResponse<MemoryRecords> fullFetchResponse(Set<TopicPartition> tpSet, MemoryRecords records, Errors error, long hw, int throttleTime) {
+        return fullFetchResponse(tpSet, records, error, hw, FetchResponse.INVALID_LAST_STABLE_OFFSET, throttleTime);
+    }
+
+    private FetchResponse<MemoryRecords> fullFetchResponse(Set<TopicPartition> tpSet, MemoryRecords records, Errors error, long hw,
                                             long lastStableOffset, int throttleTime) {
-        Map<TopicPartition, FetchResponse.PartitionData<MemoryRecords>> partitions = Collections.singletonMap(tp,
-                new FetchResponse.PartitionData<>(error, hw, lastStableOffset, 0L, null, records));
+        Map<TopicPartition, FetchResponse.PartitionData<MemoryRecords>> partitions = tpSet.stream()
+            .collect(Collectors.toMap(topicPartition -> topicPartition,
+                topicPartition -> new FetchResponse.PartitionData<>(error, hw, lastStableOffset, 0L, null, records)));
         return new FetchResponse<>(Errors.NONE, new LinkedHashMap<>(partitions), throttleTime, INVALID_SESSION_ID);
     }
 


### PR DESCRIPTION
The current KafkaConsumer code includes support for allocating buffers from MemoryPool when allocating bytes for requests to Brokers. However, the code doesn't release them back to the pool and hence, rendering pooling moot. Currently, it works because it uses MemoryPool.NONE which just mallocs buffer every time a buffer is requested. However, this won't work if a different memory pool implementation is used.

The consumer can't just release the pool back into the memory because the fetch requests keep on holding on to the references to the pool in CompletedFetch objects which live across multiple poll calls. The idea here is to use ref counting based approach, where the ClientResponse increments ref count every time a CompletedFetch object is created and decrement when the fetch is drained after a poll calls returning records.

For the rest of the things such as metadata, offset commit, list offsets it is somewhat easier as the client is done with the response bytes after response future callback is completed.

This PR also adds the ClientResponseWithFinalize class for debugging purposes as well protected by `linkedin.enable.client.resonse.leakcheck` flag. The class uses finalizer to check whether there is some issue in code due to which the buffer wasn't released back to the pool yet. However, during in an actual production setting, the finalizers are costly and hence, not enabled by default.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
