### PR TITLE
[LI-HOTFIX] Honor the result of whether there should be a backoff for TruncateAndFetch

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractAsyncFetcher.scala
+++ b/core/src/main/scala/kafka/server/AbstractAsyncFetcher.scala
@@ -130,14 +130,13 @@ abstract class AbstractAsyncFetcher(clientId: String,
 
       (fetchStates, fetchRequestOpt)
     }
-    if (fetchRequestOpt.isEmpty) {
-      trace(s"There are no active partitions. Back off for $fetchBackOffMs ms before sending a fetch request")
-      true
-    } else {
-      fetchRequestOpt.foreach { fetchRequest =>
+
+    fetchRequestOpt match {
+      case None =>
+        trace(s"There are no active partitions. Back off for $fetchBackOffMs ms before sending a fetch request")
+        true
+      case Some(fetchRequest) =>
         processFetchRequest(fetchStates, fetchRequest)
-      }
-      false
     }
   }
 


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
The current implementation has a bug in that the boolean value returned by
processFetchRequest is discarded. The result indicates whether there should be
a backoff before the next TruncateAndFetch event is enqueued.

This PR addresses this bug by propagating the boolean value back into the
truncateAndFetch method.

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
