### PR TITLE
[LI-HOTFIX] Fix RF determination when validating with LiCreateTopicPolicy

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -70,7 +70,7 @@ object KafkaController extends Logging {
             }
             // Use min size of all replica lists as a stand in for replicationFactor. Generally replicas sizes should be
             // the same, but minBy gets us the worst case.
-            val replicationFactor = partitionsAssignment.minBy(_._2.replicas.size)._1.toShort
+            val replicationFactor = partitionsAssignment.minBy(_._2.replicas.size)._2.replicas.size.toShort
             policy.validate(new CreateTopicPolicy.RequestMetadata(topic, partitionsAssignment.size, replicationFactor,
               jPartitionAssignment.asJava, new java.util.HashMap[String, String]()))
           }


### PR DESCRIPTION
TICKET = N/A 
EXIT = MANUAL

In the code path, it tries to determine the RF using the minimum of replica counts.

However, `partitionsAssignment` is a `partitionId -> replicaAssignment` map (`Map[Int, ReplicaAssignment]`),
so `partitionsAssignment.minBy(_._2.replicas.size)` returns of tuple of `(Int, ReplicaAssignement)`, which correspond to the partition with least replicas, and the original code is just a random partition ID.
```scala
val replicationFactor = partitionsAssignment.minBy(_._2.replicas.size)._1.toShort
```
To fix this, it should retrieve the replica size from the tuple as replication factor instead.

