### PR TITLE
Add end-to-end message latency sensor for kafka producer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1381,6 +1381,10 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         private final Time time;
         private final long startTime;
 
+        private InterceptorCallback(Callback userCallback, ProducerInterceptors<K, V> interceptors, TopicPartition tp) {
+           this(userCallback, Long.MIN_VALUE, null, interceptors, tp);
+        }
+
         private InterceptorCallback(Callback userCallback, long startTime, Time time, ProducerInterceptors<K, V> interceptors, TopicPartition tp) {
             this.userCallback = userCallback;
             this.interceptors = interceptors;
@@ -1392,7 +1396,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         public void onCompletion(RecordMetadata metadata, Exception exception) {
             metadata = metadata != null ? metadata : new RecordMetadata(tp, -1, -1, RecordBatch.NO_TIMESTAMP, Long.valueOf(-1L), -1, -1);
             this.interceptors.onAcknowledgement(metadata, exception);
-            recordMsgProducingLatency(startTime, time.milliseconds());
+            if (time != null){
+                recordMsgProducingLatency(startTime, time.milliseconds());
+            }
             if (this.userCallback != null)
                 this.userCallback.onCompletion(metadata, exception);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.clients.producer;
 
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientUtils;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -1382,7 +1382,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         private final long startTime;
 
         private InterceptorCallback(Callback userCallback, ProducerInterceptors<K, V> interceptors, TopicPartition tp) {
-           this(userCallback, Long.MIN_VALUE, null, interceptors, tp);
+            this(userCallback, Long.MIN_VALUE, null, interceptors, tp);
         }
 
         private InterceptorCallback(Callback userCallback, long startTime, Time time, ProducerInterceptors<K, V> interceptors, TopicPartition tp) {
@@ -1396,7 +1396,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         public void onCompletion(RecordMetadata metadata, Exception exception) {
             metadata = metadata != null ? metadata : new RecordMetadata(tp, -1, -1, RecordBatch.NO_TIMESTAMP, Long.valueOf(-1L), -1, -1);
             this.interceptors.onAcknowledgement(metadata, exception);
-            if (time != null){
+            if (time != null) {
                 recordMsgProducingLatency(startTime, time.milliseconds());
             }
             if (this.userCallback != null)

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -239,7 +239,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     public static final String NETWORK_THREAD_PREFIX = "kafka-producer-network-thread";
     public static final String PRODUCER_METRIC_GROUP_NAME = "producer-metrics";
     private static Sensor msgSendLatencySensor = null;
-    private static AtomicLong msgQueuingTime;
+    private static AtomicLong msgQueuingTime = new AtomicLong(0);
 
     private final String clientId;
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -58,6 +58,8 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.record.AbstractRecords;
@@ -247,6 +249,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     private final Sender sender;
     private final Thread ioThread;
     private final CompressionType compressionType;
+    private final Sensor msgSendLatencySensor;
     private final Sensor errors;
     private final Time time;
     private final Serializer<K> keySerializer;
@@ -355,6 +358,15 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             reporters.add(new JmxReporter(JMX_PREFIX));
             this.metrics = new Metrics(metricConfig, reporters, time);
             this.metrics.setReplaceOnDuplicateMetric(config.getBoolean(ProducerConfig.METRICS_REPLACE_ON_DUPLICATE_CONFIG));
+            this.msgSendLatencySensor = metrics.sensor("message-produce-latency-avg");
+            this.msgSendLatencySensor.add(new MetricName("message-produce-latency-avg",
+                PRODUCER_METRIC_GROUP_NAME,
+                "The average latency between record queuing and get acknowledged in ms",
+                Collections.singletonMap("client-id", clientId)), new Avg());
+            this.msgSendLatencySensor.add(new MetricName("message-produce-latency-max",
+                PRODUCER_METRIC_GROUP_NAME,
+                "The max latency between record queuing and get acknowledged in ms",
+                Collections.singletonMap("client-id", clientId)), new Max());
             this.partitioner = config.getConfiguredInstance(ProducerConfig.PARTITIONER_CLASS_CONFIG, Partitioner.class);
             long retryBackoffMs = config.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG);
             if (keySerializer == null) {
@@ -935,6 +947,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             if (transactionManager != null && transactionManager.isTransactional()) {
                 transactionManager.failIfNotReadyForSend();
             }
+            long startTime = time.milliseconds();
             RecordAccumulator.RecordAppendResult result = accumulator.append(tp, timestamp, serializedKey,
                     serializedValue, headers, interceptCallback, remainingWaitMs, true);
 
@@ -960,6 +973,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 log.trace("Waking up the sender since topic {} partition {} is either full or getting a new batch", record.topic(), partition);
                 this.sender.wakeup();
             }
+            long endTime = time.milliseconds();
+            msgSendLatencySensor.record(endTime - startTime, endTime);
             return result.future;
             // handling exceptions and record the errors;
             // for API exceptions return them in the future,


### PR DESCRIPTION
Description: 
Introduced an end-to-end sensor in KafkaProducer to measure the latency between message queued into RecordAccumulator object and ack is recieved.
 
### Committer Checklist (excluded from commit message)
- [✅] Verify design and implementation 
- [✅] Verify test coverage and CI build status
- [✅] Verify documentation (including upgrade notes)
