### PR TITLE
[LI-CHERRY-PICK] MINOR: Bump version of grgit to 4.1.1 (#11561)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ import java.security.MessageDigest
 buildscript {
   repositories {
     mavenCentral()
-    jcenter()
     maven {
       url "https://plugins.gradle.org/m2/"
     }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -69,7 +69,7 @@ versions += [
   commonsCli: "1.4",
   gradle: "5.6.2",
   gradleVersionsPlugin: "0.21.0",
-  grgit: "3.1.1",
+  grgit: "4.1.1",
   guava: "30.1.1-jre",
   httpclient: "4.5.9",
   easymock: "4.0.2",


### PR DESCRIPTION
grgit 4.1.0 caused unsupported version error during gradle builds.
The reason was that grgit 4.1.0 uses always the latest JGit version
internally. Unfortunately, the latest JGit version was compiled with
a Java version later than Java 8 which caused the unsupported version
error during gradle builds for Java 8.

grgit 4.1.1 fixed this issue by upper bounding the version of JGrit
to a version that is still compiled with Java 8. Consequently, we can
remove the hotfix we merged in commit d1e0d2b474b0bdb0b0141b6d341ce77dd331a8d4
and instead bump the grgit version from 4.1.0 to 4.1.1.

Reviewer: John Roesler <vvcephei@apache.org>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
