### PR TITLE
[LI-HOTFIX] Fix the uploadArchivesAll command

### DIFF
--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -177,4 +177,4 @@ jobs:
           JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
         run: |
-          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} clients:uploadArchivesAll core:uploadArchivesAll --no-daemon
+          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} uploadArchivesAll --no-daemon


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION = The uploadArchivesAll is a root level gradle command,
and thus shouldn't be called under the subproject.
EXIT_CRITERIA = N/A


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
