### PR TITLE
[LI-HOTFIX] CI: Split test builds to multiple jobs

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -15,18 +15,18 @@
 # specific language governing permissions and limitations
 # under the License
 
-name: Release build on tags
+name: Code analysis
 
-# Run this workflow every time a tag is created/pushed
 on:
+  pull_request:
   push:
-    tags:
-      - '*'
+    # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
+    branches: ['2.4-li']
 
 jobs:
-  build:
+  all:
     # Name the Job
-    name: Build tagged commit and upload an archive
+    name: all
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     steps:
@@ -41,19 +41,5 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '8'
-      - name: Set up release version env variable
-        run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Print the release version
-        run: |
-          echo "Release version (tag name): ${{ env.RELEASE_VERSION }}"
-      - name: Build with Gradle and run all tests
-        # exclude the streams test and connect test
-        # Set maxTestRetries & maxTestRetryFailures for flaky tests.  This is the setup in upstream Jenkinsfile
-        run: ./gradlew -PmaxTestRetries=3 cleanTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest :clients:test :core:test --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
-      - name: Upload archive
-        env:
-          JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
-          JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
-        run: |
-          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} :clients:uploadArchives :core:uploadArchives --no-daemon
+      - name: Run rat code analysis steps
+        run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --no-daemon -PxmlSpotBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed

--- a/.github/workflows/int-test.yml
+++ b/.github/workflows/int-test.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+name: intTest
+
+on:
+  pull_request:
+  push:
+    # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
+    branches: ['2.4-li']
+
+jobs:
+  clients:
+    # Name the Job
+    name: clients
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
+          fetch-depth: 0
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - name: Run tests
+        run: ./gradlew cleanTest clients:integrationTest --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
+  core:
+    # Name the Job
+    name: core (${{ matrix.prefixes }})
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # We still want to see all jobs' build result to the end
+      matrix:
+        prefixes:
+          - A B C
+          - D E F
+          - G H I J K
+          - L M N O
+          - P Q
+          - R S
+          - T U V W X Y Z
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
+          fetch-depth: 0
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - name: Run tests
+        env:
+          PREFIXES: ${{ matrix.prefixes }}
+        # Use set -f to disable shell expansion on *
+        run: >
+          set -f
+          && ./gradlew -PtestLoggingEvents=started,passed,skipped,failed --no-daemon cleanTest core:integrationTest `for i in $PREFIXES; do printf ' --tests %s*' $i; done`
+          && set +f
+

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,17 +15,18 @@
 # specific language governing permissions and limitations
 # under the License
 
-name: Pull Request Build with Unit Test Workflow
+name: unitTest
 
-# Run this workflow every time a new pull request is created in the repository
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+  push:
+    # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
+    branches: ['2.4-li']
 
 jobs:
-  build:
+  clients:
     # Name the Job
-    name: Build Pull Request and run all unit tests
+    name: clients
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     steps:
@@ -36,10 +37,29 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
           fetch-depth: 0
-      - name: Set up JDK 1.8
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
-      - name: Build with Gradle and run all unit tests
-        # exclude the streams test and connect test
-        run: ./gradlew cleanTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest :clients:unitTest :core:unitTest --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
+          java-version: '8'
+      - name: Run tests
+        run: ./gradlew cleanTest clients:unitTest --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
+
+  core:
+    # Name the Job
+    name: core
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
+          fetch-depth: 0
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - name: Run tests
+        run: ./gradlew cleanTest core:unitTest --no-daemon -PtestLoggingEvents=started,passed,skipped,failed

--- a/README.md
+++ b/README.md
@@ -36,15 +36,6 @@ To publish a release, go to [the release page](https://github.com/linkedin/kafka
 Once the release tag is created, a test job will be triggered to run the necessary tests. And once the test passes, the artifacts
 will be published to [the bintray hosting LinkedIn projects](https://dl.bintray.com/linkedin/maven/com/linkedin/kafka/kafka_2.12/).
 
-Currently we've configured the CI flow to run only unit tests for 'clients' and 'core' when a pull request is created or updated:
-```./gradlew :clients:unitTest :core:unitTest```
-    
-In contrast, all tests for 'cliests' and 'core' are run when creating a release, which may be significantly longer than running the unit tests:
-```./gradlew :clients:test :core:test```
-
-The reason for this mixed approach is to get faster feedback from CI during code reviews
-and still gain the more through test coverage when publishing a release.
-
 ### Contributing ###
 
 At this moment we are not accepting external contributions directly. Please

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,6 @@ group=com.linkedin.kafka
 version=2.4.2-SNAPSHOT
 scalaVersion=2.12.10
 task=build
-org.gradle.jvmargs=-Xmx1024m -Xss2m
+org.gradle.jvmargs=-Xmx2g -Xss4m
 skipSigning=true
 jfrogRepoUrl=https://linkedin.jfrog.io/artifactory/kafka


### PR DESCRIPTION
LI_DESCRIPTION =
Previously we've experienced some patches passed unit test build but failed the main release build,
so we want to run integration tests on PR too.  However, running all tests at once
makes the PR feedback time too long, so we split them to subsets (by the prefix of test name)
and put them to multiple jobs for faster feedback.

The retry mechanics is unfortunately only available in 2.7+, because it
requires junit >= 5.7 (with experiment at least 4.13 doesn't work).

TICKET = N/A
EXIT_CRITERIA = N/A