### PR TITLE
[LI-HOTFIX] Fixing the broken tests in RequestQuotaTest caused by the new moveController API

### DIFF
--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -520,6 +520,9 @@ class RequestQuotaTest extends BaseRequestTest {
             new util.ArrayList[Node](), new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataPartitionState](), new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataBroker](),
             new util.ArrayList[LiCombinedControlRequestData.StopReplicaPartitionState]())
 
+        case ApiKeys.LI_MOVE_CONTROLLER =>
+          new LiMoveControllerRequest.Builder(new LiMoveControllerRequestData(), ApiKeys.LI_MOVE_CONTROLLER.latestVersion)
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
Recently we added the moveController API to the KafkaAdminClient,
which caused some tests in the RequestQuotaTest to fail.
This PR fixes the broken tests by recognizing the new LI_MOVE_CONTROLLER API key.

EXIT_CRITERIA = this change has the same exit criteria as the
original PR that added the moveController API.

All of the tests are passing according to the command
`./gradlew :core:test :clients:test`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
