### PR TITLE
[LI-HOTFIX] Reject stale metadata from different cluster.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -238,6 +238,8 @@ public class Metadata implements Closeable {
         if (isClosed())
             throw new IllegalStateException("Update requested after metadata close");
 
+        validateCluster(response.clusterId());
+
         if (requestVersion == this.requestVersion)
             this.needUpdate = false;
         else
@@ -263,6 +265,35 @@ public class Metadata implements Closeable {
         clusterResourceListeners.onUpdate(cache.cluster().clusterResource());
 
         log.debug("Updated cluster metadata updateVersion {} to {}", this.updateVersion, this.cache);
+    }
+
+    private void validateCluster(String newClusterId) {
+        String previousClusterId = this.cache.cluster().clusterResource().clusterId();
+
+        if (previousClusterId != null && newClusterId != null && !previousClusterId.equals(newClusterId)) {
+            // kafka cluster id is unique.
+            // On client side, the cluster id in Metadata is only null during bootstrap, and client is
+            // expected to talk to the same cluster during its life cycle. Therefore if cluster id changes
+            // during metadata update, meaning this metadata update response is from a different cluster,
+            // client should reject this response and not update cached cluster to the wrong cluster
+
+            // Since removing brokers and adding to another cluster can be common operation,
+            // it might be more suitable to just throw an exception for update and fail this update operation
+            // instead of bringing down the client completely, so that the metadata can be updated later from
+            // other brokers in the same cluster.
+
+            // this code path will only get executed when all brokers in original cluster has been removed and
+            // one/some brokers have been added to another. If only some of the original brokers were removed/added
+            // to another cluster, the client should get updated metadata with valid brokers from other hosts.
+            // so we can just throw an exception and close the network client
+
+            log.error("Received metadata from a different cluster {}, current cluster {} has no valid brokers anymore,"
+                + "please reboot the producer/consumer", newClusterId, previousClusterId);
+
+            throw new StaleClusterMetadataException(
+                "Trying to access a different cluster " + newClusterId + ", previous connected cluster " + previousClusterId);
+
+        }
     }
 
     private void maybeSetMetadataError(Cluster cluster) {

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -633,7 +633,16 @@ public class NetworkClient implements KafkaClient {
         long updatedNow = this.time.milliseconds();
         List<ClientResponse> responses = new ArrayList<>();
         handleCompletedSends(responses, updatedNow);
-        handleCompletedReceives(responses, updatedNow);
+
+        try {
+            handleCompletedReceives(responses, updatedNow);
+        } catch (StaleClusterMetadataException e) {
+            // upon stale metadata exception from a different cluster, close the network client
+            // the producer/consumer will hit closedSelector exception and close
+            log.error("Received stale metadata from a different cluster, close the network client now");
+            this.close();
+        }
+
         handleDisconnections(responses, updatedNow);
         handleConnections();
         handleInitiateApiVersionRequests(updatedNow);

--- a/clients/src/main/java/org/apache/kafka/clients/StaleClusterMetadataException.java
+++ b/clients/src/main/java/org/apache/kafka/clients/StaleClusterMetadataException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.errors.InvalidMetadataException;
+
+/**
+ * Thrown when current metadata is from a stale cluster that has a different cluster id
+ * than original cluster.
+ *
+ * Note: this is not a public API.
+ */
+public class StaleClusterMetadataException extends InvalidMetadataException {
+    private static final long serialVersionUID = 1L;
+
+    public StaleClusterMetadataException() {}
+
+    public StaleClusterMetadataException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1013,7 +1013,7 @@ public class FetcherTest {
     public void testEpochSetInFetchRequest() {
         buildFetcher();
         subscriptions.assignFromUser(singleton(tp0));
-        MetadataResponse metadataResponse = TestUtils.metadataUpdateWith("dummy", 1,
+        MetadataResponse metadataResponse = TestUtils.metadataUpdateWith(null, 1,
                 Collections.emptyMap(), Collections.singletonMap(topicName, 4), tp -> 99);
         client.updateMetadata(metadataResponse);
 
@@ -2309,7 +2309,7 @@ public class FetcherTest {
         client.updateMetadata(initialUpdateResponse);
 
         // Metadata update with leader epochs
-        MetadataResponse metadataResponse = TestUtils.metadataUpdateWith("dummy", 1,
+        MetadataResponse metadataResponse = TestUtils.metadataUpdateWith(null, 1,
                 Collections.emptyMap(), Collections.singletonMap(topicName, 4), tp -> 99);
         client.updateMetadata(metadataResponse);
 
@@ -3296,7 +3296,7 @@ public class FetcherTest {
         // Initialize the epoch=1
         Map<String, Integer> partitionCounts = new HashMap<>();
         partitionCounts.put(tp0.topic(), 4);
-        MetadataResponse metadataResponse = TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> 1);
+        MetadataResponse metadataResponse = TestUtils.metadataUpdateWith(null, 1, Collections.emptyMap(), partitionCounts, tp -> 1);
         metadata.update(metadataResponse, 0L);
 
         // Seek
@@ -3327,7 +3327,7 @@ public class FetcherTest {
 
         final int epochOne = 1;
 
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1,
+        metadata.update(TestUtils.metadataUpdateWith(null, 1,
                 Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
 
         Node node = metadata.fetch().nodes().get(0);
@@ -3374,7 +3374,7 @@ public class FetcherTest {
         final int epochTwo = 2;
 
         // Start with metadata, epoch=1
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1,
+        metadata.update(TestUtils.metadataUpdateWith(null, 1,
                 Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
 
         // Offset validation requires OffsetForLeaderEpoch request v3 or higher
@@ -3388,7 +3388,7 @@ public class FetcherTest {
         subscriptions.seekUnvalidated(tp0, new SubscriptionState.FetchPosition(0, Optional.of(epochOne), leaderAndEpoch));
 
         // Update metadata to epoch=2, enter validation
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1,
+        metadata.update(TestUtils.metadataUpdateWith(null, 1,
                 Collections.emptyMap(), partitionCounts, tp -> epochTwo), 0L);
         fetcher.validateOffsetsIfNeeded();
 
@@ -3406,7 +3406,7 @@ public class FetcherTest {
 
         final int epochOne = 1;
 
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
+        metadata.update(TestUtils.metadataUpdateWith(null, 1, Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
 
         // Offset validation requires OffsetForLeaderEpoch request v3 or higher
         Node node = metadata.fetch().nodes().get(0);
@@ -3448,7 +3448,7 @@ public class FetcherTest {
         final int epochThree = 3;
 
         // Start with metadata, epoch=1
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
+        metadata.update(TestUtils.metadataUpdateWith(null, 1, Collections.emptyMap(), partitionCounts, tp -> epochOne), 0L);
 
         // Offset validation requires OffsetForLeaderEpoch request v3 or higher
         Node node = metadata.fetch().nodes().get(0);
@@ -3459,7 +3459,7 @@ public class FetcherTest {
         subscriptions.seekValidated(tp0, new SubscriptionState.FetchPosition(0, Optional.of(epochOne), leaderAndEpoch));
 
         // Update metadata to epoch=2, enter validation
-        metadata.update(TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> epochTwo), 0L);
+        metadata.update(TestUtils.metadataUpdateWith(null, 1, Collections.emptyMap(), partitionCounts, tp -> epochTwo), 0L);
         fetcher.validateOffsetsIfNeeded();
         assertTrue(subscriptions.awaitingValidation(tp0));
 
@@ -3517,7 +3517,7 @@ public class FetcherTest {
         // Initialize the epoch=2
         Map<String, Integer> partitionCounts = new HashMap<>();
         partitionCounts.put(tp0.topic(), 4);
-        MetadataResponse metadataResponse = TestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), partitionCounts, tp -> 2);
+        MetadataResponse metadataResponse = TestUtils.metadataUpdateWith(null, 1, Collections.emptyMap(), partitionCounts, tp -> 2);
         metadata.update(metadataResponse, 0L);
 
         // Offset validation requires OffsetForLeaderEpoch request v3 or higher


### PR DESCRIPTION
This patch adds validation during metadata update to reject md from different cluster to avoid clients consuming/producing to unexpected cluster when all brokers in current cluster are removed and added to a different cluster.

TICKET =
LI_DESCRIPTION = LIKAFKA-32543,
EXIT_CRITERIA = MANUAL this is not going to merged with upstream

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
