### PR TITLE
[LI-HOTFIX] Add the move controller RPC

### DIFF
--- a/bin/kafka-li-cluster.sh
+++ b/bin/kafka-li-cluster.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.LiClusterCommand "$@"

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1090,6 +1090,15 @@ public interface Admin extends AutoCloseable {
     SkipShutdownSafetyCheckResult skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions options);
 
     /**
+     * Move the kafka controller to a different host.
+     * When the active controller is elected via Zookeeper, this API will send
+     * an LiMoveControllerRequest to a kafka broker, which will delete the /controller znode.
+     *
+     * @param options The options to use when moving the controller.
+     */
+    MoveControllerResult moveController(MoveControllerOptions options);
+
+    /**
      * Describes all entities matching the provided filter that have at least one client quota configuration
      * value defined.
      * <p>

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -87,6 +87,7 @@ import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.Altera
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse;
 import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData;
+import org.apache.kafka.common.message.LiMoveControllerRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
@@ -165,6 +166,8 @@ import org.apache.kafka.common.requests.LeaveGroupRequest;
 import org.apache.kafka.common.requests.LeaveGroupResponse;
 import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckRequest;
 import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckResponse;
+import org.apache.kafka.common.requests.LiMoveControllerRequest;
+import org.apache.kafka.common.requests.LiMoveControllerResponse;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.ListPartitionReassignmentsRequest;
@@ -3247,6 +3250,38 @@ public class KafkaAdminClient extends AdminClient {
         }, now);
 
         return new SkipShutdownSafetyCheckResult(future);
+    }
+
+    @Override
+    public MoveControllerResult moveController(MoveControllerOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        runnable.call(new Call("moveController", calcDeadlineMs(now, options.timeoutMs()),
+            new LeastLoadedNodeProvider()) {
+
+            @Override
+            AbstractRequest.Builder createRequest(int timeoutMs) {
+                return new LiMoveControllerRequest.Builder(new LiMoveControllerRequestData(), (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                LiMoveControllerResponse response = (LiMoveControllerResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                if (error != Errors.NONE) {
+                    future.completeExceptionally(error.exception());
+                    return;
+                }
+
+                future.complete(null);
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        }, now);
+        return new MoveControllerResult(future);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerOptions.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#moveController(MoveControllerOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class MoveControllerOptions extends AbstractOptions<MoveControllerOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link Admin#moveController()}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class MoveControllerResult {
+    private final KafkaFuture<Void> future;
+
+    MoveControllerResult(KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -59,6 +59,8 @@ import org.apache.kafka.common.message.LeaderAndIsrRequestData;
 import org.apache.kafka.common.message.LeaderAndIsrResponseData;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
+import org.apache.kafka.common.message.LiMoveControllerRequestData;
+import org.apache.kafka.common.message.LiMoveControllerResponseData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.AlterPartitionReassignmentsRequestData;
@@ -222,7 +224,8 @@ public enum ApiKeys {
     // LinkedIn API keys for APIs not yet upstreamed.
     LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK(1000, "LiControlledShutdownSkipSafetyCheck", true, LiControlledShutdownSkipSafetyCheckRequestData.SCHEMAS, LiControlledShutdownSkipSafetyCheckResponseData.SCHEMAS),
 
-    LI_COMBINED_CONTROL(1001, "LiCombinedControl", true, LiCombinedControlRequestData.SCHEMAS, LiCombinedControlResponseData.SCHEMAS);
+    LI_COMBINED_CONTROL(1001, "LiCombinedControl", true, LiCombinedControlRequestData.SCHEMAS, LiCombinedControlResponseData.SCHEMAS),
+    LI_MOVE_CONTROLLER(1002, "LiMoveController", true, LiMoveControllerRequestData.SCHEMAS, LiMoveControllerResponseData.SCHEMAS);
 
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -247,6 +247,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return new LiControlledShutdownSkipSafetyCheckRequest(struct, apiVersion);
             case LI_COMBINED_CONTROL:
                 return new LiCombinedControlRequest(struct, apiVersion);
+            case LI_MOVE_CONTROLLER:
+                return new LiMoveControllerRequest(struct, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -184,6 +184,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return new LiControlledShutdownSkipSafetyCheckResponse(struct, version);
             case LI_COMBINED_CONTROL:
                 return new LiCombinedControlResponse(struct, version);
+            case LI_MOVE_CONTROLLER:
+                return new LiMoveControllerResponse(struct, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerRequest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.LiMoveControllerRequestData;
+import org.apache.kafka.common.message.LiMoveControllerResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+
+public class LiMoveControllerRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiMoveControllerRequest> {
+        private final LiMoveControllerRequestData data;
+
+        public Builder(LiMoveControllerRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiMoveControllerRequest build(short version) {
+            return new LiMoveControllerRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiMoveControllerRequestData data;
+
+    public LiMoveControllerRequest(LiMoveControllerRequestData data, short version) {
+        super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, version);
+        this.data = data;
+    }
+
+    public LiMoveControllerRequest(Struct struct, short version) {
+        super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, version);
+        this.data = new LiMoveControllerRequestData(struct, version);
+    }
+
+    @Override
+    protected Struct toStruct() {
+        return data.toStruct(this.version());
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiMoveControllerResponseData data = new LiMoveControllerResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiMoveControllerResponse(data);
+    }
+
+    public LiMoveControllerRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerRequest.java
@@ -27,7 +27,7 @@ public class LiMoveControllerRequest extends AbstractRequest {
         private final LiMoveControllerRequestData data;
 
         public Builder(LiMoveControllerRequestData data, short allowedVersion) {
-            super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, allowedVersion);
+            super(ApiKeys.LI_MOVE_CONTROLLER, allowedVersion);
             this.data = data;
         }
 
@@ -45,12 +45,12 @@ public class LiMoveControllerRequest extends AbstractRequest {
     private final LiMoveControllerRequestData data;
 
     public LiMoveControllerRequest(LiMoveControllerRequestData data, short version) {
-        super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, version);
+        super(ApiKeys.LI_MOVE_CONTROLLER, version);
         this.data = data;
     }
 
     public LiMoveControllerRequest(Struct struct, short version) {
-        super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, version);
+        super(ApiKeys.LI_MOVE_CONTROLLER, version);
         this.data = new LiMoveControllerRequestData(struct, version);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerResponse.java
@@ -24,12 +24,6 @@ import java.util.Collections;
 import java.util.Map;
 
 public class LiMoveControllerResponse extends AbstractResponse {
-    /**
-     * Possible error codes:
-     * <p>
-     * UNKNOWN(-1) (this is because IllegalStateException may be thrown in `KafkaController.shutdownBroker`, it would be good to improve this)
-     * STALE_CONTROLLER_EPOCH(11)
-     */
     private final LiMoveControllerResponseData data;
 
     public LiMoveControllerResponse(LiMoveControllerResponseData data) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerResponse.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.LiMoveControllerResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class LiMoveControllerResponse extends AbstractResponse {
+    /**
+     * Possible error codes:
+     * <p>
+     * UNKNOWN(-1) (this is because IllegalStateException may be thrown in `KafkaController.shutdownBroker`, it would be good to improve this)
+     * STALE_CONTROLLER_EPOCH(11)
+     */
+    private final LiMoveControllerResponseData data;
+
+    public LiMoveControllerResponse(LiMoveControllerResponseData data) {
+        this.data = data;
+    }
+
+    public LiMoveControllerResponse(Struct struct, short version) {
+        this.data = new LiMoveControllerResponseData(struct, version);
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    protected Struct toStruct(short version) {
+        return data.toStruct(version);
+    }
+
+    public LiMoveControllerResponseData data() {
+        return data;
+    }
+
+    public static LiMoveControllerResponse prepareResponse(Errors error) {
+        LiMoveControllerResponseData data = new LiMoveControllerResponseData();
+        data.setErrorCode(error.code());
+        return new LiMoveControllerResponse(data);
+    }
+}

--- a/clients/src/main/resources/common/message/LiMoveControllerRequest.json
+++ b/clients/src/main/resources/common/message/LiMoveControllerRequest.json
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1002,
+  "type": "request",
+  "name": "LiMoveControllerRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+  ]
+}

--- a/clients/src/main/resources/common/message/LiMoveControllerResponse.json
+++ b/clients/src/main/resources/common/message/LiMoveControllerResponse.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1002,
+  "type": "response",
+  "name": "LiMoveControllerResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -491,6 +491,11 @@ public class MockAdminClient extends AdminClient {
         return null;
     }
 
+    @Override
+    public MoveControllerResult moveController(MoveControllerOptions options) {
+        return null;
+    }
+
     public void setFetchesRemainingUntilVisible(String topicName, int fetchesRemainingUntilVisible) {
         TopicMetadata metadata = allTopics.get(topicName);
         if (metadata == null) {

--- a/core/src/main/scala/kafka/admin/LiClusterCommand.scala
+++ b/core/src/main/scala/kafka/admin/LiClusterCommand.scala
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.admin
+
+import joptsimple.OptionSpec
+import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Exit, Logging}
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.admin.{Admin, MoveControllerOptions, AdminClient => JAdminClient}
+import org.apache.kafka.common.utils.Utils
+import java.util.Properties
+
+object LiClusterCommand extends Logging {
+  def createAdminClient(commandConfig: Properties, bootstrapServer: Option[String]): Admin = {
+    bootstrapServer match {
+      case Some(serverList) => commandConfig.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, serverList)
+      case None =>
+    }
+    JAdminClient.create(commandConfig)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val opts = new ControllerCommandOptions(args)
+    opts.checkArgs()
+
+    val adminClient = createAdminClient(opts.commandConfig, opts.bootstrapServer)
+
+    var exitCode = 0
+    try {
+      if (opts.hasMoveControllerOption) {
+        val moveControllerResult = adminClient.moveController(new MoveControllerOptions())
+        moveControllerResult.all().get()
+        println("The move-controller request has completed successfully.")
+      }
+    } catch {
+      case throwable: Throwable =>
+        println("Error while executing cluster command: " + throwable.getMessage)
+        error(Utils.stackTrace(throwable))
+        exitCode = 1
+    } finally {
+      adminClient.close()
+      Exit.exit(exitCode)
+    }
+  }
+
+  class ControllerCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
+    private val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The Kafka server to connect to. In case of providing this, a direct Zookeeper connection won't be required.")
+      .withRequiredArg
+      .describedAs("server to connect to")
+      .ofType(classOf[String])
+    private val commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client. " +
+      "This is used only with --bootstrap-server option for describing and altering broker configs.")
+      .withRequiredArg
+      .describedAs("command config property file")
+      .ofType(classOf[String])
+    private val moveControllerOpt = parser.accepts("move-controller", "Move the controller to a different host.")
+
+    options = parser.parse(args : _*)
+    def has(builder: OptionSpec[_]): Boolean = options.has(builder)
+    def valueAsOption[A](option: OptionSpec[A], defaultValue: Option[A] = None): Option[A] = if (has(option)) Some(options.valueOf(option)) else defaultValue
+    def hasMoveControllerOption: Boolean = has(moveControllerOpt)
+    def bootstrapServer: Option[String] = valueAsOption(bootstrapServerOpt)
+    def commandConfig: Properties = if (has(commandConfigOpt)) Utils.loadProps(options.valueOf(commandConfigOpt)) else new Properties()
+
+    def checkArgs(): Unit = {
+      if (args.length == 0)
+        CommandLineUtils.printUsageAndDie(parser, "move a controller")
+
+      CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps to move a controller.")
+
+      // should have exactly one action
+      val actions = Seq(moveControllerOpt).count(options.has)
+      if (actions != 1)
+        CommandLineUtils.printUsageAndDie(parser, "Command must include exactly one action: --move-controller")
+      if (!has(bootstrapServerOpt)) {
+        throw new IllegalArgumentException("The --bootstrap-server option must be set")
+      }
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -187,6 +187,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         // LinkedIn internal request types
         case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => handleLiControlledShutdownSkipSafetyCheck(request)
         case ApiKeys.LI_COMBINED_CONTROL => handleLiCombinedControlRequest(request)
+        case ApiKeys.LI_MOVE_CONTROLLER => handleMoveControllerRequest(request)
       }
     } catch {
       case e: FatalExitError => throw e
@@ -3142,5 +3143,21 @@ class KafkaApis(val requestChannel: RequestChannel,
     responseData.setStopReplicaPartitionErrors(stopReplicaPartitionErrors)
 
     sendResponseExemptThrottle(request, new LiCombinedControlResponse(responseData))
+  }
+
+  def handleMoveControllerRequest(request: RequestChannel.Request): Unit = {
+    authorizeClusterOperation(request, CLUSTER_ACTION)
+    val moveControllerRequest = request.body[LiMoveControllerRequest]
+
+    val moveControllerResponse = try {
+      val expectedControllerEpochZkVersion = controller.controllerContext.epochZkVersion
+      zkClient.deleteController(expectedControllerEpochZkVersion)
+      LiMoveControllerResponse.prepareResponse(Errors.NONE)
+    } catch {
+      case throwable: Throwable  =>
+        moveControllerRequest.getErrorResponse(throwable)
+    }
+
+    sendResponseExemptThrottle(request, moveControllerResponse)
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3150,8 +3150,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val moveControllerRequest = request.body[LiMoveControllerRequest]
 
     val moveControllerResponse = try {
-      val expectedControllerEpochZkVersion = controller.controllerContext.epochZkVersion
-      zkClient.deleteController(expectedControllerEpochZkVersion)
+      zkClient.deleteControllerRaw()
       LiMoveControllerResponse.prepareResponse(Errors.NONE)
     } catch {
       case throwable: Throwable  =>

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -1204,6 +1204,16 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
   }
 
   /**
+   * Deletes the controller znode without checking the expectedControllerEpochZkVersion
+   * This is used to force a controller switch from the cli.
+   * @param expectedControllerEpochZkVersion expected controller epoch zkVersion.
+   */
+  def deleteControllerRaw(): Unit = {
+    val deleteRequest = DeleteRequest(ControllerZNode.path, ZkVersion.MatchAnyVersion)
+    retryRequestUntilConnected(deleteRequest, ZkVersion.MatchAnyVersion)
+  }
+
+  /**
    * Gets the controller epoch.
    * @return optional (Int, Stat) that is Some if the controller epoch path exists and None otherwise.
    */


### PR DESCRIPTION
TICKET = LIKAFKA-37769
LI_DESCRIPTION =
In order to make Kafka SOX compliant, all of the znodes need to be protected with ACLS and become writable only by kafka-server. This means the `ktool cluster move-controller` command will be rejected. 

To continue supporting the ktool command above, this PR adds a new `moveController` API to the KafkaAdminClient.
EXIT_CRITERIA = We can deprecate this PR if either of the following two conditions is met
1) this change is merged in upstream
2) a new equivalent API is added upstream that works based on the Raft-based controller quorum, and we are deprecating zookeeper.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
