### PR TITLE
[LI-HOTFIX] Making the ExcludePartitions field in MetadataRequest an optional field

### DIFF
--- a/clients/src/main/resources/common/message/MetadataRequest.json
+++ b/clients/src/main/resources/common/message/MetadataRequest.json
@@ -42,7 +42,7 @@
       "about": "Whether to include cluster authorized operations." },
     { "name": "IncludeTopicAuthorizedOperations", "type": "bool", "versions": "8+",
       "about": "Whether to include topic authorized operations." },
-    { "name": "ExcludePartitions", "type": "bool", "versions": "9+", "default": "false",
+    { "name": "ExcludePartitions", "type": "bool", "tag": 0, "taggedVersions": "9+", "versions": "9+", "default": "false",
       "about": "Whether to exclude partitions in the MetadataResponse." }
   ]
 }


### PR DESCRIPTION
TICKET = LIKAFKA-37320
LI_DESCRIPTION =
After the change made in b28666d5d8ff72f3cc595dcafbc17383253749a4,
an old client version sending a MetadataRequest without the "ExcludePartitions"
field to a new kafka server version expecting the field will result in the exception below.
This PR turns the "ExcludePartitions" field into an optional one introduced in KIP-482.

```
org.apache.kafka.common.errors.InvalidRequestException: Error getting request for apiKey: METADATA, apiVersion: 9, connectionId: 10.154.165.183:16637-10.154.87.109:44876-2848, listenerName: ListenerName(SSL), principal: User:likafka-cruise-control:None:prod-ltx1
        at org.apache.kafka.common.requests.RequestContext.parseRequest(RequestContext.java:70) ~[kafka-clients-2.4.1.26.jar:?]
        at kafka.network.RequestChannel$Request.<init>(RequestChannel.scala:89) ~[kafka_2.12-2.4.1.26.jar:?]
        at kafka.network.Processor.$anonfun$processCompletedReceives$1(SocketServer.scala:928) ~[kafka_2.12-2.4.1.26.jar:?]
        at kafka.network.Processor.$anonfun$processCompletedReceives$1$adapted(SocketServer.scala:909) ~[kafka_2.12-2.4.1.26.jar:?]
        at scala.collection.Iterator.foreach(Iterator.scala:941) [scala-library-2.12.10.jar:?]
        at scala.collection.Iterator.foreach$(Iterator.scala:941) [scala-library-2.12.10.jar:?]
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1429) [scala-library-2.12.10.jar:?]
        at scala.collection.IterableLike.foreach(IterableLike.scala:74) [scala-library-2.12.10.jar:?]
        at scala.collection.IterableLike.foreach$(IterableLike.scala:73) [scala-library-2.12.10.jar:?]
        at scala.collection.AbstractIterable.foreach(Iterable.scala:56) [scala-library-2.12.10.jar:?]
        at kafka.network.Processor.processCompletedReceives(SocketServer.scala:909) [kafka_2.12-2.4.1.26.jar:?]
        at kafka.network.Processor.run(SocketServer.scala:799) [kafka_2.12-2.4.1.26.jar:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: org.apache.kafka.common.protocol.types.SchemaException: Error reading field '_tagged_fields': java.nio.BufferUnderflowException
        at org.apache.kafka.common.protocol.types.Schema.read(Schema.java:118) ~[kafka-clients-2.4.1.26.jar:?]
        at org.apache.kafka.common.protocol.ApiKeys.parseRequest(ApiKeys.java:327) ~[kafka-clients-2.4.1.26.jar:?]
        at org.apache.kafka.common.requests.RequestContext.parseRequest(RequestContext.java:65) ~[kafka-clients-2.4.1.26.jar:?]
        ... 12 more
```

I've verified the change with the following combinations of client and server versions, and they all work as expected. The client command is 
`./bin/kafka-topics.sh --bootstrap-server localhost:9092 --list`
which triggers the `listTopics()` api and sends a Metadata request to the server.

1. New Client, New Server (functional and there is a performance gain)
2. Old Client, New Server (functional but there is no performance gain since all of the partitions info are still being returned).
3. New Client, Old Server (function but there is no performance gain)

EXIT_CRITERIA = When this change is merged in upstream and the corresponding change is pulled into a future release.