### PR TITLE
Removing entries from the shuttingdownBrokerIds upon broker startup

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -186,7 +186,7 @@ class ControllerContext {
       (brokerAndEpochs map { case (broker, brokerEpoch) => (broker.id, brokerEpoch)})
 
     shuttingDownBrokerIds = shuttingDownBrokerIds.filter(b =>
-      liveBrokerEpochs.contains(b._1) && b._2 < liveBrokerEpochs(b._1))
+      liveBrokerEpochs.contains(b._1) && b._2 >= liveBrokerEpochs(b._1))
   }
 
   def removeLiveBrokers(brokerIds: Set[Int]): Unit = {

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -645,6 +645,58 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilTrue(() => newController.controllerContext.topicMinIsrConfig.getOrElse(topic, -1) == 1, "Controller never saw min.insync.replicas config change for topic.")
   }
 
+  /**
+   * Test that rolling controlled shutdown of several brokers can be allowed by the availability safety check
+   */
+  @Test
+  def testRollingControlledShutdown(): Unit = {
+    val expectedReplicaAssignment = Map(0  -> List(0, 1))
+    val topic = "test"
+    val partition = 0
+    // create brokers
+    val serverConfigs = TestUtils.createBrokerConfigs(2, zkConnect, enableControlledShutdown = true, enableControlledShutdownSafetyCheck = true)
+      .map{props => {
+        props.setProperty(KafkaConfig.ControlledShutdownMaxRetriesProp, "2147483640")
+        props.setProperty(KafkaConfig.ControlledShutdownSafetyCheckRedundancyFactorProp, "0")
+        KafkaConfig.fromProps(props)
+      }
+      }
+
+    servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    TestUtils.waitUntilControllerElected(zkClient)
+
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers)
+
+    // Attempt to shut down and then restart broker1
+    val broker1 = servers.filter(s => s.config.brokerId == 1).head
+    broker1.shutdown()
+    var activeServers = servers.filter(s => s.config.brokerId != 1)
+    TestUtils.waitUntilTrue(() =>
+      activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size != 2),
+      "Topic test not created after timeout")
+
+    broker1.startup()
+    TestUtils.waitUntilTrue(() =>
+      servers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic, partition).get.isr.size == 2),
+      "The ISR does not include the full set after the offline broker is restarted")
+
+    // now try to shutdown broker 0
+    val broker0 = servers.filter(s => s.config.brokerId == 0).head
+    broker0.shutdown()
+    activeServers = Seq(broker1)
+    TestUtils.waitUntilTrue(() =>
+      activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size != 2),
+      "Topic test not created after timeout")
+
+
+    // The test has completed. In order for both brokers to be shutdown, one option is to delete the topic
+    adminZkClient.deleteTopic(topic)
+    val controllerId = zkClient.getControllerId.get
+    val controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+    TestUtils.waitUntilTrue(() => controller.topicDeletionManager.isTopicQueuedUpForDeletion(topic),
+      s"Deletion of the topic $topic never happened")
+  }
+
   @Test
   def testTopicsBeingDeletedDoesNotBlockShutdown(): Unit = {
     val expectedReplicaAssignment = Map(0  -> List(0, 1, 2, 3))


### PR DESCRIPTION
Consider a cluster having two brokers (id=0 and id=1) configured with 
 ```
<property name="kafka.controlledShutdownEnable" value="true">
<property name="kafka.controlledShutdownMaxRetries" value="2147483640">
 <property name="kafka.controlledShutdownSafetyCheckEnable" value="true">
 <property name="kafka.controlledShutdownSafetyCheckRedundancyFactor" value="0">
```
and a partition having two replicas on these two brokers.

If broker1 goes through the controlled shutdown process and starts up, the current implementation uses the following logic to update the `shuttingdownBrokerIds`:

```
shuttingDownBrokerIds = shuttingDownBrokerIds.filter(b =>
      liveBrokerEpochs.contains(b._1) && b._2 < liveBrokerEpochs(b._1))
```
which means broker1's previous shutting epoch is still retained in the shuttingDownBrokerIds after it restarts.

Later on, if broker0 needs to restart, the controller uses the `leaderForControlledShutdown` method to elect a new leader for partitions led by broker0:
```
def leaderForControlledShutdown(controllerContext: ControllerContext,
                                  leaderAndIsrs: Seq[(TopicPartition, LeaderAndIsr)]): Seq[ElectionResult] = {
    val shuttingDownBrokerIdSet = controllerContext.shuttingDownBrokerIds.keySet.toSet
    leaderAndIsrs.map { case (partition, leaderAndIsr) =>
      leaderForControlledShutdown(partition, leaderAndIsr, shuttingDownBrokerIdSet, controllerContext)
    }
  }
```
The `leaderForControlledShutdown` would still treat broker1 as a shutting down broker, and therefore won't be able to transfer the leadership to broker1, despite its readiness to serve as the leader.

This PR resolves the problem by changing the update logic of `shuttingDownBrokerIds` such that the entry of a restarted broker would be removed from it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
