### PR TITLE
[LI-HOTFIX] Consolidate the interactions between the RequestHandler threads and fetcher threads

### DIFF
--- a/core/src/main/scala/kafka/server/AsyncReplicaFetcher.scala
+++ b/core/src/main/scala/kafka/server/AsyncReplicaFetcher.scala
@@ -51,7 +51,8 @@ class AsyncReplicaFetcher(name: String,
     sourceBroker = sourceBroker,
     failedPartitions,
     fetchBackOffMs = brokerConfig.replicaFetchBackoffMs,
-    fetcherEventBus = fetcherEventBus) {
+    fetcherEventBus = fetcherEventBus,
+    fetcherId = fetcherId) {
 
   private val replicaId = brokerConfig.brokerId
   private val logContext = new LogContext(s"[ReplicaFetcher replicaId=$replicaId, leaderId=${sourceBroker.id}, " +

--- a/core/src/main/scala/kafka/server/FetcherManagerTrait.scala
+++ b/core/src/main/scala/kafka/server/FetcherManagerTrait.scala
@@ -18,11 +18,11 @@
 package kafka.server
 
 import org.apache.kafka.common.TopicPartition
-import scala.collection.{Map, Set}
+
+import scala.collection.Map
 
 trait FetcherManagerTrait {
-  def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState]): Unit
-  def removeFetcherForPartitions(partitions: Set[TopicPartition]): Unit
-  def shutdownIdleFetcherThreads(): Unit
+  def addFetcherForPartitions(partitionAndOffsets: Map[TopicPartition, InitialFetchState], partitionModifications: PartitionModifications): Unit
+  def modifyPartitionsAndShutdownIdleFetchers(partitionModifications: PartitionModifications): Unit
   def shutdown(): Unit
 }

--- a/core/src/main/scala/kafka/server/FetcherState.scala
+++ b/core/src/main/scala/kafka/server/FetcherState.scala
@@ -32,21 +32,13 @@ object FetcherState {
     override protected def hasRateAndTimeMetric: Boolean = false
   }
 
-  case object AddPartitions extends FetcherState {
+  case object ModifyPartitionsAndGetCount extends FetcherState {
     def value = 1
   }
 
-  case object RemovePartitions extends FetcherState {
+  case object TruncateAndFetch extends FetcherState {
     def value = 2
   }
 
-  case object GetPartitionCount extends FetcherState {
-    def value = 3
-  }
-
-  case object TruncateAndFetch extends FetcherState {
-    def value = 4
-  }
-
-  val values: Seq[FetcherState] = Seq(Idle, AddPartitions, RemovePartitions, GetPartitionCount, TruncateAndFetch)
+  val values: Seq[FetcherState] = Seq(Idle, ModifyPartitionsAndGetCount, TruncateAndFetch)
 }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -258,7 +258,6 @@ class KafkaApis(val requestChannel: RequestChannel,
     } else {
       val stopReplicaResponse = doHandleStopReplicaRequest(request, stopReplicaRequest)
       sendResponseExemptThrottle(request, stopReplicaResponse)
-      CoreUtils.swallow(replicaManager.replicaFetcherManager.shutdownIdleFetcherThreads(), this)
     }
   }
 

--- a/core/src/main/scala/kafka/server/PartitionModifications.scala
+++ b/core/src/main/scala/kafka/server/PartitionModifications.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.server
 
 import org.apache.kafka.common.TopicPartition

--- a/core/src/main/scala/kafka/server/PartitionModifications.scala
+++ b/core/src/main/scala/kafka/server/PartitionModifications.scala
@@ -1,0 +1,15 @@
+package kafka.server
+
+import org.apache.kafka.common.TopicPartition
+
+import scala.collection.mutable
+
+case class FollowerPartitionStateInFetcher(brokerIdAndFetcherId: BrokerIdAndFetcherId, offsetAndEpoch: OffsetAndEpoch) {
+
+}
+
+class PartitionModifications {
+  val partitionsToRemove = mutable.Set[TopicPartition]()
+  val partitionsToMakeFollowerWithOffsetAndEpoch = mutable.Map[TopicPartition, FollowerPartitionStateInFetcher]()
+}
+

--- a/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import kafka.cluster.BrokerEndPoint
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.utils.Time
 
@@ -43,5 +44,25 @@ class ReplicaFetcherManager(brokerConfig: KafkaConfig,
     info("shutting down")
     closeAllFetchers()
     info("shutdown completed")
+  }
+
+  override def modifyPartitionsAndShutdownIdleFetchers(partitionModifications: PartitionModifications): Unit = {
+    removeFetcherForPartitions(partitionModifications.partitionsToRemove)
+
+    partitionModifications.partitionsToMakeFollowerWithOffsetAndEpoch.groupBy(_._2.brokerIdAndFetcherId).map {
+      case (brokerIdAndFetcherId, followerPartitionStates) => {
+        fetcherThreadMap.get(brokerIdAndFetcherId) match {
+          case Some(thread) => {
+            val initialOffsetAndEpochs = followerPartitionStates.map{ case (topicPartition, followerPartitionState) =>
+              (topicPartition, followerPartitionState.offsetAndEpoch)
+            }
+            addPartitionsToFetcherThread(thread, initialOffsetAndEpochs)
+          }
+          case _ => error(s"Unable to find the fetcher with id $brokerIdAndFetcherId")
+        }
+      }
+    }
+
+    shutdownIdleFetcherThreads()
   }
 }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -422,7 +422,10 @@ class ReplicaManager(val config: KafkaConfig,
         val partitions = stopReplicaRequest.partitions.asScala.toSet
         controllerEpoch = stopReplicaRequest.controllerEpoch
         // First stop fetchers for all partitions, then stop the corresponding replicas
-        replicaFetcherManager.removeFetcherForPartitions(partitions)
+        // replicaFetcherManager.removeFetcherForPartitions(partitions)
+        val partitionModifications = new PartitionModifications
+        partitionModifications.partitionsToRemove ++= partitions
+        replicaFetcherManager.modifyPartitionsAndShutdownIdleFetchers(partitionModifications)
         // replicaAlterLogDirsManager.removeFetcherForPartitions(partitions)
         for (topicPartition <- partitions){
           try {
@@ -1292,14 +1295,15 @@ class ReplicaManager(val config: KafkaConfig,
         val partitionsToBeFollower = partitionStates -- partitionsTobeLeader.keys
 
         val highWatermarkCheckpoints = new LazyOffsetCheckpoints(this.highWatermarkCheckpoints)
+        val partitionModifications = new PartitionModifications
         val partitionsBecomeLeader = if (partitionsTobeLeader.nonEmpty)
           makeLeaders(controllerId, controllerEpoch, partitionsTobeLeader, correlationId, responseMap,
-            highWatermarkCheckpoints)
+            highWatermarkCheckpoints, partitionModifications)
         else
           Set.empty[Partition]
         val partitionsBecomeFollower = if (partitionsToBeFollower.nonEmpty)
           makeFollowers(controllerId, controllerEpoch, partitionsToBeFollower, correlationId, responseMap,
-            highWatermarkCheckpoints)
+            highWatermarkCheckpoints, partitionModifications)
         else
           Set.empty[Partition]
 
@@ -1353,8 +1357,8 @@ class ReplicaManager(val config: KafkaConfig,
           }
         }
 //        replicaAlterLogDirsManager.addFetcherForPartitions(futureReplicasAndInitialOffset)
+        replicaFetcherManager.modifyPartitionsAndShutdownIdleFetchers(partitionModifications)
 
-        replicaFetcherManager.shutdownIdleFetcherThreads()
         onLeadershipChange(partitionsBecomeLeader, partitionsBecomeFollower)
         val responsePartitions = responseMap.iterator.map { case (tp, error) =>
           new LeaderAndIsrPartitionError()
@@ -1387,7 +1391,8 @@ class ReplicaManager(val config: KafkaConfig,
                           partitionStates: Map[Partition, LeaderAndIsrPartitionState],
                           correlationId: Int,
                           responseMap: mutable.Map[TopicPartition, Errors],
-                          highWatermarkCheckpoints: OffsetCheckpoints): Set[Partition] = {
+                          highWatermarkCheckpoints: OffsetCheckpoints,
+                          partitionModifications: PartitionModifications): Set[Partition] = {
     partitionStates.keys.foreach { partition =>
       stateChangeLogger.trace(s"Handling LeaderAndIsr request correlationId $correlationId from " +
         s"controller $controllerId epoch $controllerEpoch starting the become-leader transition for " +
@@ -1401,7 +1406,7 @@ class ReplicaManager(val config: KafkaConfig,
 
     try {
       // First stop fetchers for all the partitions
-      replicaFetcherManager.removeFetcherForPartitions(partitionStates.keySet.map(_.topicPartition))
+      partitionModifications.partitionsToRemove ++= partitionStates.keySet.map(_.topicPartition)
       // Update the partition information to be the leader
       partitionStates.foreach { case (partition, partitionState) =>
         try {
@@ -1468,7 +1473,8 @@ class ReplicaManager(val config: KafkaConfig,
                             partitionStates: Map[Partition, LeaderAndIsrPartitionState],
                             correlationId: Int,
                             responseMap: mutable.Map[TopicPartition, Errors],
-                            highWatermarkCheckpoints: OffsetCheckpoints) : Set[Partition] = {
+                            highWatermarkCheckpoints: OffsetCheckpoints,
+                            partitionModifications: PartitionModifications) : Set[Partition] = {
     partitionStates.foreach { case (partition, partitionState) =>
       stateChangeLogger.trace(s"Handling LeaderAndIsr request correlationId $correlationId from controller $controllerId " +
         s"epoch $controllerEpoch starting the become-follower transition for partition ${partition.topicPartition} with leader " +
@@ -1520,7 +1526,7 @@ class ReplicaManager(val config: KafkaConfig,
         }
       }
 
-      replicaFetcherManager.removeFetcherForPartitions(partitionsToMakeFollower.map(_.topicPartition))
+      partitionModifications.partitionsToRemove ++= partitionsToMakeFollower.map(_.topicPartition)
       partitionsToMakeFollower.foreach { partition =>
         stateChangeLogger.trace(s"Stopped fetchers as part of become-follower request from controller $controllerId " +
           s"epoch $controllerEpoch with correlation id $correlationId for partition ${partition.topicPartition} with leader " +
@@ -1553,7 +1559,7 @@ class ReplicaManager(val config: KafkaConfig,
           partition.topicPartition -> InitialFetchState(leader, partition.getLeaderEpoch, fetchOffset)
        }.toMap
 
-        replicaFetcherManager.addFetcherForPartitions(partitionsToMakeFollowerWithLeaderAndOffset)
+        replicaFetcherManager.addFetcherForPartitions(partitionsToMakeFollowerWithLeaderAndOffset, partitionModifications)
         partitionsToMakeFollowerWithLeaderAndOffset.foreach { case (partition, initialFetchState) =>
           stateChangeLogger.trace(s"Started fetcher to new leader as part of become-follower " +
             s"request from controller $controllerId epoch $controllerEpoch with correlation id $correlationId for " +
@@ -1681,7 +1687,9 @@ class ReplicaManager(val config: KafkaConfig,
         partition.futureLog.exists { _.parentDir == dir }
       }.toSet
 
-      replicaFetcherManager.removeFetcherForPartitions(newOfflinePartitions)
+      val partitionModifications = new PartitionModifications
+      partitionModifications.partitionsToRemove ++= newOfflinePartitions
+      replicaFetcherManager.modifyPartitionsAndShutdownIdleFetchers(partitionModifications)
 //      replicaAlterLogDirsManager.removeFetcherForPartitions(newOfflinePartitions ++ partitionsWithOfflineFutureReplica.map(_.topicPartition))
 
       partitionsWithOfflineFutureReplica.foreach(partition => partition.removeFutureLocalReplica(deleteFromLogDir = false))

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1405,7 +1405,6 @@ class ReplicaManager(val config: KafkaConfig,
     val partitionsToMakeLeaders = mutable.Set[Partition]()
 
     try {
-      // First stop fetchers for all the partitions
       partitionModifications.partitionsToRemove ++= partitionStates.keySet.map(_.topicPartition)
       // Update the partition information to be the leader
       partitionStates.foreach { case (partition, partitionState) =>

--- a/core/src/test/scala/unit/kafka/server/FetcherEventBusTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetcherEventBusTest.scala
@@ -20,9 +20,9 @@ package unit.kafka.server
 import java.util.Date
 import java.util.concurrent.locks.{Condition, Lock}
 import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
-
 import kafka.server._
 import kafka.utils.MockTime
+import org.apache.kafka.common.TopicPartition
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
@@ -52,7 +52,7 @@ class FetcherEventBusTest {
     assertTrue(counter == 0)
 
     // put a event to unblock the runnable
-    fetcherEventBus.put(AddPartitions(Map.empty, null))
+    fetcherEventBus.put(ModifyPartitionsAndGetCount(Set.empty, Map.empty, null))
     service.shutdown()
     runnableFinished.await()
     assertTrue(counter == 1)
@@ -61,9 +61,9 @@ class FetcherEventBusTest {
   @Test
   def testQueuedEvent(): Unit = {
     val fetcherEventBus = new FetcherEventBus(new MockTime())
-    val addPartitions = AddPartitions(Map.empty, null)
-    fetcherEventBus.put(addPartitions)
-    assertTrue(fetcherEventBus.getNextEvent().event == addPartitions)
+    val modifyPartitions = ModifyPartitionsAndGetCount(Set.empty, Map.empty, null)
+    fetcherEventBus.put(modifyPartitions)
+    assertTrue(fetcherEventBus.getNextEvent().event == modifyPartitions)
   }
 
 
@@ -74,7 +74,7 @@ class FetcherEventBusTest {
     val lowPriorityTask = TruncateAndFetch
     fetcherEventBus.put(lowPriorityTask)
 
-    val highPriorityTask = AddPartitions(Map.empty, null)
+    val highPriorityTask = ModifyPartitionsAndGetCount(Set.empty, Map.empty, null)
     fetcherEventBus.put(highPriorityTask)
 
     val expectedSequence = Seq(highPriorityTask, lowPriorityTask)
@@ -94,10 +94,10 @@ class FetcherEventBusTest {
     // according to their sequence numbers in a FIFO manner
     val fetcherEventBus = new FetcherEventBus(new MockTime())
 
-    val task1 = AddPartitions(Map.empty, null)
+    val task1 = ModifyPartitionsAndGetCount(Set.empty, Map.empty, null)
     fetcherEventBus.put(task1)
 
-    val task2 = AddPartitions(Map.empty, null)
+    val task2 = ModifyPartitionsAndGetCount(Set.empty, Map.empty, null)
     fetcherEventBus.put(task2)
 
     val expectedSequence = Seq(task1, task2)
@@ -141,15 +141,15 @@ class FetcherEventBusTest {
     val time = new MockTime()
     val condition = new MockCondition
     val fetcherEventBus = new FetcherEventBus(time, new MockConditionFactory(condition))
-    val addPartitions = AddPartitions(Map.empty, null)
+    val modifyPartitions = ModifyPartitionsAndGetCount(Set.empty, Map.empty, null)
     val delay = 1000
-    fetcherEventBus.schedule(new DelayedFetcherEvent(delay, addPartitions))
+    fetcherEventBus.schedule(new DelayedFetcherEvent(delay, modifyPartitions))
     assertEquals(1, fetcherEventBus.scheduledEventQueueSize())
     val service = Executors.newSingleThreadExecutor()
 
     val future = service.submit(new Runnable {
       override def run(): Unit = {
-        assertTrue(fetcherEventBus.getNextEvent().event == addPartitions)
+        assertTrue(fetcherEventBus.getNextEvent().event == modifyPartitions)
         assertTrue(condition.awaitCalled)
         assertEquals(0, fetcherEventBus.scheduledEventQueueSize())
       }
@@ -164,10 +164,10 @@ class FetcherEventBusTest {
     val time = new MockTime()
     val condition = new MockCondition
     val fetcherEventBus = new FetcherEventBus(time, new MockConditionFactory(condition))
-    val secondTask = AddPartitions(Map.empty, null)
+    val secondTask = ModifyPartitionsAndGetCount(Set(new TopicPartition("topic1", 1)), Map.empty, null)
     fetcherEventBus.schedule(new DelayedFetcherEvent(200, secondTask))
 
-    val firstTask = RemovePartitions(Set.empty, null)
+    val firstTask = ModifyPartitionsAndGetCount(Set(new TopicPartition("topic2", 2)), Map.empty, null)
     fetcherEventBus.schedule(new DelayedFetcherEvent(100, firstTask))
 
     val service = Executors.newSingleThreadExecutor()
@@ -194,11 +194,11 @@ class FetcherEventBusTest {
     val condition = new MockCondition
     val fetcherEventBus = new FetcherEventBus(time, new MockConditionFactory(condition))
 
-    val queuedEvent = RemovePartitions(Set.empty, null)
+    val queuedEvent = ModifyPartitionsAndGetCount(Set(new TopicPartition("topic1", 1)), Map.empty, null)
     fetcherEventBus.put(queuedEvent)
 
     val delay = 10
-    val scheduledEvent = AddPartitions(Map.empty, null)
+    val scheduledEvent = ModifyPartitionsAndGetCount(Set(new TopicPartition("topic2", 2)), Map.empty, null)
     fetcherEventBus.schedule(new DelayedFetcherEvent(delay, scheduledEvent))
 
     val service = Executors.newSingleThreadExecutor()

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1391,7 +1391,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
       isFuture = EasyMock.eq(false))).andReturn(mockLog).anyTimes
     if (expectTruncation) {
       EasyMock.expect(mockLogMgr.truncateTo(Map(topicPartitionObj -> offsetFromLeader),
-        isFuture = false)).once
+        isFuture = false)).atLeastOnce()
     }
     EasyMock.expect(mockLogMgr.initializingLog(topicPartitionObj)).anyTimes
     EasyMock.expect(mockLogMgr.getLog(topicPartitionObj, isFuture = true)).andReturn(None)
@@ -1481,7 +1481,16 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
 
             val initialOffset = OffsetAndEpoch(offset = 0L, leaderEpoch = leaderEpochInLeaderAndIsr)
 
-            fetcherEventManager.addPartitions(Map(new TopicPartition(topic, topicPartition) -> initialOffset))
+            val partitionModifications = new PartitionModifications
+            partitionModifications.partitionsToMakeFollowerWithOffsetAndEpoch ++= Map(new TopicPartition(topic, topicPartition) ->
+              FollowerPartitionStateInFetcher(BrokerIdAndFetcherId(sourceBroker.id, fetcherId), initialOffset))
+            fetcherEventManager.modifyPartitionsAndGetCount(partitionModifications)
+            // call doWork to add the partitions
+            fetcherEventManager.thread.doWork()
+            // trigger one round of TruncateAndFetch
+            fetcherEventManager.fetcherEventBus.put(TruncateAndFetch)
+            fetcherEventManager.thread.doWork()
+
             countDownLatch.countDown()
             fetcherEventManager
           }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -854,7 +854,7 @@ class ReplicaManagerTest(liAsyncFetcherEnabled: Boolean) {
         new Node(leaderBrokerId, "host2", 1)).asJava).build()
     replicaManager.becomeLeaderOrFollower(correlationId, leaderAndIsrRequest0,
       (_, followers) => assertEquals(followerBrokerId, followers.head.partitionId))
-    assertTrue(countDownLatch.await(1000L, TimeUnit.MILLISECONDS))
+    assertTrue(countDownLatch.await(5000L, TimeUnit.MILLISECONDS))
 
     // Truncation should have happened once
     EasyMock.verify(mockLogMgr)


### PR DESCRIPTION
TICKET = LIKAFKA-39536
LI_DESCRIPTION =
In the current code base, the request handler threads need to sync with each fetcher thread
multiple times during the processing of a LeaderAndIsr request, using the
AddPartitions, RemovePartitions, and GetPartitionsCount events.
Each event may be delayed up to request.timeout.ms, i.e. 300s as configured in our clusters.

This PR tries to mitigate the problem by consolidating the multiple events into one
single event ModifyPartitionsAndGetCount for the processing of a LeaderAndIsr request.
Processing of the StopReplica requests has also been migrated to use the
ModifyPartitionsAndGetCount event.

Besides this code change, I also plan to test a reduced value of request timeout
for the fetcher use case.

EXIT_CRITERIA = When this change gets merged in upstream

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
