### PR TITLE
Make KafkaConsumer's NetworkReceive memory pool configurable by ConsumerConfig

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
@@ -150,6 +150,10 @@ public class ClientResponse {
     }
 
     public void incRefCount() {
+        if (!usingMemoryPool()) {
+            return;
+        }
+
         if (bufferReleased && usingMemoryPool()) {
             // If somebody tried to call incRefCount after buffer has been released. This shouldn't happen
             throw new IllegalStateException(
@@ -159,6 +163,10 @@ public class ClientResponse {
     }
 
     public void decRefCount() {
+        if (!usingMemoryPool()) {
+            return;
+        }
+
         long value = refCount.decrementAndGet();
         if (value < 0 && usingMemoryPool()) {
             // Oops! This seems to be a place where we shouldn't get to.

--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
@@ -154,7 +154,7 @@ public class ClientResponse {
             return;
         }
 
-        if (bufferReleased && usingMemoryPool()) {
+        if (bufferReleased) {
             // If somebody tried to call incRefCount after buffer has been released. This shouldn't happen
             throw new IllegalStateException(
                 "Ref count being incremented again after buffer release. This should never happen.");
@@ -168,7 +168,7 @@ public class ClientResponse {
         }
 
         long value = refCount.decrementAndGet();
-        if (value < 0 && usingMemoryPool()) {
+        if (value < 0) {
             // Oops! This seems to be a place where we shouldn't get to.
             // However, to save users from exceptions, who don't use pooling, don't throw an exception.
             throw new IllegalStateException("Ref count decremented below zero. This should never happen.");

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -102,17 +102,6 @@ public class CommonClientConfigs {
     public static final String ENABLE_STICKY_METADATA_FETCH_DOC = "Fetch metadata from the least loaded broker if false. Otherwise fetch metadata "
                                                          + "from the same broker until it is disconnected.";
 
-    public static final String POOL_CLASS_NAME_CONFIG = "pool.class.name";
-    public static final String POOL_CLASS_NAME_DOC = "Memory pool class to pool the fetched data from broker. If not specified, uses MemoryPool.NONE.";
-
-    public static final String POOL_INSTANCE_CONFIG = "pool.instance";
-    public static final String POOL_INSTANCE_DOC =
-        "A specific instance of MemoryPool to be used. Useful in cases where the MemoryPool is supposed to be"
-            + "shared amongst various Kafka Consumers. Please specify pool.class.name as org.apache.kafka.common.memory.GlobalPoolDelegate in order for this to work.";
-
-    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
-    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";
-
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -102,6 +102,13 @@ public class CommonClientConfigs {
     public static final String ENABLE_STICKY_METADATA_FETCH_DOC = "Fetch metadata from the least loaded broker if false. Otherwise fetch metadata "
                                                          + "from the same broker until it is disconnected.";
 
+    public static final String POOL_CLASS_NAME_CONFIG = "pool.class.name";
+    public static final String POOL_CLASS_NAME_DOC = "Memory pool class to pool the fetched data from broker. If not specified, uses MemoryPool.NONE.";
+
+    public static final String POOL_INSTANCE_CONFIG = "pool.instance";
+    public static final String POOL_INSTANCE_DOC =
+        "A specific instance of MemoryPool to be used. Useful in cases where the MemoryPool is supposed to be"
+            + "shared amongst various Kafka Consumers. Please specify pool.class.name as org.apache.kafka.common.memory.GlobalPoolDelegate in order for this to work.";
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -275,7 +275,10 @@ public class ConsumerConfig extends AbstractConfig {
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
     public static final String POOL_CLASS_NAME_CONFIG = "linkedin.pool.class.name";
-    public static final String POOL_CLASS_NAME_DOC = "Memory pool class to pool the fetched data from broker. If not specified, uses MemoryPool.NONE.";
+    public static final String POOL_CLASS_NAME_DOC = "FQCN of MemoryPool implementation to pool the fetched data from broker. The implementation should have default no args constructor."
+        + " This config is optional and uses MemoryPool.NONE by default. This means that it will call ByteBuf.allocate() on every new response from Broker."
+        + " If you want to configure a MemoryPool object with custom parameters, then specify this config as org.apache.kafka.common.memory.GlobalPoolDelegate and which will proxy"
+        + " all the calls to instance of MemoryPool object passed in KafkaConsumer properties linkedin.memorypool.pool.instance key";
 
     public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
     public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -274,7 +274,7 @@ public class ConsumerConfig extends AbstractConfig {
     private static final String ALLOW_AUTO_CREATE_TOPICS_DOC = "The client-side (consumer) permission to allow auto-topic creation. Both the client-side and the broker-side should enable auto-topic creation in order for a topic to be automatically created";
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
-    public static final String POOL_CLASS_NAME_CONFIG = "pool.class.name";
+    public static final String POOL_CLASS_NAME_CONFIG = "linkedin.pool.class.name";
     public static final String POOL_CLASS_NAME_DOC = "Memory pool class to pool the fetched data from broker. If not specified, uses MemoryPool.NONE.";
 
     public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -275,7 +275,7 @@ public class ConsumerConfig extends AbstractConfig {
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
     public static final String POOL_CLASS_NAME_CONFIG = "linkedin.pool.class.name";
-    public static final String POOL_CLASS_NAME_DOC = "FQCN of MemoryPool implementation to pool the fetched data from broker. The implementation should have default no args constructor."
+    public static final String POOL_CLASS_NAME_DOC = "FQCN of MemoryPool implementation to allow reusing memory for fetching data. The implementation should have default no args constructor."
         + " This config is optional and uses MemoryPool.NONE by default. This means that it will call ByteBuf.allocate() on every new response from Broker."
         + " If you want to configure a MemoryPool object with custom parameters, then specify this config as org.apache.kafka.common.memory.GlobalPoolDelegate and which will proxy"
         + " all the calls to instance of MemoryPool object passed in KafkaConsumer properties linkedin.memorypool.pool.instance key";

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -275,6 +274,12 @@ public class ConsumerConfig extends AbstractConfig {
     private static final String ALLOW_AUTO_CREATE_TOPICS_DOC = "The client-side (consumer) permission to allow auto-topic creation. Both the client-side and the broker-side should enable auto-topic creation in order for a topic to be automatically created";
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
+    public static final String POOL_CLASS_NAME_CONFIG = "pool.class.name";
+    public static final String POOL_CLASS_NAME_DOC = "Memory pool class to pool the fetched data from broker. If not specified, uses MemoryPool.NONE.";
+
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                                         Type.LIST,
@@ -495,16 +500,16 @@ public class ConsumerConfig extends AbstractConfig {
                                         true,
                                         Importance.MEDIUM,
                                         CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_DOC)
-                                .define(CommonClientConfigs.POOL_CLASS_NAME_CONFIG,
+                                .define(ConsumerConfig.POOL_CLASS_NAME_CONFIG,
                                         Type.CLASS,
                                         null,
                                         Importance.MEDIUM,
-                                        CommonClientConfigs.POOL_CLASS_NAME_DOC)
-                                .define(CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK,
+                                        ConsumerConfig.POOL_CLASS_NAME_DOC)
+                                .define(ConsumerConfig.ENABLE_CLIENT_RESPONSE_LEAK_CHECK,
                                         Type.BOOLEAN,
                                         false,
                                         Importance.MEDIUM,
-                                        CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC)
+                                        ConsumerConfig.ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -494,6 +495,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         true,
                                         Importance.MEDIUM,
                                         CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_DOC)
+                                .define(CommonClientConfigs.POOL_CLASS_NAME_CONFIG,
+                                        Type.CLASS,
+                                        null,
+                                        Importance.MEDIUM,
+                                        CommonClientConfigs.POOL_CLASS_NAME_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -723,11 +723,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
             int heartbeatIntervalMs = config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG);
 
-            MemoryPool memoryPool = config.getConfiguredInstance(CommonClientConfigs.POOL_CLASS_NAME_CONFIG, MemoryPool.class);
+            MemoryPool memoryPool = config.getConfiguredInstance(ConsumerConfig.POOL_CLASS_NAME_CONFIG, MemoryPool.class);
             if (memoryPool == null) {
-              memoryPool = MemoryPool.NONE;
+                memoryPool = MemoryPool.NONE;
             }
-
             Selector selector = new Selector(NetworkReceive.UNLIMITED, config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), this.metrics, this.time,
                 metricGrpPrefix, Collections.emptyMap(), true, false, channelBuilder, memoryPool, logContext);
             NetworkClient netClient = new NetworkClient(
@@ -746,15 +745,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     throttleTimeSensor,
                     logContext);
             netClient.setEnableStickyMetadataFetch(config.getBoolean(CommonClientConfigs.ENABLE_STICKY_METADATA_FETCH_CONFIG));
-            netClient.setEnableClientResponseWithFinalize(config.getBoolean(CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK));
-            this.client = new ConsumerNetworkClient(
-                    logContext,
-                    netClient,
-                    metadata,
-                    time,
-                    retryBackoffMs,
-                    config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
-                    heartbeatIntervalMs); //Will avoid blocking an extended period of time to prevent heartbeat thread starvation
+            netClient.setEnableClientResponseWithFinalize(config.getBoolean(ConsumerConfig.ENABLE_CLIENT_RESPONSE_LEAK_CHECK));
+            this.client = new ConsumerNetworkClient(logContext, netClient, metadata, time, retryBackoffMs,
+                config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), heartbeatIntervalMs); //Will avoid blocking an extended period of time to prevent heartbeat thread starvation
             OffsetResetStrategy offsetResetStrategy = OffsetResetStrategy.valueOf(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
             this.subscriptions = new SubscriptionState(offsetResetStrategy);
             this.assignors = config.getConfiguredInstances(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -39,12 +39,14 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.network.ChannelBuilder;
+import org.apache.kafka.common.network.NetworkReceive;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.requests.MetadataRequest;
@@ -721,8 +723,15 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
             int heartbeatIntervalMs = config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG);
 
+            MemoryPool memoryPool = config.getConfiguredInstance(CommonClientConfigs.POOL_CLASS_NAME_CONFIG, MemoryPool.class);
+            if (memoryPool == null) {
+              memoryPool = MemoryPool.NONE;
+            }
+
+            Selector selector = new Selector(NetworkReceive.UNLIMITED, config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), this.metrics, this.time,
+                metricGrpPrefix, Collections.emptyMap(), true, false, channelBuilder, memoryPool, logContext);
             NetworkClient netClient = new NetworkClient(
-                    new Selector(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder, logContext),
+                    selector,
                     this.metadata,
                     clientId,
                     100, // a fixed large enough value will suffice for max in-flight requests

--- a/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
@@ -25,7 +25,7 @@ public class GlobalPoolDelegate implements MemoryPool, Configurable {
     // A specific instance of MemoryPool to be used. Useful in cases where the MemoryPool is supposed to be shared
     // amongst various Kafka Consumers. Please specify pool.class.name as org.apache.kafka.common.memory.GlobalPoolDelegate
     // in order for this to work.
-    private static final String POOL_INSTANCE_CONFIG = "pool.instance";
+    private static final String POOL_INSTANCE_CONFIG = "linkedin.memorypool.pool.instance";
     private MemoryPool delegateMemoryPool;
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
@@ -1,45 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.memory;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.Configurable;
 
 
 public class GlobalPoolDelegate implements MemoryPool, Configurable {
-  private MemoryPool delegateMemoryPool;
+    // A specific instance of MemoryPool to be used. Useful in cases where the MemoryPool is supposed to be shared
+    // amongst various Kafka Consumers. Please specify pool.class.name as org.apache.kafka.common.memory.GlobalPoolDelegate
+    // in order for this to work.
+    private static final String POOL_INSTANCE_CONFIG = "pool.instance";
+    private MemoryPool delegateMemoryPool;
 
-  @Override
-  public void configure(Map<String, ?> configs) {
-    if (!configs.containsKey(CommonClientConfigs.POOL_INSTANCE_CONFIG)) {
-      throw new IllegalStateException(CommonClientConfigs.POOL_INSTANCE_CONFIG + " not found in configs while configuring "
-          + "GlobalPoolDelegate object.");
+    @Override
+    public void configure(Map<String, ?> configs) {
+        if (!configs.containsKey(POOL_INSTANCE_CONFIG)) {
+            throw new IllegalStateException(POOL_INSTANCE_CONFIG + " not found in configs while configuring "
+                + "GlobalPoolDelegate object.");
+        }
+        delegateMemoryPool = (MemoryPool) configs.get(POOL_INSTANCE_CONFIG);
     }
-    delegateMemoryPool = (MemoryPool) configs.get(CommonClientConfigs.POOL_INSTANCE_CONFIG);
-  }
 
-  @Override
-  public ByteBuffer tryAllocate(int sizeBytes) {
-    return delegateMemoryPool.tryAllocate(sizeBytes);
-  }
+    @Override
+    public ByteBuffer tryAllocate(int sizeBytes) {
+        return delegateMemoryPool.tryAllocate(sizeBytes);
+    }
 
-  @Override
-  public void release(ByteBuffer previouslyAllocated) {
-    delegateMemoryPool.release(previouslyAllocated);
-  }
+    @Override
+    public void release(ByteBuffer previouslyAllocated) {
+        delegateMemoryPool.release(previouslyAllocated);
+    }
 
-  @Override
-  public long size() {
-    return delegateMemoryPool.size();
-  }
+    @Override
+    public long size() {
+        return delegateMemoryPool.size();
+    }
 
-  @Override
-  public long availableMemory() {
-    return delegateMemoryPool.availableMemory();
-  }
+    @Override
+    public long availableMemory() {
+        return delegateMemoryPool.availableMemory();
+    }
 
-  @Override
-  public boolean isOutOfMemory() {
-    return delegateMemoryPool.isOutOfMemory();
-  }
+    @Override
+    public boolean isOutOfMemory() {
+        return delegateMemoryPool.isOutOfMemory();
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
@@ -1,0 +1,45 @@
+package org.apache.kafka.common.memory;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.Configurable;
+
+
+public class GlobalPoolDelegate implements MemoryPool, Configurable {
+  private MemoryPool delegateMemoryPool;
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    if (!configs.containsKey(CommonClientConfigs.POOL_INSTANCE_CONFIG)) {
+      throw new IllegalStateException(CommonClientConfigs.POOL_INSTANCE_CONFIG + " not found in configs while configuring "
+          + "GlobalPoolDelegate object.");
+    }
+    delegateMemoryPool = (MemoryPool) configs.get(CommonClientConfigs.POOL_INSTANCE_CONFIG);
+  }
+
+  @Override
+  public ByteBuffer tryAllocate(int sizeBytes) {
+    return delegateMemoryPool.tryAllocate(sizeBytes);
+  }
+
+  @Override
+  public void release(ByteBuffer previouslyAllocated) {
+    delegateMemoryPool.release(previouslyAllocated);
+  }
+
+  @Override
+  public long size() {
+    return delegateMemoryPool.size();
+  }
+
+  @Override
+  public long availableMemory() {
+    return delegateMemoryPool.availableMemory();
+  }
+
+  @Override
+  public boolean isOutOfMemory() {
+    return delegateMemoryPool.isOutOfMemory();
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
@@ -35,6 +35,9 @@ public class GlobalPoolDelegate implements MemoryPool, Configurable {
                 + "GlobalPoolDelegate object.");
         }
         delegateMemoryPool = (MemoryPool) configs.get(POOL_INSTANCE_CONFIG);
+        if (delegateMemoryPool == null) {
+            throw new IllegalArgumentException(POOL_INSTANCE_CONFIG + " supplied as null in configs.");
+        }
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -16,11 +16,13 @@
  */
 package org.apache.kafka.clients;
 
+import java.nio.ByteBuffer;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
@@ -38,6 +40,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import org.easymock.EasyMock;
+
 
 /**
  * A mock network client for use testing code
@@ -233,9 +237,12 @@ public class MockClient implements KafkaClient {
                 unsupportedVersionException = new UnsupportedVersionException("Api " +
                         request.apiKey() + " with version " + version);
 
+            MemoryPool memoryPool = EasyMock.createNiceMock(MemoryPool.class);
+            EasyMock.replay(memoryPool);
             ClientResponse resp = new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),
                     request.createdTimeMs(), time.milliseconds(), futureResp.disconnected,
-                    unsupportedVersionException, null, futureResp.responseBody);
+                    unsupportedVersionException, null, futureResp.responseBody, memoryPool,
+                ByteBuffer.allocate(0));
             responses.add(resp);
             iterator.remove();
             return;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients.consumer;
 
 import java.util.ArrayList;
 import org.apache.kafka.clients.ClientRequest;
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.MockClient;
@@ -188,7 +187,7 @@ public class KafkaConsumerTest {
     public void testGlobalPoolWithNoPoolInstance() {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-        config.put(CommonClientConfigs.POOL_CLASS_NAME_CONFIG, "org.apache.kafka.common.memory.GlobalPoolDelegate");
+        config.put(ConsumerConfig.POOL_CLASS_NAME_CONFIG, "org.apache.kafka.common.memory.GlobalPoolDelegate");
         new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
     }
 
@@ -202,8 +201,8 @@ public class KafkaConsumerTest {
 
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-        config.put(CommonClientConfigs.POOL_CLASS_NAME_CONFIG, "org.apache.kafka.common.memory.GlobalPoolDelegate");
-        config.put(CommonClientConfigs.POOL_INSTANCE_CONFIG, mockMemoryPool);
+        config.put(ConsumerConfig.POOL_CLASS_NAME_CONFIG, "org.apache.kafka.common.memory.GlobalPoolDelegate");
+        config.put("pool.instance", mockMemoryPool);
         KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
 
         consumer.close();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -202,7 +202,7 @@ public class KafkaConsumerTest {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         config.put(ConsumerConfig.POOL_CLASS_NAME_CONFIG, "org.apache.kafka.common.memory.GlobalPoolDelegate");
-        config.put("pool.instance", mockMemoryPool);
+        config.put("linkedin.memorypool.pool.instance", mockMemoryPool);
         KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
 
         consumer.close();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.consumer;
 
 import java.util.ArrayList;
 import org.apache.kafka.clients.ClientRequest;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.KafkaClient;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.MockClient;
@@ -39,6 +40,7 @@ import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.network.Selectable;
@@ -180,6 +182,32 @@ public class KafkaConsumerTest {
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         config.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, -2);
         new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+    }
+
+    @Test(expected = KafkaException.class)
+    public void testGlobalPoolWithNoPoolInstance() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        config.put(CommonClientConfigs.POOL_CLASS_NAME_CONFIG, "org.apache.kafka.common.memory.GlobalPoolDelegate");
+        new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+    }
+
+    @Test
+    public void testKafkaConsumerGlobalMemoryPoolInstance() {
+        // Selector initialization calls memoryPool.size() to figure out low mem threshold.
+        // Using that to verify that the memory pool instance is delegated through GlobalPoolDelegate
+        MemoryPool mockMemoryPool = EasyMock.createMock(MemoryPool.class);
+        EasyMock.expect(mockMemoryPool.size()).andReturn(Long.MAX_VALUE).once();
+        EasyMock.replay(mockMemoryPool);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        config.put(CommonClientConfigs.POOL_CLASS_NAME_CONFIG, "org.apache.kafka.common.memory.GlobalPoolDelegate");
+        config.put(CommonClientConfigs.POOL_INSTANCE_CONFIG, mockMemoryPool);
+        KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+
+        consumer.close();
+        EasyMock.verify(mockMemoryPool);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
@@ -1,8 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.memory;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,7 +44,7 @@ public class GlobalPoolDelegateTest {
 
         GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
         globalPoolDelegate.configure(
-            Collections.singletonMap(CommonClientConfigs.POOL_INSTANCE_CONFIG, mockMemoryPool));
+            Collections.singletonMap("pool.instance", mockMemoryPool));
 
         Assert.assertEquals(globalPoolDelegate.availableMemory(), 100);
         Assert.assertEquals(globalPoolDelegate.isOutOfMemory(), false);

--- a/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
@@ -1,0 +1,42 @@
+package org.apache.kafka.common.memory;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class GlobalPoolDelegateTest {
+    @Test(expected = IllegalStateException.class)
+    public void testMissingPoolInstance() {
+        GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
+        globalPoolDelegate.configure(Collections.emptyMap());
+    }
+
+    @Test
+    public void testDelegateCalls() {
+        MemoryPool mockMemoryPool = EasyMock.mock(MemoryPool.class);
+        EasyMock.expect(mockMemoryPool.availableMemory()).andReturn((long) 100).once();
+        EasyMock.expect(mockMemoryPool.isOutOfMemory()).andReturn(false).once();
+        EasyMock.expect(mockMemoryPool.size()).andReturn((long) 200).once();
+        ByteBuffer byteBuf = ByteBuffer.allocate(0);
+        EasyMock.expect(mockMemoryPool.tryAllocate(EasyMock.anyInt())).andReturn(byteBuf).once();
+        mockMemoryPool.release(EasyMock.anyObject());
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockMemoryPool);
+
+        GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
+        globalPoolDelegate.configure(
+            Collections.singletonMap(CommonClientConfigs.POOL_INSTANCE_CONFIG, mockMemoryPool));
+
+        Assert.assertEquals(globalPoolDelegate.availableMemory(), 100);
+        Assert.assertEquals(globalPoolDelegate.isOutOfMemory(), false);
+        Assert.assertEquals(globalPoolDelegate.size(), 200);
+        Assert.assertEquals(globalPoolDelegate.tryAllocate(0), byteBuf);
+        globalPoolDelegate.release(byteBuf);
+
+        EasyMock.verify(mockMemoryPool);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
@@ -33,7 +33,7 @@ public class GlobalPoolDelegateTest {
     @Test(expected = IllegalArgumentException.class)
     public void testNullPoolInstance() {
         GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
-        globalPoolDelegate.configure(Collections.emptyMap());
+        globalPoolDelegate.configure(Collections.singletonMap("linkedin.memorypool.pool.instance", null));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
@@ -30,6 +30,12 @@ public class GlobalPoolDelegateTest {
         globalPoolDelegate.configure(Collections.emptyMap());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullPoolInstance() {
+        GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
+        globalPoolDelegate.configure(Collections.emptyMap());
+    }
+
     @Test
     public void testDelegateCalls() {
         MemoryPool mockMemoryPool = EasyMock.mock(MemoryPool.class);

--- a/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
@@ -44,7 +44,7 @@ public class GlobalPoolDelegateTest {
 
         GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
         globalPoolDelegate.configure(
-            Collections.singletonMap("pool.instance", mockMemoryPool));
+            Collections.singletonMap("linkedin.memorypool.pool.instance", mockMemoryPool));
 
         Assert.assertEquals(globalPoolDelegate.availableMemory(), 100);
         Assert.assertEquals(globalPoolDelegate.isOutOfMemory(), false);


### PR DESCRIPTION
Allow the KafkaConsumer's network memory pool to be configured by ConsumerConfig.
- Supply `linkedin.pool.class.name` for memory pool implementation with default constructor with no args
- Supply `linkedin.pool.class.name` with `GloballPoolDelegate` and pass the object instance with `linkedin.memorypool.pool.instance` in properties map.
- Moved the leak check config from common client config to Consumer config

```
./gradlew cleanTest rat checkstyleMain checkstyleTest :clients:unitTest :core:unitTest --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
```