### PR TITLE
[LI-HOTFIX] Add safety check to controlled shutdown

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1553,4 +1553,12 @@ public interface Admin extends AutoCloseable {
      * Get the metrics kept by the adminClient
      */
     Map<MetricName, ? extends Metric> metrics();
+
+    /**
+     * Skip the shutdown safety check for a given (brokerId, brokerEpoch).
+     *
+     * @param options The options to use when skipping the shutdown safety check for a broker.
+     * @return The SkipShutdownSafetyCheckResult.
+     */
+    SkipShutdownSafetyCheckResult skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions options);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -139,6 +139,7 @@ import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData.U
 import org.apache.kafka.common.message.DescribeUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
+import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition;
@@ -213,6 +214,8 @@ import org.apache.kafka.common.requests.ExpireDelegationTokenRequest;
 import org.apache.kafka.common.requests.ExpireDelegationTokenResponse;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsRequest;
 import org.apache.kafka.common.requests.IncrementalAlterConfigsResponse;
+import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckRequest;
+import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckResponse;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
@@ -3324,6 +3327,44 @@ public class KafkaAdminClient extends AdminClient {
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
         return Collections.unmodifiableMap(this.metrics.metrics());
+    }
+
+    @Override
+    public SkipShutdownSafetyCheckResult skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+
+        runnable.call(new Call("skipShutdownSafetyCheck", calcDeadlineMs(now, options.timeoutMs()),
+            new ControllerNodeProvider()) {
+
+            @Override
+            AbstractRequest.Builder createRequest(int timeoutMs) {
+                return new LiControlledShutdownSkipSafetyCheckRequest.Builder(
+                    new LiControlledShutdownSkipSafetyCheckRequestData()
+                    .setBrokerId(options.brokerId())
+                    .setBrokerEpoch(options.brokerEpoch()),
+                    (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                LiControlledShutdownSkipSafetyCheckResponse response = (LiControlledShutdownSkipSafetyCheckResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                if (error != Errors.NONE) {
+                    future.completeExceptionally(error.exception());
+                    return;
+                }
+
+                future.complete(null);
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        }, now);
+
+        return new SkipShutdownSafetyCheckResult(future);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/SkipShutdownSafetyCheckOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/SkipShutdownSafetyCheckOptions.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class SkipShutdownSafetyCheckOptions extends AbstractOptions<SkipShutdownSafetyCheckOptions> {
+    private int brokerId;
+    private long brokerEpoch;
+
+    public int brokerId() {
+        return brokerId;
+    }
+
+    public long brokerEpoch() {
+        return brokerEpoch;
+    }
+
+    public SkipShutdownSafetyCheckOptions brokerId(int brokerId) {
+        this.brokerId = brokerId;
+        return this;
+    }
+
+    public SkipShutdownSafetyCheckOptions brokerEpoch(long brokerEpoch) {
+        this.brokerEpoch = brokerEpoch;
+        return this;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/SkipShutdownSafetyCheckResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/SkipShutdownSafetyCheckResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link Admin#skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class SkipShutdownSafetyCheckResult {
+    private final KafkaFuture<Void> future;
+
+    SkipShutdownSafetyCheckResult(KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -108,7 +108,10 @@ public enum ApiKeys {
     UNREGISTER_BROKER(ApiMessageType.UNREGISTER_BROKER, false, RecordBatch.MAGIC_VALUE_V0, true),
     DESCRIBE_TRANSACTIONS(ApiMessageType.DESCRIBE_TRANSACTIONS),
     LIST_TRANSACTIONS(ApiMessageType.LIST_TRANSACTIONS),
-    ALLOCATE_PRODUCER_IDS(ApiMessageType.ALLOCATE_PRODUCER_IDS, true, true);
+    ALLOCATE_PRODUCER_IDS(ApiMessageType.ALLOCATE_PRODUCER_IDS, true, true),
+
+    // LinkedIn API keys for APIs not yet upstreamed.
+    LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK(ApiMessageType.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, true, true);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -303,6 +303,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return ListTransactionsRequest.parse(buffer, apiVersion);
             case ALLOCATE_PRODUCER_IDS:
                 return AllocateProducerIdsRequest.parse(buffer, apiVersion);
+            case LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK:
+                return LiControlledShutdownSkipSafetyCheckRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -247,6 +247,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return ListTransactionsResponse.parse(responseBuffer, version);
             case ALLOCATE_PRODUCER_IDS:
                 return AllocateProducerIdsResponse.parse(responseBuffer, version);
+            case LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK:
+                return LiControlledShutdownSkipSafetyCheckResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckRequest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRespon
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.types.Struct;
 
 public class LiControlledShutdownSkipSafetyCheckRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<LiControlledShutdownSkipSafetyCheckRequest> {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData;
+import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+
+public class LiControlledShutdownSkipSafetyCheckRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiControlledShutdownSkipSafetyCheckRequest> {
+        private final LiControlledShutdownSkipSafetyCheckRequestData data;
+
+        public Builder(LiControlledShutdownSkipSafetyCheckRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiControlledShutdownSkipSafetyCheckRequest build(short version) {
+            return new LiControlledShutdownSkipSafetyCheckRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiControlledShutdownSkipSafetyCheckRequestData data;
+
+    public LiControlledShutdownSkipSafetyCheckRequest(LiControlledShutdownSkipSafetyCheckRequestData data, short version) {
+        super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, version);
+        this.data = data;
+    }
+
+    public static LiControlledShutdownSkipSafetyCheckRequest parse(ByteBuffer buffer, short version) {
+        return new LiControlledShutdownSkipSafetyCheckRequest(new LiControlledShutdownSkipSafetyCheckRequestData(
+            new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiControlledShutdownSkipSafetyCheckResponseData data = new LiControlledShutdownSkipSafetyCheckResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiControlledShutdownSkipSafetyCheckResponse(data);
+    }
+
+    @Override
+    public LiControlledShutdownSkipSafetyCheckRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckResponse.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRespon
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.types.Struct;
 
 import java.util.Collections;
 import java.util.Map;

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class LiControlledShutdownSkipSafetyCheckResponse extends AbstractResponse {
+    /**
+     * Possible error codes:
+     * <p>
+     * UNKNOWN(-1) (this is because IllegalStateException may be thrown in `KafkaController.shutdownBroker`, it would be good to improve this)
+     * STALE_CONTROLLER_EPOCH(11)
+     */
+    private final LiControlledShutdownSkipSafetyCheckResponseData data;
+
+    public LiControlledShutdownSkipSafetyCheckResponse(LiControlledShutdownSkipSafetyCheckResponseData data) {
+        super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK);
+        this.data = data;
+    }
+
+    public static LiControlledShutdownSkipSafetyCheckResponse parse(ByteBuffer buffer, short version) {
+        return new LiControlledShutdownSkipSafetyCheckResponse(new LiControlledShutdownSkipSafetyCheckResponseData(
+            new ByteBufferAccessor(buffer), version));
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return 0;
+    }
+
+    @Override
+    public LiControlledShutdownSkipSafetyCheckResponseData data() {
+        return data;
+    }
+
+    public static LiControlledShutdownSkipSafetyCheckResponse prepareResponse(Errors error) {
+        LiControlledShutdownSkipSafetyCheckResponseData data = new LiControlledShutdownSkipSafetyCheckResponseData();
+        data.setErrorCode(error.code());
+        return new LiControlledShutdownSkipSafetyCheckResponse(data);
+    }
+}

--- a/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
+++ b/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1000,
+  "type": "request",
+  "name": "LiControlledShutdownSkipSafetyCheckRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
+      "about": "The id of the broker for which controlled shutdown has been requested." },
+    { "name": "BrokerEpoch", "type": "int64", "versions": "0+", "about": "The broker epoch." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
+++ b/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
@@ -16,6 +16,7 @@
 {
   "apiKey": 1000,
   "type": "request",
+  "listeners": ["controller"],
   "name": "LiControlledShutdownSkipSafetyCheckRequest",
   "validVersions": "0-1",
   "flexibleVersions": "0+",

--- a/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckResponse.json
+++ b/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckResponse.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1000,
+  "type": "response",
+  "name": "LiControlledShutdownSkipSafetyCheckResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -53,7 +53,7 @@ public class NodeApiVersionsTest {
     @Test
     public void testUnknownApiVersionsToString() {
         NodeApiVersions versions = NodeApiVersions.create((short) 337, (short) 0, (short) 1);
-        assertTrue(versions.toString().endsWith("UNKNOWN(337): 0 to 1)"));
+        assertTrue(versions.toString().contains("UNKNOWN(337): 0 to 1"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -978,6 +978,11 @@ public class MockAdminClient extends AdminClient {
         return mockMetrics;
     }
 
+    @Override
+    public SkipShutdownSafetyCheckResult skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions options) {
+        return null;
+    }
+
     synchronized public void setFetchesRemainingUntilVisible(String topicName, int fetchesRemainingUntilVisible) {
         TopicMetadata metadata = allTopics.get(topicName);
         if (metadata == null) {

--- a/core/src/main/scala/kafka/admin/SkipShutdownSafetyCheckCommand.scala
+++ b/core/src/main/scala/kafka/admin/SkipShutdownSafetyCheckCommand.scala
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.admin
+
+import joptsimple.OptionSpecBuilder
+import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Logging}
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, SkipShutdownSafetyCheckOptions}
+import org.apache.kafka.common.utils.Utils
+
+import java.util.Properties
+
+object SkipShutdownSafetyCheckCommand extends Logging {
+  def main(args: Array[String]): Unit = {
+    val commandOpts = new SkipShutdownSafetyCheckCommandOptions(args)
+    CommandLineUtils.printHelpAndExitIfNeeded(commandOpts, "Skip shutdown safety check for a given (brokerId, brokerEpoch)")
+    CommandLineUtils.checkRequiredArgs(commandOpts.parser, commandOpts.options)
+
+    //noinspection DuplicatedCode
+    val adminProps = if (commandOpts.options.has(commandOpts.adminClientConfigOpt))
+      Utils.loadProps(commandOpts.options.valueOf(commandOpts.adminClientConfigOpt))
+    else
+      new Properties()
+
+    adminProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, commandOpts.options.valueOf(commandOpts.bootstrapServerOpt))
+    adminProps.setProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000.toString)
+
+    val adminClient = AdminClient.create(adminProps)
+
+    val options = new SkipShutdownSafetyCheckOptions()
+      .brokerId(commandOpts.options.valueOf(commandOpts.brokerIdOpt))
+      .brokerEpoch(commandOpts.options.valueOf(commandOpts.brokerEpochOpt))
+    val result = adminClient.skipShutdownSafetyCheck(options)
+
+    result.all();
+
+    println(s"Shutdown safety check will be skipped for broker ${options.brokerId()} with epoch ${options.brokerEpoch()}")
+  }
+
+  class SkipShutdownSafetyCheckCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
+    val brokerIdOpt = parser.accepts("broker-id", "Broker ID that should skip the shutdown safety check.")
+      .withRequiredArg()
+      .describedAs("Broker ID that should skip the shutdown safety check.")
+      .ofType(classOf[Int])
+
+    val brokerEpochOpt = parser.accepts("broker-epoch", "Broker epoch that should skip the shutdown safety check.")
+      .withRequiredArg()
+      .describedAs("Broker epoch that should skip the shutdown safety check.")
+      .ofType(classOf[Long])
+
+    private val bootstrapOptBuilder: OptionSpecBuilder = parser.accepts("bootstrap-server",
+      "A hostname and port for the broker to connect to, " +
+        "in the form host:port. Multiple comma-separated URLs can be given. REQUIRED unless --zookeeper is given.")
+    val bootstrapServerOpt = bootstrapOptBuilder
+      .withRequiredArg
+      .describedAs("host:port")
+      .ofType(classOf[String])
+
+    val adminClientConfigOpt = parser.accepts("admin.config",
+      "Admin client config properties file to pass to the admin client when --bootstrap-server is given.")
+      .availableIf(bootstrapServerOpt)
+      .withRequiredArg
+      .describedAs("config file")
+      .ofType(classOf[String])
+
+    options = parser.parse(args: _*)
+  }
+}

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -93,6 +93,7 @@ class ControllerContext {
   val replicaStates = mutable.Map.empty[PartitionAndReplica, ReplicaState]
   val replicasOnOfflineDirs = mutable.Map.empty[Int, Set[TopicPartition]]
 
+  // A map to indicate the explicitly configured value of min.insync.replicas config per corresponding topic.
   val topicMinIsrConfig = mutable.Map.empty[String, Int]
 
   val topicsToBeDeleted = mutable.Set.empty[String]

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -76,7 +76,8 @@ class ControllerContext {
   val stats = new ControllerStats
   var offlinePartitionCount = 0
   var preferredReplicaImbalanceCount = 0
-  val shuttingDownBrokerIds = mutable.Set.empty[Int]
+  val shuttingDownBrokerIds = mutable.Map.empty[Int, Long]
+  val skipShutdownSafetyCheck = mutable.Map.empty[Int, Long]
   private val liveBrokers = mutable.Set.empty[Broker]
   private val liveBrokerEpochs = mutable.Map.empty[Int, Long]
   var epoch: Int = KafkaController.InitialControllerEpoch
@@ -91,6 +92,8 @@ class ControllerContext {
   val partitionStates = mutable.Map.empty[TopicPartition, PartitionState]
   val replicaStates = mutable.Map.empty[PartitionAndReplica, ReplicaState]
   val replicasOnOfflineDirs = mutable.Map.empty[Int, Set[TopicPartition]]
+
+  val topicMinIsrConfig = mutable.Map.empty[String, Int]
 
   val topicsToBeDeleted = mutable.Set.empty[String]
 
@@ -201,11 +204,16 @@ class ControllerContext {
   def addLiveBrokers(brokerAndEpochs: Map[Broker, Long]): Unit = {
     liveBrokers ++= brokerAndEpochs.keySet
     liveBrokerEpochs ++= brokerAndEpochs.map { case (broker, brokerEpoch) => (broker.id, brokerEpoch) }
+
+    shuttingDownBrokerIds.retain((brokerId, epoch) =>
+      liveBrokerEpochs.contains(brokerId) && epoch < liveBrokerEpochs(brokerId))
   }
 
   def removeLiveBrokers(brokerIds: Set[Int]): Unit = {
     liveBrokers --= liveBrokers.filter(broker => brokerIds.contains(broker.id))
     liveBrokerEpochs --= brokerIds
+
+    shuttingDownBrokerIds.retain((brokerId, _) => brokerIds.contains(brokerId))
   }
 
   def updateBrokerMetadata(oldMetadata: Broker, newMetadata: Broker): Unit = {
@@ -214,7 +222,7 @@ class ControllerContext {
   }
 
   // getter
-  def liveBrokerIds: Set[Int] = liveBrokerEpochs.keySet.diff(shuttingDownBrokerIds)
+  def liveBrokerIds: Set[Int] = liveBrokerEpochs.filter(b => b._2 > shuttingDownBrokerIds.getOrElse(b._1, -1L)).keySet
   def liveOrShuttingDownBrokerIds: Set[Int] = liveBrokerEpochs.keySet
   def liveOrShuttingDownBrokers: Set[Broker] = liveBrokers
   def liveBrokerIdAndEpochs: Map[Int, Long] = liveBrokerEpochs

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -213,8 +213,6 @@ class ControllerContext {
   def removeLiveBrokers(brokerIds: Set[Int]): Unit = {
     liveBrokers --= liveBrokers.filter(broker => brokerIds.contains(broker.id))
     liveBrokerEpochs --= brokerIds
-
-    shuttingDownBrokerIds.retain((brokerId, _) => brokerIds.contains(brokerId))
   }
 
   def updateBrokerMetadata(oldMetadata: Broker, newMetadata: Broker): Unit = {

--- a/core/src/main/scala/kafka/controller/ControllerState.scala
+++ b/core/src/main/scala/kafka/controller/ControllerState.scala
@@ -114,6 +114,14 @@ object ControllerState {
     def value = 17
   }
 
+  case object TopicMinInSyncReplicasConfigChange extends ControllerState {
+    def value = 18
+  }
+
+  case object SkipControlledShutdownSafetyCheck extends ControllerState {
+    def value = 19
+  }
+
   case object TopicDeletionFlagChange extends ControllerState {
     def value = 100
   }
@@ -122,5 +130,5 @@ object ControllerState {
     AlterPartitionReassignment, AutoLeaderBalance, ManualLeaderBalance, ControlledShutdown, IsrChange,
     LeaderAndIsrResponseReceived, LogDirChange, ControllerShutdown, UncleanLeaderElectionEnable,
     TopicUncleanLeaderElectionEnable, ListPartitionReassignment, UpdateMetadataResponseReceived,
-    UpdateFeatures, TopicDeletionFlagChange)
+    UpdateFeatures, TopicMinInSyncReplicasConfigChange, SkipControlledShutdownSafetyCheck, TopicDeletionFlagChange)
 }

--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -155,9 +155,9 @@ object Election extends Logging {
    */
   def leaderForControlledShutdown(controllerContext: ControllerContext,
                                   leaderAndIsrs: Seq[(TopicPartition, LeaderAndIsr)]): Seq[ElectionResult] = {
-    val shuttingDownBrokerIds = controllerContext.shuttingDownBrokerIds.toSet
+    val shuttingDownBrokerIdSet = controllerContext.shuttingDownBrokerIds.keySet.toSet
     leaderAndIsrs.map { case (partition, leaderAndIsr) =>
-      leaderForControlledShutdown(partition, leaderAndIsr, shuttingDownBrokerIds, controllerContext)
+      leaderForControlledShutdown(partition, leaderAndIsr, shuttingDownBrokerIdSet, controllerContext)
     }
   }
 }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -37,7 +37,7 @@ import kafka.zookeeper.{StateChangeHandler, ZNodeChangeHandler, ZNodeChildChange
 import org.apache.kafka.common.ElectionType
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException, PolicyViolationException, StaleBrokerEpochException}
+import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException, NotEnoughReplicasException, PolicyViolationException, StaleBrokerEpochException}
 import org.apache.kafka.common.message.{AllocateProducerIdsRequestData, AllocateProducerIdsResponseData, AlterIsrRequestData, AlterIsrResponseData, UpdateFeaturesRequestData}
 import org.apache.kafka.common.feature.{Features, FinalizedVersionRange}
 import org.apache.kafka.common.metrics.Metrics
@@ -243,6 +243,11 @@ class KafkaController(val config: KafkaConfig,
     eventManager.put(controlledShutdownEvent)
   }
 
+  def skipControlledShutdownSafetyCheck(id: Int, brokerEpoch: Long, skipControlledShutdownSafetyCheckCallback: Try[Unit] => Unit): Unit = {
+    val skipControlledShutdownEvent = SkipControlledShutdownSafetyCheck(id, brokerEpoch, skipControlledShutdownSafetyCheckCallback)
+    eventManager.put(skipControlledShutdownEvent)
+  }
+
   private[kafka] def updateBrokerInfo(newBrokerInfo: BrokerInfo): Unit = {
     this.brokerInfo = newBrokerInfo
     zkClient.updateBrokerInfo(newBrokerInfo)
@@ -256,6 +261,10 @@ class KafkaController(val config: KafkaConfig,
     if (isActive) {
       eventManager.put(TopicUncleanLeaderElectionEnable(topic))
     }
+  }
+
+  private[kafka] def setMinInSyncReplicas(topicName: String, minInSyncReplicas: Int): Unit = {
+    eventManager.put(TopicMinInSyncReplicasConfigChange(topicName, minInSyncReplicas))
   }
 
   private def state: ControllerState = eventManager.state
@@ -593,6 +602,9 @@ class KafkaController(val config: KafkaConfig,
       topicDeletionManager.resumeDeletionForTopics(replicasForTopicsToBeDeleted.map(_.topic))
     }
     registerBrokerModificationsHandler(newBrokers)
+
+    // Clean up any shutdown znodes that may be left behind from when these brokers had shut down before.
+    zkClient.removeBrokerShutdown(newBrokers, controllerContext.epochZkVersion)
   }
 
   private def maybeResumeReassignments(shouldResume: (TopicPartition, ReplicaAssignment) => Boolean): Unit = {
@@ -627,7 +639,11 @@ class KafkaController(val config: KafkaConfig,
     info(s"Broker failure callback for ${deadBrokers.mkString(",")}")
     deadBrokers.foreach(controllerContext.replicasOnOfflineDirs.remove)
     val deadBrokersThatWereShuttingDown =
-      deadBrokers.filter(id => controllerContext.shuttingDownBrokerIds.remove(id))
+      deadBrokers.filter(id => {
+        val wasShuttingDown = controllerContext.shuttingDownBrokerIds.contains(id)
+        controllerContext.shuttingDownBrokerIds -= id
+        wasShuttingDown
+      })
     if (deadBrokersThatWereShuttingDown.nonEmpty)
       info(s"Removed ${deadBrokersThatWereShuttingDown.mkString(",")} from list of shutting down brokers.")
     val allReplicasOnDeadBrokers = controllerContext.replicasOnBrokers(deadBrokers.toSet)
@@ -949,6 +965,21 @@ class KafkaController(val config: KafkaConfig,
     controllerContext.setLiveBrokers(compatibleBrokerAndEpochs)
     info(s"Initialized broker epochs cache: ${controllerContext.liveBrokerIdAndEpochs}")
     controllerContext.setAllTopics(zkClient.getAllTopicsInCluster(true))
+
+    // Load the min.insync.replicas config for each topic. This updates the controllerContext.topicMinIsrConfig map.
+    //
+    // The goal is to keep this map up to date with all existing topics. Unfortunately it has to be updated in three
+    // differnt places to make that possible.
+    //
+    // 1. DynamicConfigManager and its TopicConfigHandler calls kafka.controller.KafkaController.setMinInSyncReplicas
+    //    for all existing topics on broker startup, and also any time the configuration of a topic changes. It does
+    //    not, however, notify the controller of newly created topics.
+    // 2. kafka.controller.KafkaController.processTopicChange is called by a ZooKeeper watch on /topics any time a new
+    //    topic is created. This handles newly created topics, but this handler *only* works in the active controller.
+    // 3. Right here when the controller is initialized after failover. This handles any topics which were created
+    //    between the moment this broker started and right now when it becomes controller again.
+    loadMinIsrForTopics(controllerContext.allTopics)
+
     registerPartitionModificationsHandlers(controllerContext.allTopics.toSeq)
     val replicaAssignmentAndTopicIds: Set[TopicIdReplicaAssignment] = getReplicaAssignmentPolicyCompliant(controllerContext.allTopics.toSet)
     processTopicIds(replicaAssignmentAndTopicIds)
@@ -962,6 +993,7 @@ class KafkaController(val config: KafkaConfig,
     }
     controllerContext.clearPartitionLeadershipInfo()
     controllerContext.shuttingDownBrokerIds.clear()
+    controllerContext.shuttingDownBrokerIds ++= zkClient.getBrokerShutdownEntries
     // register broker modifications handlers
     registerBrokerModificationsHandler(controllerContext.liveOrShuttingDownBrokerIds)
     // update the leader and isr cache for all existing partitions from Zookeeper
@@ -1345,9 +1377,60 @@ class KafkaController(val config: KafkaConfig,
     partitionStateMachine.triggerOnlinePartitionStateChange(topic)
   }
 
+  private def processTopicMinInSyncReplicasConfigChange(topic: String, minInSyncReplicas: Int): Unit = {
+    controllerContext.topicMinIsrConfig += topic -> minInSyncReplicas
+  }
+
   private def processControlledShutdown(id: Int, brokerEpoch: Long, controlledShutdownCallback: Try[Set[TopicPartition]] => Unit): Unit = {
     val controlledShutdownResult = Try { doControlledShutdown(id, brokerEpoch) }
     controlledShutdownCallback(controlledShutdownResult)
+  }
+
+  private def processSkipControlledShutdownSafetyCheck(id: Int, brokerEpoch: Long, skipControlledShutdownSafetyCheckCallback: Try[Unit] => Unit): Unit = {
+    val controlledShutdownResult = Try { doSkipControlledShutdownSafetyCheck(id, brokerEpoch) }
+    skipControlledShutdownSafetyCheckCallback(controlledShutdownResult)
+  }
+
+  private def doSkipControlledShutdownSafetyCheck(id: Int, brokerEpoch: Long): Unit = {
+    if (!isActive) {
+      throw new ControllerMovedException("Controller moved to another broker. Aborting skip shutdown safety check operation.")
+    }
+
+    val cachedBrokerEpoch = controllerContext.liveBrokerIdAndEpochs(id)
+    if (brokerEpoch < cachedBrokerEpoch) {
+      val stateBrokerEpochErrorMessage = "Received skip shutdown safety check request for an old broker epoch " +
+        s"$brokerEpoch for broker $id. Current broker epoch is $cachedBrokerEpoch."
+      info(stateBrokerEpochErrorMessage)
+      throw new StaleBrokerEpochException(stateBrokerEpochErrorMessage)
+    }
+
+    if (!controllerContext.liveOrShuttingDownBrokerIds.contains(id))
+      throw new BrokerNotAvailableException(s"Broker id $id does not exist.")
+
+    controllerContext.skipShutdownSafetyCheck += (id -> brokerEpoch)
+  }
+
+  private def safeToShutdown(id: Int, brokerEpoch: Long): Boolean = {
+    // If a topic doesn't have min.insync.replicas configured, default to 1
+    val defaultMinISRPropertyValue = 1
+
+    val atRiskPartitions = controllerContext.partitionsOnBroker(id).filter { partition =>
+      // Look up minISR for this topic, or use the default if not configured.
+      val minISR: Int = controllerContext.topicMinIsrConfig.getOrElse(partition.topic(), defaultMinISRPropertyValue)
+
+      // See which replicas are known alive and not pending shutdown for this partition
+      val liveBrokerIds = controllerContext.liveBrokerIds
+      val liveReplicasInIsr = controllerContext.partitionLeadershipInfo(partition)
+        .map(_.leaderAndIsr.isr.count({ replicaBrokerId =>
+          liveBrokerIds.contains(replicaBrokerId)
+        })).getOrElse(0)
+
+      // Consider this topic-partition at-risk if removing one broker will result in the ISR shrinking below minISR
+      debug(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Broker $id is a replica and the ISR contains $liveReplicasInIsr live replicas.")
+      liveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
+    }
+
+    atRiskPartitions.isEmpty
   }
 
   private def doControlledShutdown(id: Int, brokerEpoch: Long): Set[TopicPartition] = {
@@ -1367,12 +1450,31 @@ class KafkaController(val config: KafkaConfig,
       }
     }
 
-    info(s"Shutting down broker $id")
-
     if (!controllerContext.liveOrShuttingDownBrokerIds.contains(id))
       throw new BrokerNotAvailableException(s"Broker id $id does not exist.")
 
-    controllerContext.shuttingDownBrokerIds.add(id)
+    val actualBrokerEpoch: Long =
+      if (brokerEpoch == AbstractControlRequest.UNKNOWN_BROKER_EPOCH) {
+        val knownBrokerEpoch = controllerContext.liveBrokerIdAndEpochs.getOrElse(id, -1L)
+        info(s"Received ControlledShutdown request for broker id $id without a brokerEpoch. Using last known epoch of $knownBrokerEpoch")
+        knownBrokerEpoch
+      }
+      else brokerEpoch
+
+    if (config.controlledShutdownSafetyCheckEnable && !safeToShutdown(id, actualBrokerEpoch)) {
+      if (controllerContext.skipShutdownSafetyCheck.getOrElse(id, -1L) >= actualBrokerEpoch) {
+        info(s"Controlled shutdown safety check has been skipped for broker $id (broker epoch $actualBrokerEpoch). Allowing shutdown even though it is not safe to do so.")
+      } else {
+        info(s"Controlled shutdown safety has prevented broker $id (broker epoch $actualBrokerEpoch) from shutting down.")
+        throw new NotEnoughReplicasException(
+          s"Broker id $id cannot initiate shutdown without an impact on topic availability.")
+      }
+    }
+
+    zkClient.recordBrokerShutdown(id, brokerEpoch, controllerContext.epochZkVersion)
+    controllerContext.shuttingDownBrokerIds += (id -> brokerEpoch)
+    info(s"Shutting down broker $id")
+
     debug(s"All shutting down brokers: ${controllerContext.shuttingDownBrokerIds.mkString(",")}")
     debug(s"Live brokers: ${controllerContext.liveBrokerIds.mkString(",")}")
 
@@ -1700,6 +1802,21 @@ class KafkaController(val config: KafkaConfig,
         .reduce((s1, s2) => s1.union(s2))
       onNewPartitionCreation(partitionAssignments)
     }
+
+    // Load the min.insync.replicas config for each topic. This updates the controllerContext.topicMinIsrConfig map.
+    //
+    // The goal is to keep this map up to date with all existing topics. Unfortunately it has to be updated in three
+    // differnt places to make that possible.
+    //
+    // 1. DynamicConfigManager and its TopicConfigHandler calls kafka.controller.KafkaController.setMinInSyncReplicas
+    //    for all existing topics on broker startup, and also any time the configuration of a topic changes. It does
+    //    not, however, notify the controller of newly created topics.
+    // 2. This handler is called by a ZooKeeper watch on /topics any time a new topic is created. This handles newly
+    //    created topics, but this handler *only* works in the active controller.
+    // 3. kafka.controller.KafkaController.initializeControllerContext when the controller is initialized after
+    //    failover. This handles any topics which were created between the moment this broker started and right now when
+    //    it becomes controller again.
+    loadMinIsrForTopics(newTopics)
   }
 
   private def processTopicIds(topicIdAssignments: Set[TopicIdReplicaAssignment]): Unit = {
@@ -2559,6 +2676,15 @@ class KafkaController(val config: KafkaConfig,
     retTopicAssignment
   }
 
+  private def loadMinIsrForTopics(topicNames: Set[String]): Unit = {
+    zkClient.getMultipleEntityConfigs(ConfigType.Topic, topicNames.toSeq).foreach(entity => {
+      Try(entity._2.getProperty(KafkaConfig.MinInSyncReplicasProp).toInt) match {
+        case Success(minInSyncReplicas) => controllerContext.topicMinIsrConfig += entity._1 -> minInSyncReplicas
+        case _ =>
+      }
+    })
+  }
+
   override def process(event: ControllerEvent): Unit = {
     try {
       event match {
@@ -2575,6 +2701,8 @@ class KafkaController(val config: KafkaConfig,
           processUncleanLeaderElectionEnable()
         case TopicUncleanLeaderElectionEnable(topic) =>
           processTopicUncleanLeaderElectionEnable(topic)
+        case TopicMinInSyncReplicasConfigChange(topic, minInSyncReplicas) =>
+          processTopicMinInSyncReplicasConfigChange(topic, minInSyncReplicas)
         case ControlledShutdown(id, brokerEpoch, callback) =>
           processControlledShutdown(id, brokerEpoch, callback)
         case LeaderAndIsrResponseReceived(response, brokerId) =>
@@ -2623,6 +2751,8 @@ class KafkaController(val config: KafkaConfig,
           processAllocateProducerIds(brokerId, brokerEpoch, callback)
         case Startup =>
           processStartup()
+        case SkipControlledShutdownSafetyCheck(id, brokerEpoch, callback) =>
+          processSkipControlledShutdownSafetyCheck(id, brokerEpoch, callback)
       }
     } catch {
       case e: ControllerMovedException =>
@@ -2813,9 +2943,19 @@ case class TopicUncleanLeaderElectionEnable(topic: String) extends ControllerEve
   override def preempt(): Unit = {}
 }
 
+case class TopicMinInSyncReplicasConfigChange(topic: String, minInSyncReplicas: Int) extends ControllerEvent {
+  def state: ControllerState.TopicMinInSyncReplicasConfigChange.type = ControllerState.TopicMinInSyncReplicasConfigChange
+  override def preempt(): Unit = {}
+}
+
 case class ControlledShutdown(id: Int, brokerEpoch: Long, controlledShutdownCallback: Try[Set[TopicPartition]] => Unit) extends ControllerEvent {
   override def state: ControllerState = ControllerState.ControlledShutdown
   override def preempt(): Unit = controlledShutdownCallback(Failure(new ControllerMovedException("Controller moved to another broker")))
+}
+
+case class SkipControlledShutdownSafetyCheck(id: Int, brokerEpoch: Long, skipControlledShutdownSafetyCheckCallback: Try[Unit] => Unit) extends ControllerEvent {
+  def state: ControllerState.SkipControlledShutdownSafetyCheck.type = ControllerState.SkipControlledShutdownSafetyCheck
+  override def preempt(): Unit = {}
 }
 
 case class LeaderAndIsrResponseReceived(leaderAndIsrResponse: LeaderAndIsrResponse, brokerId: Int) extends ControllerEvent {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1446,6 +1446,13 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def safeToShutdown(id: Int, brokerEpoch: Long): Boolean = {
+    // First, check whether or not the broker requesting shutdown has already been told that it is OK to shut down
+    // at this epoch.
+    if (controllerContext.shuttingDownBrokerIds.contains(id)
+      && controllerContext.shuttingDownBrokerIds(id) >= brokerEpoch) {
+      return true
+    }
+
     // If a topic doesn't have min.insync.replicas configured, default to 1
     val defaultMinISRPropertyValue = 1
 
@@ -1455,14 +1462,14 @@ class KafkaController(val config: KafkaConfig,
 
       // See which replicas are known alive and not pending shutdown for this partition
       val liveBrokerIds = controllerContext.liveBrokerIds
-      val liveReplicasInIsr = controllerContext.partitionLeadershipInfo(partition)
-        .map(_.leaderAndIsr.isr.count({ replicaBrokerId =>
-          liveBrokerIds.contains(replicaBrokerId)
-        })).getOrElse(0)
+      val isr = controllerContext.partitionLeadershipInfo(partition).map(_.leaderAndIsr.isr).getOrElse(List.empty)
+      val remainingLiveReplicasInIsr = isr.filter(replicaId => replicaId != id).count({ replicaBrokerId =>
+        liveBrokerIds.contains(replicaBrokerId)
+      })
 
       // Consider this topic-partition at-risk if removing one broker will result in the ISR shrinking below minISR
-      debug(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Broker $id is a replica and the ISR contains $liveReplicasInIsr live replicas.")
-      liveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
+      debug(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Removing broker $id will leave $remainingLiveReplicasInIsr live replicas in the ISR.")
+      remainingLiveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
     }
 
     atRiskPartitions.isEmpty

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1413,7 +1413,15 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def processTopicMinInSyncReplicasConfigChange(topic: String, minInSyncReplicas: Int): Unit = {
-    controllerContext.topicMinIsrConfig += topic -> minInSyncReplicas
+    if (minInSyncReplicas != Defaults.MissingPerTopicConfig.toInt) {
+      // Add the explicitly configured value of min.insync.replicas config for the corresponding topic.
+      controllerContext.topicMinIsrConfig += topic -> minInSyncReplicas
+    } else {
+      // Remove the topic-level config value of min.insync.replicas to ensure that the topic config uses the default value.
+      // Note that we remove the topic from the map rather than setting its config value to the default value. This
+      // keeps the map no larger than the number of topics with explicitly configured values of min.insync.replicas.
+      controllerContext.topicMinIsrConfig -= topic
+    }
   }
 
   private def processControlledShutdown(id: Int, brokerEpoch: Long, controlledShutdownCallback: Try[Set[TopicPartition]] => Unit): Unit = {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1468,7 +1468,7 @@ class KafkaController(val config: KafkaConfig,
       })
 
       // Consider this topic-partition at-risk if removing one broker will result in the ISR shrinking below minISR
-      debug(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Removing broker $id will leave $remainingLiveReplicasInIsr live replicas in the ISR.")
+      info(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Removing broker $id will leave $remainingLiveReplicasInIsr live replicas in the ISR.")
       remainingLiveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
     }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1457,19 +1457,27 @@ class KafkaController(val config: KafkaConfig,
     val defaultMinISRPropertyValue = 1
 
     val atRiskPartitions = controllerContext.partitionsOnBroker(id).filter { partition =>
-      // Look up minISR for this topic, or use the default if not configured.
-      val minISR: Int = controllerContext.topicMinIsrConfig.getOrElse(partition.topic(), defaultMinISRPropertyValue)
+      if (topicDeletionManager.isTopicQueuedUpForDeletion(partition.topic())) {
+        // if a topic is being deleted, then it should not block the shutdown
+        false
+      } else {
+        // Look up minISR for this topic, or use the default if not configured.
+        val minISR: Int = controllerContext.topicMinIsrConfig.getOrElse(partition.topic(), defaultMinISRPropertyValue)
 
-      // See which replicas are known alive and not pending shutdown for this partition
-      val liveBrokerIds = controllerContext.liveBrokerIds
-      val isr = controllerContext.partitionLeadershipInfo(partition).map(_.leaderAndIsr.isr).getOrElse(List.empty)
-      val remainingLiveReplicasInIsr = isr.filter(replicaId => replicaId != id).count({ replicaBrokerId =>
-        liveBrokerIds.contains(replicaBrokerId)
-      })
+        // See which replicas are known alive and not pending shutdown for this partition
+        val liveBrokerIds = controllerContext.liveBrokerIds
+        val isr = controllerContext.partitionLeadershipInfo(partition).map(_.leaderAndIsr.isr).getOrElse(List.empty)
+        val remainingLiveReplicasInIsr = isr.filter(replicaId => replicaId != id).count({ replicaBrokerId =>
+          liveBrokerIds.contains(replicaBrokerId)
+        })
 
-      // Consider this topic-partition at-risk if removing one broker will result in the ISR shrinking below minISR
-      info(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Removing broker $id will leave $remainingLiveReplicasInIsr live replicas in the ISR.")
-      remainingLiveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
+        val atRisk = remainingLiveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
+        if (atRisk) {
+          // Consider this topic-partition at-risk if removing one broker will result in the ISR shrinking below minISR
+          info(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Removing broker $id will leave $remainingLiveReplicasInIsr live replicas in the ISR.")
+        }
+        atRisk
+      }
     }
 
     atRiskPartitions.isEmpty

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -95,6 +95,7 @@ object RequestConvertToJson {
       case req: DescribeProducersRequest => DescribeProducersRequestDataJsonConverter.write(req.data, request.version)
       case req: DescribeTransactionsRequest => DescribeTransactionsRequestDataJsonConverter.write(req.data, request.version)
       case req: ListTransactionsRequest => ListTransactionsRequestDataJsonConverter.write(req.data, request.version)
+      case req: LiControlledShutdownSkipSafetyCheckRequest => LiControlledShutdownSkipSafetyCheckRequestDataJsonConverter.write(req.data, request.version)
       case _ => throw new IllegalStateException(s"ApiKey ${request.apiKey} is not currently handled in `request`, the " +
         "code should be updated to do so.");
     }
@@ -170,6 +171,7 @@ object RequestConvertToJson {
       case res: DescribeProducersResponse => DescribeProducersResponseDataJsonConverter.write(res.data, version)
       case res: DescribeTransactionsResponse => DescribeTransactionsResponseDataJsonConverter.write(res.data, version)
       case res: ListTransactionsResponse => ListTransactionsResponseDataJsonConverter.write(res.data, version)
+      case res: LiControlledShutdownSkipSafetyCheckResponse => LiControlledShutdownSkipSafetyCheckResponseDataJsonConverter.write(res.data, version)
       case _ => throw new IllegalStateException(s"ApiKey ${response.apiKey} is not currently handled in `response`, the " +
         "code should be updated to do so.");
     }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -94,7 +94,9 @@ class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaC
       kafkaController.foreach(_.enableTopicUncleanLeaderElection(topic))
     }
 
-    Try(topicConfig.getProperty(KafkaConfig.MinInSyncReplicasProp).toInt) match {
+    // If the new topic config does not have min.insync.replicas configured, i.e. the topic shall use the default value,
+    // ensure that the controller knows about it.
+    Try(topicConfig.getProperty(KafkaConfig.MinInSyncReplicasProp, Defaults.MissingPerTopicConfig).toInt) match {
       case Success(minInSyncReplicas) => kafkaController.foreach(_.setMinInSyncReplicas(topic, minInSyncReplicas))
       case _ =>
     }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -39,7 +39,7 @@ import org.apache.kafka.common.utils.Sanitizer
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
-import scala.util.Try
+import scala.util.{Success, Try}
 
 /**
   * The ConfigHandler is used to process config change notifications received by the DynamicConfigManager
@@ -92,6 +92,11 @@ class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaC
 
     if (Try(topicConfig.getProperty(KafkaConfig.UncleanLeaderElectionEnableProp).toBoolean).getOrElse(false)) {
       kafkaController.foreach(_.enableTopicUncleanLeaderElection(topic))
+    }
+
+    Try(topicConfig.getProperty(KafkaConfig.MinInSyncReplicasProp).toInt) match {
+      case Success(minInSyncReplicas) => kafkaController.foreach(_.setMinInSyncReplicas(topic, minInSyncReplicas))
+      case _ =>
     }
   }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -229,6 +229,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.ALLOCATE_PRODUCER_IDS => handleAllocateProducerIdsRequest(request)
         case ApiKeys.DESCRIBE_QUORUM => forwardToControllerOrFail(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
+
+        // LinkedIn internal request types
+        case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => handleLiControlledShutdownSkipSafetyCheck(request)
       }
     } catch {
       case e: FatalExitError => throw e
@@ -3420,6 +3423,29 @@ class KafkaApis(val requestChannel: RequestChannel,
         requestHelper.sendResponseMaybeThrottle(request, throttleTimeMs =>
           new AllocateProducerIdsResponse(producerIdsResponse.setThrottleTimeMs(throttleTimeMs)))
       )
+  }
+
+  def handleLiControlledShutdownSkipSafetyCheck(request: RequestChannel.Request): Unit = {
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+
+    val skipSafetyCheckRequest = request.body[LiControlledShutdownSkipSafetyCheckRequest]
+
+    def callback(result: Try[Unit]): Unit = {
+      val response = result match {
+        case Success(partitionsRemaining) =>
+          LiControlledShutdownSkipSafetyCheckResponse.prepareResponse(Errors.NONE)
+
+        case Failure(throwable) =>
+          skipSafetyCheckRequest.getErrorResponse(throwable)
+      }
+      requestHelper.sendResponseExemptThrottle(request, response)
+    }
+
+    zkSupport.controller.skipControlledShutdownSafetyCheck(
+      skipSafetyCheckRequest.data.brokerId,
+      skipSafetyCheckRequest.data.brokerEpoch,
+      callback)
   }
 
   private def updateRecordConversionStats(request: RequestChannel.Request,

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -188,7 +188,7 @@ object Defaults {
   val ControlledShutdownRetryBackoffMs = 5000
   val ControlledShutdownEnable = true
   val ControlledShutdownSafetyCheckEnable = false
-  val ControlledShutdownSafetyCheckRedundancyFactor = 2
+  val ControlledShutdownSafetyCheckRedundancyFactor = 1
 
   /** ********* Group coordinator configuration ***********/
   val GroupMinSessionTimeoutMs = 6000
@@ -921,7 +921,7 @@ object KafkaConfig {
   val ControlledShutdownRetryBackoffMsDoc = "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying."
   val ControlledShutdownEnableDoc = "Enable controlled shutdown of the server"
   val ControlledShutdownSafetyCheckEnableDoc = s"Perform a safety check in the controller before allowing a controlled shutdown to begin. The controller will try to confirm that allowing the broker requesting shutdown to shut down will not result in any partitions going offline by shrinking the ISR below min.in.sync.replicas. This only works if $ControlledShutdownEnableProp is true."
-  val ControlledShutdownSafetyCheckRedundancyFactorDoc = s"If $ControlledShutdownSafetyCheckEnableProp is enabled, this configures the required redundancy for the safety check. If there are fewer than min.insync.replicas + $ControlledShutdownSafetyCheckRedundancyFactorProp replicas in the ISR, shutdown will not be allowed."
+  val ControlledShutdownSafetyCheckRedundancyFactorDoc = s"If $ControlledShutdownSafetyCheckEnableProp is enabled, this configures the required redundancy for the safety check. Shutdown will only be allowed if removing the broker will leave min.insync.replicas + $ControlledShutdownSafetyCheckRedundancyFactorProp replicas in the ISR."
   /** ********* Group coordinator configuration ***********/
   val GroupMinSessionTimeoutMsDoc = "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources."
   val GroupMaxSessionTimeoutMsDoc = "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures."

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -187,6 +187,8 @@ object Defaults {
   val ControlledShutdownMaxRetries = 3
   val ControlledShutdownRetryBackoffMs = 5000
   val ControlledShutdownEnable = true
+  val ControlledShutdownSafetyCheckEnable = false
+  val ControlledShutdownSafetyCheckRedundancyFactor = 2
 
   /** ********* Group coordinator configuration ***********/
   val GroupMinSessionTimeoutMs = 6000
@@ -515,6 +517,8 @@ object KafkaConfig {
   val ControlledShutdownMaxRetriesProp = "controlled.shutdown.max.retries"
   val ControlledShutdownRetryBackoffMsProp = "controlled.shutdown.retry.backoff.ms"
   val ControlledShutdownEnableProp = "controlled.shutdown.enable"
+  val ControlledShutdownSafetyCheckEnableProp = "controlled.shutdown.safety.check.enable"
+  val ControlledShutdownSafetyCheckRedundancyFactorProp = "controlled.shutdown.safety.check.redundancy.factor"
   /** ********* Group coordinator configuration ***********/
   val GroupMinSessionTimeoutMsProp = "group.min.session.timeout.ms"
   val GroupMaxSessionTimeoutMsProp = "group.max.session.timeout.ms"
@@ -916,6 +920,8 @@ object KafkaConfig {
   val ControlledShutdownMaxRetriesDoc = "Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens"
   val ControlledShutdownRetryBackoffMsDoc = "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying."
   val ControlledShutdownEnableDoc = "Enable controlled shutdown of the server"
+  val ControlledShutdownSafetyCheckEnableDoc = s"Perform a safety check in the controller before allowing a controlled shutdown to begin. The controller will try to confirm that allowing the broker requesting shutdown to shut down will not result in any partitions going offline by shrinking the ISR below min.in.sync.replicas. This only works if $ControlledShutdownEnableProp is true."
+  val ControlledShutdownSafetyCheckRedundancyFactorDoc = s"If $ControlledShutdownSafetyCheckEnableProp is enabled, this configures the required redundancy for the safety check. If there are fewer than min.insync.replicas + $ControlledShutdownSafetyCheckRedundancyFactorProp replicas in the ISR, shutdown will not be allowed."
   /** ********* Group coordinator configuration ***********/
   val GroupMinSessionTimeoutMsDoc = "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources."
   val GroupMaxSessionTimeoutMsDoc = "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures."
@@ -1242,6 +1248,8 @@ object KafkaConfig {
       .define(ControlledShutdownMaxRetriesProp, INT, Defaults.ControlledShutdownMaxRetries, MEDIUM, ControlledShutdownMaxRetriesDoc)
       .define(ControlledShutdownRetryBackoffMsProp, LONG, Defaults.ControlledShutdownRetryBackoffMs, MEDIUM, ControlledShutdownRetryBackoffMsDoc)
       .define(ControlledShutdownEnableProp, BOOLEAN, Defaults.ControlledShutdownEnable, MEDIUM, ControlledShutdownEnableDoc)
+      .define(ControlledShutdownSafetyCheckEnableProp, BOOLEAN, Defaults.ControlledShutdownSafetyCheckEnable, MEDIUM, ControlledShutdownSafetyCheckEnableDoc)
+      .define(ControlledShutdownSafetyCheckRedundancyFactorProp, INT, Defaults.ControlledShutdownSafetyCheckRedundancyFactor, MEDIUM, ControlledShutdownSafetyCheckRedundancyFactorDoc)
 
       /** ********* Group coordinator configuration ***********/
       .define(GroupMinSessionTimeoutMsProp, INT, Defaults.GroupMinSessionTimeoutMs, MEDIUM, GroupMinSessionTimeoutMsDoc)
@@ -1745,6 +1753,8 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val controlledShutdownMaxRetries = getInt(KafkaConfig.ControlledShutdownMaxRetriesProp)
   val controlledShutdownRetryBackoffMs = getLong(KafkaConfig.ControlledShutdownRetryBackoffMsProp)
   val controlledShutdownEnable = getBoolean(KafkaConfig.ControlledShutdownEnableProp)
+  val controlledShutdownSafetyCheckEnable = getBoolean(KafkaConfig.ControlledShutdownSafetyCheckEnableProp)
+  val controlledShutdownSafetyCheckRedundancyFactor = getInt(KafkaConfig.ControlledShutdownSafetyCheckRedundancyFactorProp)
 
   /** ********* Feature configuration ***********/
   def isFeatureVersioningSupported = interBrokerProtocolVersion >= KAFKA_2_7_IV0

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -81,6 +81,7 @@ object Defaults {
   val MetadataSnapshotMaxNewRecordBytes = 20 * 1024 * 1024
 
   val ProducerBatchDecompressionEnable = true
+  val MissingPerTopicConfig = "-1"
 
   /** KRaft mode configs */
   val EmptyNodeId: Int = -1

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -609,23 +609,30 @@ class KafkaServer(
                 else if (config.interBrokerProtocolVersion < KAFKA_2_4_IV1) 2
                 else 3
 
+              // Keep track of our brokerEpoch at the time we send the request. If it has changed by the time we
+              // get a response we'll start over.
+              val brokerEpochAtRequestTime = kafkaController.brokerEpoch
               val controlledShutdownRequest = new ControlledShutdownRequest.Builder(
                   new ControlledShutdownRequestData()
                     .setBrokerId(config.brokerId)
-                    .setBrokerEpoch(kafkaController.brokerEpoch),
+                    .setBrokerEpoch(brokerEpochAtRequestTime),
                     controlledShutdownApiVersion)
               val request = networkClient.newClientRequest(prevController.idString, controlledShutdownRequest,
                 time.milliseconds(), true)
               val clientResponse = NetworkClientUtils.sendAndReceive(networkClient, request, time)
 
-              val shutdownResponse = clientResponse.responseBody.asInstanceOf[ControlledShutdownResponse]
-              if (shutdownResponse.error == Errors.NONE && shutdownResponse.data.remainingPartitions.isEmpty) {
-                shutdownSucceeded = true
-                info("Controlled shutdown succeeded")
-              }
-              else {
-                info(s"Remaining partitions to move: ${shutdownResponse.data.remainingPartitions}")
-                info(s"Error from controller: ${shutdownResponse.error}")
+              if (brokerEpochAtRequestTime == kafkaController.brokerEpoch) {
+                val shutdownResponse = clientResponse.responseBody.asInstanceOf[ControlledShutdownResponse]
+                if (shutdownResponse.error == Errors.NONE && shutdownResponse.data.remainingPartitions.isEmpty) {
+                  shutdownSucceeded = true
+                  info("Controlled shutdown succeeded")
+                }
+                else {
+                  info(s"Remaining partitions to move: ${shutdownResponse.data.remainingPartitions}")
+                  info(s"Error from controller: ${shutdownResponse.error}")
+                }
+              } else {
+                info(s"Local brokerEpoch changed from $brokerEpochAtRequestTime to ${kafkaController.brokerEpoch} while waiting for ControlledShutdownResponse. Ignoring response and trying again.")
               }
             }
             catch {

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -80,6 +80,16 @@ object BrokerIdsZNode {
   def encode: Array[Byte] = null
 }
 
+object BrokerShutdownNode {
+  def path = s"${BrokersZNode.path}/shutdown"
+}
+
+object BrokerShutdownIdZNode {
+  def path(id: Int) = s"${BrokerShutdownNode.path}/$id"
+  def encode(epoch: Long): Array[Byte] = epoch.toString.getBytes(UTF_8)
+  def decode(bytes: Array[Byte]): Long = new String(bytes, UTF_8).toLong
+}
+
 object BrokerInfo {
 
   /**
@@ -974,6 +984,7 @@ object ZkData {
   // Important: it is necessary to add any new top level Zookeeper path to the Seq
   val SecureRootPaths = Seq(AdminZNode.path,
     BrokersZNode.path,
+    BrokerShutdownNode.path,
     ClusterZNode.path,
     ConfigZNode.path,
     ControllerZNode.path,
@@ -988,6 +999,7 @@ object ZkData {
   val PersistentZkPaths = Seq(
     ConsumerPathZNode.path, // old consumer path
     BrokerIdsZNode.path,
+    BrokerShutdownNode.path,
     TopicsZNode.path,
     ConfigEntityChangeNotificationZNode.path,
     DeleteTopicsZNode.path,

--- a/core/src/test/scala/integration/kafka/api/FixedPortTestUtils.scala
+++ b/core/src/test/scala/integration/kafka/api/FixedPortTestUtils.scala
@@ -44,7 +44,8 @@ object FixedPortTestUtils {
     enableDeleteTopic: Boolean = false): Seq[Properties] = {
     val ports = FixedPortTestUtils.choosePorts(numConfigs)
     (0 until numConfigs).map { node =>
-      TestUtils.createBrokerConfig(node, zkConnect, enableControlledShutdown, enableDeleteTopic, ports(node))
+      TestUtils.createBrokerConfig(node, zkConnect, enableControlledShutdown, enableDeleteTopic = enableDeleteTopic,
+        port = ports(node))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -128,7 +128,7 @@ class ControllerChannelManagerTest {
     val batch = new MockControllerBrokerRequestBatch(context)
 
     // 2 is shutting down, 3 is dead
-    context.shuttingDownBrokerIds.add(2)
+    context.shuttingDownBrokerIds += (2 -> 0)
     context.removeLiveBrokers(Set(3))
 
     val partition = new TopicPartition("foo", 0)
@@ -336,7 +336,7 @@ class ControllerChannelManagerTest {
     val batch = new MockControllerBrokerRequestBatch(context)
 
     // 2 is shutting down, 3 is dead
-    context.shuttingDownBrokerIds.add(2)
+    context.shuttingDownBrokerIds += (2 -> 0)
     context.removeLiveBrokers(Set(3))
 
     batch.newBatch()
@@ -721,7 +721,7 @@ class ControllerChannelManagerTest {
     val batch = new MockControllerBrokerRequestBatch(context)
 
     // 2 is shutting down, 3 is dead
-    context.shuttingDownBrokerIds.add(2)
+    context.shuttingDownBrokerIds += (2 -> 0)
     context.removeLiveBrokers(Set(3))
 
     val partitions = Map(

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -684,6 +684,41 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
   }
 
   @Test
+  def testTopicsBeingDeletedDoesNotBlockShutdown(): Unit = {
+    val expectedReplicaAssignment = Map(0  -> List(0, 1, 2, 3))
+    val topic = "test"
+    // create brokers
+    val serverConfigs = TestUtils.createBrokerConfigs(4, zkConnect, true, enableControlledShutdownSafetyCheck = true)
+      .map(props => {
+        props.put(KafkaConfig.ControlledShutdownMaxRetriesProp, Int.MaxValue.toString)
+        KafkaConfig.fromProps(props)
+      })
+    servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    TestUtils.waitUntilControllerElected(zkClient)
+
+    // create the topic with min ISR of 2, which should allow one broker to shut down but should block subsequent
+    // shutdowns unless the topic is deleted.
+    val topicConfig = new Properties()
+    topicConfig.setProperty(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+
+    // shutdown one broker so that the topic deletion can be queued but not completed
+    val broker2 = servers.find(_.config.brokerId == 2).get
+    broker2.shutdown()
+
+    // delete one topic
+    adminZkClient.deleteTopic(topic)
+    val controllerId = zkClient.getControllerId.get
+    val controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+    TestUtils.waitUntilTrue(() => controller.topicDeletionManager.isTopicQueuedUpForDeletion(topic),
+      s"Deletion of the topic $topic never happened")
+
+    // test that a 2nd broker can still shutdown after the topic is being queued for deletion
+    val broker1 = servers.find(_.config.brokerId == 1).get
+    broker1.shutdown()
+  }
+
+  @Test
   def testControllerRejectControlledShutdownRequestWithStaleBrokerEpoch(): Unit = {
     // create brokers
     val serverConfigs = TestUtils.createBrokerConfigs(2, zkConnect, false).map(KafkaConfig.fromProps)

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -26,7 +26,8 @@ import kafka.metrics.KafkaYammerMetrics
 import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.{LogCaptureAppender, TestUtils}
 import kafka.zk.{FeatureZNodeStatus, _}
-import org.apache.kafka.common.errors.{ControllerMovedException, StaleBrokerEpochException}
+import org.apache.kafka.common.errors.{ControllerMovedException, NotEnoughReplicasException, StaleBrokerEpochException}
+import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.feature.Features
 import org.apache.kafka.common.metrics.KafkaMetric
 import org.apache.kafka.common.protocol.Errors
@@ -574,6 +575,106 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     assertEquals(1, partitionsRemaining.size)
     // leader doesn't change since all the replicas are shut down
     assertTrue(servers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.leader == 0))
+  }
+
+  @Test
+  def testControlledShutdownRejectRequestForAvailabilityRisk(): Unit = {
+    val expectedReplicaAssignment = Map(0  -> List(0, 1, 2, 3))
+    val topic = "test"
+    val partition = 0
+    // create brokers
+    val serverConfigs = TestUtils.createBrokerConfigs(4, zkConnect, false, enableControlledShutdownSafetyCheck = true)
+      .map(KafkaConfig.fromProps)
+    servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    TestUtils.waitUntilControllerElected(zkClient)
+
+    // create the topic with min ISR of 2, which should allow one broker to shut down but should block subsequent
+    // shutdowns.
+    val topicConfig = new Properties()
+    topicConfig.setProperty(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+
+    val controllerId = zkClient.getControllerId.get
+    val controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+    val resultQueue = new LinkedBlockingQueue[Try[collection.Set[TopicPartition]]]()
+
+    controller.setMinInSyncReplicas(topic, 2)
+    TestUtils.waitUntilTrue(() => controller.controllerContext.topicMinIsrConfig.getOrElse(topic, -1) == 2, "Controller never saw min.insync.replicas config change for topic.")
+
+    // Attempt to shut down one broker, which should be allowed with the ISR at 3 and the min ISR of 2
+    val controlledShutdownCallback = (controlledShutdownResult: Try[collection.Set[TopicPartition]]) => resultQueue.put(controlledShutdownResult)
+    controller.controlledShutdown(2, servers.find(_.config.brokerId == 2).get.kafkaController.brokerEpoch, controlledShutdownCallback)
+    var partitionsRemaining = resultQueue.take().get
+    var activeServers = servers.filter(s => s.config.brokerId != 2)
+    // wait for the update metadata request to trickle to the brokers
+    TestUtils.waitUntilTrue(() =>
+      activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size != 4),
+      "Topic test not created after timeout")
+    assertEquals(0, partitionsRemaining.size)
+    var partitionStateInfo = activeServers.head.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get
+    var leaderAfterShutdown = partitionStateInfo.leader
+    assertTrue(Set(0, 1, 3).contains(leaderAfterShutdown))
+    assertEquals(3, partitionStateInfo.isr.size)
+    assertEquals(List(0, 1, 3), partitionStateInfo.isr.asScala)
+
+    // Now attempt to shut down a second broker which should fail with NotEnoughReplicasException
+    @volatile var notEnoughReplicasDetected = false
+    controller.controlledShutdown(1, servers.find(_.config.brokerId == 1).get.kafkaController.brokerEpoch, {
+      case scala.util.Failure(exception) if exception.isInstanceOf[NotEnoughReplicasException] => notEnoughReplicasDetected = true
+      case _ =>
+    })
+
+    TestUtils.waitUntilTrue(() => notEnoughReplicasDetected, "Fail to detect expected NotEnoughReplicasException")
+
+    // The epoch for broker 2 will be 49 every time. This is because every time a test case is run in this suite, a
+    // fresh ZooKeeper state is created, and the epoch comes from the czxid of the broker znode. Since this test always
+    // registers the brokers one at a time in the same order, from 3 to 0, the epochs will be consistent across runs.
+    val expectedShutdownEntries = Map(2 -> 49)
+    assertEquals(expectedShutdownEntries, zkClient.getBrokerShutdownEntries)
+
+    // Now ensure that after the controller moves, shutdown is still rejected.
+    zkClient.deleteController(controller.controllerContext.epochZkVersion)
+    TestUtils.waitUntilTrue(() => !controller.isActive, "Controller fails to resign")
+    TestUtils.waitUntilTrue(() => zkClient.getControllerId.isDefined, "New controller failed to start")
+
+    val newControllerId = zkClient.getControllerId.get
+    val newController = servers.find(p => p.config.brokerId == newControllerId).get.kafkaController
+
+    newController.setMinInSyncReplicas(topic, 2)
+    TestUtils.waitUntilTrue(() => newController.controllerContext.topicMinIsrConfig.getOrElse(topic, -1) == 2, "Controller never saw min.insync.replicas config change for topic.")
+
+    // Controller moved, try to shut down again. We should get rejected in the same way.
+    notEnoughReplicasDetected = false
+    newController.controlledShutdown(1, servers.find(_.config.brokerId == 1).get.kafkaController.brokerEpoch, {
+      case scala.util.Failure(exception) if exception.isInstanceOf[NotEnoughReplicasException] => notEnoughReplicasDetected = true
+      case _ =>
+    })
+    TestUtils.waitUntilTrue(() => notEnoughReplicasDetected, "Fail to detect expected NotEnoughReplicasException")
+    assertEquals(expectedShutdownEntries, zkClient.getBrokerShutdownEntries)
+
+    // Tell the controller to skip shutdown for this brokerEpoch, simulating LiControlledShutdownSkipSafetyCheckRequest.
+    // After that the controller should allow the shutdown that it just rejected.
+    @volatile var skipSafetyCheckSucceeded = false
+    newController.skipControlledShutdownSafetyCheck(1, servers.find(_.config.brokerId == 1).get.kafkaController.brokerEpoch, {
+      case scala.util.Failure(exception) =>
+      case _ => skipSafetyCheckSucceeded = true
+    })
+    TestUtils.waitUntilTrue(() => skipSafetyCheckSucceeded, "Failed to skip shutdown safety check")
+
+    // Now shutting down broker id 1 should succeed.
+    newController.controlledShutdown(1, servers.find(_.config.brokerId == 1).get.kafkaController.brokerEpoch, controlledShutdownCallback)
+    partitionsRemaining = resultQueue.take().get
+    activeServers = servers.filter(s => s.config.brokerId != 1)
+    // wait for the update metadata request to trickle to the brokers
+    TestUtils.waitUntilTrue(() =>
+      activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size != 3),
+      "Topic test not created after timeout")
+    assertEquals(0, partitionsRemaining.size)
+    partitionStateInfo = activeServers.head.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get
+    leaderAfterShutdown = partitionStateInfo.leader
+    assertEquals(0, leaderAfterShutdown)
+    assertEquals(2, partitionStateInfo.isr.size)
+    assertEquals(List(0, 3), partitionStateInfo.isr.asScala)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -602,14 +602,17 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilTrue(() => controller.controllerContext.topicMinIsrConfig.getOrElse(topic, -1) == 2, "Controller never saw min.insync.replicas config change for topic.")
 
     // Attempt to shut down one broker, which should be allowed with the ISR at 3 and the min ISR of 2
+    val server2 = servers.find(s => s.config.brokerId == 2).get
     val controlledShutdownCallback = (controlledShutdownResult: Try[collection.Set[TopicPartition]]) => resultQueue.put(controlledShutdownResult)
-    controller.controlledShutdown(2, servers.find(_.config.brokerId == 2).get.kafkaController.brokerEpoch, controlledShutdownCallback)
+    controller.controlledShutdown(2, server2.kafkaController.brokerEpoch, controlledShutdownCallback)
+    server2.shutdown()
+
     var partitionsRemaining = resultQueue.take().get
-    var activeServers = servers.filter(s => s.config.brokerId != 2)
+    var activeServers = servers.filterNot(_ == server2)
     // wait for the update metadata request to trickle to the brokers
     TestUtils.waitUntilTrue(() =>
       activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size != 4),
-      "Topic test not created after timeout")
+      "ISR did not get updated on all brokers after timeout")
     assertEquals(0, partitionsRemaining.size)
     var partitionStateInfo = activeServers.head.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get
     var leaderAfterShutdown = partitionStateInfo.leader
@@ -662,13 +665,16 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilTrue(() => skipSafetyCheckSucceeded, "Failed to skip shutdown safety check")
 
     // Now shutting down broker id 1 should succeed.
-    newController.controlledShutdown(1, servers.find(_.config.brokerId == 1).get.kafkaController.brokerEpoch, controlledShutdownCallback)
+    val server1 = servers.find(s => s.config.brokerId == 1).get
+    newController.controlledShutdown(1, server1.kafkaController.brokerEpoch, controlledShutdownCallback)
+    server1.shutdown()
+
     partitionsRemaining = resultQueue.take().get
-    activeServers = servers.filter(s => s.config.brokerId != 1)
+    activeServers = activeServers.filterNot(server => server == server1)
     // wait for the update metadata request to trickle to the brokers
     TestUtils.waitUntilTrue(() =>
       activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size != 3),
-      "Topic test not created after timeout")
+      "ISR did not get updated on all brokers after timeout")
     assertEquals(0, partitionsRemaining.size)
     partitionStateInfo = activeServers.head.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get
     leaderAfterShutdown = partitionStateInfo.leader

--- a/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
@@ -191,7 +191,7 @@ class PartitionStateMachineTest {
     controllerContext.setLiveBrokers(Map(
       TestUtils.createBrokerAndEpoch(brokerId, "host", 0),
       TestUtils.createBrokerAndEpoch(otherBrokerId, "host", 0)))
-    controllerContext.shuttingDownBrokerIds.add(brokerId)
+    controllerContext.shuttingDownBrokerIds += (brokerId -> 0)
     controllerContext.updatePartitionFullReplicaAssignment(
       partition,
       ReplicaAssignment(Seq(brokerId, otherBrokerId))

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -697,6 +697,8 @@ class KafkaConfigTest {
         case KafkaConfig.ControlledShutdownMaxRetriesProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.ControlledShutdownRetryBackoffMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.ControlledShutdownEnableProp => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")
+        case KafkaConfig.ControlledShutdownSafetyCheckEnableProp => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")
+        case KafkaConfig.ControlledShutdownSafetyCheckRedundancyFactorProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.GroupMinSessionTimeoutMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.GroupMaxSessionTimeoutMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.GroupInitialRebalanceDelayMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -644,6 +644,14 @@ class RequestQuotaTest extends BaseRequestTest {
 
         case ApiKeys.ALLOCATE_PRODUCER_IDS =>
           new AllocateProducerIdsRequest.Builder(new AllocateProducerIdsRequestData())
+
+        case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK =>
+          new LiControlledShutdownSkipSafetyCheckRequest.Builder(
+            new LiControlledShutdownSkipSafetyCheckRequestData()
+              .setBrokerId(112)
+              .setBrokerEpoch(6431),
+            ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK.latestVersion)
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -40,7 +40,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerializer, StringDeserializer, StringSerializer}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.metadata.BrokerState
-import org.junit.jupiter.api.{BeforeEach, Test, Timeout}
+import org.junit.jupiter.api.{BeforeEach, Disabled, Test, Timeout}
 import org.junit.jupiter.api.Assertions._
 
 import scala.jdk.CollectionConverters._
@@ -149,6 +149,8 @@ class ServerShutdownTest extends ZooKeeperTestHarness {
   }
 
   @Test
+  @Disabled
+  // This test will not work because of PR #241 and hang indefinitely. We rely on ZK to do controlled shutdown.
   def testCleanShutdownWithZkUnavailable(): Unit = {
     val server = new KafkaServer(config, threadNamePrefix = Option(this.getClass.getName))
     server.startup()

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -192,6 +192,7 @@ object TestUtils extends Logging {
   def createBrokerConfigs(numConfigs: Int,
     zkConnect: String,
     enableControlledShutdown: Boolean = true,
+    enableControlledShutdownSafetyCheck: Boolean = false,
     enableDeleteTopic: Boolean = true,
     interBrokerSecurityProtocol: Option[SecurityProtocol] = None,
     trustStoreFile: Option[File] = None,
@@ -207,7 +208,7 @@ object TestUtils extends Logging {
     defaultReplicationFactor: Short = 1,
     startingIdNumber: Int = 0): Seq[Properties] = {
     (startingIdNumber until numConfigs).map { node =>
-      createBrokerConfig(node, zkConnect, enableControlledShutdown, enableDeleteTopic, RandomPort,
+      createBrokerConfig(node, zkConnect, enableControlledShutdown, enableControlledShutdownSafetyCheck, enableDeleteTopic, RandomPort,
         interBrokerSecurityProtocol, trustStoreFile, saslProperties, enablePlaintext = enablePlaintext, enableSsl = enableSsl,
         enableSaslPlaintext = enableSaslPlaintext, enableSaslSsl = enableSaslSsl, rack = rackInfo.get(node), logDirCount = logDirCount, enableToken = enableToken,
         numPartitions = numPartitions, defaultReplicationFactor = defaultReplicationFactor)
@@ -252,6 +253,7 @@ object TestUtils extends Logging {
   def createBrokerConfig(nodeId: Int,
                          zkConnect: String,
                          enableControlledShutdown: Boolean = true,
+                         enableControlledShutdownSafetyCheck: Boolean = false,
                          enableDeleteTopic: Boolean = true,
                          port: Int = RandomPort,
                          interBrokerSecurityProtocol: Option[SecurityProtocol] = None,
@@ -303,6 +305,7 @@ object TestUtils extends Logging {
     props.put(KafkaConfig.ReplicaSocketTimeoutMsProp, "1500")
     props.put(KafkaConfig.ControllerSocketTimeoutMsProp, "1500")
     props.put(KafkaConfig.ControlledShutdownEnableProp, enableControlledShutdown.toString)
+    props.put(KafkaConfig.ControlledShutdownSafetyCheckEnableProp, enableControlledShutdownSafetyCheck.toString)
     props.put(KafkaConfig.DeleteTopicEnableProp, enableDeleteTopic.toString)
     props.put(KafkaConfig.LogDeleteDelayMsProp, "1000")
     props.put(KafkaConfig.ControlledShutdownRetryBackoffMsProp, "100")

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -96,7 +96,7 @@ public class CheckpointBench {
     public void setup() {
         this.scheduler = new KafkaScheduler(1, "scheduler-thread", true);
         this.brokerProperties = KafkaConfig.fromProps(TestUtils.createBrokerConfig(
-                0, TestUtils.MockZkConnect(), true, true, 9092, Option.empty(), Option.empty(),
+                0, TestUtils.MockZkConnect(), true, true, true, 9092, Option.empty(), Option.empty(),
                 Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
                 (short) 1));
         this.metrics = new Metrics();

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -107,7 +107,7 @@ public class PartitionCreationBench {
 
         this.scheduler = new KafkaScheduler(1, "scheduler-thread", true);
         this.brokerProperties = KafkaConfig.fromProps(TestUtils.createBrokerConfig(
-                0, TestUtils.MockZkConnect(), true, true, 9092, Option.empty(), Option.empty(),
+                0, TestUtils.MockZkConnect(), true, true, true, 9092, Option.empty(), Option.empty(),
                 Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
                 (short) 1));
         this.metrics = new Metrics();


### PR DESCRIPTION
*This is an LI-HOTFIX cherry-picked from the 2.4-li branch ([commit c337e4752e](https://github.com/linkedin/kafka/commit/c337e4752e)). The reviewer can refer to the original change to see which parts needed to be changed for Kafka 3.0*

The controller will not allow a broker to initiate controlled shutdown
unless the shutdown is unlikely to lead to a topic-partition ISR
shrinking below the min.insync.replicas setting for that topic.

This new functionality is optional and disabled by default. The
following new configs have been added:

* controlled.shutdown.safety.check.enable: Enable this safety check
  for any ControlledShutdownRequest handled by the controller.
* controlled.shutdown.safety.check.redundancy.factor: Additional
  replicas above min.insync.replicas that are required for any
  topic-partition to allow shutdown of a broker. Default is 2, so if a
  topic has min.insync.replicas=2, then the ISR must have 4 replicas
  to allow shutdown.

By default a broker attempting shutdown will only send
ControlledShutdownRequest to the controller 3 times with a 5 second
sleep in between. If it is desired to never skip controlled shutdown,
controlled.shutdown.max.retries can be increased to a much larger
value than 3. It can be set to 2147483647 (Integer.MAX_VALUE) to
effectively retry forever.

A controller integration test has been added which exercises this code
with a simulated three node cluster with a topic configured with
min.insync.replicas=2, allowing only one broker to shut down at a
time.

In ControllerContext, instead of maintaining a list of broker ids that
have begun shutting down called shuttingDownBrokers, a map of brokerId
-> brokerEpoch. This will make it easier to keep this map and broker
presence notifications (via zookeeper) in sync.

When a ControlledShutdown request is allowed to begin, it is recorded
in zookeeper under /brokers/shutdown/<broker-id>, with the value of
the broker epoch. On controller initialization this is loaded into
controllerContext.shuttingDownBrokers. When a broker has restarted, it
will come back with a new broker epoch which will take precedence over
the epoch in controllerContext.shuttingDownBrokers.

The controller now needs to know the min.insync.replicas of every
topic. This is done by a combination of DynamicConfigManager,
a full scan of all topic configs on controller failover, and a /topics
znode watcher. All update a map in ControllerContext.

In order to allow skipping the safety check, this patch adds
LiControlledShutdownSkipSafetyCheckRequest. It takes a brokerId
and brokerEpoch. When sent to the controller, the controller
will record it in a map in memory.

After handling that request, the controller will ignore the results of
the safety check for any request with that brokerId and epoch <= the
epoch provided via LiControlledShutdownSkipSafetyCheckRequest.

This is not persisted to zookeeper since this is an emergency
action. If the controller moves then an admin can just send the
request again.

This request is authorized as a cluster action.

Since LiControlledShutdownSkipSafetyCheck is not submitted to
upstream, it has been added with an ApiKey of 1000. The largest ApiKey
in upstream is 47. This new API is only meant to be used by
AdminClient and is not meant to be an inter-broker request. So this
sets the precedent that if we have an admin-only API we want to add
that isn't upstream yet, we can give it an ApiKey of 1000+. Then if
this internal-only admin API does make it upstream, migrating our
tools to it will be easy since usage should be minimal.

This required fixing a couple of tests that made assumptions about
ApiKeys, namely that the array of api keys now has gaps in it. Now
ApiKeys#hasKeys returns true if the key is within range *and* the
entry in the ID_TO_TYPE array is not null.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
