### PR TITLE
[LI-HOTFIX] Improve passthrough performance in Log.append

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -760,6 +760,82 @@ class Log(@volatile private var _dir: File,
   }
 
   /**
+   * Append records to the active segment of the log.
+   *
+   * This method accepts a MemoryRecords with a buffer that contains one or more valid MemoryRecords and calls
+   * appendSingleBatch for each individually. This allows multiple batches to be aggregated in a single
+   * record_set, but still be processed without forcing offset assignment.
+   *
+   * @param records The log records to append
+   * @param origin Declares the origin of the append which affects required validations
+   * @param interBrokerProtocolVersion Inter-broker message protocol version
+   * @param validateAndAssignOffsets Should the log assign offsets to this message set or blindly apply what it is given
+   * @param leaderEpoch The partition's leader epoch which will be applied to messages when offsets are assigned on the leader
+   * @param requestLocal The request local instance if assignOffsets is true
+   * @param ignoreRecordSize true to skip validation of record size.
+   * @throws KafkaStorageException If the append fails due to an I/O error.
+   * @throws OffsetsOutOfOrderException If out of order offsets found in 'records'
+   * @throws UnexpectedAppendOffsetException If the first or last offset in append is less than next offset
+   * @return Information about the appended messages including the first and last offset.
+   */
+  private def append(records: MemoryRecords,
+                     origin: AppendOrigin,
+                     interBrokerProtocolVersion: ApiVersion,
+                     validateAndAssignOffsets: Boolean,
+                     leaderEpoch: Int,
+                     requestLocal: Option[RequestLocal],
+                     ignoreRecordSize: Boolean): LogAppendInfo = {
+    val batches = records.batches()
+
+    if (batches.asScala.isEmpty) {
+      return analyzeAndValidateRecords(records, origin, ignoreRecordSize, leaderEpoch)
+    }
+    val remainingBytes = records.buffer().duplicate()
+    batches.asScala.map(b => {
+      // Create the current record set using only the first batch
+      val batchSize = b.sizeInBytes()
+      val batchBuffer = remainingBytes.slice()
+      batchBuffer.limit(batchSize)
+      val batchRecords = MemoryRecords.readableRecords(batchBuffer)
+
+      // Advance the position in remaining bytes
+      remainingBytes.position(remainingBytes.position() + batchSize)
+
+      // Append the single record batch to the log
+      appendSingleBatch(batchRecords, origin, interBrokerProtocolVersion, validateAndAssignOffsets, leaderEpoch, requestLocal, ignoreRecordSize)
+    }).reduceLeft((info1, info2) => {
+      // Don't assume that the max timestamp is always in the later batch
+      var maxTimestamp = info1.maxTimestamp
+      var offsetofMaxTimestamp = info1.offsetOfMaxTimestamp
+      if (info2.maxTimestamp > info1.maxTimestamp) {
+        maxTimestamp = info2.maxTimestamp
+        offsetofMaxTimestamp = info2.offsetOfMaxTimestamp
+      }
+      val combinedRecordConversionStats = info1.recordConversionStats
+      combinedRecordConversionStats.add(info2.recordConversionStats)
+
+      // Combine the LogAppendInfo to maintain an overall result to return
+      LogAppendInfo(
+        info1.firstOffset,
+        info2.lastOffset,
+        info2.lastLeaderEpoch,
+        maxTimestamp,
+        offsetofMaxTimestamp,
+        info1.logAppendTime,
+        info1.logStartOffset,
+        combinedRecordConversionStats,
+        info1.sourceCodec,
+        info1.targetCodec,
+        info1.shallowCount + info2.shallowCount,
+        info1.validBytes + info2.validBytes,
+        info1.offsetsMonotonic && info2.offsetsMonotonic,
+        info1.lastOffsetOfFirstBatch,
+        info1.recordErrors ++ info2.recordErrors,
+        info1.errorMessage + info2.errorMessage
+      )
+    })
+  }
+  /**
    * Append this message set to the active segment of the log, rolling over to a fresh segment if necessary.
    *
    * This method will generally be responsible for assigning offsets to the messages,
@@ -777,7 +853,7 @@ class Log(@volatile private var _dir: File,
    * @throws UnexpectedAppendOffsetException If the first or last offset in append is less than next offset
    * @return Information about the appended messages including the first and last offset.
    */
-  private def append(records: MemoryRecords,
+  private def appendSingleBatch(records: MemoryRecords,
                      origin: AppendOrigin,
                      interBrokerProtocolVersion: ApiVersion,
                      validateAndAssignOffsets: Boolean,

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -23,12 +23,13 @@ import java.nio.file.Files
 import java.util.concurrent.{Callable, Executors}
 import java.util.regex.Pattern
 import java.util.{Collections, Optional, Properties}
-import kafka.common.{OffsetsOutOfOrderException, RecordValidationException, UnexpectedAppendOffsetException}
+
+import kafka.common.{RecordValidationException, UnexpectedAppendOffsetException}
 import kafka.log.Log.DeleteDirSuffix
 import kafka.metrics.KafkaYammerMetrics
 import kafka.server.checkpoints.LeaderEpochCheckpointFile
 import kafka.server.epoch.{EpochEntry, LeaderEpochFileCache}
-import kafka.server.{BrokerTopicStats, FetchHighWatermark, FetchIsolation, FetchLogEnd, FetchTxnCommitted, KafkaConfig, LogOffsetMetadata, PartitionMetadataFile}
+import kafka.server.{BrokerTopicStats, FetchDataInfo, FetchHighWatermark, FetchIsolation, FetchLogEnd, FetchTxnCommitted, LogOffsetMetadata, PartitionMetadataFile}
 import kafka.utils._
 import org.apache.kafka.common.{InvalidRecordException, KafkaException, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
@@ -49,7 +50,6 @@ import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ListBuffer
 
 class LogTest {
-  var config: KafkaConfig = null
   val brokerTopicStats = new BrokerTopicStats
   val tmpDir = TestUtils.tempDir()
   val logDir = TestUtils.randomPartitionLogDir(tmpDir)
@@ -57,10 +57,7 @@ class LogTest {
   def metricsKeySet = KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala
 
   @BeforeEach
-  def setUp(): Unit = {
-    val props = TestUtils.createBrokerConfig(0, "127.0.0.1:1", port = -1)
-    config = KafkaConfig.fromProps(props)
-  }
+  def setUp(): Unit = {}
 
   @AfterEach
   def tearDown(): Unit = {
@@ -1701,6 +1698,133 @@ class LogTest {
   }
 
   /**
+   * This test generates a single record set that is a concatenation of many valid record sets, and appends them to
+   * a log. It then checks to make sure we can read them all back.
+   */
+  @Test
+  def testAppendManyRecordSets() {
+    val msgFormatSet = Set(RecordBatch.MAGIC_VALUE_V0, RecordBatch.MAGIC_VALUE_V1, RecordBatch.MAGIC_VALUE_V2)
+    msgFormatSet.foreach { magic =>
+      appendManyRecordSets(createLog(TestUtils.randomPartitionLogDir(tmpDir), LogTestUtils.createLogConfig(segmentBytes = 100)),
+        CompressionType.NONE, magic)
+      appendManyRecordSets(createLog(TestUtils.randomPartitionLogDir(tmpDir), LogTestUtils.createLogConfig(segmentBytes = 100)),
+        CompressionType.GZIP, magic)
+      appendManyRecordSets(createLog(TestUtils.randomPartitionLogDir(tmpDir), LogTestUtils.createLogConfig(segmentBytes = 100)),
+        CompressionType.SNAPPY, magic)
+      appendManyRecordSets(createLog(TestUtils.randomPartitionLogDir(tmpDir), LogTestUtils.createLogConfig(segmentBytes = 100)),
+        CompressionType.LZ4, magic)
+    }
+  }
+
+  def readUncommitted(log: Log, startOffset: Long, maxLength: Int, maxOffset: Option[Long] = None): FetchDataInfo = {
+    log.read(startOffset,
+      maxLength = maxLength,
+      isolation = FetchLogEnd,
+      minOneMessage = false)
+  }
+
+  def appendManyRecordSets(log: Log,
+                           compressionType: CompressionType, magicValue: Byte) {
+    val values = (0 until 50).map(id => TestUtils.randomBytes(10)).toArray
+
+    // Build a single buffer with all record sets appended
+    val recordBuffer = ByteBuffer.allocate(5000)
+    for(value <- values) {
+      recordBuffer.put(
+        TestUtils.singletonRecords(
+          value = value, codec = compressionType, magicValue = magicValue).buffer())
+    }
+
+    // Close the buffer and create a MemoryRecords wrapping it
+    recordBuffer.flip()
+    recordBuffer.position(0)
+    val records = MemoryRecords.readableRecords(recordBuffer.slice())
+
+    log.appendAsLeader(records, leaderEpoch = 0)
+
+
+    for(i <- values.indices) {
+      val read = readUncommitted(log, i, 100, Some(i+1)).records.batches.iterator.next()
+      assertEquals(i, read.lastOffset, "Offset read should match order appended.")
+      val actual = read.iterator.next()
+      assertNull(actual.key, "Key should be null")
+      assertEquals(ByteBuffer.wrap(values(i)), actual.value, "Values not equal")
+    }
+    assertEquals(0, readUncommitted(log, values.length, 100, None).records.batches.asScala.size,
+      "Reading beyond the last message returns nothing.")
+  }
+
+  /**
+   * This test makes sure that appending an empty record set does not fail. There should be no exception raised
+   */
+  @Test
+  def testAppendEmptyRecordSet() {
+    val logConfig = LogTestUtils.createLogConfig(segmentBytes = 71)
+    val log = createLog(logDir, logConfig)
+    log.appendAsFollower(MemoryRecords.withRecords(CompressionType.NONE))
+    log.appendAsFollower(MemoryRecords.withRecords(CompressionType.GZIP))
+    log.appendAsFollower(MemoryRecords.withRecords(CompressionType.LZ4))
+    log.appendAsFollower(MemoryRecords.withRecords(CompressionType.SNAPPY))
+  }
+
+  /**
+   * This test generates a single record set that is a concatenation of many valid record sets, with one empty record
+   * set in the middle, and appends them to a log. It then checks to make sure we can read them all back.
+   */
+  @Test
+  def testAppendManyRecordSetsWithEmpty() {
+    val msgFormatSet = Set(RecordBatch.MAGIC_VALUE_V0, RecordBatch.MAGIC_VALUE_V1, RecordBatch.MAGIC_VALUE_V2)
+    msgFormatSet.foreach { magic =>
+      appendManyRecordSets(createLog(TestUtils.randomPartitionLogDir(tmpDir), LogTestUtils.createLogConfig(segmentBytes = 100)),
+        CompressionType.NONE, magic)
+      appendManyRecordSets(createLog(TestUtils.randomPartitionLogDir(tmpDir), LogTestUtils.createLogConfig(segmentBytes = 100)),
+        CompressionType.GZIP, magic)
+      appendManyRecordSets(createLog(TestUtils.randomPartitionLogDir(tmpDir), LogTestUtils.createLogConfig(segmentBytes = 100)),
+        CompressionType.SNAPPY, magic)
+      appendManyRecordSets(createLog(TestUtils.randomPartitionLogDir(tmpDir), LogTestUtils.createLogConfig(segmentBytes = 100)),
+        CompressionType.LZ4, magic)
+    }
+
+  }
+
+  def appendManyRecordSetsWithEmpty(log: Log, compressionType: CompressionType, magicValue: Byte): Unit = {
+    val values1 = (0 until 50 by 2).map(id => TestUtils.randomBytes(10)).toArray
+    val values2 = (50 until 100 by 2).map(id => TestUtils.randomBytes(10)).toArray
+
+    // Build a single buffer with all record sets appended
+    val recordBuffer = ByteBuffer.allocate(4000)
+    for (v <- values1) {
+      recordBuffer.put(
+        TestUtils.singletonRecords(value = v, codec = compressionType, magicValue = magicValue).buffer()
+      )
+    }
+    recordBuffer.put(MemoryRecords.withRecords(magicValue, CompressionType.NONE).buffer())
+    for (v <- values2) {
+      recordBuffer.put(
+        TestUtils.singletonRecords(value = v, codec = compressionType, magicValue = magicValue).buffer()
+      )
+    }
+
+    // Close the buffer and create a MemoryRecords wrapping it
+    recordBuffer.flip()
+    recordBuffer.position(0)
+    val records = MemoryRecords.readableRecords(recordBuffer.slice())
+
+    log.appendAsLeader(records, leaderEpoch = 0)
+
+    val values = values1 ++ values2
+    for (i <- values.indices) {
+      val read = readUncommitted(log, i, 100, Some(i + 1)).records.batches.iterator.next()
+      assertEquals(i, read.lastOffset, "Offset read should match order appended.")
+      val actual = read.iterator.next()
+      assertNull(actual.key, "Key should be null")
+      assertEquals(ByteBuffer.wrap(values(i)), actual.value, "Values not equal")
+    }
+    assertEquals(0, readUncommitted(log, values.length, 100, None).records.batches.asScala.size,
+      "Reading beyond the last message returns nothing.")
+  }
+
+  /**
    * This test covers an odd case where we have a gap in the offsets that falls at the end of a log segment.
    * Specifically we create a log where the last message in the first segment has offset 0. If we
    * then read offset 1, we should expect this read to come from the second segment, even though the
@@ -2332,7 +2456,7 @@ class LogTest {
     buffer.flip()
     val memoryRecords = MemoryRecords.readableRecords(buffer)
 
-    assertThrows(classOf[OffsetsOutOfOrderException], () =>
+    assertThrows(classOf[UnexpectedAppendOffsetException], () =>
       log.appendAsFollower(memoryRecords)
     )
   }
@@ -2360,10 +2484,8 @@ class LogTest {
     assertEquals(7L, log.logStartOffset)
     assertEquals(7L, log.logEndOffset)
 
-    val firstOffset = 4L
-    val magicVals = Seq(RecordBatch.MAGIC_VALUE_V0, RecordBatch.MAGIC_VALUE_V1, RecordBatch.MAGIC_VALUE_V2)
-    val compressionTypes = Seq(CompressionType.NONE, CompressionType.LZ4)
-    for (magic <- magicVals; compression <- compressionTypes) {
+    def testMain(magic: Byte, compression: CompressionType) {
+      val firstOffset = 4L
       val batch = TestUtils.records(List(new SimpleRecord("k1".getBytes, "v1".getBytes),
                                          new SimpleRecord("k2".getBytes, "v2".getBytes),
                                          new SimpleRecord("k3".getBytes, "v3".getBytes)),
@@ -2373,6 +2495,15 @@ class LogTest {
       val exception = assertThrows(classOf[UnexpectedAppendOffsetException], () => log.appendAsFollower(records = batch))
       assertEquals(firstOffset, exception.firstOffset, s"Magic=$magic, compressionType=$compression, UnexpectedAppendOffsetException#firstOffset")
       assertEquals(firstOffset + 2, exception.lastOffset, s"Magic=$magic, compressionType=$compression, UnexpectedAppendOffsetException#lastOffset")
+    }
+
+    // For this test, we need a batch with multiple records. It appears that the above TestUtils.records() actually
+    // returns multiple batches with single record for magic values V0 and V1 when compression type is NONE. Exclude
+    // these combinations.
+    testMain(RecordBatch.MAGIC_VALUE_V2, CompressionType.NONE)
+    val magicVals = Seq(RecordBatch.MAGIC_VALUE_V0, RecordBatch.MAGIC_VALUE_V1, RecordBatch.MAGIC_VALUE_V2)
+    for (magic <- magicVals) {
+      testMain(magic, CompressionType.LZ4)
     }
   }
 


### PR DESCRIPTION
TICKET = LIKAFKA-9737
LI_DESCRIPTION = Broker-side changes for pass-through solution. This is the porting for commit 0d9c527

EXIT_CRITERIA = MANUAL ["If we no longer need pass-through support in Kafka. Only known user is KMM for venice; BrooklinMM has not enabled this everywhere."]