### PR TITLE
[LI-HOTFIX] Ensure that the controller has fresh values for min.insync.replicas after topic-level configs are dropped.

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -76,6 +76,7 @@ class ControllerContext {
   val replicaStates = mutable.Map.empty[PartitionAndReplica, ReplicaState]
   val replicasOnOfflineDirs: mutable.Map[Int, Set[TopicPartition]] = mutable.Map.empty
 
+  // A map to indicate the explicitly configured value of min.insync.replicas config per corresponding topic.
   val topicMinIsrConfig = mutable.Map.empty[String, Int]
 
   val topicsToBeDeleted = mutable.Set.empty[String]

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1282,7 +1282,15 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def processTopicMinInSyncReplicasConfigChange(topic: String, minInSyncReplicas: Int): Unit = {
-    controllerContext.topicMinIsrConfig += topic -> minInSyncReplicas
+    if (minInSyncReplicas > 0) {
+      // Add the explicitly configured value of min.insync.replicas config for the corresponding topic.
+      controllerContext.topicMinIsrConfig += topic -> minInSyncReplicas
+    } else {
+      // Remove the topic-level config value of min.insync.replicas to ensure that the topic config uses the default value.
+      // Note that we remove the topic from the map rather than setting its config value to the default value. This
+      // keeps the map no larger than the number of topics with explicitly configured values of min.insync.replicas.
+      controllerContext.topicMinIsrConfig -= topic
+    }
   }
 
   private def preemptControlledShutdown(id: Int, brokerEpoch: Long, controlledShutdownCallback: Try[Set[TopicPartition]] => Unit): Unit = {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1282,7 +1282,7 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def processTopicMinInSyncReplicasConfigChange(topic: String, minInSyncReplicas: Int): Unit = {
-    if (minInSyncReplicas > 0) {
+    if (minInSyncReplicas != Defaults.MissingPerTopicConfig.toInt) {
       // Add the explicitly configured value of min.insync.replicas config for the corresponding topic.
       controllerContext.topicMinIsrConfig += topic -> minInSyncReplicas
     } else {

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -89,7 +89,10 @@ class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaC
       kafkaController.enableTopicUncleanLeaderElection(topic)
     }
 
-    Try(topicConfig.getProperty(KafkaConfig.MinInSyncReplicasProp).toInt) match {
+    // If the new topic config does not have min.insync.replicas configured, i.e. the topic shall use the default value,
+    // ensure that the controller knows about it.
+    val missingMinISRPropertyValue = "-1"
+    Try(topicConfig.getProperty(KafkaConfig.MinInSyncReplicasProp, missingMinISRPropertyValue).toInt) match {
       case Success(minInSyncReplicas) => kafkaController.setMinInSyncReplicas(topic, minInSyncReplicas)
       case _ =>
     }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -91,8 +91,7 @@ class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaC
 
     // If the new topic config does not have min.insync.replicas configured, i.e. the topic shall use the default value,
     // ensure that the controller knows about it.
-    val missingMinISRPropertyValue = "-1"
-    Try(topicConfig.getProperty(KafkaConfig.MinInSyncReplicasProp, missingMinISRPropertyValue).toInt) match {
+    Try(topicConfig.getProperty(KafkaConfig.MinInSyncReplicasProp, Defaults.MissingPerTopicConfig).toInt) match {
       case Success(minInSyncReplicas) => kafkaController.setMinInSyncReplicas(topic, minInSyncReplicas)
       case _ =>
     }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -79,6 +79,7 @@ object Defaults {
     "RawKafkaConsumerFactory", "RawKafkaConsumerFactoryFactory", "RawKafkaProducerFactory", "RawKafkaProducerFactoryFactory",
     "AvroKafkaProducerBuilder", "AvroKafkaConsumerBuilder", "RawKafkaProducerBuilder", "RawKafkaConsumerBuilder",
     "TrackerProcessorFactory", "TrackingConsumerFactory", "TrackingProducerFactory")
+  val MissingPerTopicConfig = "-1"
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassName = ""


### PR DESCRIPTION
TICKET = CM-79574
LI_DESCRIPTION =
The following series of events causes the Controller to keep stale config value for min.insync.replicas config.
This can cause a broker shutdown to be blocked when ISR-based shutdown logic is adopted.

1. Given a topic T, set its topic-level min.insync.replicas config value to XXX.
2. Then remove the topic-level min.insync.replicas config value of topic T

Currently, step-1 will cause the controller update its "controllerContext.topicMinIsrConfig" value for the topic T to XXX.
However, step-2 will not remove the config value XXX from "controllerContext.topicMinIsrConfig". As a result, Controller
will cache a stale config value of XXX for topic T. The expected behavior was for the topic to use the default config value
after its topic-level config was removed.

* The above events can cause the ISR-based shutdown logic to block shutdown. For example,
	1. Set the min.insync.replicas=2 for topic T.
	2. Remvoe topic-level min.insync.replicas config value for topic T.
	3. Use redundancy factor of 1 for ISR-based shutdown logic.
	4. Observe that controller will block shutdown for a partition of the topic with the following log:

	```
	T-2 has min.insync.replicas=2 and a redundancy factor of 1. Removing broker XXX will leave 2 live replicas in the ISR.
	```

EXIT_CRITERIA = When this change is merged in upstream and the corresponding change is pulled into a future release.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
