### PR TITLE
Ignoring the failed tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.common.config.ConfigException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ClientUtilsTest {
@@ -106,6 +108,7 @@ public class ClientUtilsTest {
     }
 
     @Test
+    @Ignore
     public void testResolveDnsLookupAllIps() throws UnknownHostException {
         assertTrue(ClientUtils.resolve("kafka.apache.org", ClientDnsLookup.USE_ALL_DNS_IPS).size() > 1);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -255,6 +255,7 @@ public class ClusterConnectionStatesTest {
         assertSame(currAddress, connectionStates.currentAddress(nodeId1));
     }
 
+    @Ignore
     @Test
     public void testMultipleIPsWithDefault() throws UnknownHostException {
         assertTrue(ClientUtils.resolve(hostTwoIps, ClientDnsLookup.USE_ALL_DNS_IPS).size() > 1);
@@ -281,6 +282,7 @@ public class ClusterConnectionStatesTest {
         assertNotSame(addr1, addr3);
     }
 
+    @Ignore
     @Test
     public void testHostResolveChange() throws UnknownHostException, ReflectiveOperationException {
         assertTrue(ClientUtils.resolve(hostTwoIps, ClientDnsLookup.USE_ALL_DNS_IPS).size() > 1);


### PR DESCRIPTION
Several tests are failing since the domain `kafka.apache.org` that used to resolve to more than 1 IPv4 addresses are not only resolving to 1 IPv4 address. 
The upstream code has overhauled the ClusterConnectionStatesTest. We are simply ignoring these tests for now, and will get the new logic from upstream after a major version rebase.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
