### PR TITLE
[LI-HOTFIX] Add broker-side observer interface and NoOpObserver implementation

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -68,6 +68,7 @@ class ControllerServer(
   var authorizer: Option[Authorizer] = null
   var tokenCache: DelegationTokenCache = null
   var credentialProvider: CredentialProvider = null
+  var observer: Observer = null
   var socketServer: SocketServer = null
   val socketServerFirstBoundPortFuture = new CompletableFuture[Integer]()
   var controller: Controller = null
@@ -132,10 +133,12 @@ class ControllerServer(
 
       tokenCache = new DelegationTokenCache(ScramMechanism.mechanismNames)
       credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
+      observer = Observer(config)
       socketServer = new SocketServer(config,
         metrics,
         time,
         credentialProvider,
+        observer,
         apiVersionManager)
       socketServer.startup(startProcessingRequests = false, controlPlaneListener = None, config.controllerListeners)
 

--- a/core/src/main/scala/kafka/server/NoOpObserver.scala
+++ b/core/src/main/scala/kafka/server/NoOpObserver.scala
@@ -1,0 +1,46 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import java.util.Map
+import java.util.concurrent.TimeUnit
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ProduceRequest, RequestContext}
+
+/**
+  * An observer implementation that has no operation and serves as a place holder.
+  */
+class NoOpObserver extends Observer {
+
+  def configure(configs: Map[String, _]): Unit = {}
+
+  /**
+    * Observe a request and its corresponding response.
+    */
+  def observe(requestContext: RequestContext, request: AbstractRequest, response: AbstractResponse): Unit = {}
+
+  /**
+    * Observe a produce request
+    */
+  def observeProduceRequest(requestContext: RequestContext, produceRequest: ProduceRequest): Unit = {}
+
+  /**
+    * Close the observer with timeout.
+    */
+  def close(timeout: Long, unit: TimeUnit): Unit = {}
+
+}

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -1,0 +1,123 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import java.util.concurrent.TimeUnit
+import kafka.network.RequestChannel
+import kafka.utils.{CoreUtils, Logging}
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ProduceRequest, RequestContext}
+import org.apache.kafka.common.Configurable
+
+/**
+  * Top level interface that all pluggable observer must implement. Kafka will read the 'observer.class.name' config
+  * value at startup time, create an instance of the specificed class using the default constructor, and call its
+  * 'configure' method.
+  *
+  * From that point onwards, every pair of request and response will be routed to the 'record' method.
+  *
+  * If 'observer.class.name' has no value specified or the specified class does not exist, the <code>NoOpObserver</code>
+  * will be used as a place holder.
+  */
+trait Observer extends Configurable {
+
+  /**
+    * Observe a request and its corresponding response
+    *
+    * @param requestContext the context information about the request
+    * @param request  the request being observed for a various purpose(s)
+    * @param response the response to the request
+    */
+  def observe(requestContext: RequestContext, request: AbstractRequest, response: AbstractResponse): Unit
+
+  /**
+    * Observe a produce request. This method handles only the produce request since produce request is special in
+    * two ways. Firstly, if ACK is set to be 0, there is no produce response associated with the produce request.
+    * Secondly, the lifecycle of some inner fields in a ProduceRequest is shorter than the lifecycle of the produce
+    * request itself. That means in some situations, when <code>observe</code> is called on a produce request and
+    * response pair, some fields in the produce request has been null-ed already so that the produce request and
+    * response is not observable (or no useful information). Therefore this method exists for the purpose of allowing
+    * users to observe on the produce request before its corresponding response is created.
+    *
+    * @param requestContext the context information about the request
+    * @param produceRequest  the produce request being observed for a various purpose(s)
+    */
+  def observeProduceRequest(requestContext: RequestContext, produceRequest: ProduceRequest): Unit
+
+  /**
+    * Close the observer with timeout.
+    *
+    * @param timeout the maximum time to wait to close the observer.
+    * @param unit    the time unit.
+    */
+  def close(timeout: Long, unit: TimeUnit): Unit
+}
+
+object Observer extends Logging {
+
+  /**
+   * Create a new observer from the given Kafka config.
+   * @param config the Kafka configuration defining observer properties.
+   * @return
+   */
+  def apply(config: KafkaConfig): Observer = {
+    val observer = try {
+      CoreUtils.createObject[Observer](config.ObserverClassName)
+    } catch {
+      case e: Exception =>
+        error(s"Creating observer instance from the given class name ${config.ObserverClassName} failed.", e)
+        new NoOpObserver
+    }
+    observer.configure(config.originals())
+    observer
+  }
+
+  /**
+    * Generates a description of the given request and response. It could be used mostly for debugging purpose.
+    *
+    * @param request  the request being described
+    * @param response the response to the request
+    */
+  def describeRequestAndResponse(request: RequestChannel.Request, response: AbstractResponse): String = {
+    var requestDesc = "Request"
+    var responseDesc = "Response"
+    try {
+      if (request == null) {
+        requestDesc += " null"
+      } else {
+        requestDesc += (" header: " + request.header)
+        requestDesc += (" from service with principal: " +
+          request.session.sanitizedUser +
+          " IP address: " + request.session.clientAddress)
+      }
+      requestDesc += " | " // Separate the response description from the request description
+
+      if (response == null) {
+        responseDesc += " null"
+      } else {
+        responseDesc += (if (response.errorCounts == null || response.errorCounts.size == 0) {
+          " with no error"
+        } else {
+          " with errors: " + response.errorCounts
+        })
+      }
+    } catch {
+      case e: Exception => return e.toString // If describing fails, return the exception message directly
+    }
+    requestDesc + responseDesc
+  }
+}

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -72,7 +72,7 @@ object Observer extends Logging {
   /**
    * Create a new observer from the given Kafka config.
    * @param config the Kafka configuration defining observer properties.
-   * @return
+   * @return A configured instance of Observer.
    */
   def apply(config: KafkaConfig): Observer = {
     val observer = try {

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -23,7 +23,7 @@ import joptsimple.OptionException
 import kafka.network.SocketServer
 import kafka.raft.{KafkaRaftManager, RaftManager}
 import kafka.security.CredentialProvider
-import kafka.server.{KafkaConfig, KafkaRequestHandlerPool, MetaProperties, SimpleApiVersionManager}
+import kafka.server.{KafkaConfig, KafkaRequestHandlerPool, MetaProperties, NoOpObserver, Observer, SimpleApiVersionManager}
 import kafka.utils.{CommandDefaultOptions, CommandLineUtils, CoreUtils, Exit, Logging, ShutdownableThread}
 import org.apache.kafka.common.errors.InvalidConfigurationException
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
@@ -61,6 +61,7 @@ class TestRaftServer(
   private val shutdownLatch = new CountDownLatch(1)
   private val threadNamePrefix = "test-raft"
 
+  var observer: Observer = null
   var socketServer: SocketServer = _
   var credentialProvider: CredentialProvider = _
   var tokenCache: DelegationTokenCache = _
@@ -73,7 +74,8 @@ class TestRaftServer(
     credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
 
     val apiVersionManager = new SimpleApiVersionManager(ListenerType.CONTROLLER)
-    socketServer = new SocketServer(config, metrics, time, credentialProvider, apiVersionManager)
+    observer = Observer(config)
+    socketServer = new SocketServer(config, metrics, time, credentialProvider, observer, apiVersionManager)
     socketServer.startup(startProcessingRequests = false)
 
     val metaProperties = MetaProperties(

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -102,6 +102,8 @@ class KafkaApisTest {
   private val metrics = new Metrics()
   private val brokerId = 1
   private var metadataCache: MetadataCache = MetadataCache.zkMetadataCache(brokerId)
+  private val authorizer: Option[Authorizer] = None
+  private val observer: Observer = EasyMock.createNiceMock(classOf[Observer])
   private val clientQuotaManager: ClientQuotaManager = EasyMock.createNiceMock(classOf[ClientQuotaManager])
   private val clientRequestQuotaManager: ClientRequestQuotaManager = EasyMock.createNiceMock(classOf[ClientRequestQuotaManager])
   private val clientControllerQuotaManager: ControllerMutationQuotaManager = EasyMock.createNiceMock(classOf[ControllerMutationQuotaManager])
@@ -182,6 +184,7 @@ class KafkaApisTest {
       metadataCache,
       metrics,
       authorizer,
+      observer,
       quotas,
       fetchManager,
       brokerTopicStats,
@@ -1589,7 +1592,7 @@ class KafkaApisTest {
 
       assertEquals(1, response.data.responses.size)
       val topicProduceResponse = response.data.responses.asScala.head
-      assertEquals(1, topicProduceResponse.partitionResponses.size)   
+      assertEquals(1, topicProduceResponse.partitionResponses.size)
       val partitionProduceResponse = topicProduceResponse.partitionResponses.asScala.head
       assertEquals(Errors.INVALID_PRODUCER_EPOCH, Errors.forCode(partitionProduceResponse.errorCode))
     }

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -796,6 +796,10 @@ class KafkaConfigTest {
         case KafkaConfig.KafkaMetricsReporterClassesProp => // ignore
         case KafkaConfig.KafkaMetricsPollingIntervalSecondsProp => //ignore
 
+        // Broker-side observer configs
+        case KafkaConfig.ObserverClassNameProp => // ignore since even if the class name is invalid, a NoOpObserver class is used instead
+        case KafkaConfig.ObserverShutdownTimeoutMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")
+
         // Raft Quorum Configs
         case RaftConfig.QUORUM_VOTERS_CONFIG => // ignore string
         case RaftConfig.QUORUM_ELECTION_TIMEOUT_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number")

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -32,6 +32,7 @@ import kafka.server.KafkaApis;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaConfig$;
 import kafka.server.MetadataCache;
+import kafka.server.Observer;
 import kafka.server.ZkMetadataCache;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
@@ -98,6 +99,7 @@ public class MetadataRequestBenchmark {
     private RequestChannel requestChannel = Mockito.mock(RequestChannel.class, Mockito.withSettings().stubOnly());
     private RequestChannel.Metrics requestChannelMetrics = Mockito.mock(RequestChannel.Metrics.class);
     private ReplicaManager replicaManager = Mockito.mock(ReplicaManager.class);
+    private Observer observer = Mockito.mock(Observer.class);
     private GroupCoordinator groupCoordinator = Mockito.mock(GroupCoordinator.class);
     private ZkAdminManager adminManager = Mockito.mock(ZkAdminManager.class);
     private TransactionCoordinator transactionCoordinator = Mockito.mock(TransactionCoordinator.class);
@@ -185,6 +187,7 @@ public class MetadataRequestBenchmark {
             metadataCache,
             metrics,
             Option.empty(),
+            observer,
             quotaManagers,
             fetchManager,
             brokerTopicStats,


### PR DESCRIPTION
TICKET = LIKAFKA-21968
LI_DESCRIPTION = The observer interface lets us provide implementation which provides the usage accounting data unit for the C2S V3 service.

EXIT_CRITERIA = MANUAL [""]

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
