### PR TITLE
[LI-HOTFIX] Improving performance of the isReplicaOnline method

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -508,12 +508,12 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
   /** Send UpdateMetadataRequest to the given brokers for the given partitions and partitions that are being deleted */
   def addUpdateMetadataRequestForBrokers(brokerIds: Seq[Int],
                                          partitions: collection.Set[TopicPartition]): Unit = {
-
+    val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
     def updateMetadataRequestPartitionInfo(partition: TopicPartition, beingDeleted: Boolean): Unit = {
       controllerContext.partitionLeadershipInfo.get(partition) match {
         case Some(LeaderIsrAndControllerEpoch(leaderAndIsr, controllerEpoch)) =>
           val replicas = controllerContext.partitionReplicaAssignment(partition)
-          val offlineReplicas = replicas.filter(!controllerContext.isReplicaOnline(_, partition))
+          val offlineReplicas = replicas.filter(!controllerContextSnapshot.isReplicaOnline(_, partition))
           val updatedLeaderAndIsr =
             if (beingDeleted) LeaderAndIsr.duringDelete(leaderAndIsr.isr)
             else leaderAndIsr

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -225,14 +225,6 @@ class ControllerContext {
     }.toSet
   }
 
-  def isReplicaOnline(brokerId: Int, topicPartition: TopicPartition, includeShuttingDownBrokers: Boolean = false): Boolean = {
-    val brokerOnline = {
-      if (includeShuttingDownBrokers) liveOrShuttingDownBrokerIds.contains(brokerId)
-      else liveBrokerIds.contains(brokerId)
-    }
-    brokerOnline && !replicasOnOfflineDirs.getOrElse(brokerId, Set.empty).contains(topicPartition)
-  }
-
   def replicasOnBrokers(brokerIds: Set[Int]): Set[PartitionAndReplica] = {
     brokerIds.flatMap { brokerId =>
       partitionAssignments.flatMap {
@@ -257,8 +249,9 @@ class ControllerContext {
   }
 
   def allLiveReplicas(): Set[PartitionAndReplica] = {
+    val snapshot = ControllerContextSnapshot(this)
     replicasOnBrokers(liveBrokerIds).filter { partitionAndReplica =>
-      isReplicaOnline(partitionAndReplica.replica, partitionAndReplica.topicPartition)
+      snapshot.isReplicaOnline(partitionAndReplica.replica, partitionAndReplica.topicPartition)
     }
   }
 
@@ -270,12 +263,13 @@ class ControllerContext {
   def onlineAndOfflineReplicas: (Set[PartitionAndReplica], Set[PartitionAndReplica]) = {
     val onlineReplicas = mutable.Set.empty[PartitionAndReplica]
     val offlineReplicas = mutable.Set.empty[PartitionAndReplica]
+    val snapshot = ControllerContextSnapshot(this)
     for ((topic, partitionAssignments) <- partitionAssignments;
          (partitionId, assignment) <- partitionAssignments) {
       val partition = new TopicPartition(topic, partitionId)
       for (replica <- assignment.replicas) {
         val partitionAndReplica = PartitionAndReplica(partition, replica)
-        if (isReplicaOnline(replica, partition))
+        if (snapshot.isReplicaOnline(replica, partition))
           onlineReplicas.add(partitionAndReplica)
         else
           offlineReplicas.add(partitionAndReplica)
@@ -430,4 +424,23 @@ class ControllerContext {
   private def isValidPartitionStateTransition(partition: TopicPartition, targetState: PartitionState): Boolean =
     targetState.validPreviousStates.contains(partitionStates(partition))
 
+}
+
+/**
+  * The ControllerContextSnapshot is an immutable snapshot of the ControllorContext.
+  * The motivation for this class is that we don't need to calculate certain fields
+  * repeatedly, including liveBrokerIds and liveOrShuttingDownBrokerIds.
+  */
+case class ControllerContextSnapshot(controllerContext: ControllerContext) {
+  val liveBrokerIds = controllerContext.liveBrokerIds
+  val liveOrShuttingDownBrokerIds = controllerContext.liveOrShuttingDownBrokerIds
+  val replicasOnOfflineDirs = controllerContext.replicasOnOfflineDirs
+
+  def isReplicaOnline(brokerId: Int, topicPartition: TopicPartition, includeShuttingDownBrokers: Boolean = false): Boolean = {
+    val brokerOnline = {
+      if (includeShuttingDownBrokers) liveOrShuttingDownBrokerIds.contains(brokerId)
+      else liveBrokerIds.contains(brokerId)
+    }
+    brokerOnline && !replicasOnOfflineDirs.getOrElse(brokerId, Set.empty).contains(topicPartition)
+  }
 }

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -427,10 +427,10 @@ class ControllerContext {
 }
 
 /**
-  * The ControllerContextSnapshot is an immutable snapshot of the ControllorContext.
-  * The motivation for this class is that we don't need to calculate certain fields
-  * repeatedly, including liveBrokerIds and liveOrShuttingDownBrokerIds.
-  */
+ * The ControllerContextSnapshot is an immutable snapshot of the ControllorContext.
+ * The motivation for this class is that we don't need to calculate certain fields
+ * repeatedly, including liveBrokerIds and liveOrShuttingDownBrokerIds.
+ */
 case class ControllerContextSnapshot(controllerContext: ControllerContext) {
   val liveBrokerIds = controllerContext.liveBrokerIds
   val liveOrShuttingDownBrokerIds = controllerContext.liveOrShuttingDownBrokerIds

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -80,12 +80,13 @@ abstract class PartitionStateMachine(controllerContext: ControllerContext) exten
    * zookeeper
    */
   private def initializePartitionState(): Unit = {
+    val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
     for (topicPartition <- controllerContext.allPartitions) {
       // check if leader and isr path exists for partition. If not, then it is in NEW state
       controllerContext.partitionLeadershipInfo.get(topicPartition) match {
         case Some(currentLeaderIsrAndEpoch) =>
           // else, check if the leader for partition is alive. If yes, it is in Online state, else it is in Offline state
-          if (controllerContext.isReplicaOnline(currentLeaderIsrAndEpoch.leaderAndIsr.leader, topicPartition))
+          if (controllerContextSnapshot.isReplicaOnline(currentLeaderIsrAndEpoch.leaderAndIsr.leader, topicPartition))
           // leader is alive
             controllerContext.putPartitionState(topicPartition, OnlinePartition)
           else
@@ -271,10 +272,11 @@ class ZkPartitionStateMachine(config: KafkaConfig,
    * @return The partitions that have been successfully initialized.
    */
   private def initializeLeaderAndIsrForPartitions(partitions: Seq[TopicPartition]): Seq[TopicPartition] = {
+    val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
     val successfulInitializations = mutable.Buffer.empty[TopicPartition]
     val replicasPerPartition = partitions.map(partition => partition -> controllerContext.partitionReplicaAssignment(partition))
     val liveReplicasPerPartition = replicasPerPartition.map { case (partition, replicas) =>
-        val liveReplicasForPartition = replicas.filter(replica => controllerContext.isReplicaOnline(replica, partition))
+        val liveReplicasForPartition = replicas.filter(replica => controllerContextSnapshot.isReplicaOnline(replica, partition))
         partition -> liveReplicasForPartition
     }
     val (partitionsWithoutLiveReplicas, partitionsWithLiveReplicas) = liveReplicasPerPartition.partition { case (_, liveReplicas) => liveReplicas.isEmpty }
@@ -460,9 +462,10 @@ class ZkPartitionStateMachine(config: KafkaConfig,
     leaderAndIsrs: Seq[(TopicPartition, LeaderAndIsr)],
     allowUnclean: Boolean
   ): Seq[(TopicPartition, Option[LeaderAndIsr], Boolean)] = {
+    val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
     val (partitionsWithNoLiveInSyncReplicas, partitionsWithLiveInSyncReplicas) = leaderAndIsrs.partition {
       case (partition, leaderAndIsr) =>
-        val liveInSyncReplicas = leaderAndIsr.isr.filter(controllerContext.isReplicaOnline(_, partition))
+        val liveInSyncReplicas = leaderAndIsr.isr.filter(controllerContextSnapshot.isReplicaOnline(_, partition))
         liveInSyncReplicas.isEmpty
     }
 

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -55,11 +55,12 @@ abstract class ReplicaStateMachine(controllerContext: ControllerContext) extends
    * in zookeeper
    */
   private def initializeReplicaState(): Unit = {
+    val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
     controllerContext.allPartitions.foreach { partition =>
       val replicas = controllerContext.partitionReplicaAssignment(partition)
       replicas.foreach { replicaId =>
         val partitionAndReplica = PartitionAndReplica(partition, replicaId)
-        if (controllerContext.isReplicaOnline(replicaId, partition)) {
+        if (controllerContextSnapshot.isReplicaOnline(replicaId, partition)) {
           controllerContext.putReplicaState(partitionAndReplica, OnlineReplica)
         } else {
           // mark replicas on dead brokers as failed for topic deletion, if they belong to a topic to be deleted.


### PR DESCRIPTION
TICKET = LIKAFKA-38536
LI_DESCRIPTION =
Profiling shows that the ControllerContext.isReplicaOnline method is taking a significant portion of the CPU during controller initialization.
https://harrier.tools.corp.linkedin.com/#/lnkd-services/profiler/event/41572?isAsyncProfiler=true&metri

The ControllerContext.isReplicaOnline method is frequently called inside a loop,
and internally this method relies on several derived fields in the ControllerContext.
Repeatedly calculating the derived fields could be expensive, and yet these fields
do not change between iterations of the loop.

This PR creates a new class ControllerContextSnapshot that tries to cache
the derived fields in order to save the repeated computation and speed up the
controller.

EXIT_CRITERIA = When this change is proposed in upstream kafka and pulled internally.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
