### PR TITLE
[LI-HOTFIX] CI: Build on both Scala 2.11 & 2.12

### DIFF
--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -45,12 +45,15 @@ jobs:
         run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --no-daemon -PxmlSpotBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
   unit-test:
     # Name the Job
-    name: ${{ matrix.module }}:unitTest
+    name: ${{ matrix.module }}:unitTest_${{ matrix.scalaVersion }}
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # We still want to see all jobs' build result to the end
       matrix:
+        scalaVersion:
+          - 2.11
+          - 2.12
         module:
           - core
           - clients
@@ -68,13 +71,20 @@ jobs:
           java-version: '8'
       - name: Run tests
         env:
+          SCALA_VERSION: ${{ matrix.scalaVersion }}
           MODULE: ${{ matrix.module }}
-        run: ./gradlew -PmaxTestRetries=3 cleanTest "$MODULE:unitTest" --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
+        run: ./gradlew -PscalaVersion="$SCALA_VERSION" -PmaxTestRetries=3 cleanTest "$MODULE:unitTest" --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
   int-test-clients:
     # Name the Job
-    name: clients:integrationTest
+    name: clients:integrationTest_${{ matrix.scalaVersion }}
     # Set the type of machine to run on
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # We still want to see all jobs' build result to the end
+      matrix:
+        scalaVersion:
+          - 2.11
+          - 2.12
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
@@ -88,15 +98,20 @@ jobs:
         with:
           java-version: '8'
       - name: Run tests
-        run: ./gradlew cleanTest clients:integrationTest --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
+        env:
+          SCALA_VERSION: ${{ matrix.scalaVersion }}
+        run: ./gradlew -PscalaVersion="$SCALA_VERSION" cleanTest clients:integrationTest --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
   int-test-core:
     # Name the Job
-    name: core:integrationTest (${{ matrix.prefix }})
+    name: core:integrationTest_${{ matrix.scalaVersion }} (${{ matrix.prefix }})
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # We still want to see all jobs' build result to the end
       matrix:
+        scalaVersion:
+          - 2.11
+          - 2.12
         prefix:
           - A B C
           - D E F
@@ -119,11 +134,12 @@ jobs:
           java-version: '8'
       - name: Run tests
         env:
+          SCALA_VERSION: ${{ matrix.scalaVersion }}
           PREFIX: ${{ matrix.prefix }}
         # Use set -f to disable shell expansion on *
         run: >
           set -f
-          && ./gradlew -PtestLoggingEvents=started,passed,skipped,failed --no-daemon cleanTest core:integrationTest `for i in $PREFIX; do printf ' --tests %s*' $i; done`
+          && ./gradlew -PscalaVersion="$SCALA_VERSION" -PtestLoggingEvents=started,passed,skipped,failed --no-daemon cleanTest core:integrationTest `for i in $PREFIX; do printf ' --tests %s*' $i; done`
           && set +f
 
 
@@ -161,4 +177,4 @@ jobs:
           JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
         run: |
-          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} clients:uploadArchives core:uploadArchives --no-daemon
+          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} clients:uploadArchivesAll core:uploadArchivesAll --no-daemon

--- a/.github/workflows/int-test.yml
+++ b/.github/workflows/int-test.yml
@@ -26,9 +26,15 @@ on:
 jobs:
   clients:
     # Name the Job
-    name: clients
+    name: clients_${{ matrix.scalaVersion }}
     # Set the type of machine to run on
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # We still want to see all jobs' build result to the end
+      matrix:
+        scalaVersion:
+          - 2.11
+          - 2.12
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
@@ -42,15 +48,20 @@ jobs:
         with:
           java-version: '8'
       - name: Run tests
-        run: ./gradlew cleanTest clients:integrationTest --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
+        env:
+          SCALA_VERSION: ${{ matrix.scalaVersion }}
+        run: ./gradlew -Pversion=${{ env.RELEASE_VERSION }} cleanTest clients:integrationTest --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
   core:
     # Name the Job
-    name: core (${{ matrix.prefix }})
+    name: core_${{ matrix.scalaVersion }} (${{ matrix.prefix }})
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # We still want to see all jobs' build result to the end
       matrix:
+        scalaVersion:
+          - 2.11
+          - 2.12
         prefix:
           - A B C
           - D E F
@@ -73,10 +84,11 @@ jobs:
           java-version: '8'
       - name: Run tests
         env:
+          SCALA_VERSION: ${{ matrix.scalaVersion }}
           PREFIX: ${{ matrix.prefix }}
         # Use set -f to disable shell expansion on *
         run: >
           set -f
-          && ./gradlew -PtestLoggingEvents=started,passed,skipped,failed --no-daemon cleanTest core:integrationTest `for i in $PREFIX; do printf ' --tests %s*' $i; done`
+          && ./gradlew -PscalaVersion="$SCALA_VERSION" -PtestLoggingEvents=started,passed,skipped,failed --no-daemon cleanTest core:integrationTest `for i in $PREFIX; do printf ' --tests %s*' $i; done`
           && set +f
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,12 +26,15 @@ on:
 jobs:
   unit-test:
     # Name the Job
-    name: ${{ matrix.module }}
+    name: ${{ matrix.module }}_${{ matrix.scalaVersion }}
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # We still want to see all jobs' build result to the end
       matrix:
+        scalaVersion:
+          - 2.11
+          - 2.12
         module:
           - core
           - clients
@@ -49,7 +52,8 @@ jobs:
           java-version: '8'
       - name: Run tests
         env:
+          SCALA_VERSION: ${{ matrix.scalaVersion }}
           MODULE: ${{ matrix.module }}
-        run: ./gradlew cleanTest "$MODULE:unitTest" --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
+        run: ./gradlew -PscalaVersion="$SCALA_VERSION" cleanTest "$MODULE:unitTest" --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -486,6 +486,13 @@ subprojects {
       ]
     }
 
+    // This is a temporary hack to build with 2.11
+    if (versions.baseScala in ['2.11']) {
+      scalaCompileOptions.additionalParameters += [
+        "-target:jvm-1.8"
+      ]
+    }
+
   // these options are valid for Scala versions < 2.13 only
   // Scala 2.13 removes them, see https://github.com/scala/scala/pull/6502 and https://github.com/scala/scala/pull/5969
     if (versions.baseScala in ['2.11','2.12']) {

--- a/clients/src/main/java/org/apache/kafka/common/quota/ClientQuotaEntity.java
+++ b/clients/src/main/java/org/apache/kafka/common/quota/ClientQuotaEntity.java
@@ -60,7 +60,27 @@ public class ClientQuotaEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(entries);
+        /*
+         * On Scala 2.11 this original implementation
+         * ```
+         * return Objects.hash(entries);
+         * ```
+         * breaks the contract that if .equals() returns true then .hashCode should be equal
+         * issue: https://github.com/scala/bug/issues/10663
+         *
+         * So we have to manually port the implementation in new Scala back
+         * https://github.com/scala/scala/pull/6233
+         */
+
+        // java.util.Map has the following contract for its hashCode:
+        // The hash code of a map is defined to be the sum of the hash codes of each entry in the map's entrySet() view.
+        int sumHashCode = 0;
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            final String k = entry.getKey();
+            final String v = entry.getValue();
+            sumHashCode += (k == null ? 0 : k.hashCode()) ^ (v == null ? 0 : v.hashCode());
+        }
+        return sumHashCode;
     }
 
     @Override

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -22,6 +22,7 @@ import java.nio._
 import java.nio.channels._
 import java.util.concurrent.locks.{Lock, ReadWriteLock}
 import java.lang.management._
+import java.util.function.{Consumer, Supplier}
 import java.util.{Base64, Properties, UUID}
 
 import com.typesafe.scalalogging.Logger
@@ -331,6 +332,23 @@ object CoreUtils {
       case None =>
         val value = createValue
         map.putIfAbsent(key, value).getOrElse(value)
+    }
+  }
+
+  /**
+   * Converts a Scala Consumer to Java Consumer.
+   * This is for helping with Scala 2.11's bad compatibility with Java functional interface
+   *
+   * @param consumer
+   * @tparam T
+   * @return A converted java.util.function.Consumer[T]
+   */
+  @Deprecated
+  def toJavaConsumer[T](consumer: T => Unit): Consumer[T] = {
+    new Consumer[T] {
+      override def accept(t: T): Unit = {
+        consumer(t)
+      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/zookeeper/ZooKeeperMainWithTlsSupportForKafka.scala
+++ b/core/src/main/scala/org/apache/zookeeper/ZooKeeperMainWithTlsSupportForKafka.scala
@@ -23,6 +23,7 @@ import org.apache.zookeeper.cli.CommandNotFoundException
 import org.apache.zookeeper.cli.MalformedCommandException
 import org.apache.zookeeper.client.ZKClientConfig
 
+import scala.collection.{JavaConversions, JavaConverters}
 import scala.collection.JavaConverters._
 
 object ZooKeeperMainWithTlsSupportForKafka {
@@ -70,7 +71,7 @@ class ZooKeeperMainWithTlsSupportForKafka(args: Array[String], val zkClientConfi
 
   def kafkaTlsUsage(): Unit = {
     System.err.println("ZooKeeper -server host:port [-zk-tls-config-file <file>] cmd args")
-    asScalaSet(ZooKeeperMain.commandMap.keySet).toList.sorted.foreach(cmd =>
+    JavaConversions.asScalaSet(ZooKeeperMain.commandMap.keySet).toList.sorted.foreach(cmd =>
       System.err.println(s"\t$cmd ${ZooKeeperMain.commandMap.get(cmd)}"))
   }
 

--- a/core/src/test/scala/unit/kafka/controller/ControllerRequestMergerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerRequestMergerTest.scala
@@ -18,7 +18,9 @@
 package unit.kafka.controller
 
 import java.util
+
 import kafka.controller.ControllerRequestMerger
+import kafka.utils.CoreUtils.toJavaConsumer
 import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.LiCombinedControlRequestData.StopReplicaPartitionState
@@ -259,12 +261,12 @@ class ControllerRequestMergerTest {
     val expectedPartitions: Seq[List[StopReplicaPartitionState]] = requests.map{request => {
       var transformedPartitions = List[StopReplicaPartitionState]()
 
-      request.partitions().forEach{partition =>
+      request.partitions().forEach(toJavaConsumer((partition: TopicPartition)=>
         transformedPartitions = new StopReplicaPartitionState()
         .setTopicName(partition.topic())
         .setPartitionIndex(partition.partition())
         .setDeletePartitions(request.deletePartitions())
-        .setBrokerEpoch(brokerEpoch):: transformedPartitions}
+        .setBrokerEpoch(brokerEpoch):: transformedPartitions))
       transformedPartitions
     }}
 

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -255,7 +255,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
       (Some("user-4"), None),
       (Some(null), Some("client-id-2")),
       (None, Some("client-id-1")),
-      (None, Some("client-id-3")),
+      (None, Some("client-id-3"))
     ).map { case (u, c) =>
         new ClientQuotaEntity((u.map((ClientQuotaEntity.USER, _)) ++
           c.map((ClientQuotaEntity.CLIENT_ID, _))).toMap.asJava)
@@ -374,11 +374,11 @@ class ClientQuotasRequestTest extends BaseRequestTest {
     val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.USER -> "user with spaces")).asJava)
 
     alterEntityQuotas(entity, Map(
-      (ProducerByteRateProp -> Some(20000.0)),
+      (ProducerByteRateProp -> Some(20000.0))
     ), validateOnly = false)
 
     verifyDescribeEntityQuotas(entity, Map(
-      (ProducerByteRateProp -> 20000.0),
+      (ProducerByteRateProp -> 20000.0)
     ))
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,8 @@ ext {
   libs = [:]
 
   // Enabled by default when commands like `testAll` are invoked
-  defaultScalaVersions = [ '2.11', '2.12', '2.13' ]
+  // Linkedin is not supporting 2.13 for now
+  defaultScalaVersions = [ '2.11', '2.12' ]
   // Available if -PscalaVersion is used. This is useful when we want to support a Scala version that has
   // a higher minimum Java requirement than Kafka. This was previously the case for Scala 2.12 and Java 7.
   availableScalaVersions = [ '2.11', '2.12', '2.13' ]


### PR DESCRIPTION
Samza is still on Scala 2.11. Upgrading to 2.12 would impact downstream
dependents, so we publish 2.11 together temporarily

TICKET = N/A
EXIT_CRITERIA = "When no longer needing 2.11"