### PR TITLE
[LI-HOTFIX] Disable the logging of UpdateMetadata live brokers in the LiCombinedControlRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
@@ -137,9 +137,14 @@ public class LiCombinedControlRequest extends AbstractControlRequest {
             bld.append("\t" + Utils.join(leaderAndIsrLiveLeaders, ", ") + "\n");
 
             bld.append("updateMetadataLiveBrokers=\n");
+            /**
+             * Now that the LiCombinedControl request has been enabled in production for several months and proven
+             * to be a stable feature, we can skip the logging of live brokers in the UpdateMetadata request to
+             * make the log file sizes smaller.
             for (LiCombinedControlRequestData.UpdateMetadataBroker broker: updateMetadataLiveBrokers) {
                 bld.append("\t" + broker + "\n");
             }
+             */
 
             bld.append("stopReplicaPartitions=\n");
             for (LiCombinedControlRequestData.StopReplicaPartitionState partitionState: stopReplicaPartitions) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
@@ -138,7 +138,7 @@ public class LiCombinedControlRequest extends AbstractControlRequest {
 
             bld.append("updateMetadataLiveBrokers=\n");
             /**
-             * Now that the LiCombinedControl request has been enabled in production for several months and proven
+             * Now that the LiCombinedControl request has been enabled in production and proven
              * to be a stable feature, we can skip the logging of live brokers in the UpdateMetadata request to
              * make the log file sizes smaller.
             for (LiCombinedControlRequestData.UpdateMetadataBroker broker: updateMetadataLiveBrokers) {


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
Initially, when developing the LiCombinedControlRequest feature, we turned on logging
of UpdateMetadata live brokers in the LiCombinedControlRequest to ensure the correctness of the
feature. Now that the feature has proven to be stable, it's better to turn off the logging
to make the log files smaller.
EXIT_CRITERIA = This change has the same exit criteria as the LiCombinedControlRequest feature

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
