### PR TITLE
[LI-HOTFIX] Fix build for Java 11+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
   dependencies {
     // For Apache Rat plugin to ignore non-Git files
     classpath "org.ajoberstar.grgit:grgit-core:$versions.grgit"
+    classpath libs.jaxbApi
   }
 }
 
@@ -104,7 +105,7 @@ ext {
 
   defaultMaxHeapSize = "2g"
   defaultJvmArgs = ["-Xss4m", "-XX:+UseParallelGC"]
-  if (JavaVersion.current() == JavaVersion.VERSION_16)  
+  if (JavaVersion.current() == JavaVersion.VERSION_16)
     defaultJvmArgs.add("--illegal-access=permit")
 
   userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null


### PR DESCRIPTION
The `javax.xml.bind` package was deprecated since Java 9, and has been removed from Java 11. The `build.gradle` script uses a call to `DataTypeConverter` that relies on the `javax.xml.bind` package, and hence, fails to build on any JDK at or above JDK 11. This is provided by the `javax.xml.bind:jaxb-api` artifact, and is already a part of Kafka's dependencies.

`./gradlew jar` succeeds.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
