### PR TITLE
[LI-HOTFIX] Adding new metrics for MetadataAllTopics request rate and response size distribution

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -57,6 +57,7 @@ object RequestChannel extends Logging {
     private val metricsMap = mutable.Map[String, RequestMetrics]()
 
     (ApiKeys.values.toSeq.map(_.name) ++
+        Seq(RequestMetrics.MetadataAllTopics) ++
         Seq(RequestMetrics.consumerFetchMetricName, RequestMetrics.followFetchMetricName)).foreach { name =>
       metricsMap.put(name, new RequestMetrics(name))
     }
@@ -83,6 +84,7 @@ object RequestChannel extends Logging {
     @volatile var apiRemoteCompleteTimeNanos = -1L
     @volatile var messageConversionsTimeNanos = 0L
     @volatile var temporaryMemoryBytes = 0L
+    @volatile var responseBytes = 0L
     @volatile var recordNetworkThreadTimeCallback: Option[Long => Unit] = None
 
     val session = Session(context.principal, context.clientAddress)
@@ -155,7 +157,11 @@ object RequestChannel extends Logging {
           )
         }
         else Seq.empty
-      val metricNames = fetchMetricNames :+ header.apiKey.name
+      val metadataMetricNames =
+        if (header.apiKey() == ApiKeys.METADATA && body[MetadataRequest].isAllTopics) {
+          Seq(RequestMetrics.MetadataAllTopics)
+        } else Seq.empty
+      val metricNames =  (fetchMetricNames ++ metadataMetricNames) :+ header.apiKey.name
       metricNames.foreach { metricName =>
         val m = metrics(metricName)
         m.requestRate(header.apiVersion).mark()
@@ -167,6 +173,7 @@ object RequestChannel extends Logging {
         m.responseSendTimeHist.update(Math.round(responseSendTimeMs))
         m.totalTimeHist.update(Math.round(totalTimeMs))
         m.requestBytesHist.update(sizeOfBodyInBytes)
+        m.responseBytesHist.update(responseBytes)
         m.messageConversionsTimeHist.foreach(_.update(Math.round(messageConversionsTimeMs)))
         m.tempMemoryBytesHist.foreach(_.update(temporaryMemoryBytes))
       }
@@ -384,6 +391,7 @@ class RequestChannel(val queueSize: Int, val metricNamePrefix : String, val time
 object RequestMetrics {
   val consumerFetchMetricName = ApiKeys.FETCH.name + "Consumer"
   val followFetchMetricName = ApiKeys.FETCH.name + "Follower"
+  val MetadataAllTopics = ApiKeys.METADATA.name + "AllTopics"
 
   val RequestsPerSec = "RequestsPerSec"
   val RequestQueueTimeMs = "RequestQueueTimeMs"
@@ -394,6 +402,7 @@ object RequestMetrics {
   val ResponseSendTimeMs = "ResponseSendTimeMs"
   val TotalTimeMs = "TotalTimeMs"
   val RequestBytes = "RequestBytes"
+  val ResponseBytes = "ResponseBytes"
   val MessageConversionsTimeMs = "MessageConversionsTimeMs"
   val TemporaryMemoryBytes = "TemporaryMemoryBytes"
   val ErrorsPerSec = "ErrorsPerSec"
@@ -420,6 +429,8 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
   val totalTimeHist = newHistogram(TotalTimeMs, biased = true, tags)
   // request size in bytes
   val requestBytesHist = newHistogram(RequestBytes, biased = true, tags)
+  // response size in bytes
+  val responseBytesHist = newHistogram(ResponseBytes, biased = true, tags)
   // time for message conversions (only relevant to fetch and produce requests)
   val messageConversionsTimeHist =
     if (name == ApiKeys.FETCH.name || name == ApiKeys.PRODUCE.name)
@@ -483,6 +494,7 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
     removeMetric(TotalTimeMs, tags)
     removeMetric(ResponseSendTimeMs, tags)
     removeMetric(RequestBytes, tags)
+    removeMetric(ResponseBytes, tags)
     removeMetric(ResponseSendTimeMs, tags)
     if (name == ApiKeys.FETCH.name || name == ApiKeys.PRODUCE.name) {
       removeMetric(MessageConversionsTimeMs, tags)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3048,6 +3048,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val response = responseOpt match {
       case Some(response) =>
         val responseSend = request.context.buildResponse(response)
+        request.responseBytes = responseSend.size()
         val responseString =
           if (RequestChannel.isRequestLoggingEnabled) Some(response.toString(request.context.apiVersion))
           else None

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -101,6 +101,18 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     verifyBrokerAuthenticationMetrics(server)
   }
 
+  @Test
+  def testAllTopicsMetadataMetrics(): Unit = {
+    val adminClient = createAdminClient()
+    adminClient.listTopics().names().get()
+
+    val requestRateMeter = yammerMeterWithPrefix("kafka.network:type=RequestMetrics,name=RequestsPerSec,request=MetadataAllTopics")
+    assertTrue("The MetadataAllTopics RequestsPerSec metric is not recorded", requestRateMeter.count() == 1)
+
+    val responseBytesHist = yammerHistogram("kafka.network:type=RequestMetrics,name=ResponseBytes,request=MetadataAllTopics")
+    assertTrue("The MetadataAllTopics ResponseBytes metric is not recorded", responseBytesHist.count() == 1)
+  }
+
   private def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int,
       recordSize: Int, tp: TopicPartition) = {
     val bytes = new Array[Byte](recordSize)
@@ -288,6 +300,16 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
       .getOrElse(fail(s"Unable to find broker metric $name: allMetrics: ${allMetrics.keySet.map(_.getMBeanName)}"))
     metric match {
       case m: Histogram => m
+      case m => fail(s"Unexpected broker metric of class ${m.getClass}")
+    }
+  }
+
+  private def yammerMeterWithPrefix(prefix: String): Meter = {
+    val allMetrics = Metrics.defaultRegistry.allMetrics.asScala
+    val (_, metric) = allMetrics.find { case (n, _) => n.getMBeanName.startsWith(prefix) }
+      .getOrElse(fail(s"Unable to find broker metric with prefix $prefix: allMetrics: ${allMetrics.keySet.map(_.getMBeanName)}"))
+    metric match {
+      case m: Meter => m
       case m => fail(s"Unexpected broker metric of class ${m.getClass}")
     }
   }


### PR DESCRIPTION
TICKET = LIKAFKA-39573
LI_DESCRIPTION =
Currently, Kafka emits a metric to show the rate of Metadata requests.

However, not all metadata requests are equal. If the topics field of the Metadata request is null, it indicates that the Metadata request is retrieving the metadata of all topics. In this PR, we add a new metric to indicate the rate of such topics=null Metadata requests.

Besides, we are adding another metric to show the size distribution of Metadata responses sent back to clients. This will help us identify brokers that are overloaded with large Metadata responses.

EXIT_CRITERIA = When this change is merged in upstream Kafka and pulled into this repo.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
