### PR TITLE
Resolve the bootstrap server when cluster metadata hasn't been refreshed for a long time

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -116,6 +116,12 @@ public class CommonClientConfigs {
                                                                  + "of 3 lowest-expected-latency nodes)";
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = LeastLoadedNodeAlgorithm.VANILLA.name();
 
+    public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG = "li.client.cluster.metadata.expire.time.ms";
+    public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_DOC = "The configuration controls the max time the client cluster metadata can remain idle/unchanged before "
+                                                                 + "trying to resolve the bootstrap servers from given url again; different from the other metadata.max.age.ms config, "
+                                                                 + "which will try to refresh metadata by choosing from existing resolved node set, this config will force resolving "
+                                                                 + "the bootstrap url again to get new node set and use the new node set to send update metadata request";
+
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
@@ -64,6 +64,11 @@ public class ManualMetadataUpdater implements MetadataUpdater {
     }
 
     @Override
+    public boolean isUpdateClusterMetadataDue(long now) {
+        return false;
+    }
+
+    @Override
     public long maybeUpdate(long now) {
         return Long.MAX_VALUE;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -76,6 +76,10 @@ public class Metadata implements Closeable {
     private boolean isClosed;
     private final Map<TopicPartition, Integer> lastSeenLeaderEpochs;
 
+    private final long maxClusterMetadataExpireTimeMs;
+    private int nodesTriedSinceLastSuccessfulRefresh;
+    private boolean forceClusterMetadataUpdateFromBootstrap;
+
     /**
      * Create a new Metadata instance
      *
@@ -89,6 +93,14 @@ public class Metadata implements Closeable {
                     long metadataExpireMs,
                     LogContext logContext,
                     ClusterResourceListeners clusterResourceListeners) {
+        this(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, Long.MAX_VALUE);
+    }
+
+    public Metadata(long refreshBackoffMs,
+        long metadataExpireMs,
+        LogContext logContext,
+        ClusterResourceListeners clusterResourceListeners,
+        long metadataClusterMetadataExpireTimeMs) {
         this.log = logContext.logger(Metadata.class);
         this.refreshBackoffMs = refreshBackoffMs;
         this.metadataExpireMs = metadataExpireMs;
@@ -102,6 +114,9 @@ public class Metadata implements Closeable {
         this.lastSeenLeaderEpochs = new HashMap<>();
         this.invalidTopics = Collections.emptySet();
         this.unauthorizedTopics = Collections.emptySet();
+        this.maxClusterMetadataExpireTimeMs = metadataClusterMetadataExpireTimeMs;
+        this.nodesTriedSinceLastSuccessfulRefresh = 0;
+        this.forceClusterMetadataUpdateFromBootstrap = false;
     }
 
     /**
@@ -109,6 +124,26 @@ public class Metadata implements Closeable {
      */
     public synchronized Cluster fetch() {
         return cache.cluster();
+    }
+
+    /**
+     * Increment the nodesTriedSinceLastSuccessfulRefresh
+     */
+    public synchronized void incrementNodesTriedSinceLastSuccessfulRefresh() {
+        this.nodesTriedSinceLastSuccessfulRefresh++;
+    }
+
+    /**
+     * Whether the client should update the cluster metadata by resolving the bootstrap server again
+     * @param nowMs
+     * @return true if client hasn't refreshed cluster metadata for maxClusterMetadataExpireTimeMs and
+     * has tried connecting to at least one node in current node set; or forceClusterMetadataUpdateFromBootstrap
+     * has been set by receiving stale metadata from a different cluster
+     */
+    public synchronized boolean shouldUpdateClusterMetadataFromBootstrap(long nowMs) {
+        return (this.nodesTriedSinceLastSuccessfulRefresh >= 1 &&
+            this.lastSuccessfulRefreshMs + this.maxClusterMetadataExpireTimeMs <= nowMs) ||
+            this.forceClusterMetadataUpdateFromBootstrap;
     }
 
     /**
@@ -144,6 +179,15 @@ public class Metadata implements Closeable {
     public synchronized int requestUpdate() {
         this.needUpdate = true;
         return this.updateVersion;
+    }
+
+    /**
+     * Request an update of the current cluster metadata info by resolving the bootstrap server and randomly pick
+     * a node from the resolved node set. This happens when client receives stale metadata response from brokers in
+     * a different cluster and need to refresh the cluster metadata without waiting for maxClusterMetadataExpireTimeMs
+     */
+    public synchronized void requestClusterMetadataUpdateFromBootstrap() {
+        this.forceClusterMetadataUpdateFromBootstrap = true;
     }
 
     /**
@@ -238,7 +282,18 @@ public class Metadata implements Closeable {
         if (isClosed())
             throw new IllegalStateException("Update requested after metadata close");
 
-        validateCluster(response.clusterId());
+        if (!validateCluster(response.clusterId())) {
+            //if validateCluster fails, do not update metadataCache with the wrong cluster information,
+            //just return and wait for next update
+            //
+            //here we don't blacklist this node from the cluster's
+            //node set since we don't have enough information from the response to map to the actual node,
+            //and since there are usually hours to days interval before we put a removed broker to a different
+            //cluster, clients should either find another node in cached node set or resolved bootstrap server
+            //again and find a new node to send update metadata request, it should be ok to not blacklist this node
+            requestClusterMetadataUpdateFromBootstrap();
+            return;
+        }
 
         if (requestVersion == this.requestVersion)
             this.needUpdate = false;
@@ -248,6 +303,8 @@ public class Metadata implements Closeable {
         this.lastRefreshMs = now;
         this.lastSuccessfulRefreshMs = now;
         this.updateVersion += 1;
+        this.nodesTriedSinceLastSuccessfulRefresh = 0;
+        this.forceClusterMetadataUpdateFromBootstrap = false;
 
         String previousClusterId = cache.cluster().clusterResource().clusterId();
 
@@ -267,8 +324,9 @@ public class Metadata implements Closeable {
         log.debug("Updated cluster metadata updateVersion {} to {}", this.updateVersion, this.cache);
     }
 
-    private void validateCluster(String newClusterId) {
+    private boolean validateCluster(String newClusterId) {
         String previousClusterId = this.cache.cluster().clusterResource().clusterId();
+        boolean validateResult = true;
 
         if (previousClusterId != null && newClusterId != null && !previousClusterId.equals(newClusterId)) {
             // kafka cluster id is unique.
@@ -288,12 +346,12 @@ public class Metadata implements Closeable {
             // so we can just throw an exception and close the network client
 
             log.error("Received metadata from a different cluster {}, current cluster {} has no valid brokers anymore,"
-                + "please reboot the producer/consumer", newClusterId, previousClusterId);
+                + "please consider reboot the producer/consumer", newClusterId, previousClusterId);
 
-            throw new StaleClusterMetadataException(
-                "Trying to access a different cluster " + newClusterId + ", previous connected cluster " + previousClusterId);
-
+            validateResult = false;
         }
+
+        return validateResult;
     }
 
     private void maybeSetMetadataError(Cluster cluster) {

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -43,6 +43,12 @@ public interface MetadataUpdater extends Closeable {
     boolean isUpdateDue(long now);
 
     /**
+     * Returns true if the cluster metadata hasn't refreshed for li.client.cluster.metadata.expire.time.ms
+     * and has tried at least one node in the cached metadata node set
+     */
+    boolean isUpdateClusterMetadataDue(long now);
+
+    /**
      * Starts a cluster metadata update if needed and possible. Returns the time until the metadata update (which would
      * be 0 if an update has been started as a result of this call).
      *

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -789,7 +789,7 @@ public class NetworkClient implements KafkaClient {
             throw new IllegalStateException("leastLoadedNodeAlgorithm cannot be null");
         }
 
-        if (this.metadataUpdater.isUpdateClusterMetadataDue(now) && !this.bootstrapServers.isEmpty()) {
+        if (this.metadataUpdater.isUpdateClusterMetadataDue(now)) {
             //update cluster metadata due, resolve bootstrap server and randomly pick up
             //one node from the resolved node set as least loaded node
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -95,6 +95,11 @@ public class AdminMetadataManager {
         }
 
         @Override
+        public boolean isUpdateClusterMetadataDue(long now) {
+            return false;
+        }
+
+        @Override
         public long maybeUpdate(long now) {
             return Long.MAX_VALUE;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -312,6 +312,8 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
 
+    public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG = CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG;
+
 
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
@@ -356,6 +358,12 @@ public class ConsumerConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.LOW,
                                         CommonClientConfigs.METADATA_MAX_AGE_DOC)
+                                .define(LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG,
+                                        Type.LONG,
+                                        60 * 60 * 1000,
+                                        atLeast(0),
+                                        Importance.LOW,
+                                        CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_DOC)
                                 .define(ENABLE_AUTO_COMMIT_CONFIG,
                                         Type.BOOLEAN,
                                         true,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -733,7 +733,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     config.getLong(ConsumerConfig.METADATA_MAX_AGE_CONFIG),
                     !config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
                     config.getBoolean(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
-                    subscriptions, logContext, clusterResourceListeners);
+                    subscriptions, logContext, clusterResourceListeners,
+                    config.getLong(ConsumerConfig.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG));
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
                     config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG), config.getString(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG));
             this.metadata.bootstrap(addresses, time.milliseconds());
@@ -768,7 +769,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     apiVersions,
                     throttleTimeSensor,
                     logContext,
-                    leastLoadedNodeAlgorithm);
+                    leastLoadedNodeAlgorithm,
+                    config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
 
             this.client = new ConsumerNetworkClient(
                     logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
@@ -39,7 +39,19 @@ public class ConsumerMetadata extends Metadata {
                             SubscriptionState subscription,
                             LogContext logContext,
                             ClusterResourceListeners clusterResourceListeners) {
-        super(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners);
+        this(refreshBackoffMs, metadataExpireMs, includeInternalTopics, allowAutoTopicCreation,
+            subscription, logContext, clusterResourceListeners, Long.MAX_VALUE);
+    }
+
+    public ConsumerMetadata(long refreshBackoffMs,
+        long metadataExpireMs,
+        boolean includeInternalTopics,
+        boolean allowAutoTopicCreation,
+        SubscriptionState subscription,
+        LogContext logContext,
+        ClusterResourceListeners clusterResourceListeners,
+        long clusterMetadataExpireMs) {
+        super(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, clusterMetadataExpireMs);
         this.includeInternalTopics = includeInternalTopics;
         this.allowAutoTopicCreation = allowAutoTopicCreation;
         this.subscription = subscription;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -419,7 +419,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         clusterResourceListeners,
                         Time.SYSTEM,
                         config.getLong(ProducerConfig.METADATA_TOPIC_EXPIRY_MS_CONFIG),
-                        config.getBoolean(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG));
+                        config.getBoolean(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
+                        config.getLong(ProducerConfig.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG));
                 this.metadata.bootstrap(addresses, time.milliseconds());
             }
             this.errors = this.metrics.sensor("errors");
@@ -465,7 +466,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 apiVersions,
                 throttleTimeSensor,
                 logContext,
-                leastLoadedNodeAlgorithm);
+                leastLoadedNodeAlgorithm,
+                producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
         int retries = configureRetries(producerConfig, transactionManager != null, log);
         short acks = configureAcks(producerConfig, transactionManager != null, log);
         return new Sender(logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -263,6 +263,8 @@ public class ProducerConfig extends AbstractConfig {
     public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
 
+    public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG = CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Collections.emptyList(), new ConfigDef.NonNullValidator(), Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
                                 .define(CLIENT_DNS_LOOKUP_CONFIG,
@@ -310,6 +312,12 @@ public class ProducerConfig extends AbstractConfig {
                                         Importance.MEDIUM,
                                         REQUEST_TIMEOUT_MS_DOC)
                                 .define(METADATA_MAX_AGE_CONFIG, Type.LONG, 5 * 60 * 1000, atLeast(0), Importance.LOW, METADATA_MAX_AGE_DOC)
+                                .define(LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG,
+                                        Type.LONG,
+                                        60 * 60 * 1000,
+                                        atLeast(0),
+                                        Importance.LOW,
+                                        CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_DOC)
                                 .define(METRICS_SAMPLE_WINDOW_MS_CONFIG,
                                         Type.LONG,
                                         30000,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -68,6 +68,21 @@ public class ProducerMetadata extends Metadata {
         this.allowAutoTopicCreation = allowAutoTopicCreation;
     }
 
+    public ProducerMetadata(long refreshBackoffMs,
+        long metadataExpireMs,
+        LogContext logContext,
+        ClusterResourceListeners clusterResourceListeners,
+        Time time,
+        long topicExpiryMs,
+        boolean allowAutoTopicCreation,
+        long clusterMetadataExpireMs) {
+        super(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, clusterMetadataExpireMs);
+        this.log = logContext.logger(ProducerMetadata.class);
+        this.time = time;
+        this.topicExpiryMs = topicExpiryMs;
+        this.allowAutoTopicCreation = allowAutoTopicCreation;
+    }
+
     @Override
     public synchronized MetadataRequest.Builder newMetadataRequestBuilder() {
         return new MetadataRequest.Builder(new ArrayList<>(topics.keySet()), allowAutoTopicCreation);

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
@@ -37,6 +38,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.MockClusterResourceListener;
+import org.apache.kafka.test.MockSelector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Test;
 
@@ -59,10 +61,23 @@ import static org.junit.Assert.assertTrue;
 
 public class MetadataTest {
 
+    protected final int defaultRequestTimeoutMs = 1000;
+    protected final MockTime time = new MockTime();
+    protected final MockSelector selector = new MockSelector(time);
+    protected final Node node = TestUtils.singletonCluster().nodes().iterator().next();
+
     private long refreshBackoffMs = 100;
     private long metadataExpireMs = 1000;
     private Metadata metadata = new Metadata(refreshBackoffMs, metadataExpireMs, new LogContext(),
             new ClusterResourceListeners());
+
+    private Metadata clusterMetadata = new Metadata(refreshBackoffMs, metadataExpireMs, new LogContext(),
+        new ClusterResourceListeners(), 0);
+
+    private NetworkClient clusterClient = new NetworkClient(selector, clusterMetadata, "mock-cluster-md", Integer.MAX_VALUE,
+        0, 0, 64 * 1024, 64 * 1024,
+        defaultRequestTimeoutMs, ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), null, new LogContext(),
+        LeastLoadedNodeAlgorithm.VANILLA, Collections.singletonList("some.invalid.hostname.foo.bar.local:9999"));
 
     private static MetadataResponse emptyMetadataResponse() {
         return MetadataResponse.prepareResponse(
@@ -76,6 +91,23 @@ public class MetadataTest {
     public void testMetadataUpdateAfterClose() {
         metadata.close();
         metadata.update(emptyMetadataResponse(), 1000);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testResolveBootstrapAfterClusterMetadataTimeout() {
+        List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(Collections.singletonList("example.com:10000"));
+        //bootstrap the metadata cache with some valid nodes
+        clusterMetadata.bootstrap(addresses, time.milliseconds());
+
+        //first time call leastLoadedNode on the created NetworkClient should pass since nodesTriedSinceLastSuccessfulRefresh is 0
+        clusterClient.leastLoadedNode(time.milliseconds());
+
+        //simulate metadata refresh attempt by incrementing the nodesTriedSinceLastSuccessfulRefresh by 1
+        clusterMetadata.incrementNodesTriedSinceLastSuccessfulRefresh();
+
+        //now second call to leastLoadedNode on the NetworkClient should fail since we passed an invalid bootstrap server to it
+        //it should throw a ConfigException of no resolvable bootstrap server in provided urls
+        clusterClient.leastLoadedNode(time.milliseconds());
     }
 
     private static void checkTimeToNextUpdate(long refreshBackoffMs, long metadataExpireMs) {


### PR DESCRIPTION
[LI-HOTFIX] Resolve the bootstrap server when cluster metadata hasn't been refreshed for a long time

This patch adds a config li.client.cluster.metadata.expire.time.ms which controls the max time cluster metadata can remain unchanged. On NetworkClient.poll, if this timeout has been reached and the client has tried half of the nodes in the original cached node set and failed, it will try to resolve the bootstrap servers again and use the newly resolved nodes to pick a leastLoadedNode to send updateMetadataRequest.

This is to avoid following two scenarios:
1. consumer has been idle for a long time, and whole cluster has been swapped. This case, all the cached nodes are invalid and resolve bootstrap is needed.
2. consumer hasn't refreshed metadata for a long time and some brokers in the cluster had been moved to another cluster, and the client randomly picks up the moved broker to send md request and get a response for a different cluster. In this case, we simply reject the stale md response and resolve bootstrap when conditions are met.

TICKET =
    LI_DESCRIPTION = LIKAFKA-40759,
    EXIT_CRITERIA = MANUAL this is not going to merged with upstream


*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
