### PR TITLE
Add metrics to monitor the rate of  metadata request sent by kafka clients

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -101,6 +101,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.protocol.Errors;
@@ -270,6 +271,11 @@ public class KafkaAdminClient extends AdminClient {
      * The metrics for this KafkaAdminClient.
      */
     private final Metrics metrics;
+
+    /**
+     * The sensor for rate of metadata requests sent by this KafkaAdminClient
+     */
+    private final Sensor adminClientMetadataRequestRateSensor;
 
     /**
      * The network client to use.
@@ -497,6 +503,14 @@ public class KafkaAdminClient extends AdminClient {
         this.time = time;
         this.metadataManager = metadataManager;
         this.metrics = metrics;
+        this.adminClientMetadataRequestRateSensor = metrics.sensor("admin-client-metadata-request-rate-sensor");
+        this.adminClientMetadataRequestRateSensor.add(new Meter(metrics.metricName("admin-client-metadata-request-rate",
+            "admin-client-metrics",
+            "The average per-second number of metadata request sent by the admin client"),
+            metrics.metricName("admin-client-metadata-request-sent-total",
+                "admin-client-metrics",
+                "The total number of metadata requests sent by the admin client")
+        ));
         this.client = client;
         this.runnable = new AdminClientRunnable();
         String threadName = NETWORK_THREAD_PREFIX + " | " + clientId;
@@ -1508,6 +1522,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             AbstractRequest.Builder createRequest(int timeoutMs) {
+                adminClientMetadataRequestRateSensor.record();
                 return MetadataRequest.Builder.allTopicsOnly();
             }
 
@@ -1563,6 +1578,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             AbstractRequest.Builder createRequest(int timeoutMs) {
+                adminClientMetadataRequestRateSensor.record();
                 if (supportsDisablingTopicCreation)
                     return new MetadataRequest.Builder(new MetadataRequestData()
                         .setTopics(convertToMetadataRequestTopic(topicNamesList))

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1301,6 +1301,7 @@ public class KafkaAdminClient extends AdminClient {
                     // Since this only requests node information, it's safe to pass true
                     // for allowAutoTopicCreation (and it simplifies communication with
                     // older brokers)
+                    adminClientMetadataRequestRateSensor.record();
                     return new MetadataRequest.Builder(new MetadataRequestData()
                         .setTopics(Collections.emptyList())
                         .setAllowAutoTopicCreation(true));
@@ -1663,6 +1664,7 @@ public class KafkaAdminClient extends AdminClient {
             AbstractRequest.Builder createRequest(int timeoutMs) {
                 // Since this only requests node information, it's safe to pass true for allowAutoTopicCreation (and it
                 // simplifies communication with older brokers)
+                adminClientMetadataRequestRateSensor.record();
                 return new MetadataRequest.Builder(new MetadataRequestData()
                     .setTopics(Collections.emptyList())
                     .setAllowAutoTopicCreation(true)
@@ -2397,6 +2399,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             AbstractRequest.Builder createRequest(int timeoutMs) {
+                adminClientMetadataRequestRateSensor.record();
                 return new MetadataRequest.Builder(new MetadataRequestData()
                     .setTopics(convertToMetadataRequestTopic(topics))
                     .setAllowAutoTopicCreation(false));
@@ -2931,6 +2934,7 @@ public class KafkaAdminClient extends AdminClient {
         runnable.call(new Call("findAllBrokers", deadline, new LeastLoadedNodeProvider()) {
             @Override
             AbstractRequest.Builder createRequest(int timeoutMs) {
+                adminClientMetadataRequestRateSensor.record();
                 return new MetadataRequest.Builder(new MetadataRequestData()
                     .setTopics(Collections.emptyList())
                     .setAllowAutoTopicCreation(true));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1013,8 +1013,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 fetcher.clearBufferedDataForUnassignedTopics(topics);
                 log.info("Subscribed to topic(s): {}", Utils.join(topics, ", "));
                 if (this.subscriptions.subscribe(new HashSet<>(topics), listener)) {
-                  metadata.requestUpdateForNewTopics();
-                  kafkaConsumerMetrics.recordMetadataRequest();
+                   metadata.requestUpdateForNewTopics();
+                   kafkaConsumerMetrics.recordMetadataRequest();
                 }
             }
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1014,7 +1014,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 log.info("Subscribed to topic(s): {}", Utils.join(topics, ", "));
                 if (this.subscriptions.subscribe(new HashSet<>(topics), listener))
                     metadata.requestUpdateForNewTopics();
-                    kafkaConsumerMetrics.recordMetadataRequest();
+                kafkaConsumerMetrics.recordMetadataRequest();
             }
         } finally {
             release();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1014,6 +1014,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 log.info("Subscribed to topic(s): {}", Utils.join(topics, ", "));
                 if (this.subscriptions.subscribe(new HashSet<>(topics), listener))
                     metadata.requestUpdateForNewTopics();
+                    kafkaConsumerMetrics.recordMetadataRequest();
             }
         } finally {
             release();
@@ -1078,6 +1079,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             this.subscriptions.subscribe(pattern, listener);
             this.coordinator.updatePatternSubscription(metadata.fetch());
             this.metadata.requestUpdateForNewTopics();
+            this.kafkaConsumerMetrics.recordMetadataRequest();
         } finally {
             release();
         }
@@ -1170,6 +1172,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 if (this.subscriptions.assignFromUser(new HashSet<>(partitions))) {
                     if (!skipMetadataCacheUpdate) {
                         metadata.requestUpdateForNewTopics();
+                        kafkaConsumerMetrics.recordMetadataRequest();
                     }
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1013,8 +1013,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 fetcher.clearBufferedDataForUnassignedTopics(topics);
                 log.info("Subscribed to topic(s): {}", Utils.join(topics, ", "));
                 if (this.subscriptions.subscribe(new HashSet<>(topics), listener)) {
-                   metadata.requestUpdateForNewTopics();
-                   kafkaConsumerMetrics.recordMetadataRequest();
+                    metadata.requestUpdateForNewTopics();
+                    kafkaConsumerMetrics.recordMetadataRequest();
                 }
             }
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -735,7 +735,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     config.getLong(ConsumerConfig.METADATA_MAX_AGE_CONFIG),
                     !config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
                     config.getBoolean(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
-                    subscriptions, logContext, clusterResourceListeners);
+                    subscriptions, logContext, clusterResourceListeners, metrics);
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
                     config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG), config.getString(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG));
             this.metadata.bootstrap(addresses);
@@ -1014,7 +1014,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 log.info("Subscribed to topic(s): {}", Utils.join(topics, ", "));
                 if (this.subscriptions.subscribe(new HashSet<>(topics), listener)) {
                     metadata.requestUpdateForNewTopics();
-                    kafkaConsumerMetrics.recordMetadataRequest();
+                    metadata.recordMetadataRequest();
                 }
             }
         } finally {
@@ -1080,7 +1080,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             this.subscriptions.subscribe(pattern, listener);
             this.coordinator.updatePatternSubscription(metadata.fetch());
             this.metadata.requestUpdateForNewTopics();
-            this.kafkaConsumerMetrics.recordMetadataRequest();
+            this.metadata.recordMetadataRequest();
         } finally {
             release();
         }
@@ -1173,7 +1173,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 if (this.subscriptions.assignFromUser(new HashSet<>(partitions))) {
                     if (!skipMetadataCacheUpdate) {
                         metadata.requestUpdateForNewTopics();
-                        kafkaConsumerMetrics.recordMetadataRequest();
+                        metadata.recordMetadataRequest();
                     }
                 }
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1012,9 +1012,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 throwIfNoAssignorsConfigured();
                 fetcher.clearBufferedDataForUnassignedTopics(topics);
                 log.info("Subscribed to topic(s): {}", Utils.join(topics, ", "));
-                if (this.subscriptions.subscribe(new HashSet<>(topics), listener))
-                    metadata.requestUpdateForNewTopics();
-                kafkaConsumerMetrics.recordMetadataRequest();
+                if (this.subscriptions.subscribe(new HashSet<>(topics), listener)) {
+                  metadata.requestUpdateForNewTopics();
+                  kafkaConsumerMetrics.recordMetadataRequest();
+                }
             }
         } finally {
             release();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -234,7 +234,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                 .collect(Collectors.toSet());
         if (subscriptions.subscribeFromPattern(topicsToSubscribe))
             metadata.requestUpdateForNewTopics();
-            sensors.metadataRequestRateSensor.record();
+        sensors.metadataRequestRateSensor.record();
     }
 
     private ConsumerPartitionAssignor lookupAssignor(String name) {
@@ -266,7 +266,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
                 if (this.subscriptions.subscribeFromPattern(newSubscription))
                     metadata.requestUpdateForNewTopics();
-                    sensors.metadataRequestRateSensor.record();
+                sensors.metadataRequestRateSensor.record();
                 this.joinedSubscription = newJoinedSubscription;
             }
         }
@@ -522,7 +522,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         // which ensures that all metadata changes will eventually be seen
         if (this.subscriptions.groupSubscribe(topics))
             metadata.requestUpdateForNewTopics();
-            sensors.metadataRequestRateSensor.record();
+        sensors.metadataRequestRateSensor.record();
 
         // update metadata (if needed) and keep track of the metadata used for assignment so that
         // we can check after rebalance completion whether anything has changed

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -232,9 +232,11 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         final Set<String> topicsToSubscribe = cluster.topics().stream()
                 .filter(subscriptions::matchesSubscribedPattern)
                 .collect(Collectors.toSet());
-        if (subscriptions.subscribeFromPattern(topicsToSubscribe))
+        if (subscriptions.subscribeFromPattern(topicsToSubscribe)) {
             metadata.requestUpdateForNewTopics();
-        sensors.metadataRequestRateSensor.record();
+            sensors.metadataRequestRateSensor.record();
+        }
+
     }
 
     private ConsumerPartitionAssignor lookupAssignor(String name) {
@@ -264,9 +266,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                 newSubscription.addAll(addedTopics);
                 newJoinedSubscription.addAll(addedTopics);
 
-                if (this.subscriptions.subscribeFromPattern(newSubscription))
+                if (this.subscriptions.subscribeFromPattern(newSubscription)) {
                     metadata.requestUpdateForNewTopics();
-                sensors.metadataRequestRateSensor.record();
+                    sensors.metadataRequestRateSensor.record();
+                }
                 this.joinedSubscription = newJoinedSubscription;
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -200,7 +200,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         }
 
         this.metadata.requestUpdate();
-        this.sensors.metadataRequestRateSensor.record();
+        this.metadata.recordMetadataRequest();
     }
 
     @Override
@@ -234,7 +234,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                 .collect(Collectors.toSet());
         if (subscriptions.subscribeFromPattern(topicsToSubscribe)) {
             metadata.requestUpdateForNewTopics();
-            sensors.metadataRequestRateSensor.record();
+            metadata.recordMetadataRequest();
         }
 
     }
@@ -268,7 +268,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
                 if (this.subscriptions.subscribeFromPattern(newSubscription)) {
                     metadata.requestUpdateForNewTopics();
-                    sensors.metadataRequestRateSensor.record();
+                    metadata.recordMetadataRequest();
                 }
                 this.joinedSubscription = newJoinedSubscription;
             }
@@ -477,7 +477,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                     // passed.
                     if (this.metadata.timeToAllowUpdate(timer.currentTimeMs()) == 0) {
                         this.metadata.requestUpdate();
-                        this.sensors.metadataRequestRateSensor.record();
+                        this.metadata.recordMetadataRequest();
                     }
 
                     if (!client.ensureFreshMetadata(timer)) {
@@ -523,9 +523,11 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
     private void updateGroupSubscription(Set<String> topics) {
         // the leader will begin watching for changes to any of the topics the group is interested in,
         // which ensures that all metadata changes will eventually be seen
-        if (this.subscriptions.groupSubscribe(topics))
+        if (this.subscriptions.groupSubscribe(topics)) {
             metadata.requestUpdateForNewTopics();
-        sensors.metadataRequestRateSensor.record();
+            metadata.recordMetadataRequest();
+        }
+
 
         // update metadata (if needed) and keep track of the metadata used for assignment so that
         // we can check after rebalance completion whether anything has changed
@@ -1281,19 +1283,9 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         private final Sensor assignCallbackSensor;
         private final Sensor loseCallbackSensor;
         private final Sensor pollInterval;
-        private final Sensor metadataRequestRateSensor;
 
         private ConsumerCoordinatorMetrics(Metrics metrics, String metricGrpPrefix) {
             this.metricGrpName = metricGrpPrefix + "-coordinator-metrics";
-
-            this.metadataRequestRateSensor = metrics.sensor("consumer-coordinator-metadata-request-rate");
-            this.metadataRequestRateSensor.add(new Meter(metrics.metricName("consumer-coordinator-metadata-request-rate",
-                this.metricGrpName,
-                "The average per-second number of metadata request sent by the consumer-coordinator"),
-                metrics.metricName("consumer-coordinator-metadata-request-sent-total",
-                    this.metricGrpName,
-                    "The total number of metadata requests sent by the consumer-coordinator")
-                ));
             this.commitSensor = metrics.sensor("commit-latency");
             this.commitSensor.add(metrics.metricName("commit-latency-avg",
                 this.metricGrpName,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -51,7 +51,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
-import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
@@ -18,6 +18,9 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.utils.LogContext;
 
@@ -31,6 +34,8 @@ public class ConsumerMetadata extends Metadata {
     private final boolean allowAutoTopicCreation;
     private final SubscriptionState subscription;
     private final Set<String> transientTopics;
+    private final Sensor metadataRequestRateSensor;
+    private final Metrics metrics;
 
     public ConsumerMetadata(long refreshBackoffMs,
                             long metadataExpireMs,
@@ -38,16 +43,30 @@ public class ConsumerMetadata extends Metadata {
                             boolean allowAutoTopicCreation,
                             SubscriptionState subscription,
                             LogContext logContext,
-                            ClusterResourceListeners clusterResourceListeners) {
+                            ClusterResourceListeners clusterResourceListeners,
+                            Metrics metrics) {
         super(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners);
         this.includeInternalTopics = includeInternalTopics;
         this.allowAutoTopicCreation = allowAutoTopicCreation;
         this.subscription = subscription;
         this.transientTopics = new HashSet<>();
+        this.metrics = metrics;
+        this.metadataRequestRateSensor = metrics.sensor("consumer-metadata-request-rate");
+        this.metadataRequestRateSensor.add(new Meter(metrics.metricName("consumer-metadata-request-rate",
+            "consumer-metrics",
+            "The average per-second number of metadata request sent by the consumer"),
+            metrics.metricName("consumer-metadata-request-sent-total",
+                "consumer-metrics",
+                "The total number of metadata requests sent by the consumer")
+        ));
     }
 
     public boolean allowAutoTopicCreation() {
         return allowAutoTopicCreation;
+    }
+
+    public void recordMetadataRequest() {
+        this.metadataRequestRateSensor.record();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
@@ -41,6 +41,8 @@ public class FetcherMetricsRegistry {
     public MetricNameTemplate recordsLeadMin;
     public MetricNameTemplate fetchThrottleTimeAvg;
     public MetricNameTemplate fetchThrottleTimeMax;
+    public MetricNameTemplate metadataRequestRate;
+    public MetricNameTemplate metadataRequestTotal;
     public MetricNameTemplate topicFetchSizeAvg;
     public MetricNameTemplate topicFetchSizeMax;
     public MetricNameTemplate topicBytesConsumedRate;
@@ -94,7 +96,10 @@ public class FetcherMetricsRegistry {
                 "The number of fetch requests per second.", tags);
         this.fetchRequestTotal = new MetricNameTemplate("fetch-total", groupName,
                 "The total number of fetch requests.", tags);
-
+        this.metadataRequestTotal = new MetricNameTemplate("consumer-metadata-request-sent-total",
+            "consumer-metrics", "The total number of metadata requests sent by the consumer", tags);
+        this.metadataRequestRate = new MetricNameTemplate("consumer-metadata-request-rate", "consumer-metrics",
+            "The average per-second number of metadata request sent by the consumer", tags);
         this.recordsLagMax = new MetricNameTemplate("records-lag-max", groupName,
                 "The maximum lag in terms of number of records for any partition in this window", tags);
         this.recordsLeadMin = new MetricNameTemplate("records-lead-min", groupName,
@@ -175,7 +180,9 @@ public class FetcherMetricsRegistry {
             partitionRecordsLead,
             partitionRecordsLeadMin,
             partitionRecordsLeadAvg,
-            partitionPreferredReadReplica
+            partitionPreferredReadReplica,
+            metadataRequestRate,
+            metadataRequestTotal
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
@@ -32,7 +32,6 @@ public class KafkaConsumerMetrics implements AutoCloseable {
     private final MetricName lastPollMetricName;
     private final Sensor timeBetweenPollSensor;
     private final Sensor pollIdleSensor;
-    private final Sensor metadataRequestRateSensor;
     private long lastPollMs;
     private long pollStartMs;
     private long timeSinceLastPollMs;
@@ -67,14 +66,6 @@ public class KafkaConsumerMetrics implements AutoCloseable {
                 metricGroupName,
                 "The average fraction of time the consumer's poll() is idle as opposed to waiting for the user code to process records."),
                 new Avg());
-        this.metadataRequestRateSensor = metrics.sensor("consumer-metadata-request");
-        this.metadataRequestRateSensor.add(new Meter(metrics.metricName("consumer-metadata-request-rate-",
-            metricGroupName,
-            "The average per-second number of metadata request sent by the consumer"),
-            metrics.metricName("consumer-metadata-request-sent-total",
-                metricGroupName,
-                "The total number of metadata requests sent by the consumer")
-        ));
     }
 
     public void recordPollStart(long pollStartMs) {
@@ -88,10 +79,6 @@ public class KafkaConsumerMetrics implements AutoCloseable {
         long pollTimeMs = pollEndMs - pollStartMs;
         double pollIdleRatio = pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
         this.pollIdleSensor.record(pollIdleRatio);
-    }
-
-    public void recordMetadataRequest() {
-        this.metadataRequestRateSensor.record();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.common.metrics.stats.Meter;
 
 
 public class KafkaConsumerMetrics implements AutoCloseable {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
@@ -24,12 +24,15 @@ import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.metrics.stats.Meter;
+
 
 public class KafkaConsumerMetrics implements AutoCloseable {
     private final Metrics metrics;
     private final MetricName lastPollMetricName;
     private final Sensor timeBetweenPollSensor;
     private final Sensor pollIdleSensor;
+    private final Sensor metadataRequestRateSensor;
     private long lastPollMs;
     private long pollStartMs;
     private long timeSinceLastPollMs;
@@ -64,6 +67,14 @@ public class KafkaConsumerMetrics implements AutoCloseable {
                 metricGroupName,
                 "The average fraction of time the consumer's poll() is idle as opposed to waiting for the user code to process records."),
                 new Avg());
+        this.metadataRequestRateSensor = metrics.sensor("consumer-metadata-request");
+        this.metadataRequestRateSensor.add(new Meter(metrics.metricName("consumer-metadata-request-rate-",
+            metricGroupName,
+            "The average per-second number of metadata request sent by the consumer"),
+            metrics.metricName("consumer-metadata-request-sent-total",
+                metricGroupName,
+                "The total number of metadata requests sent by the consumer")
+        ));
     }
 
     public void recordPollStart(long pollStartMs) {
@@ -77,6 +88,10 @@ public class KafkaConsumerMetrics implements AutoCloseable {
         long pollTimeMs = pollEndMs - pollStartMs;
         double pollIdleRatio = pollTimeMs * 1.0 / (pollTimeMs + timeSinceLastPollMs);
         this.pollIdleSensor.record(pollIdleRatio);
+    }
+
+    public void recordMetadataRequest() {
+        this.metadataRequestRateSensor.record();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -58,6 +58,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.record.AbstractRecords;
@@ -248,6 +249,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     private final Thread ioThread;
     private final CompressionType compressionType;
     private final Sensor errors;
+    private final Sensor metadataRequestRateSensor;
     private final Time time;
     private final Serializer<K> keySerializer;
     private final Serializer<V> valueSerializer;
@@ -354,6 +356,14 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                     Collections.singletonMap(ProducerConfig.CLIENT_ID_CONFIG, clientId));
             reporters.add(new JmxReporter(JMX_PREFIX));
             this.metrics = new Metrics(metricConfig, reporters, time);
+            this.metadataRequestRateSensor = metrics.sensor("producer-metadata-request-rate");
+            this.metadataRequestRateSensor.add(new Meter(metrics.metricName("producer-metadata-request-rate",
+                "producer-metrics",
+                "The average per-second number of metadata request sent by the producer"),
+                metrics.metricName("producer-metadata-request-sent-total",
+                    "producer-metrics",
+                    "The total number of metadata requests sent by the producer")
+            ));
             this.metrics.setReplaceOnDuplicateMetric(config.getBoolean(ProducerConfig.METRICS_REPLACE_ON_DUPLICATE_CONFIG));
             this.partitioner = config.getConfiguredInstance(ProducerConfig.PARTITIONER_CLASS_CONFIG, Partitioner.class);
             long retryBackoffMs = config.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG);
@@ -1033,7 +1043,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             }
             metadata.add(topic);
             int version = metadata.requestUpdate();
-            this.metrics.sensor("metadata-request-rate").record();
+            this.metadataRequestRateSensor.record();
             sender.wakeup();
             try {
                 metadata.awaitUpdate(version, remainingWaitMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1033,6 +1033,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             }
             metadata.add(topic);
             int version = metadata.requestUpdate();
+            this.metrics.sensor("metadata-request-rate").record();
             sender.wakeup();
             try {
                 metadata.awaitUpdate(version, remainingWaitMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -58,7 +58,6 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.record.AbstractRecords;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -19,6 +19,9 @@ package org.apache.kafka.clients.producer.internals;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Meter;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.LogContext;
@@ -41,6 +44,8 @@ public class ProducerMetadata extends Metadata {
     private final Logger log;
     private final Time time;
     private final long topicExpiryMs;
+    private final Sensor metadataRequestRateSensor;
+    private final Metrics metrics;
 
     // LI-HOTFIX: this constructor should only be used for unit tests
     // after the following hotfix changes:
@@ -51,7 +56,7 @@ public class ProducerMetadata extends Metadata {
         LogContext logContext,
         ClusterResourceListeners clusterResourceListeners,
         Time time) {
-        this(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, time, TOPIC_EXPIRY_MS, true);
+        this(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, time, TOPIC_EXPIRY_MS, true, new Metrics());
     }
 
     public ProducerMetadata(long refreshBackoffMs,
@@ -60,12 +65,25 @@ public class ProducerMetadata extends Metadata {
                             ClusterResourceListeners clusterResourceListeners,
                             Time time,
                             long topicExpiryMs,
-                            boolean allowAutoTopicCreation) {
+                            boolean allowAutoTopicCreation,
+                            Metrics metrics) {
         super(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners);
         this.log = logContext.logger(ProducerMetadata.class);
         this.time = time;
         this.topicExpiryMs = topicExpiryMs;
         this.allowAutoTopicCreation = allowAutoTopicCreation;
+        this.metrics = metrics;
+        this.metadataRequestRateSensor = metrics.sensor("producer-metadata-request-rate");
+        this.metadataRequestRateSensor.add(new Meter(metrics.metricName("producer-metadata-request-rate",
+            "producer-metrics",
+            "The average per-second number of metadata request sent by the producer"),
+            metrics.metricName("producer-metadata-request-sent-total",
+                "producer-metrics",
+                "The total number of metadata requests sent by the producer")
+        ));
+    }
+    public void recordMetadataRequest() {
+        this.metadataRequestRateSensor.record();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -351,6 +351,8 @@ public class Sender implements Runnable {
             log.debug("Requesting metadata update due to unknown leader topics from the batched records: {}",
                 result.unknownLeaderTopics);
             this.metadata.requestUpdate();
+            this.sensors.metadataRequestRateSensor.record();
+
         }
 
         // remove any nodes we aren't ready to send to
@@ -833,6 +835,7 @@ public class Sender implements Runnable {
         public final Sensor compressionRateSensor;
         public final Sensor maxRecordSizeSensor;
         public final Sensor batchSplitSensor;
+        public final Sensor metadataRequestRateSensor;
         private final SenderMetricsRegistry metrics;
         private final Time time;
 
@@ -858,6 +861,9 @@ public class Sender implements Runnable {
             this.recordsPerRequestSensor = metrics.sensor("records-per-request");
             this.recordsPerRequestSensor.add(new Meter(metrics.recordSendRate, metrics.recordSendTotal));
             this.recordsPerRequestSensor.add(metrics.recordsPerRequestAvg, new Avg());
+
+            this.metadataRequestRateSensor = metrics.sensor("metadata-request-rate");
+            this.metadataRequestRateSensor.add(new Meter(metrics.metadataRequestRate, metrics.metadataRequestSentTotal));
 
             this.retrySensor = metrics.sensor("record-retries");
             this.retrySensor.add(new Meter(metrics.recordRetryRate, metrics.recordRetryTotal));

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -351,7 +351,7 @@ public class Sender implements Runnable {
             log.debug("Requesting metadata update due to unknown leader topics from the batched records: {}",
                 result.unknownLeaderTopics);
             this.metadata.requestUpdate();
-            this.sensors.metadataRequestRateSensor.record();
+            this.metadata.recordMetadataRequest();
 
         }
 
@@ -478,6 +478,7 @@ public class Sender implements Runnable {
             // For non-coordinator requests, sleep here to prevent a tight loop when no node is available
             time.sleep(retryBackoffMs);
             metadata.requestUpdate();
+            metadata.recordMetadataRequest();
         }
 
         transactionManager.retry(nextRequestHandler);
@@ -566,6 +567,7 @@ public class Sender implements Runnable {
             log.trace("Retry InitProducerIdRequest in {}ms.", retryBackoffMs);
             time.sleep(retryBackoffMs);
             metadata.requestUpdate();
+            metadata.recordMetadataRequest();
         }
     }
 
@@ -685,6 +687,7 @@ public class Sender implements Runnable {
                             "to request metadata update now", batch.topicPartition, error.exception().toString());
                 }
                 metadata.requestUpdate();
+                metadata.recordMetadataRequest();
             }
         } else {
             completeBatch(batch, response);
@@ -835,7 +838,6 @@ public class Sender implements Runnable {
         public final Sensor compressionRateSensor;
         public final Sensor maxRecordSizeSensor;
         public final Sensor batchSplitSensor;
-        public final Sensor metadataRequestRateSensor;
         private final SenderMetricsRegistry metrics;
         private final Time time;
 
@@ -861,9 +863,6 @@ public class Sender implements Runnable {
             this.recordsPerRequestSensor = metrics.sensor("records-per-request");
             this.recordsPerRequestSensor.add(new Meter(metrics.recordSendRate, metrics.recordSendTotal));
             this.recordsPerRequestSensor.add(metrics.recordsPerRequestAvg, new Avg());
-
-            this.metadataRequestRateSensor = metrics.sensor("metadata-request-rate");
-            this.metadataRequestRateSensor.add(new Meter(metrics.metadataRequestRate, metrics.metadataRequestSentTotal));
 
             this.retrySensor = metrics.sensor("record-retries");
             this.retrySensor.add(new Meter(metrics.recordRetryRate, metrics.recordRetryTotal));

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
@@ -41,7 +41,7 @@ public class SenderMetricsRegistry {
     public final MetricName recordQueueTimeAvg;
     public final MetricName recordQueueTimeMax;
     public final MetricName requestLatencyAvg;
-    public final MetricName requestLatencyMax;   
+    public final MetricName requestLatencyMax;
     public final MetricName produceThrottleTimeAvg;
     public final MetricName produceThrottleTimeMax;
     public final MetricName recordSendRate;
@@ -57,6 +57,8 @@ public class SenderMetricsRegistry {
     public final MetricName metadataAge;
     public final MetricName batchSplitRate;
     public final MetricName batchSplitTotal;
+    public final MetricName metadataRequestRate;
+    public final MetricName metadataRequestSentTotal;
 
     private final MetricNameTemplate topicRecordSendRate;
     private final MetricNameTemplate topicRecordSendTotal;
@@ -67,7 +69,7 @@ public class SenderMetricsRegistry {
     private final MetricNameTemplate topicRecordRetryTotal;
     private final MetricNameTemplate topicRecordErrorRate;
     private final MetricNameTemplate topicRecordErrorTotal;
-    
+
     private final Metrics metrics;
     private final Set<String> tags;
     private final LinkedHashSet<String> topicTags;
@@ -76,9 +78,9 @@ public class SenderMetricsRegistry {
         this.metrics = metrics;
         this.tags = this.metrics.config().tags().keySet();
         this.allTemplates = new ArrayList<>();
-        
+
         /***** Client level *****/
-        
+
         this.batchSizeAvg = createMetricName("batch-size-avg",
                 "The average number of bytes sent per partition per-request.");
         this.batchSizeMax = createMetricName("batch-size-max",
@@ -89,41 +91,45 @@ public class SenderMetricsRegistry {
                 "The average time in ms record batches spent in the send buffer.");
         this.recordQueueTimeMax = createMetricName("record-queue-time-max",
                 "The maximum time in ms record batches spent in the send buffer.");
-        this.requestLatencyAvg = createMetricName("request-latency-avg", 
+        this.requestLatencyAvg = createMetricName("request-latency-avg",
                 "The average request latency in ms");
-        this.requestLatencyMax = createMetricName("request-latency-max", 
+        this.requestLatencyMax = createMetricName("request-latency-max",
                 "The maximum request latency in ms");
-        this.recordSendRate = createMetricName("record-send-rate", 
+        this.recordSendRate = createMetricName("record-send-rate",
                 "The average number of records sent per second.");
-        this.recordSendTotal = createMetricName("record-send-total", 
+        this.recordSendTotal = createMetricName("record-send-total",
                 "The total number of records sent.");
         this.recordsPerRequestAvg = createMetricName("records-per-request-avg",
                 "The average number of records per request.");
         this.recordRetryRate = createMetricName("record-retry-rate",
                 "The average per-second number of retried record sends");
-        this.recordRetryTotal = createMetricName("record-retry-total", 
+        this.recordRetryTotal = createMetricName("record-retry-total",
                 "The total number of retried record sends");
         this.recordErrorRate = createMetricName("record-error-rate",
                 "The average per-second number of record sends that resulted in errors");
         this.recordErrorTotal = createMetricName("record-error-total",
                 "The total number of record sends that resulted in errors");
-        this.recordSizeMax = createMetricName("record-size-max", 
+        this.recordSizeMax = createMetricName("record-size-max",
                 "The maximum record size");
-        this.recordSizeAvg = createMetricName("record-size-avg", 
+        this.recordSizeAvg = createMetricName("record-size-avg",
                 "The average record size");
         this.requestsInFlight = createMetricName("requests-in-flight",
                 "The current number of in-flight requests awaiting a response.");
         this.metadataAge = createMetricName("metadata-age",
                 "The age in seconds of the current producer metadata being used.");
-        this.batchSplitRate = createMetricName("batch-split-rate", 
+        this.batchSplitRate = createMetricName("batch-split-rate",
                 "The average number of batch splits per second");
-        this.batchSplitTotal = createMetricName("batch-split-total", 
+        this.batchSplitTotal = createMetricName("batch-split-total",
                 "The total number of batch splits");
 
         this.produceThrottleTimeAvg = createMetricName("produce-throttle-time-avg",
                 "The average time in ms a request was throttled by a broker");
         this.produceThrottleTimeMax = createMetricName("produce-throttle-time-max",
                 "The maximum time in ms a request was throttled by a broker");
+        this.metadataRequestRate = createMetricName("metadata-request-rate",
+                "The average per-second number of metadata request sent by the producer");
+        this.metadataRequestSentTotal = createMetricName("metadata-request-sent-total",
+            "The total number of metadata requests sent by the producer");
 
         /***** Topic level *****/
         this.topicTags = new LinkedHashSet<>(tags);
@@ -136,7 +142,7 @@ public class SenderMetricsRegistry {
                 "The total number of records sent for a topic.");
         this.topicByteRate = createTopicTemplate("byte-rate",
                 "The average number of bytes sent per second for a topic.");
-        this.topicByteTotal = createTopicTemplate("byte-total", 
+        this.topicByteTotal = createTopicTemplate("byte-total",
                 "The total number of bytes sent for a topic.");
         this.topicCompressionRate = createTopicTemplate("compression-rate",
                 "The average compression rate of record batches for a topic.");

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
@@ -57,8 +57,6 @@ public class SenderMetricsRegistry {
     public final MetricName metadataAge;
     public final MetricName batchSplitRate;
     public final MetricName batchSplitTotal;
-    public final MetricName metadataRequestRate;
-    public final MetricName metadataRequestSentTotal;
 
     private final MetricNameTemplate topicRecordSendRate;
     private final MetricNameTemplate topicRecordSendTotal;
@@ -82,54 +80,50 @@ public class SenderMetricsRegistry {
         /***** Client level *****/
 
         this.batchSizeAvg = createMetricName("batch-size-avg",
-                "The average number of bytes sent per partition per-request.");
+            "The average number of bytes sent per partition per-request.");
         this.batchSizeMax = createMetricName("batch-size-max",
-                "The max number of bytes sent per partition per-request.");
+            "The max number of bytes sent per partition per-request.");
         this.compressionRateAvg = createMetricName("compression-rate-avg",
-                "The average compression rate of record batches.");
+            "The average compression rate of record batches.");
         this.recordQueueTimeAvg = createMetricName("record-queue-time-avg",
-                "The average time in ms record batches spent in the send buffer.");
+            "The average time in ms record batches spent in the send buffer.");
         this.recordQueueTimeMax = createMetricName("record-queue-time-max",
-                "The maximum time in ms record batches spent in the send buffer.");
+            "The maximum time in ms record batches spent in the send buffer.");
         this.requestLatencyAvg = createMetricName("request-latency-avg",
-                "The average request latency in ms");
+            "The average request latency in ms");
         this.requestLatencyMax = createMetricName("request-latency-max",
-                "The maximum request latency in ms");
+            "The maximum request latency in ms");
         this.recordSendRate = createMetricName("record-send-rate",
-                "The average number of records sent per second.");
+            "The average number of records sent per second.");
         this.recordSendTotal = createMetricName("record-send-total",
-                "The total number of records sent.");
+            "The total number of records sent.");
         this.recordsPerRequestAvg = createMetricName("records-per-request-avg",
-                "The average number of records per request.");
+            "The average number of records per request.");
         this.recordRetryRate = createMetricName("record-retry-rate",
-                "The average per-second number of retried record sends");
+            "The average per-second number of retried record sends");
         this.recordRetryTotal = createMetricName("record-retry-total",
-                "The total number of retried record sends");
+            "The total number of retried record sends");
         this.recordErrorRate = createMetricName("record-error-rate",
-                "The average per-second number of record sends that resulted in errors");
+            "The average per-second number of record sends that resulted in errors");
         this.recordErrorTotal = createMetricName("record-error-total",
-                "The total number of record sends that resulted in errors");
+            "The total number of record sends that resulted in errors");
         this.recordSizeMax = createMetricName("record-size-max",
-                "The maximum record size");
+            "The maximum record size");
         this.recordSizeAvg = createMetricName("record-size-avg",
-                "The average record size");
+            "The average record size");
         this.requestsInFlight = createMetricName("requests-in-flight",
-                "The current number of in-flight requests awaiting a response.");
+            "The current number of in-flight requests awaiting a response.");
         this.metadataAge = createMetricName("metadata-age",
-                "The age in seconds of the current producer metadata being used.");
+            "The age in seconds of the current producer metadata being used.");
         this.batchSplitRate = createMetricName("batch-split-rate",
-                "The average number of batch splits per second");
+            "The average number of batch splits per second");
         this.batchSplitTotal = createMetricName("batch-split-total",
-                "The total number of batch splits");
+            "The total number of batch splits");
 
         this.produceThrottleTimeAvg = createMetricName("produce-throttle-time-avg",
-                "The average time in ms a request was throttled by a broker");
+            "The average time in ms a request was throttled by a broker");
         this.produceThrottleTimeMax = createMetricName("produce-throttle-time-max",
-                "The maximum time in ms a request was throttled by a broker");
-        this.metadataRequestRate = createMetricName("metadata-request-rate",
-                "The average per-second number of metadata request sent by the producer");
-        this.metadataRequestSentTotal = createMetricName("metadata-request-sent-total",
-            "The total number of metadata requests sent by the producer");
+            "The maximum time in ms a request was throttled by a broker");
 
         /***** Topic level *****/
         this.topicTags = new LinkedHashSet<>(tags);
@@ -137,23 +131,23 @@ public class SenderMetricsRegistry {
 
         // We can't create the MetricName up front for these, because we don't know the topic name yet.
         this.topicRecordSendRate = createTopicTemplate("record-send-rate",
-                "The average number of records sent per second for a topic.");
+            "The average number of records sent per second for a topic.");
         this.topicRecordSendTotal = createTopicTemplate("record-send-total",
-                "The total number of records sent for a topic.");
+            "The total number of records sent for a topic.");
         this.topicByteRate = createTopicTemplate("byte-rate",
-                "The average number of bytes sent per second for a topic.");
+            "The average number of bytes sent per second for a topic.");
         this.topicByteTotal = createTopicTemplate("byte-total",
-                "The total number of bytes sent for a topic.");
+            "The total number of bytes sent for a topic.");
         this.topicCompressionRate = createTopicTemplate("compression-rate",
-                "The average compression rate of record batches for a topic.");
+            "The average compression rate of record batches for a topic.");
         this.topicRecordRetryRate = createTopicTemplate("record-retry-rate",
-                "The average per-second number of retried record sends for a topic");
+            "The average per-second number of retried record sends for a topic");
         this.topicRecordRetryTotal = createTopicTemplate("record-retry-total",
-                "The total number of retried record sends for a topic");
+            "The total number of retried record sends for a topic");
         this.topicRecordErrorRate = createTopicTemplate("record-error-rate",
-                "The average per-second number of record sends that resulted in errors for a topic");
+            "The average per-second number of record sends that resulted in errors for a topic");
         this.topicRecordErrorTotal = createTopicTemplate("record-error-total",
-                "The total number of record sends that resulted in errors for a topic");
+            "The total number of record sends that resulted in errors for a topic");
 
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1894,7 +1894,7 @@ public class KafkaConsumerTest {
 
     private ConsumerMetadata createMetadata(SubscriptionState subscription) {
         return new ConsumerMetadata(0, Long.MAX_VALUE, false, false,
-                                    subscription, new LogContext(), new ClusterResourceListeners());
+                                    subscription, new LogContext(), new ClusterResourceListeners(), new Metrics());
     }
 
     private Node prepareRebalance(MockClient client, Node node, final Set<String> subscribedTopics, ConsumerPartitionAssignor assignor, List<TopicPartition> partitions, Node coordinator) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -111,9 +111,10 @@ public class AbstractCoordinatorTest {
     private void setupCoordinator(int retryBackoffMs, int rebalanceTimeoutMs, Optional<String> groupInstanceId) {
         LogContext logContext = new LogContext();
         this.mockTime = new MockTime();
+        metrics = new Metrics(mockTime);
         ConsumerMetadata metadata = new ConsumerMetadata(retryBackoffMs, 60 * 60 * 1000L,
                 false, false, new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST),
-                logContext, new ClusterResourceListeners());
+                logContext, new ClusterResourceListeners(), metrics);
 
         this.mockClient = new MockClient(mockTime, metadata);
         this.consumerClient = new ConsumerNetworkClient(logContext,
@@ -123,7 +124,6 @@ public class AbstractCoordinatorTest {
                                                         retryBackoffMs,
                                                         REQUEST_TIMEOUT_MS,
                                                         HEARTBEAT_INTERVAL_MS);
-        metrics = new Metrics(mockTime);
 
         mockClient.updateMetadata(TestUtils.metadataUpdateWith(1, emptyMap()));
         this.node = metadata.fetch().nodes().get(0);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -169,13 +169,13 @@ public class ConsumerCoordinatorTest {
     public void setup() {
         LogContext logContext = new LogContext();
         this.subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST);
-        this.metadata = new ConsumerMetadata(0, Long.MAX_VALUE, false,
-                false, subscriptions, logContext, new ClusterResourceListeners());
         this.client = new MockClient(time, metadata);
         this.client.updateMetadata(metadataResponse);
         this.consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time, 100,
                 requestTimeoutMs, Integer.MAX_VALUE);
         this.metrics = new Metrics(time);
+        this.metadata = new ConsumerMetadata(0, Long.MAX_VALUE, false,
+            false, subscriptions, logContext, new ClusterResourceListeners(), metrics);
         this.rebalanceListener = new MockRebalanceListener();
         this.mockOffsetCommitCallback = new MockCommitCallback();
         this.partitionAssignor.clear();
@@ -1470,7 +1470,7 @@ public class ConsumerCoordinatorTest {
 
     private void testInternalTopicInclusion(boolean includeInternalTopics) {
         metadata = new ConsumerMetadata(0, Long.MAX_VALUE, includeInternalTopics,
-                false, subscriptions, new LogContext(), new ClusterResourceListeners());
+                false, subscriptions, new LogContext(), new ClusterResourceListeners(), metrics);
         client = new MockClient(time, metadata);
         try (ConsumerCoordinator coordinator = buildCoordinator(rebalanceConfig, new Metrics(), assignors, false)) {
             subscriptions.subscribe(Pattern.compile(".*"), rebalanceListener);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -169,13 +169,13 @@ public class ConsumerCoordinatorTest {
     public void setup() {
         LogContext logContext = new LogContext();
         this.subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST);
+        this.metrics = new Metrics(time);
+        this.metadata = new ConsumerMetadata(0, Long.MAX_VALUE, false,
+            false, subscriptions, logContext, new ClusterResourceListeners(), metrics);
         this.client = new MockClient(time, metadata);
         this.client.updateMetadata(metadataResponse);
         this.consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time, 100,
                 requestTimeoutMs, Integer.MAX_VALUE);
-        this.metrics = new Metrics(time);
-        this.metadata = new ConsumerMetadata(0, Long.MAX_VALUE, false,
-            false, subscriptions, logContext, new ClusterResourceListeners(), metrics);
         this.rebalanceListener = new MockRebalanceListener();
         this.mockOffsetCommitCallback = new MockCommitCallback();
         this.partitionAssignor.clear();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
@@ -168,7 +169,7 @@ public class ConsumerMetadataTest {
         long refreshBackoffMs = 50;
         long expireMs = 50000;
         return new ConsumerMetadata(refreshBackoffMs, expireMs, includeInternalTopics, false,
-                subscription, new LogContext(), new ClusterResourceListeners());
+                subscription, new LogContext(), new ClusterResourceListeners(), new Metrics());
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -4179,11 +4179,11 @@ public class FetcherTest {
                                    SubscriptionState subscriptionState,
                                    LogContext logContext) {
         time = new MockTime(1);
-        subscriptions = subscriptionState;
-        client = new MockClient(time, metadata);
         metrics = new Metrics(metricConfig, time);
+        subscriptions = subscriptionState;
         metadata = new ConsumerMetadata(0, metadataExpireMs, false, false,
             subscriptions, logContext, new ClusterResourceListeners(), metrics);
+        client = new MockClient(time, metadata);
         consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time,
                 100, 1000, Integer.MAX_VALUE);
         metricsRegistry = new FetcherMetricsRegistry(metricConfig.tags().keySet(), "consumer" + groupId);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -4180,10 +4180,10 @@ public class FetcherTest {
                                    LogContext logContext) {
         time = new MockTime(1);
         subscriptions = subscriptionState;
-        metadata = new ConsumerMetadata(0, metadataExpireMs, false, false,
-                subscriptions, logContext, new ClusterResourceListeners());
         client = new MockClient(time, metadata);
         metrics = new Metrics(metricConfig, time);
+        metadata = new ConsumerMetadata(0, metadataExpireMs, false, false,
+            subscriptions, logContext, new ClusterResourceListeners(), metrics);
         consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time,
                 100, 1000, Integer.MAX_VALUE);
         metricsRegistry = new FetcherMetricsRegistry(metricConfig.tags().keySet(), "consumer" + groupId);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.EpochEndOffset;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
@@ -158,7 +159,7 @@ public class OffsetForLeaderEpochClientTest {
         time = new MockTime(1);
         subscriptions = new SubscriptionState(logContext, offsetResetStrategy);
         metadata = new ConsumerMetadata(0, Long.MAX_VALUE, false, false,
-                subscriptions, logContext, new ClusterResourceListeners());
+                subscriptions, logContext, new ClusterResourceListeners(), new Metrics());
         client = new MockClient(time, metadata);
         consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time,
                 100, 1000, Integer.MAX_VALUE);


### PR DESCRIPTION
Add metrics to monitor the rate of  metadata request sent by kafka clients in following 3 categories:

1. rate of implicit MD requests triggered by errors or periodic cache refreshes
2. rate of explicit cheap MD requests, e.g. those triggered  by the describeTopics API
3. rate of explicit expensive MD requests (topics=null) retrieving the entire metadata set, e.g. those triggered by the listTopics() API

### Committer Checklist (excluded from commit message)
- [✅ ] Verify design and implementation 
- [✅  ] Verify test coverage and CI build status
- [✅ ] Verify documentation (including upgrade notes)
