### PR TITLE
[LI-HOTFIX] Stop enqueuing unnecessary LeaderAndIsrResponseReceived events

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -20,6 +20,7 @@ package kafka.controller
 import kafka.utils.{LiDecomposedControlResponse, LiDecomposedControlResponseUtils, Logging}
 import org.apache.kafka.common.message.LiCombinedControlRequestData
 import org.apache.kafka.common.message.LiCombinedControlRequestData._
+import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.LiCombinedControlTransformer
 import org.apache.kafka.common.{Node, TopicPartition}
@@ -235,10 +236,12 @@ class ControllerRequestMerger extends Logging {
     // Currently, there is no callback for the UpdateMetadataResponse
     val LiDecomposedControlResponse(leaderAndIsrResponse, _, stopReplicaResponse) =
       LiDecomposedControlResponseUtils.decomposeResponse(response.asInstanceOf[LiCombinedControlResponse])
-    if (leaderAndIsrCallback != null) {
+    if (leaderAndIsrCallback != null
+      && (!leaderAndIsrResponse.partitions().isEmpty() || leaderAndIsrResponse.error() != Errors.NONE)) {
       leaderAndIsrCallback(leaderAndIsrResponse)
     }
-    if (stopReplicaCallback != null) {
+    if (stopReplicaCallback != null
+      && (!stopReplicaResponse.partitionErrors().isEmpty()) || stopReplicaResponse.error() != Errors.NONE) {
       stopReplicaCallback(stopReplicaResponse)
     }
   }

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -237,11 +237,13 @@ class ControllerRequestMerger extends Logging {
     val LiDecomposedControlResponse(leaderAndIsrResponse, _, stopReplicaResponse) =
       LiDecomposedControlResponseUtils.decomposeResponse(response.asInstanceOf[LiCombinedControlResponse])
     if (leaderAndIsrCallback != null
-      && (!leaderAndIsrResponse.partitions().isEmpty() || leaderAndIsrResponse.error() != Errors.NONE)) {
+      && (!leaderAndIsrResponse.partitions().isEmpty || leaderAndIsrResponse.error() != Errors.NONE)) {
+      // fire callback only if leaderAndIsrResponse is non-empty or contains errors
       leaderAndIsrCallback(leaderAndIsrResponse)
     }
     if (stopReplicaCallback != null
-      && (!stopReplicaResponse.partitionErrors().isEmpty()) || stopReplicaResponse.error() != Errors.NONE) {
+      && (!stopReplicaResponse.partitionErrors().isEmpty || stopReplicaResponse.error() != Errors.NONE)) {
+      // fire callback only if stopReplicaResponse is non-empty or contains errors
       stopReplicaCallback(stopReplicaResponse)
     }
   }

--- a/core/src/test/scala/unit/kafka/controller/ControllerRequestMergerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerRequestMergerTest.scala
@@ -22,8 +22,10 @@ import kafka.controller.ControllerRequestMerger
 import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.LiCombinedControlRequestData.StopReplicaPartitionState
+import org.apache.kafka.common.message.LiCombinedControlResponseData
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataPartitionState}
-import org.apache.kafka.common.requests.{LeaderAndIsrRequest, LiCombinedControlRequest, StopReplicaRequest, UpdateMetadataRequest}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{AbstractResponse, LeaderAndIsrRequest, LiCombinedControlResponse, StopReplicaRequest, UpdateMetadataRequest}
 import org.apache.kafka.common.utils.LiCombinedControlTransformer
 import org.junit.{Assert, Before, Test}
 
@@ -272,5 +274,95 @@ class ControllerRequestMergerTest {
       Assert.assertEquals("Mismatched controller epoch", controllerEpoch, liCombinedControlRequest.controllerEpoch())
       Assert.assertEquals("Mismatched partition states", expectedPartitions(i).asJava, liCombinedControlRequest.stopReplicaPartitionStates())
     }
+  }
+
+  @Test
+  def testNotTriggerCallbackForUpdateMetadataReqeust(): Unit = {
+    var leaderAndISRCallbackInvocationCount = 0
+    var stopReplicaCallbackInvocationCount = 0
+    controllerRequestMerger.leaderAndIsrCallback = (response: AbstractResponse) => {
+      leaderAndISRCallbackInvocationCount += 1
+    }
+
+    controllerRequestMerger.stopReplicaCallback = (response: AbstractResponse) => {
+      stopReplicaCallbackInvocationCount += 1
+    }
+
+    // response that contains metadata only
+    val responseUpdateMetadataData = new LiCombinedControlResponseData().setUpdateMetadataErrorCode(Errors.NONE.code())
+    val responseUpdateMetadata = new LiCombinedControlResponse(responseUpdateMetadataData)
+
+    controllerRequestMerger.triggerCallback(responseUpdateMetadata)
+
+    // metadata only response would not trigger any callback
+    Assert.assertEquals("Mismatched callback count", 0, leaderAndISRCallbackInvocationCount)
+    Assert.assertEquals("Mismatched callback count", 0, stopReplicaCallbackInvocationCount)
+
+    // LeaderAndISR response with some errors
+    val responseLeaderAndISRData1 =
+      new LiCombinedControlResponseData().setLeaderAndIsrErrorCode(Errors.UNKNOWN_SERVER_ERROR.code());
+    val responseLeaderAndISR1 = new LiCombinedControlResponse(responseLeaderAndISRData1)
+
+    // LeaderAndISR response with non-empty partitions
+    val partitionsError = createLeaderAndISRResponsePartitions("foo",
+      Seq(Errors.NONE, Errors.CLUSTER_AUTHORIZATION_FAILED))
+    val responseLeaderAndISRData2 = new LiCombinedControlResponseData().setLeaderAndIsrPartitionErrors(partitionsError)
+    val responseLeaderAndISR2 = new LiCombinedControlResponse(responseLeaderAndISRData2)
+
+    // leaderAndISRCallbackInvocationCount increased with error LeaderAndISR response
+    controllerRequestMerger.triggerCallback(responseLeaderAndISR1)
+    Assert.assertEquals("Mismatched callback count", 1, leaderAndISRCallbackInvocationCount)
+
+    // leaderAndISRCallbackInvocationCount increased with non-empty LeaderAndISR response
+    controllerRequestMerger.triggerCallback(responseLeaderAndISR2)
+    Assert.assertEquals("Mismatched callback count", 2, leaderAndISRCallbackInvocationCount)
+
+    // stopReplicaCallbackInvocationCount has not been increased
+    Assert.assertEquals("Mismatched callback count", 0, stopReplicaCallbackInvocationCount)
+
+    // StopReplica response with some errors
+    val responseStopReplicaData1 =
+      new LiCombinedControlResponseData().setStopReplicaErrorCode(Errors.UNKNOWN_SERVER_ERROR.code())
+    val responseStopReplica1 = new LiCombinedControlResponse(responseStopReplicaData1)
+
+    // StopReplica response with non-empty partitions
+    val stopReplicaPartitionsError = createStopReplicaResponsePartitions("foo",
+      Seq(Errors.NONE, Errors.CLUSTER_AUTHORIZATION_FAILED))
+    val responseStopReplicaData2 =
+      new LiCombinedControlResponseData().setStopReplicaPartitionErrors(stopReplicaPartitionsError);
+    val responseStopReplica2 = new LiCombinedControlResponse(responseStopReplicaData2)
+
+    // stopReplicaCallbackInvocationCount increased with error StopReplica response
+    controllerRequestMerger.triggerCallback(responseStopReplica1)
+    Assert.assertEquals("Mismatched callback count", 1, stopReplicaCallbackInvocationCount)
+
+    // stopReplicaCallbackInvocationCount increased with non-empty StopReplica response
+    controllerRequestMerger.triggerCallback(responseStopReplica2)
+    Assert.assertEquals("Mismatched callback count", 2, stopReplicaCallbackInvocationCount)
+
+    // leaderAndISRCallbackInvocationCount remains unchanged
+    Assert.assertEquals("Mismatched callback count", 2, leaderAndISRCallbackInvocationCount)
+  }
+
+  private def createLeaderAndISRResponsePartitions(topicName: String, errors: Seq[Errors]) = {
+    val partitions = new util.ArrayList[LiCombinedControlResponseData.LeaderAndIsrPartitionError]
+    var partitionIndex = 0
+    for (error <- errors) {
+      partitions.add(new LiCombinedControlResponseData.LeaderAndIsrPartitionError().setTopicName(topicName).setPartitionIndex({
+        partitionIndex += 1; partitionIndex - 1
+      }).setErrorCode(error.code))
+    }
+    partitions
+  }
+
+  private def createStopReplicaResponsePartitions(topicName: String, errors: Seq[Errors]) = {
+    val partitions = new util.ArrayList[LiCombinedControlResponseData.StopReplicaPartitionError]
+    var partitionIndex = 0
+    for (error <- errors) {
+      partitions.add(new LiCombinedControlResponseData.StopReplicaPartitionError().setTopicName(topicName).setPartitionIndex({
+        partitionIndex += 1; partitionIndex - 1
+      }).setErrorCode(error.code))
+    }
+    partitions
   }
 }

--- a/core/src/test/scala/unit/kafka/controller/ControllerRequestMergerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerRequestMergerTest.scala
@@ -277,7 +277,7 @@ class ControllerRequestMergerTest {
   }
 
   @Test
-  def testNotTriggerCallbackForUpdateMetadataReqeust(): Unit = {
+  def testNotTriggerCallbackForUpdateMetadataRequest(): Unit = {
     var leaderAndISRCallbackInvocationCount = 0
     var stopReplicaCallbackInvocationCount = 0
     controllerRequestMerger.leaderAndIsrCallback = (response: AbstractResponse) => {
@@ -300,7 +300,7 @@ class ControllerRequestMergerTest {
 
     // LeaderAndISR response with some errors
     val responseLeaderAndISRData1 =
-      new LiCombinedControlResponseData().setLeaderAndIsrErrorCode(Errors.UNKNOWN_SERVER_ERROR.code());
+      new LiCombinedControlResponseData().setLeaderAndIsrErrorCode(Errors.UNKNOWN_SERVER_ERROR.code())
     val responseLeaderAndISR1 = new LiCombinedControlResponse(responseLeaderAndISRData1)
 
     // LeaderAndISR response with non-empty partitions
@@ -329,7 +329,7 @@ class ControllerRequestMergerTest {
     val stopReplicaPartitionsError = createStopReplicaResponsePartitions("foo",
       Seq(Errors.NONE, Errors.CLUSTER_AUTHORIZATION_FAILED))
     val responseStopReplicaData2 =
-      new LiCombinedControlResponseData().setStopReplicaPartitionErrors(stopReplicaPartitionsError);
+      new LiCombinedControlResponseData().setStopReplicaPartitionErrors(stopReplicaPartitionsError)
     val responseStopReplica2 = new LiCombinedControlResponse(responseStopReplicaData2)
 
     // stopReplicaCallbackInvocationCount increased with error StopReplica response
@@ -349,7 +349,8 @@ class ControllerRequestMergerTest {
     var partitionIndex = 0
     for (error <- errors) {
       partitions.add(new LiCombinedControlResponseData.LeaderAndIsrPartitionError().setTopicName(topicName).setPartitionIndex({
-        partitionIndex += 1; partitionIndex - 1
+        partitionIndex += 1
+        partitionIndex - 1
       }).setErrorCode(error.code))
     }
     partitions
@@ -360,7 +361,8 @@ class ControllerRequestMergerTest {
     var partitionIndex = 0
     for (error <- errors) {
       partitions.add(new LiCombinedControlResponseData.StopReplicaPartitionError().setTopicName(topicName).setPartitionIndex({
-        partitionIndex += 1; partitionIndex - 1
+        partitionIndex += 1
+        partitionIndex - 1
       }).setErrorCode(error.code))
     }
     partitions


### PR DESCRIPTION
TICKET = LIKAFKA-40059
LI_DESCRIPTION =

With li combined request feature, a combined response will cause the controller to enqueue an event of LeaderAndIsrResponseReceived, regardless of whether the combined request contains LeaderAndIsr Request or not.

As a result, a LI combined request with only metadata update would end up generating an empty LeaderAndIsrResponseReceived event in the controller queue when the response is received by the controller.

Since the controller may send out "metadata update requests" to all live brokers, it fills up the controller queue with empty LeaderAndIsrResponseReceived events quickly (e.g., single metadata update request can generate X LeaderAndIsrResponseReceived events in the controller queue, where X = number of live brokers in the cluster).

EXIT_CRITERIA = MANUAL ["when li combined request/response is no longer needed"]
