### PR TITLE
[LI-HOTFIX] Make KafkaConsumer's NetworkReceive memory pool configurable by ConsumerConfig

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
@@ -150,6 +150,10 @@ public class ClientResponse {
     }
 
     public void incRefCount() {
+        if (!usingMemoryPool()) {
+            return;
+        }
+
         if (bufferReleased && usingMemoryPool()) {
             // If somebody tried to call incRefCount after buffer has been released. This shouldn't happen
             throw new IllegalStateException(
@@ -159,6 +163,10 @@ public class ClientResponse {
     }
 
     public void decRefCount() {
+        if (!usingMemoryPool()) {
+            return;
+        }
+
         long value = refCount.decrementAndGet();
         if (value < 0 && usingMemoryPool()) {
             // Oops! This seems to be a place where we shouldn't get to.

--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
@@ -154,7 +154,7 @@ public class ClientResponse {
             return;
         }
 
-        if (bufferReleased && usingMemoryPool()) {
+        if (bufferReleased) {
             // If somebody tried to call incRefCount after buffer has been released. This shouldn't happen
             throw new IllegalStateException(
                 "Ref count being incremented again after buffer release. This should never happen.");
@@ -168,7 +168,7 @@ public class ClientResponse {
         }
 
         long value = refCount.decrementAndGet();
-        if (value < 0 && usingMemoryPool()) {
+        if (value < 0) {
             // Oops! This seems to be a place where we shouldn't get to.
             // However, to save users from exceptions, who don't use pooling, don't throw an exception.
             throw new IllegalStateException("Ref count decremented below zero. This should never happen.");

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -158,9 +158,6 @@ public class CommonClientConfigs {
                                                                  + "of 3 lowest-expected-latency nodes)";
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = LeastLoadedNodeAlgorithm.VANILLA.name();
 
-    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
-    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";
-
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -307,7 +307,7 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
 
     public static final String POOL_CLASS_NAME_CONFIG = "linkedin.pool.class.name";
-    public static final String POOL_CLASS_NAME_DOC = "FQCN of MemoryPool implementation to pool the fetched data from broker. The implementation should have default no args constructor."
+    public static final String POOL_CLASS_NAME_DOC = "FQCN of MemoryPool implementation to allow reusing memory for fetching data. The implementation should have default no args constructor."
         + " This config is optional and uses MemoryPool.NONE by default. This means that it will call ByteBuf.allocate() on every new response from Broker."
         + " If you want to configure a MemoryPool object with custom parameters, then specify this config as org.apache.kafka.common.memory.GlobalPoolDelegate and which will proxy"
         + " all the calls to instance of MemoryPool object passed in KafkaConsumer properties linkedin.memorypool.pool.instance key";

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -307,7 +307,10 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
 
     public static final String POOL_CLASS_NAME_CONFIG = "linkedin.pool.class.name";
-    public static final String POOL_CLASS_NAME_DOC = "Memory pool class to pool the fetched data from broker. If not specified, uses MemoryPool.NONE.";
+    public static final String POOL_CLASS_NAME_DOC = "FQCN of MemoryPool implementation to pool the fetched data from broker. The implementation should have default no args constructor."
+        + " This config is optional and uses MemoryPool.NONE by default. This means that it will call ByteBuf.allocate() on every new response from Broker."
+        + " If you want to configure a MemoryPool object with custom parameters, then specify this config as org.apache.kafka.common.memory.GlobalPoolDelegate and which will proxy"
+        + " all the calls to instance of MemoryPool object passed in KafkaConsumer properties linkedin.memorypool.pool.instance key";
 
     public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
     public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -306,6 +306,12 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
 
+    public static final String POOL_CLASS_NAME_CONFIG = "linkedin.pool.class.name";
+    public static final String POOL_CLASS_NAME_DOC = "Memory pool class to pool the fetched data from broker. If not specified, uses MemoryPool.NONE.";
+
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK = "linkedin.enable.client.resonse.leakcheck";
+    public static final String ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC = "Use ClientResponse with finalize method to check the release of NetworkReceive buffer.";
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                                         Type.LIST,
@@ -560,11 +566,16 @@ public class ConsumerConfig extends AbstractConfig {
                                         new EnumValueValidator<>(LeastLoadedNodeAlgorithm.class),
                                         Importance.MEDIUM,
                                         LEAST_LOADED_NODE_ALGORITHM_DOC)
-                                .define(CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK,
+                                .define(ConsumerConfig.POOL_CLASS_NAME_CONFIG,
+                                        Type.CLASS,
+                                        null,
+                                        Importance.MEDIUM,
+                                        ConsumerConfig.POOL_CLASS_NAME_DOC)
+                                .define(ConsumerConfig.ENABLE_CLIENT_RESPONSE_LEAK_CHECK,
                                         Type.BOOLEAN,
                                         false,
                                         Importance.MEDIUM,
-                                        CommonClientConfigs.ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC)
+                                        ConsumerConfig.ENABLE_CLIENT_RESPONSE_LEAK_CHECK_DOC)
                                 .withClientSslSupport()
                                 .withClientSaslSupport();
     }

--- a/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.memory;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.kafka.common.Configurable;
+
+
+public class GlobalPoolDelegate implements MemoryPool, Configurable {
+    // A specific instance of MemoryPool to be used. Useful in cases where the MemoryPool is supposed to be shared
+    // amongst various Kafka Consumers. Please specify pool.class.name as org.apache.kafka.common.memory.GlobalPoolDelegate
+    // in order for this to work.
+    private static final String POOL_INSTANCE_CONFIG = "linkedin.memorypool.pool.instance";
+    private MemoryPool delegateMemoryPool;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        if (!configs.containsKey(POOL_INSTANCE_CONFIG)) {
+            throw new IllegalStateException(POOL_INSTANCE_CONFIG + " not found in configs while configuring "
+                + "GlobalPoolDelegate object.");
+        }
+        delegateMemoryPool = (MemoryPool) configs.get(POOL_INSTANCE_CONFIG);
+    }
+
+    @Override
+    public ByteBuffer tryAllocate(int sizeBytes) {
+        return delegateMemoryPool.tryAllocate(sizeBytes);
+    }
+
+    @Override
+    public void release(ByteBuffer previouslyAllocated) {
+        delegateMemoryPool.release(previouslyAllocated);
+    }
+
+    @Override
+    public long size() {
+        return delegateMemoryPool.size();
+    }
+
+    @Override
+    public long availableMemory() {
+        return delegateMemoryPool.availableMemory();
+    }
+
+    @Override
+    public boolean isOutOfMemory() {
+        return delegateMemoryPool.isOutOfMemory();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/GlobalPoolDelegate.java
@@ -35,6 +35,9 @@ public class GlobalPoolDelegate implements MemoryPool, Configurable {
                 + "GlobalPoolDelegate object.");
         }
         delegateMemoryPool = (MemoryPool) configs.get(POOL_INSTANCE_CONFIG);
+        if (delegateMemoryPool == null) {
+            throw new IllegalArgumentException(POOL_INSTANCE_CONFIG + " supplied as null in configs.");
+        }
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -16,10 +16,12 @@
  */
 package org.apache.kafka.clients;
 
+import java.nio.ByteBuffer;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
@@ -39,6 +41,8 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.stream.Collectors;
+import org.mockito.Mockito;
+
 
 /**
  * A mock network client for use testing code
@@ -229,9 +233,11 @@ public class MockClient implements KafkaClient {
                 unsupportedVersionException = new UnsupportedVersionException("Api " +
                         request.apiKey() + " with version " + version);
 
+            MemoryPool memoryPool = Mockito.mock(MemoryPool.class);
             ClientResponse resp = new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),
                     request.createdTimeMs(), time.milliseconds(), futureResp.disconnected,
-                    unsupportedVersionException, null, futureResp.responseBody);
+                    unsupportedVersionException, null, futureResp.responseBody, memoryPool,
+                ByteBuffer.allocate(0));
             responses.add(resp);
             iterator.remove();
             return;

--- a/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
@@ -30,6 +30,12 @@ public class GlobalPoolDelegateTest {
         globalPoolDelegate.configure(Collections.emptyMap());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullPoolInstance() {
+        GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
+        globalPoolDelegate.configure(Collections.emptyMap());
+    }
+
     @Test
     public void testDelegateCalls() {
         MemoryPool mockMemoryPool = Mockito.mock(MemoryPool.class);

--- a/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
@@ -33,7 +33,7 @@ public class GlobalPoolDelegateTest {
     @Test(expected = IllegalArgumentException.class)
     public void testNullPoolInstance() {
         GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
-        globalPoolDelegate.configure(Collections.emptyMap());
+        globalPoolDelegate.configure(Collections.singletonMap("linkedin.memorypool.pool.instance", null));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GlobalPoolDelegateTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.memory;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+
+public class GlobalPoolDelegateTest {
+    @Test(expected = IllegalStateException.class)
+    public void testMissingPoolInstance() {
+        GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
+        globalPoolDelegate.configure(Collections.emptyMap());
+    }
+
+    @Test
+    public void testDelegateCalls() {
+        MemoryPool mockMemoryPool = Mockito.mock(MemoryPool.class);
+        Mockito.when(mockMemoryPool.availableMemory()).thenReturn((long) 100);
+        Mockito.when(mockMemoryPool.isOutOfMemory()).thenReturn(false);
+        Mockito.when(mockMemoryPool.size()).thenReturn((long) 200);
+        ByteBuffer byteBuf = ByteBuffer.allocate(0);
+        Mockito.when(mockMemoryPool.tryAllocate(Mockito.anyInt())).thenReturn(byteBuf);
+        Mockito.doNothing().when(mockMemoryPool).release(Mockito.any());
+
+        GlobalPoolDelegate globalPoolDelegate = new GlobalPoolDelegate();
+        globalPoolDelegate.configure(
+            Collections.singletonMap("linkedin.memorypool.pool.instance", mockMemoryPool));
+
+        Assert.assertEquals(globalPoolDelegate.availableMemory(), 100);
+        Assert.assertEquals(globalPoolDelegate.isOutOfMemory(), false);
+        Assert.assertEquals(globalPoolDelegate.size(), 200);
+        Assert.assertEquals(globalPoolDelegate.tryAllocate(0), byteBuf);
+        globalPoolDelegate.release(byteBuf);
+
+        Mockito.verify(mockMemoryPool, Mockito.times(1)).availableMemory();
+        Mockito.verify(mockMemoryPool, Mockito.times(1)).isOutOfMemory();
+        Mockito.verify(mockMemoryPool, Mockito.times(1)).size();
+        Mockito.verify(mockMemoryPool, Mockito.times(1)).tryAllocate(Mockito.anyInt());
+        Mockito.verify(mockMemoryPool, Mockito.times(1)).release(Mockito.any());
+    }
+}


### PR DESCRIPTION
TICKET = KAFKA-13188
LI_DESCRIPTION =
Allow the KafkaConsumer's network memory pool to be configured by ConsumerConfig.
- Supply `linkedin.pool.class.name` for memory pool implementation with default constructor with no args
- Supply `linkedin.pool.class.name` with `GloballPoolDelegate` and pass the object instance with `linkedin.memorypool.pool.instance` in properties map.
- Moved the leak check config from common client config to Consumer config

EXIT_CRITERIA = If and when the upstream ticket is merged, and the changes are pulled in

```
./gradlew cleanTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest :clients:unitTest :core:unitTest --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed

```