### PR TITLE
Added remote log subsystem implementation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -860,6 +860,7 @@ project(':core') {
     implementation project(':metadata')
     implementation project(':raft')
     implementation project(':storage')
+    implementation project(':storage:api')
 
     implementation libs.argparse4j
     implementation libs.jacksonDatabind
@@ -2224,6 +2225,7 @@ project(':jmh-benchmarks') {
     implementation project(':metadata')
     implementation project(':streams')
     implementation project(':core')
+    implementation project(':storage')
     implementation project(':clients').sourceSets.test.output
     implementation project(':core').sourceSets.test.output
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/OffsetMovedToTieredStorageException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OffsetMovedToTieredStorageException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class OffsetMovedToTieredStorageException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public OffsetMovedToTieredStorageException(String message) {
+        super(message);
+    }
+
+    public OffsetMovedToTieredStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -364,7 +364,7 @@ public enum Errors {
     INCONSISTENT_TOPIC_ID(103, "The log's topic ID did not match the topic ID in the request", InconsistentTopicIdException::new),
     INCONSISTENT_CLUSTER_ID(104, "The clusterId in the request does not match that found on the server", InconsistentClusterIdException::new),
     TRANSACTIONAL_ID_NOT_FOUND(105, "The transactionalId could not be found", TransactionalIdNotFoundException::new),
-    OFFSET_MOVED_TO_TIERED_STORAGE(106, "The requested offset is moved to tiered storage.", OffsetMovedToTieredStorageException::new);
+    OFFSET_MOVED_TO_TIERED_STORAGE(107, "The requested offset is moved to tiered storage.", OffsetMovedToTieredStorageException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -364,7 +364,14 @@ public enum Errors {
     INCONSISTENT_TOPIC_ID(103, "The log's topic ID did not match the topic ID in the request", InconsistentTopicIdException::new),
     INCONSISTENT_CLUSTER_ID(104, "The clusterId in the request does not match that found on the server", InconsistentClusterIdException::new),
     TRANSACTIONAL_ID_NOT_FOUND(105, "The transactionalId could not be found", TransactionalIdNotFoundException::new),
-    OFFSET_MOVED_TO_TIERED_STORAGE(107, "The requested offset is moved to tiered storage.", OffsetMovedToTieredStorageException::new);
+    /*
+    We want OffsetMovedToTieredStorageException to map to LI_OFFSET_MOVED_TO_TIERED_STORAGE with the error code 1107,
+    until Kafka trunk gets an error code for OFFSET_MOVED_TO_TIERED_STORAGE. At that point, we will change the map so
+    that OffsetMovedToTieredStorageException maps to it instead. On the processing side, we will still process both
+    LI_OFFSET_MOVED_TO_TIERED_STORAGE and OFFSET_MOVED_TO_TIERED_STORAGE in the same way for a while, and then remove
+    LI_OFFSET_MOVED_TO_TIERED_STORAGE and fully move to using OFFSET_MOVED_TO_TIERED_STORAGE.
+     */
+    LI_OFFSET_MOVED_TO_TIERED_STORAGE(1107, "The requested offset is moved to tiered storage.", OffsetMovedToTieredStorageException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -83,6 +83,7 @@ import org.apache.kafka.common.errors.NotEnoughReplicasAfterAppendException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.kafka.common.errors.OffsetMetadataTooLarge;
+import org.apache.kafka.common.errors.OffsetMovedToTieredStorageException;
 import org.apache.kafka.common.errors.OffsetNotAvailableException;
 import org.apache.kafka.common.errors.OffsetOutOfRangeException;
 import org.apache.kafka.common.errors.OperationNotAttemptedException;
@@ -362,7 +363,8 @@ public enum Errors {
     BROKER_ID_NOT_REGISTERED(102, "The given broker ID was not registered.", BrokerIdNotRegisteredException::new),
     INCONSISTENT_TOPIC_ID(103, "The log's topic ID did not match the topic ID in the request", InconsistentTopicIdException::new),
     INCONSISTENT_CLUSTER_ID(104, "The clusterId in the request does not match that found on the server", InconsistentClusterIdException::new),
-    TRANSACTIONAL_ID_NOT_FOUND(105, "The transactionalId could not be found", TransactionalIdNotFoundException::new);
+    TRANSACTIONAL_ID_NOT_FOUND(105, "The transactionalId could not be found", TransactionalIdNotFoundException::new),
+    OFFSET_MOVED_TO_TIERED_STORAGE(106, "The requested offset is moved to tiered storage.", OffsetMovedToTieredStorageException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/record/RemoteLogInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RemoteLogInputStream.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.common.errors.CorruptRecordException;
+import org.apache.kafka.common.utils.Utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import static org.apache.kafka.common.record.Records.HEADER_SIZE_UP_TO_MAGIC;
+import static org.apache.kafka.common.record.Records.LOG_OVERHEAD;
+import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
+import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
+import static org.apache.kafka.common.record.Records.SIZE_OFFSET;
+
+public class RemoteLogInputStream implements LogInputStream<RecordBatch> {
+    private final InputStream is;
+    private final ByteBuffer logHeaderBuffer = ByteBuffer.allocate(HEADER_SIZE_UP_TO_MAGIC);
+
+    public RemoteLogInputStream(InputStream is) {
+        this.is = is;
+    }
+
+    @Override
+    public RecordBatch nextBatch() throws IOException {
+        logHeaderBuffer.rewind();
+        Utils.readFully(is, logHeaderBuffer);
+
+        if (logHeaderBuffer.position() < HEADER_SIZE_UP_TO_MAGIC)
+            return null;
+
+        logHeaderBuffer.rewind();
+        logHeaderBuffer.getLong(OFFSET_OFFSET);
+        int size = logHeaderBuffer.getInt(SIZE_OFFSET);
+
+        // V0 has the smallest overhead, stricter checking is done later
+        if (size < LegacyRecord.RECORD_OVERHEAD_V0)
+            throw new CorruptRecordException(String.format("Found record size %d smaller than minimum record " +
+                                                                   "overhead (%d).", size, LegacyRecord.RECORD_OVERHEAD_V0));
+
+        byte magic = logHeaderBuffer.get(MAGIC_OFFSET);
+        ByteBuffer buffer = ByteBuffer.allocate(size + LOG_OVERHEAD);
+        System.arraycopy(logHeaderBuffer.array(), 0, buffer.array(), 0, logHeaderBuffer.limit());
+        buffer.position(logHeaderBuffer.limit());
+
+        Utils.readFully(is, buffer);
+        if (buffer.position() != size + LOG_OVERHEAD)
+            return null;
+        buffer.rewind();
+
+        MutableRecordBatch batch;
+        if (magic > RecordBatch.MAGIC_VALUE_V1)
+            batch = new DefaultRecordBatch(buffer);
+        else
+            batch = new AbstractLegacyRecordBatch.ByteBufferLegacyRecordBatch(buffer);
+
+        return batch;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -38,6 +38,10 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 public class ListOffsetsRequest extends AbstractRequest {
+    /**
+     * It is used to represent the earliest message stored in the local log which is also called the local-log-start-offset
+     */
+    public static final long EARLIEST_LOCAL_TIMESTAMP = -4L;
     public static final long EARLIEST_TIMESTAMP = -2L;
     public static final long LATEST_TIMESTAMP = -1L;
     public static final long MAX_TIMESTAMP = -3L;

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -41,7 +41,13 @@ public class ListOffsetsRequest extends AbstractRequest {
     /**
      * It is used to represent the earliest message stored in the local log which is also called the local-log-start-offset
      */
-    public static final long EARLIEST_LOCAL_TIMESTAMP = -4L;
+    /*
+    We named this LI_EARLIEST_LOCAL_TIMESTAMP and used -104 as the value, because Kafka trunk will eventually have a
+    EARLIEST_LOCAL_TIMESTAMP, and we are not sure about the timestamp code for that yet. We want to be able to run with
+    both of them enabled for some time before removing LI_EARLIEST_LOCAL_TIMESTAMP and fully moving
+    to EARLIEST_LOCAL_TIMESTAMP.
+     */
+    public static final long LI_EARLIEST_LOCAL_TIMESTAMP = -104L;
     public static final long EARLIEST_TIMESTAMP = -2L;
     public static final long LATEST_TIMESTAMP = -1L;
     public static final long MAX_TIMESTAMP = -3L;

--- a/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+
+/**
+ * A class loader that looks for classes and resources in a specified class path first, before delegating to its parent
+ * class loader.
+ */
+public class ChildFirstClassLoader extends URLClassLoader {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    /**
+     * @param classPath Class path string
+     * @param parent    The parent classloader. If the required class / resource cannot be found in the given classPath,
+     *                  this classloader will be used to find the class / resource.
+     */
+    public ChildFirstClassLoader(String classPath, ClassLoader parent) {
+        super(classpath2URLs(classPath), parent);
+    }
+
+    static private URL[] classpath2URLs(String classPath) {
+        ArrayList<URL> urls = new ArrayList<>();
+        for (String path : classPath.split(File.pathSeparator)) {
+            if (path == null || path.trim().isEmpty())
+                continue;
+            File f = new File(path);
+
+            if (path.endsWith("/*")) {
+                try {
+                    File parent = new File(new File(f.getCanonicalPath()).getParent());
+                    if (parent.isDirectory()) {
+                        File[] files = parent.listFiles((dir, name) -> {
+                            String lower = name.toLowerCase(Locale.ROOT);
+                            return lower.endsWith(".jar") || lower.endsWith(".zip");
+                        });
+                        if (files != null) {
+                            for (File jarFile : files) {
+                                urls.add(jarFile.getCanonicalFile().toURI().toURL());
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                }
+            } else if (f.exists()) {
+                try {
+                    urls.add(f.getCanonicalFile().toURI().toURL());
+                } catch (IOException e) {
+                }
+            }
+        }
+        return urls.toArray(new URL[0]);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> c = findLoadedClass(name);
+
+            if (c == null) {
+                try {
+                    c = findClass(name);
+                } catch (ClassNotFoundException e) {
+                    // try parent
+                    c = super.loadClass(name, false);
+                }
+            }
+
+            if (resolve)
+                resolveClass(c);
+
+            return c;
+        }
+    }
+
+    @Override
+    public URL getResource(String name) {
+        URL url = findResource(name);
+        if (url == null) {
+            // try parent
+            url = super.getResource(name);
+        }
+        return url;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        Enumeration<URL> urls1 = findResources(name);
+        Enumeration<URL> urls2 = getParent() != null ? getParent().getResources(name) : null;
+
+        return new Enumeration<URL>() {
+            @Override
+            public boolean hasMoreElements() {
+                return (urls1 != null && urls1.hasMoreElements()) || (urls2 != null && urls2.hasMoreElements());
+            }
+
+            @Override
+            public URL nextElement() {
+                if (urls1 != null && urls1.hasMoreElements())
+                    return urls1.nextElement();
+                if (urls2 != null && urls2.hasMoreElements())
+                    return urls2.nextElement();
+                throw new NoSuchElementException();
+            }
+        };
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import org.apache.kafka.common.KafkaException;
+
 
 /**
  * A class loader that looks for classes and resources in a specified class path first, before delegating to its parent
@@ -50,8 +52,8 @@ public class ChildFirstClassLoader extends URLClassLoader {
                 continue;
             File f = new File(path);
 
-            if (path.endsWith("/*")) {
-                try {
+            try {
+                if (path.endsWith("/*")) {
                     File parent = new File(new File(f.getCanonicalPath()).getParent());
                     if (parent.isDirectory()) {
                         File[] files = parent.listFiles((dir, name) -> {
@@ -64,13 +66,11 @@ public class ChildFirstClassLoader extends URLClassLoader {
                             }
                         }
                     }
-                } catch (IOException e) {
-                }
-            } else if (f.exists()) {
-                try {
+                } else if (f.exists()) {
                     urls.add(f.getCanonicalFile().toURI().toURL());
-                } catch (IOException e) {
                 }
+            } catch (IOException e) {
+                throw new KafkaException(e);
             }
         }
         return urls.toArray(new URL[0]);

--- a/clients/src/test/java/org/apache/kafka/common/record/RemoteLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/RemoteLogInputStreamTest.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V0;
+import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V1;
+import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V2;
+import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
+import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
+import static org.apache.kafka.common.record.TimestampType.NO_TIMESTAMP_TYPE;
+import static org.apache.kafka.test.TestUtils.tempFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RemoteLogInputStreamTest {
+
+    private static class Args {
+        private final byte magic;
+        private final CompressionType compression;
+
+        public Args(byte magic, CompressionType compression) {
+            this.magic = magic;
+            this.compression = compression;
+        }
+
+        @Override
+        public String toString() {
+            return "Args{magic=" + magic + ", compression=" + compression + "}";
+        }
+    }
+
+    private static class RemoteLogInputStreamArgsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            List<Arguments> values = new ArrayList<>();
+            for (byte magic : asList(MAGIC_VALUE_V0, MAGIC_VALUE_V1, MAGIC_VALUE_V2)) {
+                for (CompressionType type : CompressionType.values()) {
+                    values.add(Arguments.of(new Args(magic, type)));
+                }
+            }
+            return values.stream();
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(RemoteLogInputStreamArgsProvider.class)
+    public void testSimpleBatchIteration(Args args) throws IOException {
+        byte magic = args.magic;
+        CompressionType compression = args.compression;
+        if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
+            return;
+
+        SimpleRecord firstBatchRecord = new SimpleRecord(3241324L, "a".getBytes(), "foo".getBytes());
+        SimpleRecord secondBatchRecord = new SimpleRecord(234280L, "b".getBytes(), "bar".getBytes());
+
+        File file = tempFile();
+        try (FileRecords fileRecords = FileRecords.open(file)) {
+            fileRecords.append(MemoryRecords.withRecords(magic, 0L, compression, CREATE_TIME, firstBatchRecord));
+            fileRecords.append(MemoryRecords.withRecords(magic, 1L, compression, CREATE_TIME, secondBatchRecord));
+            fileRecords.flush();
+        }
+
+        try (FileInputStream is = new FileInputStream(file)) {
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+
+            RecordBatch firstBatch = logInputStream.nextBatch();
+            assertGenericRecordBatchData(args, firstBatch, 0L, 3241324L, firstBatchRecord);
+            assertNoProducerData(firstBatch);
+
+            RecordBatch secondBatch = logInputStream.nextBatch();
+            assertGenericRecordBatchData(args, secondBatch, 1L, 234280L, secondBatchRecord);
+            assertNoProducerData(secondBatch);
+
+            assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(RemoteLogInputStreamArgsProvider.class)
+    public void testBatchIterationWithMultipleRecordsPerBatch(Args args) throws IOException {
+        byte magic = args.magic;
+        CompressionType compression = args.compression;
+        if (magic < MAGIC_VALUE_V2 && compression == CompressionType.NONE)
+            return;
+
+        if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
+            return;
+
+        SimpleRecord[] firstBatchRecords = new SimpleRecord[]{
+            new SimpleRecord(3241324L, "a".getBytes(), "1".getBytes()),
+            new SimpleRecord(234280L, "b".getBytes(), "2".getBytes())
+        };
+
+        SimpleRecord[] secondBatchRecords = new SimpleRecord[]{
+            new SimpleRecord(238423489L, "c".getBytes(), "3".getBytes()),
+            new SimpleRecord(897839L, null, "4".getBytes()),
+            new SimpleRecord(8234020L, "e".getBytes(), null)
+        };
+
+        File file = tempFile();
+        try (FileRecords fileRecords = FileRecords.open(file)) {
+            fileRecords.append(MemoryRecords.withRecords(magic, 0L, compression, CREATE_TIME, firstBatchRecords));
+            fileRecords.append(MemoryRecords.withRecords(magic, 1L, compression, CREATE_TIME, secondBatchRecords));
+            fileRecords.flush();
+        }
+
+        try (FileInputStream is = new FileInputStream(file)) {
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+
+            RecordBatch firstBatch = logInputStream.nextBatch();
+            assertNoProducerData(firstBatch);
+            assertGenericRecordBatchData(args, firstBatch, 0L, 3241324L, firstBatchRecords);
+
+            RecordBatch secondBatch = logInputStream.nextBatch();
+            assertNoProducerData(secondBatch);
+            assertGenericRecordBatchData(args, secondBatch, 1L, 238423489L, secondBatchRecords);
+
+            assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(RemoteLogInputStreamArgsProvider.class)
+    public void testBatchIterationV2(Args args) throws IOException {
+        byte magic = args.magic;
+        CompressionType compression = args.compression;
+        if (magic != MAGIC_VALUE_V2)
+            return;
+
+        long producerId = 83843L;
+        short producerEpoch = 15;
+        int baseSequence = 234;
+        int partitionLeaderEpoch = 9832;
+
+        SimpleRecord[] firstBatchRecords = new SimpleRecord[]{
+            new SimpleRecord(3241324L, "a".getBytes(), "1".getBytes()),
+            new SimpleRecord(234280L, "b".getBytes(), "2".getBytes())
+        };
+
+        SimpleRecord[] secondBatchRecords = new SimpleRecord[]{
+            new SimpleRecord(238423489L, "c".getBytes(), "3".getBytes()),
+            new SimpleRecord(897839L, null, "4".getBytes()),
+            new SimpleRecord(8234020L, "e".getBytes(), null)
+        };
+
+        File file = tempFile();
+        try (FileRecords fileRecords = FileRecords.open(file)) {
+            fileRecords.append(MemoryRecords.withIdempotentRecords(magic, 15L, compression, producerId,
+                producerEpoch, baseSequence, partitionLeaderEpoch, firstBatchRecords));
+            fileRecords.append(MemoryRecords.withTransactionalRecords(magic, 27L, compression, producerId,
+                producerEpoch, baseSequence + firstBatchRecords.length, partitionLeaderEpoch, secondBatchRecords));
+            fileRecords.flush();
+        }
+
+        try (FileInputStream is = new FileInputStream(file)) {
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+
+            RecordBatch firstBatch = logInputStream.nextBatch();
+            assertProducerData(firstBatch, producerId, producerEpoch, baseSequence, false, firstBatchRecords);
+            assertGenericRecordBatchData(args, firstBatch, 15L, 3241324L, firstBatchRecords);
+            assertEquals(partitionLeaderEpoch, firstBatch.partitionLeaderEpoch());
+
+            RecordBatch secondBatch = logInputStream.nextBatch();
+            assertProducerData(secondBatch, producerId, producerEpoch, baseSequence + firstBatchRecords.length,
+                true, secondBatchRecords);
+            assertGenericRecordBatchData(args, secondBatch, 27L, 238423489L, secondBatchRecords);
+            assertEquals(partitionLeaderEpoch, secondBatch.partitionLeaderEpoch());
+
+            assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(RemoteLogInputStreamArgsProvider.class)
+    public void testBatchIterationIncompleteBatch(Args args) throws IOException {
+        byte magic = args.magic;
+        CompressionType compression = args.compression;
+        if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
+            return;
+
+        try (FileRecords fileRecords = FileRecords.open(tempFile())) {
+            SimpleRecord firstBatchRecord = new SimpleRecord(100L, "foo".getBytes());
+            SimpleRecord secondBatchRecord = new SimpleRecord(200L, "bar".getBytes());
+
+            fileRecords.append(MemoryRecords.withRecords(magic, 0L, compression, CREATE_TIME, firstBatchRecord));
+            fileRecords.append(MemoryRecords.withRecords(magic, 1L, compression, CREATE_TIME, secondBatchRecord));
+            fileRecords.flush();
+            fileRecords.truncateTo(fileRecords.sizeInBytes() - 13);
+
+            FileLogInputStream logInputStream = new FileLogInputStream(fileRecords, 0, fileRecords.sizeInBytes());
+
+            FileLogInputStream.FileChannelRecordBatch firstBatch = logInputStream.nextBatch();
+            assertNoProducerData(firstBatch);
+            assertGenericRecordBatchData(args, firstBatch, 0L, 100L, firstBatchRecord);
+
+            assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    private void assertProducerData(RecordBatch batch, long producerId, short producerEpoch, int baseSequence,
+                                    boolean isTransactional, SimpleRecord... records) {
+        assertEquals(producerId, batch.producerId());
+        assertEquals(producerEpoch, batch.producerEpoch());
+        assertEquals(baseSequence, batch.baseSequence());
+        assertEquals(baseSequence + records.length - 1, batch.lastSequence());
+        assertEquals(isTransactional, batch.isTransactional());
+    }
+
+    private void assertNoProducerData(RecordBatch batch) {
+        assertEquals(RecordBatch.NO_PRODUCER_ID, batch.producerId());
+        assertEquals(RecordBatch.NO_PRODUCER_EPOCH, batch.producerEpoch());
+        assertEquals(RecordBatch.NO_SEQUENCE, batch.baseSequence());
+        assertEquals(RecordBatch.NO_SEQUENCE, batch.lastSequence());
+        assertFalse(batch.isTransactional());
+    }
+
+    private void assertGenericRecordBatchData(Args args,
+                                              RecordBatch batch,
+                                              long baseOffset,
+                                              long maxTimestamp,
+                                              SimpleRecord... records) {
+        byte magic = args.magic;
+        CompressionType compression = args.compression;
+        assertEquals(magic, batch.magic());
+        assertEquals(compression, batch.compressionType());
+
+        if (magic == MAGIC_VALUE_V0) {
+            assertEquals(NO_TIMESTAMP_TYPE, batch.timestampType());
+        } else {
+            assertEquals(CREATE_TIME, batch.timestampType());
+            assertEquals(maxTimestamp, batch.maxTimestamp());
+        }
+
+        assertEquals(baseOffset + records.length - 1, batch.lastOffset());
+        if (magic >= MAGIC_VALUE_V2)
+            assertEquals(Integer.valueOf(records.length), batch.countOrNull());
+
+        assertEquals(baseOffset, batch.baseOffset());
+        assertTrue(batch.isValid());
+
+        List<Record> batchRecords = TestUtils.toList(batch);
+        for (int i = 0; i < records.length; i++) {
+            assertEquals(baseOffset + i, batchRecords.get(i).offset());
+            assertEquals(records[i].key(), batchRecords.get(i).key());
+            assertEquals(records[i].value(), batchRecords.get(i).value());
+            if (magic == MAGIC_VALUE_V0)
+                assertEquals(NO_TIMESTAMP, batchRecords.get(i).timestamp());
+            else
+                assertEquals(records[i].timestamp(), batchRecords.get(i).timestamp());
+        }
+    }
+}
+

--- a/clients/src/test/java/org/apache/kafka/common/record/RemoteLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/RemoteLogInputStreamTest.java
@@ -67,6 +67,8 @@ public class RemoteLogInputStreamTest {
             List<Arguments> values = new ArrayList<>();
             for (byte magic : asList(MAGIC_VALUE_V0, MAGIC_VALUE_V1, MAGIC_VALUE_V2)) {
                 for (CompressionType type : CompressionType.values()) {
+                    if (type == CompressionType.PASSTHROUGH)
+                        continue;
                     values.add(Arguments.of(new Args(magic, type)));
                 }
             }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1160,7 +1160,7 @@ class Partition(val topicPartition: TopicPartition,
       case ListOffsetsRequest.LATEST_TIMESTAMP =>
         maybeOffsetsError.map(e => throw e)
           .orElse(Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, lastFetchableOffset, Optional.of(leaderEpoch))))
-      case ListOffsetsRequest.EARLIEST_TIMESTAMP | ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP =>
+      case ListOffsetsRequest.EARLIEST_TIMESTAMP | ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP =>
         getOffsetByTimestamp
       case _ =>
         getOffsetByTimestamp.filter(timestampAndOffset => timestampAndOffset.offset < lastFetchableOffset)

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -22,6 +22,7 @@ import kafka.api.{ApiVersion, LeaderAndIsr}
 import kafka.common.UnexpectedAppendOffsetException
 import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log._
+import kafka.log.remote.RemoteLogManager
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server._
 import kafka.server.checkpoints.OffsetCheckpoints
@@ -410,7 +411,7 @@ class Partition(val topicPartition: TopicPartition,
    */
   def isLeader: Boolean = leaderReplicaIdOpt.contains(localBrokerId)
 
-  private def localLogWithEpochOrException(currentLeaderEpoch: Optional[Integer],
+  def localLogWithEpochOrException(currentLeaderEpoch: Optional[Integer],
                                            requireLeader: Boolean): Log = {
     getLocalLog(currentLeaderEpoch, requireLeader) match {
       case Left(localLog) => localLog
@@ -1123,7 +1124,8 @@ class Partition(val topicPartition: TopicPartition,
   def fetchOffsetForTimestamp(timestamp: Long,
                               isolationLevel: Option[IsolationLevel],
                               currentLeaderEpoch: Optional[Integer],
-                              fetchOnlyFromLeader: Boolean): Option[TimestampAndOffset] = inReadLock(leaderIsrUpdateLock) {
+                              fetchOnlyFromLeader: Boolean,
+                              remoteLogManager: Option[RemoteLogManager] = None): Option[TimestampAndOffset] = inReadLock(leaderIsrUpdateLock) {
     // decide whether to only fetch from leader
     val localLog = localLogWithEpochOrException(currentLeaderEpoch, fetchOnlyFromLeader)
 
@@ -1149,7 +1151,7 @@ class Partition(val topicPartition: TopicPartition,
         s"start offset from the beginning of this epoch ($epochStart)."))
 
     def getOffsetByTimestamp: Option[TimestampAndOffset] = {
-      logManager.getLog(topicPartition).flatMap(log => log.fetchOffsetByTimestamp(timestamp))
+      logManager.getLog(topicPartition).flatMap(log => log.fetchOffsetByTimestamp(timestamp, remoteLogManager))
     }
 
     // If we're in the lagging HW state after a leader election, throw OffsetNotAvailable for "latest" offset
@@ -1158,7 +1160,7 @@ class Partition(val topicPartition: TopicPartition,
       case ListOffsetsRequest.LATEST_TIMESTAMP =>
         maybeOffsetsError.map(e => throw e)
           .orElse(Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, lastFetchableOffset, Optional.of(leaderEpoch))))
-      case ListOffsetsRequest.EARLIEST_TIMESTAMP =>
+      case ListOffsetsRequest.EARLIEST_TIMESTAMP | ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP =>
         getOffsetByTimestamp
       case _ =>
         getOffsetByTimestamp.filter(timestampAndOffset => timestampAndOffset.offset < lastFetchableOffset)

--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -17,7 +17,7 @@
 
 package kafka.log
 
-import java.io.{Closeable, File, RandomAccessFile}
+import java.io.{File, RandomAccessFile}
 import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.{ByteBuffer, MappedByteBuffer}
@@ -26,17 +26,17 @@ import java.util.concurrent.locks.{Lock, ReentrantLock}
 import kafka.common.IndexOffsetOverflowException
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.{CoreUtils, Logging}
-import org.apache.kafka.common.utils.{ByteBufferUnmapper, OperatingSystem, Utils}
+import org.apache.kafka.common.utils.{ByteBufferUnmapper, OperatingSystem}
 
 /**
  * The abstract index class which holds entry format agnostic methods.
  *
- * @param _file The index file
+ * @param indexFile The index file
  * @param baseOffset the base offset of the segment that this index is corresponding to.
  * @param maxIndexSize The maximum index size in bytes.
  */
-abstract class AbstractIndex(@volatile private var _file: File, val baseOffset: Long, val maxIndexSize: Int = -1,
-                             val writable: Boolean) extends Closeable {
+abstract class AbstractIndex(@volatile private var indexFile: File, val baseOffset: Long, val maxIndexSize: Int = -1,
+                             val writable: Boolean) extends CleanableIndex(indexFile) {
   import AbstractIndex._
 
   // Length of the index file
@@ -152,8 +152,6 @@ abstract class AbstractIndex(@volatile private var _file: File, val baseOffset: 
    */
   def isFull: Boolean = _entries >= _maxEntries
 
-  def file: File = _file
-
   def maxEntries: Int = _maxEntries
 
   def entries: Int = _entries
@@ -199,16 +197,6 @@ abstract class AbstractIndex(@volatile private var _file: File, val baseOffset: 
         }
       }
     }
-  }
-
-  /**
-   * Rename the file that backs this offset index
-   *
-   * @throws IOException if rename fails
-   */
-  def renameTo(f: File): Unit = {
-    try Utils.atomicMoveWithFallback(file.toPath, f.toPath, false)
-    finally _file = f
   }
 
   /**

--- a/core/src/main/scala/kafka/log/CleanableIndex.scala
+++ b/core/src/main/scala/kafka/log/CleanableIndex.scala
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.log
+
+import java.io.{Closeable, File}
+import java.nio.file.Path
+
+import org.apache.kafka.common.utils.Utils
+
+abstract class CleanableIndex(@volatile var _file: File) extends Closeable {
+
+  /**
+   * Rename the file that backs this offset index
+   *
+   * @throws IOException if rename fails
+   */
+  def renameTo(toBeRenamedFile: File): Unit = {
+    try
+      if (_file.exists) Utils.atomicMoveWithFallback(_file.toPath, toBeRenamedFile.toPath)
+    finally _file = toBeRenamedFile
+  }
+
+  def file: File = _file
+
+  def path: Path = if (file.exists()) file.toPath else null
+
+  def deleteIfExists(): Boolean
+}

--- a/core/src/main/scala/kafka/log/CleanableIndex.scala
+++ b/core/src/main/scala/kafka/log/CleanableIndex.scala
@@ -30,7 +30,7 @@ abstract class CleanableIndex(@volatile var _file: File) extends Closeable {
    */
   def renameTo(toBeRenamedFile: File): Unit = {
     try
-      if (_file.exists) Utils.atomicMoveWithFallback(_file.toPath, toBeRenamedFile.toPath)
+      if (_file.exists) Utils.atomicMoveWithFallback(_file.toPath, toBeRenamedFile.toPath, false)
     finally _file = toBeRenamedFile
   }
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -27,6 +27,7 @@ import java.util.regex.Pattern
 import kafka.api.{ApiVersion, KAFKA_0_10_0_IV0}
 import kafka.common.{LongRef, OffsetsOutOfOrderException, UnexpectedAppendOffsetException}
 import kafka.log.AppendOrigin.RaftLeader
+import kafka.log.remote.RemoteLogManager
 import kafka.message.{BrokerCompressionCodec, CompressionCodec, NoCompressionCodec}
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.checkpoints.LeaderEpochCheckpointFile
@@ -34,6 +35,7 @@ import kafka.server.epoch.LeaderEpochFileCache
 import kafka.server.{BrokerTopicStats, FetchDataInfo, FetchHighWatermark, FetchIsolation, FetchLogEnd, FetchTxnCommitted, LogDirFailureChannel, LogOffsetMetadata, OffsetAndEpoch, PartitionMetadataFile, RequestLocal}
 import kafka.utils._
 import org.apache.kafka.common.errors._
+import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.{DescribeProducersResponseData, FetchResponseData}
 import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.record._
@@ -271,7 +273,8 @@ class Log(@volatile private var _dir: File,
           val producerStateManager: ProducerStateManager,
           logDirFailureChannel: LogDirFailureChannel,
           @volatile private var _topicId: Option[Uuid],
-          val keepPartitionMetadataFile: Boolean) extends Logging with KafkaMetricsGroup {
+          val keepPartitionMetadataFile: Boolean,
+          val rlmEnabled: Boolean = false) extends Logging with KafkaMetricsGroup {
 
   import kafka.log.Log._
 
@@ -312,9 +315,19 @@ class Log(@volatile private var _dir: File,
 
   @volatile var partitionMetadataFile : PartitionMetadataFile = null
 
+  @volatile private var localLogStartOffset: Long = logStartOffset
+
+  @volatile private var highestOffsetWithRemoteIndex: Long = -1L
+
+  private def remoteLogEnabled(): Boolean = {
+    // remote logging is enabled only for non-compact and non-internal topics
+    rlmEnabled && !(config.compact || Topic.isInternal(topicPartition.topic()))
+  }
   locally {
+    val startMs = time.milliseconds
     initializePartitionMetadata()
-    updateLogStartOffset(logStartOffset)
+    updateLocalLogStartOffset(logStartOffset)
+    if (!remoteLogEnabled()) logStartOffset = localLogStartOffset
     maybeIncrementFirstUnstableOffset()
     initializeTopicId()
   }
@@ -353,6 +366,11 @@ class Log(@volatile private var _dir: File,
       // We want to keep the file and the in-memory topic ID in sync.
       _topicId = None
     }
+  }
+
+  def updateLogStartOffsetFromRemoteTier(remoteLogStartOffset: Long): Unit = {
+    if (remoteLogEnabled()) logStartOffset = if (remoteLogStartOffset < 0) localLogStartOffset else remoteLogStartOffset
+    else warn(s"updateLogStartOffsetFromRemoteTier call is ignored as remoteLogEnabled is determined to be false.")
   }
 
   def topicId: Option[Uuid] = _topicId
@@ -414,6 +432,12 @@ class Log(@volatile private var _dir: File,
 
     updateHighWatermarkMetadata(newHighWatermarkMetadata)
     newHighWatermarkMetadata.messageOffset
+  }
+
+  def updateRemoteIndexHighestOffset(offset: Long): Unit = {
+    if (!remoteLogEnabled())
+      warn(s"Received update for highest offset with remote index as: $offset, the existing value: $highestOffsetWithRemoteIndex")
+    else if (offset > highestOffsetWithRemoteIndex) highestOffsetWithRemoteIndex = offset
   }
 
   /**
@@ -562,6 +586,11 @@ class Log(@volatile private var _dir: File,
   /** The name of this log */
   def name  = dir.getName()
 
+  def loadProducerState(lastOffset: Long, reloadFromCleanShutdown: Boolean): Unit = lock synchronized {
+    rebuildProducerState(lastOffset, producerStateManager, reloadFromCleanShutdown)
+    maybeIncrementFirstUnstableOffset()
+  }
+
   private def recordVersion: RecordVersion = config.recordVersion
 
   private def initializePartitionMetadata(): Unit = lock synchronized {
@@ -611,6 +640,18 @@ class Log(@volatile private var _dir: File,
     }
   }
 
+  private def updateLocalLogStartOffset(offset: Long): Unit = {
+    localLogStartOffset = offset
+
+    if (highWatermark < offset) {
+      updateHighWatermark(offset)
+    }
+
+    if (this.recoveryPoint < offset) {
+      this.recoveryPoint = offset
+    }
+  }
+
   private def updateLogStartOffset(offset: Long): Unit = {
     logStartOffset = offset
 
@@ -626,10 +667,11 @@ class Log(@volatile private var _dir: File,
   // Rebuild producer state until lastOffset. This method may be called from the recovery code path, and thus must be
   // free of all side-effects, i.e. it must not update any log-specific state.
   private def rebuildProducerState(lastOffset: Long,
-                                   producerStateManager: ProducerStateManager): Unit = lock synchronized {
+                                   producerStateManager: ProducerStateManager,
+                                   reloadFromCleanShutdown: Boolean = false): Unit = lock synchronized {
     checkIfMemoryMappedBufferClosed()
     Log.rebuildProducerState(producerStateManager, segments, logStartOffset, lastOffset, recordVersion, time,
-      reloadFromCleanShutdown = false, logIdent)
+      reloadFromCleanShutdown, logIdent)
   }
 
   def activeProducers: Seq[DescribeProducersResponseData.ProducerState] = {
@@ -1081,6 +1123,10 @@ class Log(@volatile private var _dir: File,
     }
   }
 
+  private def maybeIncrementLocalLogStartOffset(newLogStartOffset: Long, reason: LogStartOffsetIncrementReason): Unit = {
+    maybeIncrementLogStartOffset(newLogStartOffset, reason, onlyLocalLogStartOffsetUpdate = true)
+  }
+
   /**
    * Increment the log start offset if the provided offset is larger.
    *
@@ -1091,10 +1137,13 @@ class Log(@volatile private var _dir: File,
    * @throws OffsetOutOfRangeException if the log start offset is greater than the high watermark
    * @return true if the log start offset was updated; otherwise false
    */
-  def maybeIncrementLogStartOffset(newLogStartOffset: Long, reason: LogStartOffsetIncrementReason): Boolean = {
+  def maybeIncrementLogStartOffset(newLogStartOffset: Long,
+                                   reason: LogStartOffsetIncrementReason,
+                                   onlyLocalLogStartOffsetUpdate: Boolean = false): Boolean = {
     // We don't have to write the log start offset to log-start-offset-checkpoint immediately.
     // The deleteRecordsOffset may be lost only if all in-sync replicas of this broker are shutdown
     // in an unclean manner within log.flush.start.offset.checkpoint.interval.ms. The chance of this happening is low.
+    //todo-tiering it should even update remote storage to clean until LSO
     var updatedLogStartOffset = false
     maybeHandleIOException(s"Exception while increasing log start offset for $topicPartition to $newLogStartOffset in dir ${dir.getParent}") {
       lock synchronized {
@@ -1104,12 +1153,19 @@ class Log(@volatile private var _dir: File,
 
         checkIfMemoryMappedBufferClosed()
         if (newLogStartOffset > logStartOffset) {
-          updatedLogStartOffset = true
-          updateLogStartOffset(newLogStartOffset)
-          info(s"Incremented log start offset to $newLogStartOffset due to $reason")
-          leaderEpochCache.foreach(_.truncateFromStart(logStartOffset))
-          producerStateManager.onLogStartOffsetIncremented(newLogStartOffset)
-          maybeIncrementFirstUnstableOffset()
+          localLogStartOffset = math.max(newLogStartOffset, localLogStartOffset)
+
+          // it should always get updated  if tiered-storage is not enabled.
+          if (!onlyLocalLogStartOffsetUpdate || !remoteLogEnabled()) {
+            updatedLogStartOffset = true
+            updateLogStartOffset(newLogStartOffset)
+            info(s"Incremented log start offset to $newLogStartOffset due to $reason")
+            leaderEpochCache.foreach(_.truncateFromStart(logStartOffset))
+            producerStateManager.onLogStartOffsetIncremented(newLogStartOffset)
+            maybeIncrementFirstUnstableOffset()
+          } else {
+            info(s"Incrementing local log start offset to $localLogStartOffset")
+          }
         }
       }
     }
@@ -1309,11 +1365,12 @@ class Log(@volatile private var _dir: File,
       val endOffsetMetadata = nextOffsetMetadata
       val endOffset = endOffsetMetadata.messageOffset
       var segmentOpt = segments.floorSegment(startOffset)
-
+      // todo-tiering better to have check whether the requested offset is beyond current localLogStartOffset instead of
+      //catching this exception later to fetch from remote storage
       // return error on attempt to read beyond the log end offset or read below log start offset
-      if (startOffset > endOffset || segmentOpt.isEmpty || startOffset < logStartOffset)
+      if (startOffset > endOffset || segmentOpt.isEmpty || startOffset < localLogStartOffset)
         throw new OffsetOutOfRangeException(s"Received request for offset $startOffset for partition $topicPartition, " +
-          s"but we only have log segments in the range $logStartOffset to $endOffset.")
+          s"but we only have local log segments in the range $localLogStartOffset to $endOffset.")
 
       val maxOffsetMetadata = isolation match {
         case FetchLogEnd => endOffsetMetadata
@@ -1414,19 +1471,26 @@ class Log(@volatile private var _dir: File,
    *         None if no such message is found.
    */
   @nowarn("cat=deprecation")
-  def fetchOffsetByTimestamp(targetTimestamp: Long): Option[TimestampAndOffset] = {
+  def fetchOffsetByTimestamp(targetTimestamp: Long, remoteLogManager: Option[RemoteLogManager] = None): Option[TimestampAndOffset] = {
     maybeHandleIOException(s"Error while fetching offset by timestamp for $topicPartition in dir ${dir.getParent}") {
       debug(s"Searching offset for timestamp $targetTimestamp")
 
       if (config.messageFormatVersion < KAFKA_0_10_0_IV0 &&
         targetTimestamp != ListOffsetsRequest.EARLIEST_TIMESTAMP &&
+        targetTimestamp != ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP &&
         targetTimestamp != ListOffsetsRequest.LATEST_TIMESTAMP)
         throw new UnsupportedForMessageFormatException(s"Cannot search offsets based on timestamp because message format version " +
           s"for partition $topicPartition is ${config.messageFormatVersion} which is earlier than the minimum " +
           s"required version $KAFKA_0_10_0_IV0")
 
+      // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
+      // constant time access while being safe to use with concurrent collections unlike `toArray`.
+      val segmentsCopy = logSegments.toBuffer
+
       // For the earliest and latest, we do not need to return the timestamp.
-      if (targetTimestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP) {
+      if (targetTimestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP ||
+        (!remoteLogEnabled() && targetTimestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)) {
+        // If remote log is not enabled, EARLIEST_LOCAL_TIMESTAMP is same with EARLIEST_TIMESTAMP
         // The first cached epoch usually corresponds to the log start offset, but we have to verify this since
         // it may not be true following a message format version bump as the epoch will not be available for
         // log entries written in the older format.
@@ -1436,6 +1500,11 @@ class Log(@volatile private var _dir: File,
           case _ => Optional.empty[Integer]()
         }
         Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, logStartOffset, epochOpt))
+      } else if (targetTimestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP) {
+        // EARLIEST_LOCAL_TIMESTAMP is only used by follower brokers, to find out the offset that they
+        // should start fetching from. Since the followers do not need the epoch, we can return
+        // an empty epoch here to keep things simple.
+        Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, localLogStartOffset, Optional.empty[Integer]()))
       } else if (targetTimestamp == ListOffsetsRequest.LATEST_TIMESTAMP) {
         val latestEpochOpt = leaderEpochCache.flatMap(_.latestEpoch).map(_.asInstanceOf[Integer])
         val epochOptional = Optional.ofNullable(latestEpochOpt.orNull)
@@ -1452,12 +1521,34 @@ class Log(@volatile private var _dir: File,
           latestTimestampAndOffset.offset,
           epochOptional))
       } else {
-        // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
-        // constant time access while being safe to use with concurrent collections unlike `toArray`.
-        val segmentsCopy = logSegments.toBuffer
-        // We need to search the first segment whose largest timestamp is >= the target timestamp if there is one.
-        val targetSeg = segmentsCopy.find(_.largestTimestamp >= targetTimestamp)
-        targetSeg.flatMap(_.findOffsetByTimestamp(targetTimestamp, logStartOffset))
+        var isFirstSegment = false
+        val targetSeg: Option[LogSegment] = {
+          // Get all the segments whose largest timestamp is smaller than target timestamp
+          val earlierSegs = segmentsCopy.takeWhile(_.largestTimestamp < targetTimestamp)
+          // We need to search the first segment whose largest timestamp is greater than the target timestamp if there is one.
+          if (earlierSegs.length < segmentsCopy.length) {
+            isFirstSegment = earlierSegs.isEmpty
+            Some(segmentsCopy(earlierSegs.length))
+          } else {
+            None
+          }
+        }
+
+        if (isFirstSegment && remoteLogManager.isDefined) {
+          val localOffset = targetSeg.get.findOffsetByTimestamp(targetTimestamp, localLogStartOffset)
+          val remoteOffset = remoteLogManager.get.findOffsetByTimestamp(topicPartition, targetTimestamp, logStartOffset)
+
+          if (localOffset.isEmpty)
+            remoteOffset
+          else if (remoteOffset.isEmpty)
+            localOffset
+          else if (localOffset.get.offset <= remoteOffset.get.offset)
+            localOffset
+          else
+            remoteOffset
+        } else {
+          targetSeg.flatMap(_.findOffsetByTimestamp(targetTimestamp, logStartOffset))
+        }
       }
     }
   }
@@ -1484,6 +1575,8 @@ class Log(@volatile private var _dir: File,
       case ListOffsetsRequest.LATEST_TIMESTAMP =>
         startIndex = offsetTimeArray.length - 1
       case ListOffsetsRequest.EARLIEST_TIMESTAMP =>
+        startIndex = 0
+      case ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP =>
         startIndex = 0
       case _ =>
         var isFound = false
@@ -1549,7 +1642,7 @@ class Log(@volatile private var _dir: File,
           checkIfMemoryMappedBufferClosed()
           // remove the segments for lookups
           removeAndDeleteSegments(deletable, asyncDelete = true, reason)
-          maybeIncrementLogStartOffset(segments.firstSegment.get.baseOffset, SegmentDeletion)
+          maybeIncrementLocalLogStartOffset(segments.firstSegment.get.baseOffset, SegmentDeletion)
         }
       }
       numToDelete
@@ -1585,7 +1678,12 @@ class Log(@volatile private var _dir: File,
             (logEndOffset, segment.size == 0)
           }
 
-        if (highWatermark >= upperBoundOffset && predicate(segment, nextSegmentOpt) && !isLastSegmentAndEmpty) {
+        // check not to delete segments which do not have remote indexes locally.
+        val deleteOnlyWhenRemoteIndexExistsLocally =
+          if(remoteLogEnabled()) upperBoundOffset > 0 && upperBoundOffset-1 <= highestOffsetWithRemoteIndex else true
+
+        if (deleteOnlyWhenRemoteIndexExistsLocally && highWatermark >= upperBoundOffset
+          && predicate(segment, nextSegmentOpt) && !isLastSegmentAndEmpty) {
           deletable += segment
           segmentOpt = nextSegmentOpt
         } else {
@@ -1640,8 +1738,8 @@ class Log(@volatile private var _dir: File,
 
   private def deleteLogStartOffsetBreachedSegments(): Int = {
     def shouldDelete(segment: LogSegment, nextSegmentOpt: Option[LogSegment]): Boolean = {
-      nextSegmentOpt.exists(_.baseOffset <= logStartOffset) ||
-        (nextSegmentOpt.isEmpty && logEndOffset == logStartOffset)
+      nextSegmentOpt.exists(_.baseOffset <= localLogStartOffset) ||
+        (nextSegmentOpt.isEmpty && logEndOffset == localLogStartOffset)
     }
 
     deleteOldSegments(shouldDelete, StartOffsetBreach)
@@ -1871,6 +1969,7 @@ class Log(@volatile private var _dir: File,
    * @return True iff targetOffset < logEndOffset
    */
   private[kafka] def truncateTo(targetOffset: Long): Boolean = {
+    //todo-tiering truncation is generally done to recover segments
     maybeHandleIOException(s"Error while truncating log to offset $targetOffset for $topicPartition in dir ${dir.getParent}") {
       if (targetOffset < 0)
         throw new IllegalArgumentException(s"Cannot truncate partition $topicPartition to a negative offset (%d).".format(targetOffset))
@@ -1896,6 +1995,11 @@ class Log(@volatile private var _dir: File,
             val deletable = logSegments.filter(segment => segment.baseOffset > targetOffset)
             removeAndDeleteSegments(deletable, asyncDelete = true, LogTruncation)
             activeSegment.truncateTo(targetOffset)
+
+            // TODO: @kamalcph check the logic again
+            this.localLogStartOffset = math.min(targetOffset, this.localLogStartOffset)
+            updateLogStartOffset(math.min(this.localLogStartOffset, this.logStartOffset))
+
             leaderEpochCache.foreach(_.truncateFromEnd(targetOffset))
 
             completeTruncation(
@@ -1941,7 +2045,13 @@ class Log(@volatile private var _dir: File,
     startOffset: Long,
     endOffset: Long
   ): Unit = {
-    logStartOffset = startOffset
+    // TODO: @kamalcph check the logic again.
+    if (remoteLogEnabled()) {
+      updateLocalLogStartOffset(startOffset)
+    } else {
+      updateLogStartOffset(startOffset)
+    }
+    // logStartOffset = startOffset
     nextOffsetMetadata = LogOffsetMetadata(endOffset, activeSegment.baseOffset, activeSegment.size)
     recoveryPoint = math.min(recoveryPoint, endOffset)
     rebuildProducerState(endOffset, producerStateManager)
@@ -2138,7 +2248,8 @@ object Log extends Logging {
             logDirFailureChannel: LogDirFailureChannel,
             lastShutdownClean: Boolean = true,
             topicId: Option[Uuid],
-            keepPartitionMetadataFile: Boolean): Log = {
+            keepPartitionMetadataFile: Boolean,
+            remoteLogEnable: Boolean = false): Log = {
     // create the log directory if it doesn't exist
     Files.createDirectories(dir.toPath)
     val topicPartition = Log.parseTopicPartitionName(dir)
@@ -2166,7 +2277,7 @@ object Log extends Logging {
       producerStateManager))
     new Log(dir, config, segments, offsets.logStartOffset, offsets.recoveryPoint, offsets.nextOffsetMetadata, scheduler,
       brokerTopicStats, time, producerIdExpirationCheckIntervalMs, topicPartition, leaderEpochCache,
-      producerStateManager, logDirFailureChannel, topicId, keepPartitionMetadataFile)
+      producerStateManager, logDirFailureChannel, topicId, keepPartitionMetadataFile, remoteLogEnable)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1482,10 +1482,6 @@ class Log(@volatile private var _dir: File,
           s"for partition $topicPartition is ${config.messageFormatVersion} which is earlier than the minimum " +
           s"required version $KAFKA_0_10_0_IV0")
 
-      // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
-      // constant time access while being safe to use with concurrent collections unlike `toArray`.
-      val segmentsCopy = logSegments.toBuffer
-
       // For the earliest and latest, we do not need to return the timestamp.
       if (targetTimestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP ||
         (!remoteLogEnabled() && targetTimestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)) {
@@ -1509,6 +1505,7 @@ class Log(@volatile private var _dir: File,
         val epochOptional = Optional.ofNullable(latestEpochOpt.orNull)
         Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, logEndOffset, epochOptional))
       } else if (targetTimestamp == ListOffsetsRequest.MAX_TIMESTAMP) {
+        // TODO @tchatter : Make this work for tiered storage.
         // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
         // constant time access while being safe to use with concurrent collections unlike `toArray`.
         val segmentsCopy = logSegments.toBuffer
@@ -1520,6 +1517,9 @@ class Log(@volatile private var _dir: File,
           latestTimestampAndOffset.offset,
           epochOptional))
       } else {
+        // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
+        // constant time access while being safe to use with concurrent collections unlike `toArray`.
+        val segmentsCopy = logSegments.toBuffer
         var isFirstSegment = false
         val targetSeg: Option[LogSegment] = {
           // Get all the segments whose largest timestamp is smaller than target timestamp
@@ -1534,6 +1534,7 @@ class Log(@volatile private var _dir: File,
         }
 
         if (isFirstSegment && remoteLogManager.isDefined) {
+          // FIXME @tchatter : This does not work for unclean leader election combined with tiered storage.
           val localOffset = targetSeg.get.findOffsetByTimestamp(targetTimestamp, localLogStartOffset)
           val remoteOffset = remoteLogManager.get.findOffsetByTimestamp(topicPartition, targetTimestamp, logStartOffset)
 
@@ -1994,10 +1995,6 @@ class Log(@volatile private var _dir: File,
             val deletable = logSegments.filter(segment => segment.baseOffset > targetOffset)
             removeAndDeleteSegments(deletable, asyncDelete = true, LogTruncation)
             activeSegment.truncateTo(targetOffset)
-
-            // TODO: @kamalcph check the logic again
-            this.localLogStartOffset = math.min(targetOffset, this.localLogStartOffset)
-            updateLogStartOffset(math.min(this.localLogStartOffset, this.logStartOffset))
 
             leaderEpochCache.foreach(_.truncateFromEnd(targetOffset))
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1476,7 +1476,7 @@ class Log(@volatile private var _dir: File,
 
       if (config.messageFormatVersion < KAFKA_0_10_0_IV0 &&
         targetTimestamp != ListOffsetsRequest.EARLIEST_TIMESTAMP &&
-        targetTimestamp != ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP &&
+        targetTimestamp != ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP &&
         targetTimestamp != ListOffsetsRequest.LATEST_TIMESTAMP)
         throw new UnsupportedForMessageFormatException(s"Cannot search offsets based on timestamp because message format version " +
           s"for partition $topicPartition is ${config.messageFormatVersion} which is earlier than the minimum " +
@@ -1484,7 +1484,7 @@ class Log(@volatile private var _dir: File,
 
       // For the earliest and latest, we do not need to return the timestamp.
       if (targetTimestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP ||
-        (!remoteLogEnabled() && targetTimestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)) {
+        (!remoteLogEnabled() && targetTimestamp == ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP)) {
         // If remote log is not enabled, EARLIEST_LOCAL_TIMESTAMP is same with EARLIEST_TIMESTAMP
         // The first cached epoch usually corresponds to the log start offset, but we have to verify this since
         // it may not be true following a message format version bump as the epoch will not be available for
@@ -1495,7 +1495,7 @@ class Log(@volatile private var _dir: File,
           case _ => Optional.empty[Integer]()
         }
         Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, logStartOffset, epochOpt))
-      } else if (targetTimestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP) {
+      } else if (targetTimestamp == ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP) {
         // EARLIEST_LOCAL_TIMESTAMP is only used by follower brokers, to find out the offset that they
         // should start fetching from. Since the followers do not need the epoch, we can return
         // an empty epoch here to keep things simple.
@@ -1576,7 +1576,7 @@ class Log(@volatile private var _dir: File,
         startIndex = offsetTimeArray.length - 1
       case ListOffsetsRequest.EARLIEST_TIMESTAMP =>
         startIndex = 0
-      case ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP =>
+      case ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP =>
         startIndex = 0
       case _ =>
         var isFound = false

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -586,8 +586,8 @@ class Log(@volatile private var _dir: File,
   /** The name of this log */
   def name  = dir.getName()
 
-  def loadProducerState(lastOffset: Long, reloadFromCleanShutdown: Boolean): Unit = lock synchronized {
-    rebuildProducerState(lastOffset, producerStateManager, reloadFromCleanShutdown)
+  def loadProducerState(lastOffset: Long): Unit = lock synchronized {
+    rebuildProducerState(lastOffset, producerStateManager)
     maybeIncrementFirstUnstableOffset()
   }
 
@@ -667,11 +667,10 @@ class Log(@volatile private var _dir: File,
   // Rebuild producer state until lastOffset. This method may be called from the recovery code path, and thus must be
   // free of all side-effects, i.e. it must not update any log-specific state.
   private def rebuildProducerState(lastOffset: Long,
-                                   producerStateManager: ProducerStateManager,
-                                   reloadFromCleanShutdown: Boolean = false): Unit = lock synchronized {
+                                   producerStateManager: ProducerStateManager): Unit = lock synchronized {
     checkIfMemoryMappedBufferClosed()
     Log.rebuildProducerState(producerStateManager, segments, logStartOffset, lastOffset, recordVersion, time,
-      reloadFromCleanShutdown, logIdent)
+      reloadFromCleanShutdown = false, logIdent)
   }
 
   def activeProducers: Seq[DescribeProducersResponseData.ProducerState] = {

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -504,6 +504,12 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   // completed transactions whose markers are at offsets above the high watermark
   private val unreplicatedTxns = new util.TreeMap[Long, TxnMetadata]
 
+  def reloadSegments(): Unit = {
+    info("Reloading the producer state snapshots")
+    truncateFullyAndStartAt(0L)
+    snapshots = loadSnapshots()
+  }
+
   /**
    * Load producer state snapshots by scanning the _logDir.
    */
@@ -727,6 +733,10 @@ class ProducerStateManager(val topicPartition: TopicPartition,
       // Update the last snap offset according to the serialized map
       lastSnapOffset = lastMapOffset
     }
+  }
+
+  def fetchSnapshot(offset:Long): Option[File] = {
+    Option(snapshots.get(offset)).map(_.file)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/remote/ClassLoaderAwareRemoteStorageManager.scala
+++ b/core/src/main/scala/kafka/log/remote/ClassLoaderAwareRemoteStorageManager.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.log.remote
+
+import org.apache.kafka.server.log.remote.storage.{LogSegmentData, RemoteLogSegmentMetadata, RemoteStorageManager}
+
+import java.io.InputStream
+import java.util
+
+/**
+ * A wrapper class of RemoteStorageManager that sets the context class loader when calling RSM methods.
+ */
+class ClassLoaderAwareRemoteStorageManager(val rsm: RemoteStorageManager,
+                                           val rsmClassLoader: ClassLoader) extends RemoteStorageManager {
+
+  def withClassLoader[T](fun: => T): T = {
+    val originalClassLoader = Thread.currentThread.getContextClassLoader
+    Thread.currentThread.setContextClassLoader(rsmClassLoader)
+    try {
+      fun
+    } finally {
+      Thread.currentThread.setContextClassLoader(originalClassLoader)
+    }
+  }
+
+  def delegate(): RemoteStorageManager = {
+    rsm
+  }
+
+  override def close(): Unit = withClassLoader {
+    rsm.close()
+  }
+
+  override def configure(configs: util.Map[String, _]): Unit = withClassLoader {
+    rsm.configure(configs)
+  }
+
+  override def copyLogSegmentData(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
+                                  logSegmentData: LogSegmentData): Unit = withClassLoader {
+    rsm.copyLogSegmentData(remoteLogSegmentMetadata, logSegmentData)
+  }
+
+  override def fetchLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
+                               startPosition: Int): InputStream = withClassLoader {
+    rsm.fetchLogSegment(remoteLogSegmentMetadata, startPosition)
+  }
+
+  override def fetchLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
+                               startPosition: Int,
+                               endPosition: Int): InputStream = withClassLoader {
+    rsm.fetchLogSegment(remoteLogSegmentMetadata, startPosition, endPosition)
+  }
+
+  override def fetchIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
+                          indexType: RemoteStorageManager.IndexType): InputStream = withClassLoader {
+    rsm.fetchIndex(remoteLogSegmentMetadata, indexType)
+  }
+
+  override def deleteLogSegmentData(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = withClassLoader {
+    rsm.deleteLogSegmentData(remoteLogSegmentMetadata)
+  }
+}

--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.log.remote
+
+import java.io.{File, InputStream}
+import java.nio.file.{Files, Path}
+import java.util
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import kafka.log.{CleanableIndex, Log, OffsetIndex, OffsetPosition, TimeIndex, TransactionIndex, TxnIndexSearchResult}
+import kafka.utils.{CoreUtils, Logging}
+import org.apache.kafka.common.errors.CorruptRecordException
+import org.apache.kafka.common.utils.{KafkaThread, Utils}
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType
+import org.apache.kafka.server.log.remote.storage.{RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteStorageManager}
+
+object RemoteIndexCache {
+  val DirName = "remote-log-index-cache"
+  val TmpFileSuffix = ".tmp"
+  val OffsetIndexFileSuffix = ".oi"
+  val TimeIndexFileSuffix = ".ti"
+  val TxnIndexFileSuffix = ".tx"
+}
+
+class Entry(val offsetIndex: OffsetIndex, val timeIndex: TimeIndex, val txnIndex: TransactionIndex) {
+  private val closed = new AtomicBoolean(false)
+
+  def lookupOffset(targetOffset: Long): OffsetPosition = {
+    if (closed.get()) throw new IllegalStateException("This entry is already closed")
+    else offsetIndex.lookup(targetOffset)
+  }
+
+  def lookupTimestamp(timestamp: Long, startingOffset: Long): OffsetPosition = {
+    if (closed.get()) throw new IllegalStateException("This entry is already closed")
+
+    val timestampOffset = timeIndex.lookup(timestamp)
+    offsetIndex.lookup(math.max(startingOffset, timestampOffset.offset))
+  }
+
+  def close(): Unit = {
+    if (!closed.getAndSet(true)) {
+      Array(offsetIndex, timeIndex, txnIndex).foreach(x =>
+        x.renameTo(new File(CoreUtils.replaceSuffix(x.file.getPath, "", Log.DeletedFileSuffix))))
+    }
+  }
+
+  def cleanup(): Unit = {
+    close()
+    CoreUtils.tryAll(Seq(() => offsetIndex.deleteIfExists(), () => timeIndex.deleteIfExists(), () => txnIndex.deleteIfExists()))
+  }
+}
+
+//todo-tier make maxSize configurable
+class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageManager, logDir: String) extends Logging {
+
+  val cacheDir = new File(logDir, "remote-log-index-cache")
+  @volatile var closed = false
+
+  val expiredIndexes = new LinkedBlockingQueue[Entry]()
+  val lock = new Object()
+
+  val entries: util.Map[RemoteLogSegmentId, Entry] = new java.util.LinkedHashMap[RemoteLogSegmentId, Entry](maxSize / 2,
+    0.75f, true) {
+    override def removeEldestEntry(eldest: util.Map.Entry[RemoteLogSegmentId, Entry]): Boolean = {
+      if (this.size() >= maxSize) {
+        val entry = eldest.getValue
+        // close the entries, background thread will clean them later.
+        entry.close()
+        expiredIndexes.add(entry)
+        true
+      } else {
+        false
+      }
+    }
+  }
+
+  private def init(): Unit = {
+    if (cacheDir.mkdir())
+      info(s"Created $cacheDir successfully")
+
+    // delete any .deleted files remained from the earlier run of the broker.
+    Files.list(cacheDir.toPath).forEach((path: Path) => {
+      if (path.endsWith(Log.DeletedFileSuffix)) {
+        Files.deleteIfExists(path)
+      }
+    })
+
+    //todo-tier load the stored entries into the cache.
+  }
+
+  init()
+
+  // Start cleaner thread that will clean the expired entries
+  val cleanerThread: KafkaThread = KafkaThread.daemon("remote-log-index-cleaner", () => {
+    while (!closed) {
+      try {
+        val entry = expiredIndexes.take()
+        info(s"Cleaning up index entry $entry")
+        entry.cleanup()
+      } catch {
+        case ex: Exception => error("Error occurred while fetching/cleaning up expired entry", ex)
+      }
+    }
+  })
+  cleanerThread.start()
+
+  def getIndexEntry(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Entry = {
+    def loadIndexFile[T <: CleanableIndex](fileName: String,
+                                           suffix: String,
+                                           fetchRemoteIndex: RemoteLogSegmentMetadata => InputStream,
+                                           readIndex: File => T): T = {
+      val indexFile = new File(cacheDir, fileName + suffix)
+
+      def fetchAndCreateIndex(): T = {
+        val inputStream = fetchRemoteIndex(remoteLogSegmentMetadata)
+        val tmpIndexFile = new File(cacheDir, fileName + suffix + RemoteIndexCache.TmpFileSuffix)
+
+        // Below FileChannel#transferFrom call may be efficient as it goes through a fast path of transferring directly
+        // from the source channel into the filesystem cache. But if it goes through non-fast path then it expects the
+        // inputStream to always have available bytes. This is an unnecessary restriction on RemoteStorageManager to
+        // always return InputStream to have available bytes till the end.
+        // FileChannel.open(tmpIndexFile.toPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
+        // .transferFrom(sourceChannel, 0, Int.MaxValue)
+        Files.copy(inputStream, tmpIndexFile.toPath)
+
+        Utils.atomicMoveWithFallback(tmpIndexFile.toPath, indexFile.toPath)
+        readIndex(indexFile)
+      }
+
+      if (indexFile.exists()) {
+        try {
+          readIndex(indexFile)
+        } catch {
+          case ex: CorruptRecordException =>
+            info("Error occurred while loading the stored index", ex)
+            fetchAndCreateIndex()
+        }
+      } else {
+        fetchAndCreateIndex()
+      }
+    }
+
+    lock synchronized {
+      entries.computeIfAbsent(remoteLogSegmentMetadata.remoteLogSegmentId(), (key: RemoteLogSegmentId) => {
+        val fileName = key.id().toString
+        val startOffset = remoteLogSegmentMetadata.startOffset()
+
+        val offsetIndex: OffsetIndex = loadIndexFile(fileName, RemoteIndexCache.OffsetIndexFileSuffix,
+          rlsMetadata => remoteStorageManager.fetchIndex(rlsMetadata, IndexType.OFFSET),
+          file => {
+            val index = new OffsetIndex(file, startOffset, Int.MaxValue, writable = false)
+            index.sanityCheck()
+            index
+          })
+
+        val timeIndex: TimeIndex = loadIndexFile(fileName, RemoteIndexCache.TimeIndexFileSuffix,
+          rlsMetadata => remoteStorageManager.fetchIndex(rlsMetadata, IndexType.TIMESTAMP),
+          file => {
+            val index = new TimeIndex(file, startOffset, Int.MaxValue, writable = false)
+            index.sanityCheck()
+            index
+          })
+
+        val txnIndex: TransactionIndex = loadIndexFile(fileName, RemoteIndexCache.TxnIndexFileSuffix,
+          rlsMetadata => remoteStorageManager.fetchIndex(rlsMetadata, IndexType.TRANSACTION),
+          file => {
+            val index = new TransactionIndex(startOffset, file)
+            index.sanityCheck()
+            index
+          })
+
+        new Entry(offsetIndex, timeIndex, txnIndex)
+      })
+    }
+  }
+
+  def lookupOffset(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, offset: Long): Int = {
+    getIndexEntry(remoteLogSegmentMetadata).lookupOffset(offset).position
+  }
+
+  def lookupTimestamp(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, timestamp: Long, startingOffset: Long): Int = {
+    getIndexEntry(remoteLogSegmentMetadata).lookupTimestamp(timestamp, startingOffset).position
+  }
+
+  def collectAbortedTransaction(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
+                                startOffset: Long,
+                                fetchSize: Int): TxnIndexSearchResult = {
+    val entry = getIndexEntry(remoteLogSegmentMetadata)
+    val maxOffset = entry.offsetIndex.fetchUpperBoundOffset(entry.offsetIndex.lookup(startOffset), fetchSize)
+      .map(_.offset)
+
+    maxOffset.map(x => entry.txnIndex.collectAbortedTxns(startOffset, x))
+      .getOrElse(TxnIndexSearchResult(List.empty, isComplete = false))
+  }
+
+  def close(): Unit = {
+    closed = true
+    cleanerThread.interrupt()
+  }
+
+}

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -194,15 +194,19 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
 
   private def doHandleLeaderOrFollowerPartitions(topicPartition: TopicIdPartition,
                                                  convertToLeaderOrFollower: RLMTask => Unit): Unit = {
+    var conversionRequired = true
     val rlmTaskWithFuture = leaderOrFollowerTasks.computeIfAbsent(topicPartition, (tp: TopicIdPartition) => {
       val task = new RLMTask(tp)
       // set this upfront when it is getting initialized instead of doing it after scheduling.
       convertToLeaderOrFollower(task)
+      conversionRequired = false
       info(s"Created a new task: $task and getting scheduled")
       val future = rlmScheduledThreadPool.scheduleWithFixedDelay(task, 0, delayInMs, TimeUnit.MILLISECONDS)
       RLMTaskWithFuture(task, future)
     })
-    convertToLeaderOrFollower(rlmTaskWithFuture.rlmTask)
+    if (conversionRequired) {
+      convertToLeaderOrFollower(rlmTaskWithFuture.rlmTask)
+    }
   }
 
   def onEndpointCreated(serverEndPoint: Endpoint): Unit = {

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -1,0 +1,844 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.log.remote
+
+import java.io.{Closeable, File, InputStream}
+import java.nio.ByteBuffer
+import java.nio.file.Files
+import java.util
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.{Collections, Optional}
+import kafka.cluster.Partition
+import kafka.log.Log
+import kafka.metrics.KafkaMetricsGroup
+import kafka.server.checkpoints.LeaderEpochCheckpointFile
+import kafka.server.epoch.EpochEntry
+import kafka.server.{BrokerTopicStats, FetchDataInfo, FetchTxnCommitted, KafkaConfig, LogOffsetMetadata, RemoteStorageFetchInfo}
+import kafka.utils.Logging
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.common.{Endpoint, KafkaException, TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.common.errors.OffsetOutOfRangeException
+import org.apache.kafka.common.internals.Topic
+import org.apache.kafka.common.message.FetchResponseData.AbortedTransaction
+import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
+import org.apache.kafka.common.record.{MemoryRecords, RecordBatch, RemoteLogInputStream}
+import org.apache.kafka.common.requests.FetchRequest.PartitionData
+import org.apache.kafka.common.utils.{ChildFirstClassLoader, KafkaThread, Time, Utils}
+import org.apache.kafka.server.log.remote.metadata.storage.ClassLoaderAwareRemoteLogMetadataManager
+import org.apache.kafka.server.log.remote.storage.{LogSegmentData, RemoteLogManagerConfig, RemoteLogMetadataManager, RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteLogSegmentMetadataUpdate, RemoteLogSegmentState, RemoteStorageManager}
+
+import scala.collection.mutable
+import scala.collection.Searching._
+import scala.collection.Set
+import scala.jdk.CollectionConverters._
+
+class RLMScheduledThreadPool(poolSize: Int) extends Logging {
+
+  private val scheduledThreadPool: ScheduledThreadPoolExecutor = {
+    val threadPool = new ScheduledThreadPoolExecutor(poolSize)
+    threadPool.setRemoveOnCancelPolicy(true)
+    threadPool.setExecuteExistingDelayedTasksAfterShutdownPolicy(false)
+    threadPool.setThreadFactory(new ThreadFactory {
+      private val sequence = new AtomicInteger()
+
+      override def newThread(r: Runnable): Thread = {
+        KafkaThread.daemon("kafka-rlm-thread-pool-" + sequence.incrementAndGet(), r)
+      }
+    })
+
+    threadPool
+  }
+
+  def resizePool(size: Int): Unit = {
+    info(s"Resizing pool from ${scheduledThreadPool.getCorePoolSize} to $size")
+    scheduledThreadPool.setCorePoolSize(size)
+  }
+
+  def poolSize(): Int = scheduledThreadPool.getMaximumPoolSize
+
+  def getIdlePercent(): Double = {
+    1 - scheduledThreadPool.getActiveCount().asInstanceOf[Double] / scheduledThreadPool.getCorePoolSize.asInstanceOf[Double]
+  }
+
+  def scheduleWithFixedDelay(runnable: Runnable, initialDelay: Long, delay: Long,
+                             timeUnit: TimeUnit): ScheduledFuture[_] = {
+    info(s"Scheduling runnable $runnable with initial delay: $initialDelay, fixed delay: $delay")
+    scheduledThreadPool.scheduleWithFixedDelay(runnable, initialDelay, delay, timeUnit)
+  }
+
+  def scheduleOnceWithDelay(runnable: Runnable, delay: Long,
+                            timeUnit: TimeUnit): ScheduledFuture[_] = {
+    info(s"Scheduling runnable $runnable once with delay: $delay")
+    scheduledThreadPool.schedule(runnable, delay, timeUnit)
+  }
+
+  def shutdown(): Unit = {
+    info("Shutting down scheduled thread pool")
+    scheduledThreadPool.shutdownNow()
+    //waits for 2 mins to terminate the current tasks
+    scheduledThreadPool.awaitTermination(2, TimeUnit.MINUTES)
+  }
+}
+
+trait CancellableRunnable extends Runnable {
+  @volatile private var cancelled = false
+
+  def cancel(): Unit = {
+    cancelled = true
+  }
+
+  def isCancelled(): Boolean = {
+    cancelled
+  }
+}
+
+class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
+                       updateRemoteLogStartOffset: (TopicPartition, Long) => Unit,
+                       rlmConfig: RemoteLogManagerConfig,
+                       time: Time = Time.SYSTEM,
+                       brokerId: Int,
+                       clusterId: String = "",
+                       logDir: String,
+                       brokerTopicStats: BrokerTopicStats) extends Logging with Closeable with KafkaMetricsGroup  {
+  private val leaderOrFollowerTasks: ConcurrentHashMap[TopicIdPartition, RLMTaskWithFuture] =
+    new ConcurrentHashMap[TopicIdPartition, RLMTaskWithFuture]()
+  private val remoteStorageFetcherThreadPool = new RemoteStorageReaderThreadPool(rlmConfig.remoteLogReaderThreads,
+    rlmConfig.remoteLogReaderMaxPendingTasks, time)
+
+  private val delayInMs = rlmConfig.remoteLogManagerTaskIntervalMs
+  private val poolSize = rlmConfig.remoteLogManagerThreadPoolSize
+  private val rlmScheduledThreadPool = new RLMScheduledThreadPool(poolSize)
+
+  // topic ids received on leadership changes
+  private val topicIds: mutable.Map[String, Uuid] = mutable.Map.empty
+
+  @volatile private var closed = false
+
+  newGauge("RemoteLogManagerTasksAvgIdlePercent", () => {
+    rlmScheduledThreadPool.getIdlePercent()
+  })
+
+  private def createRemoteStorageManager(): ClassLoaderAwareRemoteStorageManager = {
+    val classPath = rlmConfig.remoteStorageManagerClassPath()
+    val rsmClassLoader = {
+      if (classPath != null && classPath.trim.nonEmpty) {
+        new ChildFirstClassLoader(classPath, this.getClass.getClassLoader)
+      } else {
+        this.getClass.getClassLoader
+      }
+    }
+
+    val rsm = rsmClassLoader.loadClass(rlmConfig.remoteStorageManagerClassName())
+      .getDeclaredConstructor().newInstance().asInstanceOf[RemoteStorageManager]
+    new ClassLoaderAwareRemoteStorageManager(rsm, rsmClassLoader)
+  }
+
+  private def configureRSM(): Unit = {
+    val rsmProps = new util.HashMap[String, Any]()
+    rlmConfig.remoteStorageManagerProps().asScala.foreach { case (k, v) => rsmProps.put(k, v) }
+    rsmProps.put(KafkaConfig.BrokerIdProp, brokerId)
+    rsmProps.put("cluster.id", clusterId)
+    remoteLogStorageManager.configure(rsmProps)
+  }
+
+  private def createRemoteLogMetadataManager(): RemoteLogMetadataManager = {
+    val classPath = rlmConfig.remoteLogMetadataManagerClassPath
+
+    val rlmm: RemoteLogMetadataManager = if (classPath != null && classPath.trim.nonEmpty) {
+      val rlmmClassLoader = new ChildFirstClassLoader(classPath, this.getClass.getClassLoader)
+      val rlmmLoaded = rlmmClassLoader.loadClass(rlmConfig.remoteLogMetadataManagerClassName())
+        .getDeclaredConstructor().newInstance().asInstanceOf[RemoteLogMetadataManager]
+      new ClassLoaderAwareRemoteLogMetadataManager(rlmmLoaded, rlmmClassLoader)
+    } else {
+      this.getClass.getClassLoader.loadClass(rlmConfig.remoteLogMetadataManagerClassName()).getDeclaredConstructor()
+        .newInstance().asInstanceOf[RemoteLogMetadataManager]
+    }
+
+    rlmm
+  }
+
+  private def configureRLMM(endPoint: Endpoint): Unit = {
+    val rlmmProps = new util.HashMap[String, Any]()
+    rlmConfig.remoteLogMetadataManagerProps().asScala.foreach { case (k, v) => rlmmProps.put(k, v) }
+    rlmmProps.put(KafkaConfig.LogDirProp, logDir)
+    rlmmProps.put(KafkaConfig.BrokerIdProp, brokerId)
+    rlmmProps.put("cluster.id", clusterId)
+    rlmmProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, endPoint.host + ":" + endPoint.port)
+    rlmmProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, endPoint.securityProtocol.name)
+    remoteLogMetadataManager.configure(rlmmProps)
+  }
+
+  private val remoteLogStorageManager: ClassLoaderAwareRemoteStorageManager = createRemoteStorageManager()
+  val remoteLogMetadataManager: RemoteLogMetadataManager = createRemoteLogMetadataManager()
+
+  private val indexCache = new RemoteIndexCache(remoteStorageManager = remoteLogStorageManager, logDir = logDir)
+
+  private[remote] def rlmScheduledThreadPoolSize: Int = rlmScheduledThreadPool.poolSize()
+
+  private[remote] def leaderOrFollowerTasksSize: Int = leaderOrFollowerTasks.size()
+
+  private def doHandleLeaderOrFollowerPartitions(topicPartition: TopicIdPartition,
+                                                 convertToLeaderOrFollower: RLMTask => Unit): Unit = {
+    val rlmTaskWithFuture = leaderOrFollowerTasks.computeIfAbsent(topicPartition, (tp: TopicIdPartition) => {
+      val task = new RLMTask(tp)
+      // set this upfront when it is getting initialized instead of doing it after scheduling.
+      convertToLeaderOrFollower(task)
+      info(s"Created a new task: $task and getting scheduled")
+      val future = rlmScheduledThreadPool.scheduleWithFixedDelay(task, 0, delayInMs, TimeUnit.MILLISECONDS)
+      RLMTaskWithFuture(task, future)
+    })
+    convertToLeaderOrFollower(rlmTaskWithFuture.rlmTask)
+  }
+
+  def onEndpointCreated(serverEndPoint: Endpoint): Unit = {
+    // initialize and configure RSM and RLMM
+    configureRSM()
+    configureRLMM(serverEndPoint)
+  }
+
+  def storageManager(): RemoteStorageManager = {
+    remoteLogStorageManager.delegate()
+  }
+
+  /**
+   * Callback to receive any leadership changes for the topic partitions assigned to this broker. If there are no
+   * existing tasks for a given topic partition then it will assign new leader or follower task else it will convert the
+   * task to respective target state(leader or follower).
+   *
+   * @param partitionsBecomeLeader   partitions that have become leaders on this broker.
+   * @param partitionsBecomeFollower partitions that have become followers on this broker.
+   */
+  def onLeadershipChange(partitionsBecomeLeader: Set[Partition],
+                         partitionsBecomeFollower: Set[Partition],
+                         topicIds: util.Map[String, Uuid]): Unit = {
+    debug(s"Received leadership changes for leaders: $partitionsBecomeLeader and followers: $partitionsBecomeFollower")
+    topicIds.forEach((topic, uuid) => this.topicIds.put(topic, uuid))
+
+    // Partitions logs are available when this callback is invoked.
+    // Compact topics and internal topics are filtered here as they are not supported with tiered storage.
+    def filterPartitions(partitions: Set[Partition]): Set[Partition] = {
+      partitions.filter(partition => !(Topic.isInternal(partition.topic) || partition.log.exists(log => log.config.compact)))
+    }
+
+    val followerTopicPartitions = filterPartitions(partitionsBecomeFollower).map(partition =>
+      new TopicIdPartition(topicIds.get(partition.topic), partition.topicPartition))
+
+    val filteredLeaderPartitions = filterPartitions(partitionsBecomeLeader)
+    val leaderTopicPartitions = filteredLeaderPartitions.map(partition =>
+      new TopicIdPartition(topicIds.get(partition.topic), partition.topicPartition))
+
+    debug(s"Effective topic partitions after filtering compact and internal topics, leaders: $leaderTopicPartitions " +
+      s"and followers: $followerTopicPartitions")
+
+    if (leaderTopicPartitions.nonEmpty || followerTopicPartitions.nonEmpty) {
+     remoteLogMetadataManager.onPartitionLeadershipChanges(leaderTopicPartitions.asJava, followerTopicPartitions.asJava)
+    }
+
+    followerTopicPartitions.foreach { tp => doHandleLeaderOrFollowerPartitions(tp, task => task.convertToFollower())}
+
+    filteredLeaderPartitions.foreach { partition =>
+      doHandleLeaderOrFollowerPartitions(new TopicIdPartition(topicIds.get(partition.topic), partition.topicPartition),
+        task => task.convertToLeader(partition.getLeaderEpoch))
+    }
+  }
+
+  /**
+   * Stops partitions for copying segments, building indexes and deletes the partition in remote storage if delete flag
+   * is set as true.
+   *
+   * @param topicPartition  topic partition to be stopped.
+   * @param delete          flag to indicate whether the given topic partitions to be deleted or not.
+   */
+  def stopPartitions(topicPartition: TopicPartition, delete: Boolean): Unit = {
+    // unassign topic partitions from RLM leader/follower
+    val topicIdPartition =
+      topicIds.remove(topicPartition.topic()) match {
+        case Some(uuid) => Some(new TopicIdPartition(uuid, topicPartition))
+        case None => None
+      }
+
+    if (topicIdPartition.isDefined) {
+      val rlmTaskWithFuture = leaderOrFollowerTasks.remove(topicIdPartition.get)
+      if (rlmTaskWithFuture != null) {
+        rlmTaskWithFuture.cancel()
+      }
+    }
+
+    if (delete) {
+      try {
+        //todo-tier need to check whether it is really needed to delete from remote. This may be a delete request only
+        //for this replica. We should delete from remote storage only if the topic partition is getting deleted.
+        topicIdPartition.foreach(idPartition => {
+          remoteLogMetadataManager.listRemoteLogSegments(idPartition).forEachRemaining(elt => deleteRemoteLogSegment(elt, _ => true))
+          remoteLogMetadataManager.onStopPartitions(Collections.singleton(idPartition))
+        })
+      } catch {
+        case ex: Exception => error(s"Error occurred while deleting topic partition: $topicPartition", ex)
+      }
+    }
+  }
+
+  private def deleteRemoteLogSegment(segmentMetadata: RemoteLogSegmentMetadata, predicate: RemoteLogSegmentMetadata => Boolean): Boolean = {
+    if (predicate(segmentMetadata)) {
+      // Publish delete segment started event.
+      remoteLogMetadataManager.updateRemoteLogSegmentMetadata(
+        new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
+          RemoteLogSegmentState.DELETE_SEGMENT_STARTED, brokerId))
+
+      // Delete the segment in remote storage.
+      remoteLogStorageManager.deleteLogSegmentData(segmentMetadata)
+
+      // Publish delete segment finished event.
+      remoteLogMetadataManager.updateRemoteLogSegmentMetadata(
+        new RemoteLogSegmentMetadataUpdate(segmentMetadata.remoteLogSegmentId(), time.milliseconds(),
+          RemoteLogSegmentState.DELETE_SEGMENT_FINISHED, brokerId))
+      true
+    } else false
+  }
+
+  class RLMTask(tp: TopicIdPartition) extends CancellableRunnable with Logging {
+    this.logIdent = s"[RemoteLogManager=$brokerId partition=$tp] "
+    @volatile private var leaderEpoch: Int = -1
+
+    private def isLeader(): Boolean = leaderEpoch >= 0
+
+    // The highest offset that is already there in the remote storage
+    // When looking for new remote segments, we will only look for the remote segments that contains larger offsets
+    // todo-tier no need to call listRemoteSegments but look for epoch and its highest offset that is available in
+    // remote storage by going through the epochs in current leader-epoch cache in binary-search fashion.
+    private var readOffset: Long = loadRemoteLogSegmentEndOffset()
+
+    //todo-updating log with remote index highest offset
+    // fetchLog(tp.topicPartition()).foreach { log => log.updateRemoteIndexHighestOffset(readOffset) }
+
+    def loadRemoteLogSegmentEndOffset(): Long = {
+      // This is found by traversing from the latest leader epoch from leader epoch history and find the highest offset
+      // of a segment with that epoch copied into remote storage. If it can not find an entry then it checks for the
+      // previous leader epoch till it finds an entry, If there are no entries till the earliest leader epoch in leader
+      // epoch cache then it starts copying the segments from the earliest epoch entry’s offset.
+      val metadatas = remoteLogMetadataManager.listRemoteLogSegments(tp)
+      if(!metadatas.hasNext) -1 // Corner case when the first segment's base offset is 1 and contains only 1 record.
+      else {
+        metadatas.asScala.max(new Ordering[RemoteLogSegmentMetadata]() {
+          override def compare(x: RemoteLogSegmentMetadata,
+                               y: RemoteLogSegmentMetadata): Int = {
+            // todo-tier double check whether it covers all the cases
+            (x.startOffset() - y.startOffset()).toInt
+          }
+        }).endOffset()
+      }
+    }
+
+    //todo-updating log with remote index highest offset
+//    fetchLog(tp.topicPartition()).foreach { log => log.updateRemoteIndexHighestOffset(readOffset) }
+
+    def convertToLeader(leaderEpochVal: Int): Unit = {
+      if (leaderEpochVal < 0) {
+        throw new KafkaException(s"leaderEpoch value for topic partition $tp can not be negative")
+      }
+      leaderEpoch = leaderEpochVal
+      readOffset = loadRemoteLogSegmentEndOffset()
+    }
+
+    def convertToFollower(): Unit = {
+      leaderEpoch = -1
+    }
+
+    def copyLogSegmentsToRemote(): Unit = {
+      try {
+        fetchLog(tp.topicPartition()).foreach { log => {
+          if (isCancelled()) {
+            info(s"Skipping copying log segments as the current task is cancelled")
+            return
+          }
+
+          // LSO indicates the offset below are ready to be consumed(high-watermark or committed)
+          val lso = log.lastStableOffset
+          if (lso < 0) {
+            warn(s"lastStableOffset for partition $tp is $lso, which should not be negative.")
+          } else if (lso > 0 && readOffset < lso) {
+            // copy segments only till the min of high-watermark or stable-offset
+            // remote storage should contain only committed/acked messages
+            val fetchOffset = lso
+            debug(s"Checking for segments to copy, readOffset: $readOffset and fetchOffset: $fetchOffset")
+            val activeSegBaseOffset = log.activeSegment.baseOffset
+            val sortedSegments = log.logSegments(readOffset + 1, fetchOffset).toSeq.sortBy(_.baseOffset)
+            val index: Int = sortedSegments.map(x => x.baseOffset).search(activeSegBaseOffset) match {
+              case Found(x) => x
+              case InsertionPoint(y) => y - 1
+            }
+            if (index < 0) {
+              debug(s"No segments found to be copied for partition $tp with read offset: $readOffset and active " +
+                s"baseoffset: $activeSegBaseOffset")
+            } else {
+              sortedSegments.slice(0, index).foreach { segment =>
+                // store locally here as this may get updated after the below if condition is computed as false.
+                if (isCancelled() || !isLeader()) {
+                  info(s"Skipping copying log segments as the current task state is changed, cancelled: " +
+                    s"${isCancelled()} leader:${isLeader()}")
+                  return
+                }
+
+                val logFile = segment.log.file()
+                val fileName = logFile.getName
+                info(s"Copying $fileName to remote storage.")
+                val id = new RemoteLogSegmentId(tp, Uuid.randomUuid())
+
+                val nextOffset = segment.readNextOffset
+                //todo-tier double check on this
+                val endOffset = nextOffset - 1
+                val producerIdSnapshotFile = log.producerStateManager.fetchSnapshot(nextOffset).orNull
+
+                def createLeaderEpochs(): ByteBuffer = {
+                  val leaderEpochStateFile = new File(logFile.getParentFile, "leader-epoch-checkpoint-" + nextOffset)
+                  try {
+                    log.leaderEpochCache
+                      .map(cache => cache.writeTo(new LeaderEpochCheckpointFile(leaderEpochStateFile)))
+                      .foreach(x => {
+                        x.truncateFromEnd(nextOffset)
+                      })
+
+                    ByteBuffer.wrap(Files.readAllBytes(leaderEpochStateFile.toPath))
+                  } finally {
+                    try {
+                      Files.delete(leaderEpochStateFile.toPath)
+                    } catch {
+                      case ex: Exception => warn(s"Error occurred while deleting leader epoch file: $leaderEpochStateFile", ex)
+                    }
+                  }
+                }
+
+                def createLeaderEpochEntries(startOffset: Long): Option[collection.Seq[EpochEntry]] = {
+                  val leaderEpochStateFile = new File(logFile.getParentFile,
+                    "leader-epoch-checkpoint-entries-" + startOffset + "-" + nextOffset)
+                  try {
+                    val checkpointFile = {
+                      val file = new LeaderEpochCheckpointFile(leaderEpochStateFile)
+                      log.leaderEpochCache
+                        .map(cache => cache.writeTo(file))
+                        .map(x => {
+                          x.truncateFromStart(startOffset)
+                          x.truncateFromEnd(nextOffset)
+                          file
+                        })
+                    }
+                    checkpointFile.map(x => x.read())
+                  } finally {
+                    try {
+                      Files.delete(leaderEpochStateFile.toPath)
+                    } catch {
+                      case ex: Exception => warn(s"Error occurred while deleting leader epoch file: $leaderEpochStateFile", ex)
+                    }
+                  }
+                }
+
+                val leaderEpochs = createLeaderEpochs()
+                val segmentLeaderEpochEntries = createLeaderEpochEntries(segment.baseOffset)
+                val segmentLeaderEpochs: util.HashMap[Integer, java.lang.Long] = new util.HashMap()
+                if (segmentLeaderEpochEntries.isDefined) {
+                  segmentLeaderEpochEntries.get.foreach(entry => segmentLeaderEpochs.put(entry.epoch, entry.startOffset))
+                } else {
+                  val epoch = log.leaderEpochCache.flatMap(x => x.latestEntry.map(y => y.epoch)).getOrElse(0)
+                  segmentLeaderEpochs.put(epoch, segment.baseOffset)
+                }
+
+                val remoteLogSegmentMetadata = new RemoteLogSegmentMetadata(id, segment.baseOffset, endOffset,
+                  segment.largestTimestamp, brokerId, time.milliseconds(), segment.log.sizeInBytes(),
+                  segmentLeaderEpochs)
+
+                remoteLogMetadataManager.addRemoteLogSegmentMetadata(remoteLogSegmentMetadata)
+
+                val segmentData = new LogSegmentData(logFile.toPath, segment.lazyOffsetIndex.get.path,
+                  segment.lazyTimeIndex.get.path, Optional.ofNullable(segment.txnIndex.path),
+                  producerIdSnapshotFile.toPath, leaderEpochs)
+                remoteLogStorageManager.copyLogSegmentData(remoteLogSegmentMetadata, segmentData)
+
+                val rlsmAfterCreate = new RemoteLogSegmentMetadataUpdate(id, time.milliseconds(),
+                  RemoteLogSegmentState.COPY_SEGMENT_FINISHED, brokerId)
+
+                remoteLogMetadataManager.updateRemoteLogSegmentMetadata(rlsmAfterCreate)
+                brokerTopicStats.topicStats(tp.topicPartition().topic())
+                  .remoteBytesOutRate.mark(remoteLogSegmentMetadata.segmentSizeInBytes())
+                readOffset = endOffset
+                //todo-tier-storage
+                log.updateRemoteIndexHighestOffset(readOffset)
+              }
+            }
+          } else {
+            debug(s"Skipping copying segments, current read offset:$readOffset is and LSO:$lso ")
+          }
+        }
+        }
+      } catch {
+        case ex: Exception =>
+          brokerTopicStats.topicStats(tp.topicPartition().topic()).failedRemoteWriteRequestRate.mark()
+          error(s"Error occurred while copying log segments of partition: $tp", ex)
+      }
+    }
+
+    def handleExpiredRemoteLogSegments(): Unit = {
+
+      def handleLogStartOffsetUpdate(topicPartition: TopicPartition, remoteLogStartOffset: Long): Unit = {
+        debug(s"Updating $topicPartition with remoteLogStartOffset: $remoteLogStartOffset")
+        updateRemoteLogStartOffset(topicPartition, remoteLogStartOffset)
+      }
+
+      try {
+        if (isLeader()) {
+          // cleanup remote log segments and update the log start offset if applicable.
+          val remoteLogSegmentMetadatas = remoteLogMetadataManager.listRemoteLogSegments(tp)
+          if (!remoteLogSegmentMetadatas.hasNext)
+            None
+          else {
+            var maxStartOffset: Option[Long] = None
+
+            fetchLog(tp.topicPartition()).foreach(log => {
+              val retentionMs = log.config.retentionMs
+              var (checkTimeStampRetention, cleanupTs) =
+                if (retentionMs < 0) (false, time.milliseconds())
+                else (true, time.milliseconds() - retentionMs)
+
+              // Compute total size, this can be pushed to RLMM by introducing a new method instead of going through
+              // the collection every time.
+              var totalSize = log.size
+              remoteLogMetadataManager.listRemoteLogSegments(tp)
+                .forEachRemaining(metadata => totalSize += metadata.segmentSizeInBytes())
+
+              var remainingSize = totalSize - log.config.retentionSize
+              var checkSizeRetention = log.config.retentionSize > -1
+
+              def deleteRetentionTimeBreachedSegments(segmentMetadata: RemoteLogSegmentMetadata): Boolean = {
+                deleteRemoteLogSegment(segmentMetadata, segmentMetadata => segmentMetadata.maxTimestampMs() <= cleanupTs)
+              }
+
+              def deleteRetentionSizeBreachedSegments(segmentMetadata: RemoteLogSegmentMetadata): Boolean = {
+                deleteRemoteLogSegment(segmentMetadata,
+                  segmentMetadata => {
+                    // Assumption that segments contain size > 0
+                    if(remainingSize > 0) {
+                      remainingSize = remainingSize - segmentMetadata.segmentSizeInBytes()
+                      remainingSize >= 0
+                    } else false
+                  })
+              }
+
+              // Get earliest leader epoch and start deleting the segments.
+              log.leaderEpochCache.foreach(cache => {
+                cache.epochEntries.find(epoch => {
+                  val segmentsIterator = remoteLogMetadataManager.listRemoteLogSegments(tp, epoch.epoch)
+                  // Continue checking for one of the time or size retentions are valid for next segment if available.
+                  while ((checkTimeStampRetention || checkSizeRetention) && segmentsIterator.hasNext) {
+                    val segmentMetadata = segmentsIterator.next()
+                    // Set the max start offset, `segmentsIterator` is already returns them in ascending order.
+                    // FIXME(@kamalcph): If all the remote log segments are eligible for deletion, then the maxStartOffset should be set to None.
+                    maxStartOffset = Some(segmentMetadata.startOffset())
+
+                    var segmentDeletedWithRetentionTime = false
+
+                    if(checkTimeStampRetention) {
+                      if(deleteRetentionTimeBreachedSegments(segmentMetadata)) {
+                        info(s"Deleted remote log segment based on retention time: ${segmentMetadata.remoteLogSegmentId()}")
+                        segmentDeletedWithRetentionTime = true
+                      } else {
+                        // If we have any segment that is having the timestamp not eligible for deletion then
+                        // we will skip all the subsequent segments for the time retention checks.
+                        checkTimeStampRetention = false
+                      }
+                    } else if(checkSizeRetention && !segmentDeletedWithRetentionTime) {
+                      if(deleteRetentionSizeBreachedSegments(segmentMetadata)) {
+                        info(s"Deleted remote log segment based on retention size: ${segmentMetadata.remoteLogSegmentId()}")
+                      } else {
+                        // If we have exhausted of segments eligible for retention size, we will skip the subsequent
+                        // segments.
+                        checkSizeRetention = false
+                      }
+                    }
+                  }
+
+                  // Return only when both the retention checks are exhausted.
+                  checkTimeStampRetention && checkSizeRetention
+                })
+              })
+
+              maxStartOffset.foreach(x => handleLogStartOffsetUpdate(tp.topicPartition(), x))
+            })
+          }
+        }
+      } catch {
+        case ex: Exception => error(s"Error while cleaning up log segments for partition: $tp", ex)
+      }
+    }
+
+    override def run(): Unit = {
+      try {
+        if (!isCancelled()) {
+          //a. copy log segments to remote store
+          if (isLeader()) copyLogSegmentsToRemote()
+          else fetchLog(tp.topicPartition()).foreach { log =>
+            //todo-tier leader epoch to be computed here
+            val offset = remoteLogMetadataManager.highestOffsetForEpoch(tp, 0)
+            if (offset.isPresent) {
+              // todo-tier update remote index highest offset.
+              log.updateRemoteIndexHighestOffset(offset.get())
+            }
+          }
+
+          //b. cleanup/delete expired remote segments
+          // handleExpiredRemoteLogSegments()
+        }
+      } catch {
+        case ex: InterruptedException =>
+          warn(s"Current thread for topic-partition $tp is interrupted, this should not be rescheduled ", ex)
+        case ex: Exception =>
+          warn(
+            s"Current task for topic-partition $tp received error but it will be scheduled for next iteration: ", ex)
+      }
+    }
+
+    override def toString: String = {
+      this.getClass.toString + s"[$tp]"
+    }
+  }
+
+  def lookupPositionForOffset(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, offset: Long): Int = {
+    indexCache.lookupOffset(remoteLogSegmentMetadata, offset)
+  }
+
+  def read(remoteStorageFetchInfo: RemoteStorageFetchInfo): FetchDataInfo = {
+    val fetchMaxBytes  = remoteStorageFetchInfo.fetchMaxBytes
+    val tp = remoteStorageFetchInfo.topicPartition
+    val fetchInfo: PartitionData = remoteStorageFetchInfo.fetchInfo
+
+    val includeAbortedTxns = remoteStorageFetchInfo.fetchIsolation == FetchTxnCommitted
+
+    val offset = fetchInfo.fetchOffset
+    val maxBytes = Math.min(fetchMaxBytes, fetchInfo.maxBytes)
+
+    // get the epoch for the requested  offset from local leader epoch cache
+    // val epoch = fetchLog(tp).map(log => log.leaderEpochCache.map(cache => cache.epochForOffset()))
+    val epochForOffset: Int = 0
+    val rlsMetadata = fetchRemoteLogSegmentMetadata(tp, offset, epochForOffset)
+
+    val startPos = lookupPositionForOffset(rlsMetadata, offset)
+    var remoteSegInputStream: InputStream = null
+    try {
+      // Search forward for the position of the last offset that is greater than or equal to the target offset
+      remoteSegInputStream = remoteLogStorageManager.fetchLogSegment(rlsMetadata, startPos)
+      val remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream)
+
+      def findFirstBatch(): RecordBatch = {
+        var nextBatch: RecordBatch = null
+
+        def iterateNextBatch(): RecordBatch = {
+          nextBatch = remoteLogInputStream.nextBatch()
+          nextBatch
+        }
+        // Look for the batch which has the desired offset
+        // we will always have a batch in that segment as it is a non-compacted topic. For compacted topics, we may need
+        //to read from the subsequent segments if there is no batch available for the desired offset in the current
+        //segment. That means, desired offset is more than last offset of the current segment and immediate available
+        //offset exists in the next segment which can be higher than the desired offset.
+        while (iterateNextBatch() != null && nextBatch.lastOffset < offset) {
+        }
+        nextBatch
+      }
+
+      val firstBatch = findFirstBatch()
+
+      if (firstBatch == null)
+        return FetchDataInfo(LogOffsetMetadata(offset), MemoryRecords.EMPTY,
+          abortedTransactions = if(includeAbortedTxns) Some(List.empty) else None)
+
+      val updatedFetchSize =
+        if (remoteStorageFetchInfo.minOneMessage && firstBatch.sizeInBytes() > maxBytes) firstBatch.sizeInBytes()
+        else maxBytes
+
+      val buffer = ByteBuffer.allocate(updatedFetchSize)
+      var remainingBytes = updatedFetchSize
+
+      firstBatch.writeTo(buffer)
+      remainingBytes -= firstBatch.sizeInBytes()
+
+      if(remainingBytes > 0) {
+        // input stream is read till (startPos - 1) while getting the batch of records earlier.
+        // read the input stream until min of (EOF stream or buffer's remaining capacity).
+        Utils.readFully(remoteSegInputStream, buffer)
+      }
+      buffer.flip()
+
+      val abortedTxns = if(includeAbortedTxns) Some(collectAbortedTransactions(rlsMetadata, firstBatch.baseOffset(), updatedFetchSize)) else None
+      FetchDataInfo(LogOffsetMetadata(offset), MemoryRecords.readableRecords(buffer), abortedTransactions = abortedTxns)
+    } finally {
+      Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream")
+    }
+  }
+
+  private def collectAbortedTransactions(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, offset:Long,
+                                         fetchSize:Int): List[AbortedTransaction] = {
+    // TxnIndexSearchResult will be useful whether to search through the next segments or not.
+    indexCache.collectAbortedTransaction(remoteLogSegmentMetadata, offset, fetchSize).abortedTransactions
+      .map(_.asAbortedTransaction)
+  }
+
+  def fetchRemoteLogSegmentMetadata(tp: TopicPartition,
+                                    offset: Long,
+                                    epochForOffset: Int): RemoteLogSegmentMetadata = {
+    val topicIdPartition =
+      topicIds.get(tp.topic()) match {
+        case Some(uuid) => Some(new TopicIdPartition(uuid, tp))
+        case None => None
+      }
+
+    if (topicIdPartition.isEmpty) throw new KafkaException("No topic id registered for topic partition: " + tp)
+
+    val remoteLogSegmentMetadata = remoteLogMetadataManager.remoteLogSegmentMetadata(topicIdPartition.get, epochForOffset, offset)
+    if (!remoteLogSegmentMetadata.isPresent) throw new OffsetOutOfRangeException(
+      s"Received request for offset $offset for partition $tp, which does not exist in remote tier. Try again later.")
+
+    remoteLogSegmentMetadata.get()
+  }
+
+  def lookupTimestamp(rlsMetadata: RemoteLogSegmentMetadata, timestamp: Long, startingOffset: Long): Option[TimestampAndOffset] = {
+    val startPos = indexCache.lookupTimestamp(rlsMetadata, timestamp, startingOffset)
+
+    var remoteSegInputStream: InputStream = null
+    try {
+      // Search forward for the position of the last offset that is greater than or equal to the target offset
+      remoteSegInputStream = remoteLogStorageManager.fetchLogSegment(rlsMetadata, startPos)
+      val remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream)
+      var batch: RecordBatch = null
+      def nextBatch(): RecordBatch = {
+        batch = remoteLogInputStream.nextBatch()
+        batch
+      }
+      while (nextBatch() != null) {
+        if (batch.maxTimestamp >= timestamp && batch.lastOffset >= startingOffset) {
+          batch.iterator.asScala.foreach(record => {
+            if (record.timestamp >= timestamp && record.offset >= startingOffset)
+              return Some(new TimestampAndOffset(record.timestamp, record.offset, maybeLeaderEpoch(batch.partitionLeaderEpoch)))
+          })
+        }
+      }
+      None
+    } finally {
+      Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream")
+    }
+  }
+
+  private def maybeLeaderEpoch(leaderEpoch: Int): Optional[Integer] = {
+    if (leaderEpoch == RecordBatch.NO_PARTITION_LEADER_EPOCH)
+      Optional.empty()
+    else
+      Optional.of(leaderEpoch)
+  }
+
+  /**
+   * Search the message offset in the remote storage based on timestamp and offset.
+   *
+   * This method returns an option of TimestampOffset. The returned value is determined using the following ordered list of rules:
+   *
+   * - If there is no messages in the remote storage, return None
+   * - If all the messages in the remote storage have smaller offsets, return None
+   * - If all the messages in the remote storage have smaller timestamps, return None
+   * - If all the messages in the remote storage have larger timestamps, or no message in the remote storage has a timestamp
+   * the returned offset will be max(the earliest offset in the remote storage, startingOffset) and the timestamp will
+   * be Message.NoTimestamp.
+   * - Otherwise, return an option of TimestampOffset. The offset is the offset of the first message whose timestamp
+   * is greater than or equals to the target timestamp and whose offset is greater than or equals to the startingOffset.
+   *
+   * @param timestamp      The timestamp to search for.
+   * @param startingOffset The starting offset to search.
+   * @return the timestamp and offset of the first message that meets the requirements. None will be returned if there is no such message.
+   */
+  def findOffsetByTimestamp(tp: TopicPartition, timestamp: Long, startingOffset: Long): Option[TimestampAndOffset] = {
+    //todo-tier Here also, we do not need to go through all the remote log segments to find the segments
+    // containing the timestamp. We should find the  epoch for the startingOffset and then  traverse  through those
+    // offsets and subsequent leader epochs to find the target timestamp/offset.
+    topicIds.get(tp.topic()) match {
+      case Some(uuid) =>
+        val topicIdPartition = new TopicIdPartition(uuid, tp)
+        remoteLogMetadataManager.listRemoteLogSegments(topicIdPartition).asScala.foreach(rlsMetadata =>
+          if (rlsMetadata.maxTimestampMs() >= timestamp && rlsMetadata.endOffset() >= startingOffset) {
+            val timestampOffset = lookupTimestamp(rlsMetadata, timestamp, startingOffset)
+            if (timestampOffset.isDefined)
+              return timestampOffset
+          }
+        )
+        None
+      case None => None
+    }
+  }
+
+  /**
+   * A remote log read task returned by asyncRead(). The caller of asyncRead() can use this object to cancel a
+   * pending task or check if the task is done.
+   */
+  case class AsyncReadTask(future: Future[Unit]) {
+    def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      val r = future.cancel(mayInterruptIfRunning)
+      if (r) {
+        // Removed the cancelled task from task queue
+        remoteStorageFetcherThreadPool.purge()
+      }
+      r
+    }
+
+    def isCancelled: Boolean = future.isCancelled
+
+    def isDone: Boolean = future.isDone
+  }
+
+  /**
+   * Submit a remote log read task.
+   *
+   * This method returns immediately. The read operation is executed in a thread pool.
+   * The callback will be called when the task is done.
+   *
+   * @throws RejectedExecutionException if the task cannot be accepted for execution (task queue is full)
+   */
+  def asyncRead(fetchInfo: RemoteStorageFetchInfo, callback: RemoteLogReadResult => Unit): AsyncReadTask = {
+    AsyncReadTask(remoteStorageFetcherThreadPool.submit(new RemoteLogReader(fetchInfo, this, brokerTopicStats, callback)))
+  }
+
+  /**
+   * Stops all the threads and releases all the resources.
+   */
+  def close(): Unit = {
+    if (closed)
+      warn("Trying to close an already closed RemoteLogManager")
+    else this synchronized {
+      Utils.closeQuietly(remoteLogStorageManager, "RemoteLogStorageManager")
+      Utils.closeQuietly(remoteLogMetadataManager, "RemoteLogMetadataManager")
+      leaderOrFollowerTasks.values().forEach((taskWithFuture: RLMTaskWithFuture) => taskWithFuture.cancel())
+      rlmScheduledThreadPool.shutdown()
+      closed = true
+    }
+  }
+
+  case class RLMTaskWithFuture(rlmTask: RLMTask, future: Future[_]) {
+    def cancel(): Unit = {
+      rlmTask.cancel()
+      try {
+        future.cancel(true)
+      } catch {
+        case ex: Exception => error(s"Error occurred while canceling the task: $rlmTask", ex)
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/kafka/log/remote/RemoteLogReader.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogReader.scala
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.log.remote
+
+import kafka.server.{BrokerTopicStats, FetchDataInfo, RemoteStorageFetchInfo}
+import kafka.utils.Logging
+import org.apache.kafka.common.utils.Time
+
+class RemoteLogReader(fetchInfo: RemoteStorageFetchInfo,
+                      rlm: RemoteLogManager,
+                      brokerTopicStats: BrokerTopicStats,
+                      callback: RemoteLogReadResult => Unit) extends RemoteStorageTask[Unit] with Logging {
+  brokerTopicStats.topicStats(fetchInfo.topicPartition.topic()).remoteReadRequestRate.mark()
+
+  override def execute(): Unit = {
+    val result = {
+      try {
+        val r = rlm.read(fetchInfo)
+        brokerTopicStats.topicStats(fetchInfo.topicPartition.topic()).remoteBytesInRate.mark(r.records.sizeInBytes())
+        RemoteLogReadResult(Some(r), None)
+      } catch {
+        case e: Exception =>
+          brokerTopicStats.topicStats(fetchInfo.topicPartition.topic()).failedRemoteReadRequestRate.mark()
+          error("Error due to", e)
+          RemoteLogReadResult(None, Some(e))
+      }
+    }
+    callback(result)
+  }
+}
+
+case class RemoteLogReadResult(info: Option[FetchDataInfo], error: Option[Throwable] = None)
+
+class RemoteStorageReaderThreadPool(numThreads: Int, maxPendingTasks: Int, time: Time)
+  extends RemoteStorageThreadPool(RemoteStorageReaderThreadPool.name, RemoteStorageReaderThreadPool.threadNamePrefix,
+    numThreads, maxPendingTasks, time, RemoteStorageReaderThreadPool.metricNamePrefix)
+
+object RemoteStorageReaderThreadPool {
+  val name = "Remote Log Reader Thread Pool"
+  val threadNamePrefix = "RemoteLogReader"
+  val metricNamePrefix = "RemoteLogReader"
+}

--- a/core/src/main/scala/kafka/log/remote/RemoteStorageThreadPool.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteStorageThreadPool.scala
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.log.remote
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{Callable, LinkedBlockingQueue, ThreadFactory, ThreadPoolExecutor, TimeUnit}
+
+import kafka.metrics.KafkaMetricsGroup
+import kafka.utils.{Exit, Logging}
+import org.apache.kafka.common.internals.FatalExitError
+import org.apache.kafka.common.utils.Time
+
+abstract class RemoteStorageTask[T] extends Callable[T] with Logging {
+  override final def call(): T = {
+    this.logIdent = s"[${Thread.currentThread.getName}]: "
+    execute()
+  }
+
+  def execute(): T
+}
+
+/**
+ * A thread pool with a fixed number of threads, used by RemoteLogManager
+ *
+ * @param name Name of the thread pool
+ * @param numThreads Number of threads
+ * @param maxPendingTasks The task queue capacity. If the task queue is full, the submit() / execute() method will throw RejectedExecutionException
+ * @param metricNamePrefix The name of average idle percentage metric
+ */
+abstract class RemoteStorageThreadPool(name: String,
+                                       threadNamePrefix: String,
+                                       numThreads: Int,
+                                       maxPendingTasks: Int,
+                                       time: Time,
+                                       metricNamePrefix: String)
+  extends ThreadPoolExecutor(numThreads,
+    numThreads,
+    0L,
+    TimeUnit.MILLISECONDS,
+    new LinkedBlockingQueue[Runnable](maxPendingTasks),
+    new RemoteStorageThreadFactory(threadNamePrefix + "-")
+  ) with Logging with KafkaMetricsGroup {
+
+  newGauge(metricNamePrefix.concat("TaskQueueSize"), () => {
+    getQueue().size()
+  })
+
+  newGauge(metricNamePrefix.concat("AvgIdlePercent"), () => {
+    1 - getActiveCount.asInstanceOf[Double] / getCorePoolSize.asInstanceOf[Double]
+  })
+
+  this.logIdent = s"[$name] "
+
+  override def afterExecute(r: Runnable, e: Throwable): Unit = {
+    if (e != null) {
+      e match {
+        case e: FatalExitError =>
+          info("Stopped")
+          Exit.exit(e.statusCode())
+        case e: Throwable =>
+          if (!isShutdown)
+            error("Error due to", e)
+      }
+    }
+  }
+
+  def resizeThreadPool(newSize: Int): Unit = synchronized {
+    val currentSize = getCorePoolSize
+    if (newSize > currentSize) {
+      setMaximumPoolSize(newSize)
+      setCorePoolSize(newSize)
+    } else if (newSize < currentSize) {
+      setCorePoolSize(newSize)
+      setMaximumPoolSize(newSize)
+    }
+  }
+
+  override def shutdown(): Unit = synchronized {
+    info("shutting down")
+    shutdownNow()
+    while (!awaitTermination(5, TimeUnit.SECONDS)) {
+      info("shutting down")
+    }
+    info("shut down completely")
+  }
+}
+
+class RemoteStorageThreadFactory(namePrefix : String) extends ThreadFactory {
+  private val threadNumber = new AtomicInteger(0)
+
+  override def newThread(r: Runnable): Thread = {
+    new Thread(r, namePrefix + threadNumber.getAndIncrement)
+  }
+}

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -406,7 +406,7 @@ abstract class AbstractFetcherThread(name: String,
                 case Errors.OFFSET_OUT_OF_RANGE =>
                   if (handleOutOfRangeError(topicPartition, currentFetchState, fetchPartitionData.currentLeaderEpoch))
                     partitionsWithError += topicPartition
-                case Errors.OFFSET_MOVED_TO_TIERED_STORAGE =>
+                case Errors.LI_OFFSET_MOVED_TO_TIERED_STORAGE =>
                   // no need to retry this as it indicates that the requested offset is moved to tiered storage.
                   if (handleOffsetMovedToTieredStorage(topicPartition, currentFetchState,
                     fetchPartitionData.currentLeaderEpoch, partitionData.logStartOffset()))

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -100,6 +100,8 @@ abstract class AbstractFetcherThread(name: String,
 
   protected def fetchLatestOffsetFromLeader(topicPartition: TopicPartition, currentLeaderEpoch: Int): Long
 
+  protected def buildRemoteLogAuxState(partition: TopicPartition, currentLeaderEpoch: Int, fetchOffset: Long, leaderLogStartOffset: Long): Unit
+
   protected val isOffsetForLeaderEpochSupported: Boolean
 
   protected val isTruncationOnFetchSupported: Boolean
@@ -119,6 +121,8 @@ abstract class AbstractFetcherThread(name: String,
   override def doWork(): Unit = {
     maybeTruncate()
     maybeFetch()
+    //todo-tier implement RLSM Fetch
+//    mayBeRLSMFetch()
   }
 
   private def maybeFetch(): Unit = {
@@ -402,7 +406,11 @@ abstract class AbstractFetcherThread(name: String,
                 case Errors.OFFSET_OUT_OF_RANGE =>
                   if (handleOutOfRangeError(topicPartition, currentFetchState, fetchPartitionData.currentLeaderEpoch))
                     partitionsWithError += topicPartition
-
+                case Errors.OFFSET_MOVED_TO_TIERED_STORAGE =>
+                  // no need to retry this as it indicates that the requested offset is moved to tiered storage.
+                  if (handleOffsetMovedToTieredStorage(topicPartition, currentFetchState,
+                    fetchPartitionData.currentLeaderEpoch, partitionData.logStartOffset()))
+                    partitionsWithError += topicPartition
                 case Errors.UNKNOWN_LEADER_EPOCH =>
                   debug(s"Remote broker has a smaller leader epoch for partition $topicPartition than " +
                     s"this replica's current leader epoch of ${currentFetchState.currentLeaderEpoch}.")
@@ -635,10 +643,9 @@ abstract class AbstractFetcherThread(name: String,
     }
   }
 
-  /**
-   * Handle a partition whose offset is out of range and return a new fetch offset.
-   */
-  protected def fetchOffsetAndTruncate(topicPartition: TopicPartition, currentLeaderEpoch: Int): PartitionFetchState = {
+  private def fetchOffsetAndApplyFun(topicPartition: TopicPartition,
+                                     currentLeaderEpoch: Int,
+                                     truncateAndBuild: => Long => Unit) : PartitionFetchState = {
     val replicaEndOffset = logEndOffset(topicPartition)
 
     /**
@@ -687,13 +694,65 @@ abstract class AbstractFetcherThread(name: String,
         s"leader's start offset $leaderStartOffset")
       val offsetToFetch = Math.max(leaderStartOffset, replicaEndOffset)
       // Only truncate log when current leader's log start offset is greater than follower's log end offset.
-      if (leaderStartOffset > replicaEndOffset)
-        truncateFullyAndStartAt(topicPartition, leaderStartOffset)
+      if (leaderStartOffset > replicaEndOffset) {
+        truncateAndBuild(leaderStartOffset)
+      }
 
       val initialLag = leaderEndOffset - offsetToFetch
       fetcherLagStats.getAndMaybePut(topicPartition).lag = initialLag
       PartitionFetchState(offsetToFetch, Some(initialLag), currentLeaderEpoch,
         state = Fetching, lastFetchedEpoch = latestEpoch(topicPartition))
+    }
+  }
+
+  /**
+   * Handle a partition whose offset is out of range and return a new fetch offset.
+   */
+  protected def fetchOffsetAndTruncate(topicPartition: TopicPartition, currentLeaderEpoch: Int): PartitionFetchState = {
+    fetchOffsetAndApplyFun(topicPartition, currentLeaderEpoch,
+      leaderLogStartOffset => truncateFullyAndStartAt(topicPartition, leaderLogStartOffset))
+  }
+
+  /**
+   * Handle a partition whose offset is moved to tiered storage and return a new fetch offset.
+   */
+  protected def fetchOffsetAndBuildRemoteLogAuxState(topicPartition: TopicPartition,
+                                                     currentLeaderEpoch: Int,
+                                                     leaderLogStartOffset: Long): PartitionFetchState = {
+    fetchOffsetAndApplyFun(topicPartition, currentLeaderEpoch,
+      leaderLocalLogStartOffset =>
+        buildRemoteLogAuxState(topicPartition, currentLeaderEpoch, leaderLocalLogStartOffset, leaderLogStartOffset))
+  }
+
+  /**
+   * Handle the offset moved to tiered storage error. Return false if
+   * 1) the request succeeded or
+   * 2) was fenced and this thread haven't received new epoch,
+   * which means we need not backoff and retry. True if there was a retriable error.
+   */
+  private def handleOffsetMovedToTieredStorage(topicPartition: TopicPartition,
+                                       fetchState: PartitionFetchState,
+                                       requestEpoch: Optional[Integer],
+                                       leaderLogStartOffset: Long): Boolean = {
+    try {
+      val newFetchState = fetchOffsetAndBuildRemoteLogAuxState(topicPartition, fetchState.currentLeaderEpoch, leaderLogStartOffset)
+      partitionStates.updateAndMoveToEnd(topicPartition, newFetchState)
+      info(s"Current offset ${fetchState.fetchOffset} for partition $topicPartition is " +
+        s"moved to remote tier. Reset fetch offset to ${newFetchState.fetchOffset}")
+      false
+    } catch {
+      case _: FencedLeaderEpochException =>
+        onPartitionFenced(topicPartition, requestEpoch)
+
+      case e @ (_ : UnknownTopicOrPartitionException |
+                _ : UnknownLeaderEpochException |
+                _ : NotLeaderOrFollowerException) =>
+        info(s"Could not build remote log auxiliary state for $topicPartition due to error: ${e.getMessage}")
+        true
+
+      case e: Throwable =>
+        error(s"Error building remote log auxiliary state for $topicPartition", e)
+        true
     }
   }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -27,6 +27,7 @@ import kafka.cluster.Broker.ServerInfo
 import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.{ProducerIdManager, TransactionCoordinator}
 import kafka.log.LogManager
+import kafka.log.remote.RemoteLogManager
 import kafka.metrics.KafkaYammerMetrics
 import kafka.network.SocketServer
 import kafka.raft.RaftManager
@@ -43,12 +44,13 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.utils.{AppInfoParser, LogContext, Time, Utils}
-import org.apache.kafka.common.{ClusterResource, Endpoint}
+import org.apache.kafka.common.{ClusterResource, Endpoint, TopicPartition}
 import org.apache.kafka.metadata.{BrokerState, VersionRange}
 import org.apache.kafka.raft.{RaftClient, RaftConfig}
 import org.apache.kafka.raft.RaftConfig.AddressSpec
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.kafka.server.common.ApiMessageAndVersion
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 
 import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
@@ -111,6 +113,7 @@ class BrokerServer(
 
   var logDirFailureChannel: LogDirFailureChannel = null
   var logManager: LogManager = null
+  var remoteLogManager: RemoteLogManager = null
 
   var tokenManager: DelegationTokenManager = null
 
@@ -198,8 +201,10 @@ class BrokerServer(
 
       // Create log manager, but don't start it because we need to delay any potential unclean shutdown log recovery
       // until we catch up on the metadata log and have up-to-date topic and broker configs.
+      val remoteLogManagerConfig = new RemoteLogManagerConfig(config)
       logManager = LogManager(config, initialOfflineDirs, metadataCache, kafkaScheduler, time,
-        brokerTopicStats, logDirFailureChannel, keepPartitionMetadataFile = true)
+        brokerTopicStats, logDirFailureChannel, keepPartitionMetadataFile = true, remoteLogManagerConfig)
+      remoteLogManager = createRemoteLogManager(remoteLogManagerConfig)
 
       // Enable delegation token cache for all SCRAM mechanisms to simplify dynamic update.
       // This keeps the cache up-to-date if new SCRAM mechanisms are enabled dynamically.
@@ -258,7 +263,7 @@ class BrokerServer(
       alterIsrManager.start()
 
       this._replicaManager = new ReplicaManager(config, metrics, time, None,
-        kafkaScheduler, logManager, isShuttingDown, quotaManagers,
+        kafkaScheduler, logManager, Option.apply(remoteLogManager), isShuttingDown, quotaManagers,
         brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager,
         threadNamePrefix)
 
@@ -385,6 +390,19 @@ class BrokerServer(
       // Block until we've caught up with the latest metadata from the controller quorum.
       lifecycleManager.initialCatchUpFuture.get()
 
+      // better to start RLM (RSM and RLMM) before processing any requests so that we may avoid missing any
+      // leader/isr requests.
+      val serverEndpoint = Option.apply(remoteLogManagerConfig.remoteLogMetadataManagerListenerName())
+        .flatMap(value => {
+          val normalisedName = ListenerName.normalised(value)
+          endpoints.asScala.find(endpoint => normalisedName.value().equals(endpoint.listenerName().get()))
+        }).getOrElse(endpoints.asScala.head)
+
+
+      if (remoteLogManager != null) {
+        remoteLogManager.onEndpointCreated(serverEndpoint)
+      }
+
       // Apply the metadata log changes that we've accumulated.
       metadataPublisher = new BrokerMetadataPublisher(config, metadataCache,
         logManager, replicaManager, groupCoordinator, transactionCoordinator,
@@ -414,6 +432,19 @@ class BrokerServer(
         shutdown()
         throw e
     }
+  }
+
+  protected def createRemoteLogManager(remoteLogManagerConfig: RemoteLogManagerConfig): RemoteLogManager = {
+    if (remoteLogManagerConfig.enableRemoteStorageSystem()) {
+      def updateRemoteLogStartOffset(tp: TopicPartition, remoteLogStartOffset: Long) : Unit = {
+        logManager.getLog(tp).foreach(log => {
+          log.updateLogStartOffsetFromRemoteTier(remoteLogStartOffset)
+        })
+      }
+     new RemoteLogManager(tp => logManager.getLog(tp), updateRemoteLogStartOffset, remoteLogManagerConfig, time,
+        config.brokerId, clusterId, config.logDirs.head, brokerTopicStats)
+    }
+    null
   }
 
   def shutdown(): Unit = {

--- a/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util.concurrent.CompletableFuture
+
+import kafka.log.remote.{RemoteLogManager, RemoteLogReadResult}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors._
+
+import scala.collection._
+
+/**
+ * A remote fetch operation that can be created by the replica manager and watched
+ * in the remote fetch operation purgatory
+ */
+class DelayedRemoteFetch(remoteFetchTask: RemoteLogManager#AsyncReadTask,
+                         remoteFetchResult: CompletableFuture[RemoteLogReadResult],
+                         remoteFetchInfo: RemoteStorageFetchInfo,
+                         delayMs: Long,
+                         fetchMetadata: FetchMetadata,
+                         localReadResults: Seq[(TopicPartition, LogReadResult)],
+                         replicaManager: ReplicaManager,
+                         quota: ReplicaQuota,
+                         responseCallback: Seq[(TopicPartition, FetchPartitionData)] => Unit)
+  extends DelayedOperation(delayMs) {
+
+        /**
+         * The operation can be completed if:
+         *
+         * Case a: This broker is no longer the leader of the partition it tries to fetch
+         * Case b: This broker does not know the partition it tries to fetch
+         * Case c: The remote storage read request completed (succeeded or failed)
+         * Case d: The partition is in an offline log directory on this broker
+         * Case e: This broker is the leader, but the requested epoch is now fenced
+         *
+         * Upon completion, should return whatever data is available for each valid partition
+         */
+        override def tryComplete(): Boolean = {
+                fetchMetadata.fetchPartitionStatus.foreach {
+                        case (topicPartition, fetchStatus) =>
+                                val fetchOffset = fetchStatus.startOffsetMetadata
+                                val fetchLeaderEpoch = fetchStatus.fetchInfo.currentLeaderEpoch
+                                try {
+                                        if (fetchOffset != LogOffsetMetadata.UnknownOffsetMetadata) {
+                                                replicaManager.getPartitionOrException(topicPartition)
+                                        }
+                                } catch {
+                                        case _: KafkaStorageException => // Case d
+                                                debug(s"Partition $topicPartition is in an offline log directory, satisfy $fetchMetadata immediately")
+                                                return forceComplete()
+                                        case _: UnknownTopicOrPartitionException => // Case b
+                                                debug(s"Broker no longer knows of partition $topicPartition, satisfy $fetchMetadata immediately")
+                                                return forceComplete()
+                                        case _: FencedLeaderEpochException => // Case e
+                                                debug(s"Broker is the leader of partition $topicPartition, but the requested epoch " +
+                                                  s"$fetchLeaderEpoch is fenced by the latest leader epoch, satisfy $fetchMetadata immediately")
+                                                return forceComplete()
+                                        case _: NotLeaderOrFollowerException =>  // Case a
+                                                debug("Broker is no longer the leader of %s, satisfy %s immediately".format(topicPartition, fetchMetadata))
+                                                return forceComplete()
+                                }
+                }
+                if (remoteFetchResult.isDone)
+                        forceComplete()
+                else
+                        false
+        }
+
+        override def onExpiration():Unit = {
+                // cancel the remote storage read task, if it has not been executed yet
+                remoteFetchTask.cancel(false)
+        }
+
+        /**
+         * Upon completion, read whatever data is available and pass to the complete callback
+         */
+        override def onComplete():Unit = {
+                val fetchPartitionData = localReadResults.map { case (tp, result) =>
+                        if (tp.equals(remoteFetchInfo.topicPartition) && remoteFetchResult.isDone
+                          && result.exception.isEmpty && result.info.delayedRemoteStorageFetch.isDefined) {
+                                if (remoteFetchResult.get.error.isDefined) {
+                                        val r = replicaManager.createLogReadResult(remoteFetchResult.get.error.get)
+                                        tp -> FetchPartitionData(r.error, r.highWatermark, r.leaderLogStartOffset, r.info.records,
+                                                divergingEpoch = None, r.lastStableOffset, r.info.abortedTransactions, r.preferredReadReplica, isReassignmentFetch = false)
+                                } else {
+                                        val info = remoteFetchResult.get.info.get
+                                        tp -> FetchPartitionData(result.error, result.highWatermark, result.leaderLogStartOffset, info.records,
+                                                divergingEpoch = None, result.lastStableOffset, info.abortedTransactions, result.preferredReadReplica, isReassignmentFetch = false)
+                                }
+                        } else {
+                                tp -> FetchPartitionData(result.error, result.highWatermark, result.leaderLogStartOffset, result.info.records,
+                                        divergingEpoch = None, result.lastStableOffset, result.info.abortedTransactions, result.preferredReadReplica, isReassignmentFetch = false)
+                        }
+                }
+
+                responseCallback(fetchPartitionData)
+        }
+}

--- a/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedRemoteFetch.scala
@@ -40,6 +40,7 @@ class DelayedRemoteFetch(remoteFetchTask: RemoteLogManager#AsyncReadTask,
                          responseCallback: Seq[(TopicPartition, FetchPartitionData)] => Unit)
   extends DelayedOperation(delayMs) {
 
+        import DelayedOperation._
         /**
          * The operation can be completed if:
          *

--- a/core/src/main/scala/kafka/server/FetchDataInfo.scala
+++ b/core/src/main/scala/kafka/server/FetchDataInfo.scala
@@ -17,8 +17,10 @@
 
 package kafka.server
 
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.record.Records
+import org.apache.kafka.common.requests.FetchRequest.PartitionData
 
 sealed trait FetchIsolation
 case object FetchLogEnd extends FetchIsolation
@@ -28,4 +30,8 @@ case object FetchTxnCommitted extends FetchIsolation
 case class FetchDataInfo(fetchOffsetMetadata: LogOffsetMetadata,
                          records: Records,
                          firstEntryIncomplete: Boolean = false,
-                         abortedTransactions: Option[List[FetchResponseData.AbortedTransaction]] = None)
+                         abortedTransactions: Option[List[FetchResponseData.AbortedTransaction]] = None,
+                         delayedRemoteStorageFetch: Option[RemoteStorageFetchInfo] = None)
+
+case class RemoteStorageFetchInfo(fetchMaxBytes: Int, minOneMessage: Boolean, topicPartition: TopicPartition,
+                                  fetchInfo: PartitionData, fetchIsolation: FetchIsolation)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -83,6 +83,8 @@ import scala.annotation.nowarn
 import scala.collection.{Map, Seq, Set, immutable, mutable}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
+import kafka.coordinator.group.GroupOverview
+import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig
 
 /**
  * Logic to handle the various Kafka requests
@@ -655,7 +657,9 @@ class KafkaApis(val requestChannel: RequestChannel,
           s"${Observer.describeRequestAndResponse(request, null)}", e)
       }
 
-      val internalTopicsAllowed = request.header.clientId == AdminUtils.AdminClientId
+      val clientId = request.header.clientId
+      val internalTopicsAllowed = (clientId == AdminUtils.AdminClientId
+        || (clientId != null && clientId.startsWith(TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_CLIENT_PREFIX)))
 
       // call the replica manager to append messages to the replicas
       replicaManager.appendRecords(
@@ -1200,7 +1204,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (metadataRequest.allowAutoTopicCreation && config.autoCreateTopicsEnable && nonExistingTopics.nonEmpty) {
         if (!authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME, logIfDenied = false)) {
           val authorizedForCreateTopics = authHelper.filterByAuthorized(request.context, CREATE, TOPIC,
-            nonExistingTopics)(identity)
+            nonExistingTopics)(x => x)
           unauthorizedForCreateTopics = nonExistingTopics.diff(authorizedForCreateTopics)
           authorizedTopics = authorizedTopics.diff(unauthorizedForCreateTopics)
         }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -83,7 +83,6 @@ import scala.annotation.nowarn
 import scala.collection.{Map, Seq, Set, immutable, mutable}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
-import kafka.coordinator.group.GroupOverview
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig
 
 /**

--- a/core/src/main/scala/kafka/server/KafkaBroker.scala
+++ b/core/src/main/scala/kafka/server/KafkaBroker.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import com.yammer.metrics.core.MetricName
 import kafka.log.LogManager
+import kafka.log.remote.RemoteLogManager
 import kafka.metrics.{KafkaMetricsGroup, KafkaYammerMetrics, LinuxIoMetricsCollector}
 import kafka.network.SocketServer
 import kafka.utils.KafkaScheduler
@@ -72,6 +73,7 @@ trait KafkaBroker extends KafkaMetricsGroup {
   def kafkaScheduler: KafkaScheduler
   def kafkaYammerMetrics: KafkaYammerMetrics
   def logManager: LogManager
+  def remoteLogManager: RemoteLogManager
   def metrics: Metrics
   def quotaManagers: QuotaFactory.QuotaManagers
   def replicaManager: ReplicaManager

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -18,6 +18,7 @@ package kafka.server
 
 import java.io.File
 import java.util.concurrent.CompletableFuture
+
 import kafka.common.{InconsistentNodeIdException, KafkaException}
 import kafka.log.Log
 import kafka.metrics.{KafkaMetricsReporter, KafkaYammerMetrics}

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -199,6 +199,11 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
     BrokerTopicStats.TotalFetchRequestsPerSec -> MeterWrapper(BrokerTopicStats.TotalFetchRequestsPerSec, "requests"),
     BrokerTopicStats.FetchMessageConversionsPerSec -> MeterWrapper(BrokerTopicStats.FetchMessageConversionsPerSec, "requests"),
     BrokerTopicStats.ProduceMessageConversionsPerSec -> MeterWrapper(BrokerTopicStats.ProduceMessageConversionsPerSec, "requests"),
+    BrokerTopicStats.RemoteBytesOutPerSec -> MeterWrapper(BrokerTopicStats.RemoteBytesOutPerSec, "bytes"),
+    BrokerTopicStats.RemoteBytesInPerSec -> MeterWrapper(BrokerTopicStats.RemoteBytesInPerSec, "bytes"),
+    BrokerTopicStats.RemoteReadRequestsPerSec -> MeterWrapper(BrokerTopicStats.RemoteReadRequestsPerSec, "requests"),
+    BrokerTopicStats.FailedRemoteReadRequestsSec -> MeterWrapper(BrokerTopicStats.FailedRemoteReadRequestsSec, "requests"),
+    BrokerTopicStats.FailedRemoteWriteRequestsSec -> MeterWrapper(BrokerTopicStats.FailedRemoteWriteRequestsSec, "requests"),
     BrokerTopicStats.NoKeyCompactedTopicRecordsPerSec -> MeterWrapper(BrokerTopicStats.NoKeyCompactedTopicRecordsPerSec, "requests"),
     BrokerTopicStats.InvalidMagicNumberRecordsPerSec -> MeterWrapper(BrokerTopicStats.InvalidMagicNumberRecordsPerSec, "requests"),
     BrokerTopicStats.InvalidMessageCrcRecordsPerSec -> MeterWrapper(BrokerTopicStats.InvalidMessageCrcRecordsPerSec, "requests"),
@@ -258,6 +263,17 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
 
   def invalidOffsetOrSequenceRecordsPerSec: Meter = metricTypeMap.get(BrokerTopicStats.InvalidOffsetOrSequenceRecordsPerSec).meter()
 
+  def remoteBytesOutRate: Meter = metricTypeMap.get(BrokerTopicStats.RemoteBytesOutPerSec).meter()
+
+  def remoteBytesInRate: Meter = metricTypeMap.get(BrokerTopicStats.RemoteBytesInPerSec).meter()
+
+  def remoteReadRequestRate: Meter = metricTypeMap.get(BrokerTopicStats.RemoteReadRequestsPerSec).meter()
+
+  def failedRemoteReadRequestRate: Meter = metricTypeMap.get(BrokerTopicStats.FailedRemoteReadRequestsSec).meter()
+
+  def failedRemoteWriteRequestRate: Meter = metricTypeMap.get(BrokerTopicStats.FailedRemoteWriteRequestsSec).meter()
+
+
   def closeMetric(metricType: String): Unit = {
     val meter = metricTypeMap.get(metricType)
     if (meter != null)
@@ -282,6 +298,11 @@ object BrokerTopicStats {
   val ProduceMessageConversionsPerSec = "ProduceMessageConversionsPerSec"
   val ReassignmentBytesInPerSec = "ReassignmentBytesInPerSec"
   val ReassignmentBytesOutPerSec = "ReassignmentBytesOutPerSec"
+  val RemoteBytesOutPerSec = "RemoteBytesOutPerSec"
+  val RemoteBytesInPerSec = "RemoteBytesInPerSec"
+  val RemoteReadRequestsPerSec = "RemoteReadRequestsPerSec"
+  val FailedRemoteReadRequestsSec = "RemoteReadErrorsSec"
+  val FailedRemoteWriteRequestsSec = "RemoteWriteErrorsSec"
 
   // These following topics are for LogValidator for better debugging on failed records
   val NoKeyCompactedTopicRecordsPerSec = "NoKeyCompactedTopicRecordsPerSec"
@@ -335,6 +356,8 @@ class BrokerTopicStats extends Logging {
       topicMetrics.closeMetric(BrokerTopicStats.FailedProduceRequestsPerSec)
       topicMetrics.closeMetric(BrokerTopicStats.TotalProduceRequestsPerSec)
       topicMetrics.closeMetric(BrokerTopicStats.ProduceMessageConversionsPerSec)
+      topicMetrics.closeMetric(BrokerTopicStats.RemoteBytesOutPerSec)
+      topicMetrics.closeMetric(BrokerTopicStats.FailedRemoteWriteRequestsSec)
       topicMetrics.closeMetric(BrokerTopicStats.ReplicationBytesOutPerSec)
       topicMetrics.closeMetric(BrokerTopicStats.ReassignmentBytesOutPerSec)
     }

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -297,4 +297,15 @@ class ReplicaAlterLogDirsThread(name: String,
     }
   }
 
+  override protected def buildRemoteLogAuxState(partition: TopicPartition,
+                                                currentLeaderEpoch: Int,
+                                                fetchOffset: Long,
+                                                leaderLogStartOffset: Long): Unit = {
+    // JBOD is not supported with tiered storage.
+    truncateFullyAndStartAt(partition, fetchOffset)
+    replicaMgr.futureLocalLogOrException(partition)
+      .maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented)
+
+    // FIXME(@kamalcph): Confirm whether to rebuild the leader epoch and producer snapshots for future log.
+  }
 }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -237,7 +237,7 @@ class ReplicaFetcherThread(name: String,
 
   override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, currentLeaderEpoch: Int): Long = {
     if (brokerConfig.interBrokerProtocolVersion >= KAFKA_3_0_IV1)
-      fetchOffsetFromLeader(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)
+      fetchOffsetFromLeader(topicPartition, currentLeaderEpoch, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP)
     else
       fetchOffsetFromLeader(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_TIMESTAMP)
   }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -22,9 +22,12 @@ import java.util.Optional
 
 import kafka.api._
 import kafka.cluster.BrokerEndPoint
-import kafka.log.{LeaderOffsetIncremented, LogAppendInfo}
+import kafka.log.remote.RemoteIndexCache.TmpFileSuffix
+import kafka.log.{LeaderOffsetIncremented, Log, LogAppendInfo}
 import kafka.server.AbstractFetcherThread.ReplicaFetch
 import kafka.server.AbstractFetcherThread.ResultWithPartitions
+import kafka.server.checkpoints.LeaderEpochCheckpointFile
+import kafka.server.epoch.EpochEntry
 import kafka.utils.Implicits._
 import org.apache.kafka.clients.FetchSessionHandler
 import org.apache.kafka.common.TopicPartition
@@ -38,7 +41,10 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.MemoryRecords
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.{LogContext, Time}
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType
 
+import java.io.{File, InputStream}
+import java.nio.file.Files
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, mutable}
 import scala.compat.java8.OptionConverters._
@@ -230,7 +236,10 @@ class ReplicaFetcherThread(name: String,
   }
 
   override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, currentLeaderEpoch: Int): Long = {
-    fetchOffsetFromLeader(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_TIMESTAMP)
+    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_8_IV1)
+      fetchOffsetFromLeader(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)
+    else
+      fetchOffsetFromLeader(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_TIMESTAMP)
   }
 
   override protected def fetchLatestOffsetFromLeader(topicPartition: TopicPartition, currentLeaderEpoch: Int): Long = {
@@ -384,4 +393,47 @@ class ReplicaFetcherThread(name: String,
     !fetchState.isReplicaInSync && quota.isThrottled(topicPartition) && quota.isQuotaExceeded
   }
 
+  override protected def buildRemoteLogAuxState(partition: TopicPartition,
+                                                currentLeaderEpoch: Int,
+                                                offset: Long,
+                                                leaderLogStartOffset: Long): Unit = {
+    replicaMgr.localLog(partition).foreach(log =>
+      if (log.rlmEnabled) {
+        val epoch = log.leaderEpochCache.flatMap(cache => cache.epochForOffset(offset)).getOrElse(0)
+        replicaMgr.remoteLogManager.foreach(rlm => {
+          val rlsMetadata = rlm.fetchRemoteLogSegmentMetadata(partition, offset, epoch)
+          val epochStream = rlm.storageManager().fetchIndex(rlsMetadata, IndexType.LEADER_EPOCH)
+          val epochs = readLeaderEpochCheckpoint(epochStream, log.dir)
+
+          // Truncate the existing local log before restoring the leader epoch cache and producer snapshots.
+          truncateFullyAndStartAt(partition, offset)
+
+          log.maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented)
+          epochs.foreach(epochEntry => {
+            log.leaderEpochCache.map(cache => cache.assign(epochEntry.epoch, epochEntry.startOffset))
+          })
+          info(s"Updated the epoch cache from remote tier till offset: $offset with size: ${epochs.size} for $partition")
+
+          // restore producer snapshot
+          val snapshotFile = Log.producerSnapshotFile(log.dir, offset)
+          Files.copy(rlm.storageManager().fetchIndex(rlsMetadata, IndexType.PRODUCER_SNAPSHOT), snapshotFile.toPath)
+          log.producerStateManager.reloadSegments()
+          log.loadProducerState(offset, reloadFromCleanShutdown = false)
+          info(s"Built the leader epoch cache and producer snapshots from remote tier for $partition. " +
+            s"Active producers: ${log.producerStateManager.activeProducers.size}, LeaderLogStartOffset: $leaderLogStartOffset")
+        })
+      }
+    )
+  }
+
+  private def readLeaderEpochCheckpoint(stream: InputStream,
+                                        dir: File): List[EpochEntry] = {
+    val tmpFile = new File(dir, "leader-epoch-checkpoint" + TmpFileSuffix)
+    Files.copy(stream, tmpFile.toPath)
+    val epochEntries = new LeaderEpochCheckpointFile(tmpFile).checkpoint.read().toList
+    if (!tmpFile.delete()) {
+      logger.warn("Unable to delete the temporary leader epoch checkpoint file: {}", tmpFile.getAbsolutePath)
+    }
+    epochEntries
+  }
 }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -418,7 +418,7 @@ class ReplicaFetcherThread(name: String,
           val snapshotFile = Log.producerSnapshotFile(log.dir, offset)
           Files.copy(rlm.storageManager().fetchIndex(rlsMetadata, IndexType.PRODUCER_SNAPSHOT), snapshotFile.toPath)
           log.producerStateManager.reloadSegments()
-          log.loadProducerState(offset, reloadFromCleanShutdown = false)
+          log.loadProducerState(offset)
           info(s"Built the leader epoch cache and producer snapshots from remote tier for $partition. " +
             s"Active producers: ${log.producerStateManager.activeProducers.size}, LeaderLogStartOffset: $leaderLogStartOffset")
         })

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -236,7 +236,7 @@ class ReplicaFetcherThread(name: String,
   }
 
   override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, currentLeaderEpoch: Int): Long = {
-    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_8_IV1)
+    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_3_0_IV1)
       fetchOffsetFromLeader(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)
     else
       fetchOffsetFromLeader(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_TIMESTAMP)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -18,7 +18,7 @@ package kafka.server
 
 import java.io.File
 import java.util.Optional
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{CompletableFuture, RejectedExecutionException, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.concurrent.locks.Lock
 
@@ -28,6 +28,7 @@ import kafka.cluster.{BrokerEndPoint, Partition}
 import kafka.common.RecordValidationException
 import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log._
+import kafka.log.remote.{RemoteLogManager, RemoteLogReadResult}
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.{FetchMetadata => SFetchMetadata}
 import kafka.server.HostedPartition.Online
@@ -188,6 +189,7 @@ class ReplicaManager(val config: KafkaConfig,
                      val zkClient: Option[KafkaZkClient],
                      scheduler: Scheduler,
                      val logManager: LogManager,
+                     val remoteLogManager: Option[RemoteLogManager],
                      val isShuttingDown: AtomicBoolean,
                      quotaManagers: QuotaManagers,
                      val brokerTopicStats: BrokerTopicStats,
@@ -197,6 +199,7 @@ class ReplicaManager(val config: KafkaConfig,
                      val delayedFetchPurgatory: DelayedOperationPurgatory[DelayedFetch],
                      val delayedDeleteRecordsPurgatory: DelayedOperationPurgatory[DelayedDeleteRecords],
                      val delayedElectLeaderPurgatory: DelayedOperationPurgatory[DelayedElectLeader],
+                     val delayedRemoteFetchPurgatory: DelayedOperationPurgatory[DelayedRemoteFetch],
                      threadNamePrefix: Option[String],
                      val alterIsrManager: AlterIsrManager) extends Logging with KafkaMetricsGroup {
 
@@ -206,6 +209,7 @@ class ReplicaManager(val config: KafkaConfig,
            zkClient: Option[KafkaZkClient],
            scheduler: Scheduler,
            logManager: LogManager,
+           remoteLogManager: Option[RemoteLogManager],
            isShuttingDown: AtomicBoolean,
            quotaManagers: QuotaManagers,
            brokerTopicStats: BrokerTopicStats,
@@ -213,7 +217,7 @@ class ReplicaManager(val config: KafkaConfig,
            logDirFailureChannel: LogDirFailureChannel,
            alterIsrManager: AlterIsrManager,
            threadNamePrefix: Option[String] = None) = {
-    this(config, metrics, time, zkClient, scheduler, logManager, isShuttingDown,
+    this(config, metrics, time, zkClient, scheduler, logManager, remoteLogManager, isShuttingDown,
       quotaManagers, brokerTopicStats, metadataCache, logDirFailureChannel,
       DelayedOperationPurgatory[DelayedProduce](
         purgatoryName = "Produce", brokerId = config.brokerId,
@@ -226,6 +230,8 @@ class ReplicaManager(val config: KafkaConfig,
         purgeInterval = config.deleteRecordsPurgatoryPurgeIntervalRequests),
       DelayedOperationPurgatory[DelayedElectLeader](
         purgatoryName = "ElectLeader", brokerId = config.brokerId),
+      DelayedOperationPurgatory[DelayedRemoteFetch](
+        purgatoryName = "RemoteFetch", brokerId = config.brokerId),
       threadNamePrefix, alterIsrManager)
   }
 
@@ -247,6 +253,8 @@ class ReplicaManager(val config: KafkaConfig,
 
   private var logDirFailureHandler: LogDirFailureHandler = null
   val recompressedBatchCount: AtomicLong = new AtomicLong(0)
+
+  def getHighWatermarkCheckpoints: Map[String, OffsetCheckpointFile] = highWatermarkCheckpoints
 
   private class LogDirFailureHandler(name: String, haltBrokerOnDirFailure: Boolean) extends ShutdownableThread(name) {
     override def doWork(): Unit = {
@@ -1034,8 +1042,9 @@ class ReplicaManager(val config: KafkaConfig,
     val logReadResults = readFromLog()
 
     // check if this fetch request can be satisfied right away
-    var bytesReadable: Long = 0
+    var bytesReadable: Long = 0 // bytes available in local storage
     var errorReadingData = false
+    var remoteFetchInfo: Option[RemoteStorageFetchInfo] = None // The 1st topic-partition that has to be read from remote storage
     var hasDivergingEpoch = false
     val logReadResultMap = new mutable.HashMap[TopicPartition, LogReadResult]
     logReadResults.foreach { case (topicPartition, logReadResult) =>
@@ -1044,6 +1053,8 @@ class ReplicaManager(val config: KafkaConfig,
 
       if (logReadResult.error != Errors.NONE)
         errorReadingData = true
+      if (remoteFetchInfo.isEmpty && logReadResult.info.delayedRemoteStorageFetch.isDefined)
+        remoteFetchInfo = logReadResult.info.delayedRemoteStorageFetch
       if (logReadResult.divergingEpoch.nonEmpty)
         hasDivergingEpoch = true
       bytesReadable = bytesReadable + logReadResult.info.records.sizeInBytes
@@ -1072,21 +1083,90 @@ class ReplicaManager(val config: KafkaConfig,
       }
       val fetchMetadata: SFetchMetadata = SFetchMetadata(fetchMinBytes, fetchMaxBytes, hardMaxBytesLimit,
         fetchOnlyFromLeader, fetchIsolation, isFromFollower, replicaId, fetchPartitionStatus)
-      val delayedFetch = new DelayedFetch(timeout, fetchMetadata, this, quota, clientMetadata,
-        responseCallback)
+      if (remoteFetchInfo.isDefined) {
+        val key = new TopicPartitionOperationKey(remoteFetchInfo.get.topicPartition.topic(), remoteFetchInfo.get.topicPartition.partition())
+        val remoteFetchResult = new CompletableFuture[RemoteLogReadResult]
+        var remoteFetchTask: RemoteLogManager#AsyncReadTask  = null
+        try {
+          remoteFetchTask = remoteLogManager.get.asyncRead(remoteFetchInfo.get, (result: RemoteLogReadResult) => {
+            remoteFetchResult.complete(result)
+            delayedRemoteFetchPurgatory.checkAndComplete(key)
+          })
+        } catch {
+          // if the task queue of remote storage reader thread pool is full, return what we currently have
+          // (the data read from local log segment for the other topic-partitions) and an error for the topic-partition that
+          // we couldn't read from remote storage
+          case e: RejectedExecutionException =>
+            val fetchPartitionData = logReadResults.map { case (tp, result) =>
+              val r = {
+                if (tp.equals(remoteFetchInfo.get.topicPartition))
+                  createLogReadResult(e)
+                else
+                  result
+              }
+              tp -> FetchPartitionData(r.error, r.highWatermark, r.leaderLogStartOffset, r.info.records,
+                divergingEpoch = None, r.lastStableOffset, r.info.abortedTransactions, r.preferredReadReplica, false)
+            }
+            responseCallback(fetchPartitionData)
+            return
+        }
+        // If there is remote data, we will read remote data, instead of waiting for new data.
+        val remoteFetch = new DelayedRemoteFetch(remoteFetchTask, remoteFetchResult, remoteFetchInfo.get, timeout,
+          fetchMetadata, logReadResults, this, quota, responseCallback)
 
-      // create a list of (topic, partition) pairs to use as keys for this delayed fetch operation
-      val delayedFetchKeys = fetchPartitionStatus.map { case (tp, _) => TopicPartitionOperationKey(tp) }
+        delayedRemoteFetchPurgatory.tryCompleteElseWatch(remoteFetch, Seq(key))
+      } else {
+        // If there is not enough data to respond and there is no remote data, we will let the fetch request
+        // to wait for new data.
+        val delayedFetch = new DelayedFetch(timeout, fetchMetadata, this, quota, clientMetadata,
+          responseCallback)
 
-      // try to complete the request immediately, otherwise put it into the purgatory;
-      // this is because while the delayed fetch operation is being created, new requests
-      // may arrive and hence make this operation completable.
-      delayedFetchPurgatory.tryCompleteElseWatch(delayedFetch, delayedFetchKeys)
+        // create a list of (topic, partition) pairs to use as keys for this delayed fetch operation
+        val delayedFetchKeys = fetchPartitionStatus.map { case (tp, _) => TopicPartitionOperationKey(tp) }
+
+        // try to complete the request immediately, otherwise put it into the purgatory;
+        // this is because while the delayed fetch operation is being created, new requests
+        // may arrive and hence make this operation completable.
+        delayedFetchPurgatory.tryCompleteElseWatch(delayedFetch, delayedFetchKeys)
+      }
     }
+  }
+
+  def createLogReadResult(highWatermark: Long,
+                          leaderLogStartOffset: Long,
+                          leaderLogEndOffset: Long,
+                          e: Throwable) = {
+    LogReadResult(info = FetchDataInfo(LogOffsetMetadata.UnknownOffsetMetadata, MemoryRecords.EMPTY),
+      divergingEpoch = None,
+      highWatermark,
+      leaderLogStartOffset,
+      leaderLogEndOffset,
+      followerLogStartOffset = -1L,
+      fetchTimeMs = -1L,
+      lastStableOffset = None,
+      exception = Some(e))
+  }
+
+  def createLogReadResult(e: Throwable) = {
+    LogReadResult(info = FetchDataInfo(LogOffsetMetadata.UnknownOffsetMetadata, MemoryRecords.EMPTY),
+      divergingEpoch = None,
+      highWatermark = -1L,
+      leaderLogStartOffset = -1L,
+      leaderLogEndOffset = -1L,
+      followerLogStartOffset = -1L,
+      fetchTimeMs = -1L,
+      lastStableOffset = None,
+      exception = Some(e))
   }
 
   /**
    * Read from multiple topic partitions at the given offset up to maxSize bytes
+   *
+   * If there is a topic-partition that has to read from remote storage, this function does not read the remote storage,
+   * but returns the necessary information for the remote reading (in LogReadResult of that topic-partition).
+   *
+   * This function does not try to read any more data from location storage after the 1st remote topic-partition.
+   * In most cases, there should be enough data in the remote storage.
    */
   def readFromLocalLog(replicaId: Int,
                        fetchOnlyFromLeader: Boolean,
@@ -1098,19 +1178,34 @@ class ReplicaManager(val config: KafkaConfig,
                        clientMetadata: Option[ClientMetadata]): Seq[(TopicPartition, LogReadResult)] = {
     val traceEnabled = isTraceEnabled
 
+    def checkFetchDataInfo(partition: Partition, givenFetchedDataInfo: FetchDataInfo): FetchDataInfo = {
+      if (shouldLeaderThrottle(quota, partition, replicaId)) {
+        // If the partition is being throttled, simply return an empty set.
+        FetchDataInfo(givenFetchedDataInfo.fetchOffsetMetadata, MemoryRecords.EMPTY)
+      } else if (!hardMaxBytesLimit && givenFetchedDataInfo.firstEntryIncomplete) {
+        // For FetchRequest version 3, we replace incomplete message sets with an empty one as consumers can make
+        // progress in such cases and don't need to report a `RecordTooLargeException`
+        FetchDataInfo(givenFetchedDataInfo.fetchOffsetMetadata, MemoryRecords.EMPTY)
+      } else {
+        givenFetchedDataInfo
+      }
+    }
+
     def read(tp: TopicPartition, fetchInfo: PartitionData, limitBytes: Int, minOneMessage: Boolean): LogReadResult = {
       val offset = fetchInfo.fetchOffset
       val partitionFetchSize = fetchInfo.maxBytes
       val followerLogStartOffset = fetchInfo.logStartOffset
 
       val adjustedMaxBytes = math.min(fetchInfo.maxBytes, limitBytes)
+      var log: Log = null
+      var partition: Partition = null
       try {
         if (traceEnabled)
           trace(s"Fetching log segment for partition $tp, offset $offset, partition fetch size $partitionFetchSize, " +
             s"remaining response limit $limitBytes" +
             (if (minOneMessage) s", ignoring response/partition size limits" else ""))
 
-        val partition = getPartitionOrException(tp)
+        partition = getPartitionOrException(tp)
         val fetchTimeMs = time.milliseconds
 
         // If we are the leader, determine the preferred read-replica
@@ -1136,6 +1231,8 @@ class ReplicaManager(val config: KafkaConfig,
             exception = None)
         } else {
           // Try the read first, this tells us whether we need all of adjustedFetchSize for this partition
+          log = partition.localLogWithEpochOrException(fetchInfo.currentLeaderEpoch, fetchOnlyFromLeader)
+
           val readInfo: LogReadInfo = partition.readRecords(
             lastFetchedEpoch = fetchInfo.lastFetchedEpoch,
             fetchOffset = fetchInfo.fetchOffset,
@@ -1145,16 +1242,7 @@ class ReplicaManager(val config: KafkaConfig,
             fetchOnlyFromLeader = fetchOnlyFromLeader,
             minOneMessage = minOneMessage)
 
-          val fetchDataInfo = if (shouldLeaderThrottle(quota, partition, replicaId)) {
-            // If the partition is being throttled, simply return an empty set.
-            FetchDataInfo(readInfo.fetchedData.fetchOffsetMetadata, MemoryRecords.EMPTY)
-          } else if (!hardMaxBytesLimit && readInfo.fetchedData.firstEntryIncomplete) {
-            // For FetchRequest version 3, we replace incomplete message sets with an empty one as consumers can make
-            // progress in such cases and don't need to report a `RecordTooLargeException`
-            FetchDataInfo(readInfo.fetchedData.fetchOffsetMetadata, MemoryRecords.EMPTY)
-          } else {
-            readInfo.fetchedData
-          }
+          val fetchDataInfo = checkFetchDataInfo(partition, readInfo.fetchedData)
 
           LogReadResult(info = fetchDataInfo,
             divergingEpoch = readInfo.divergingEpoch,
@@ -1175,17 +1263,47 @@ class ReplicaManager(val config: KafkaConfig,
                  _: UnknownLeaderEpochException |
                  _: FencedLeaderEpochException |
                  _: ReplicaNotAvailableException |
-                 _: KafkaStorageException |
-                 _: OffsetOutOfRangeException) =>
-          LogReadResult(info = FetchDataInfo(LogOffsetMetadata.UnknownOffsetMetadata, MemoryRecords.EMPTY),
-            divergingEpoch = None,
-            highWatermark = Log.UnknownOffset,
-            leaderLogStartOffset = Log.UnknownOffset,
-            leaderLogEndOffset = Log.UnknownOffset,
-            followerLogStartOffset = Log.UnknownOffset,
-            fetchTimeMs = -1L,
-            lastStableOffset = None,
-            exception = Some(e))
+                 _: KafkaStorageException) =>
+          createLogReadResult(e)
+        case e: OffsetOutOfRangeException =>
+          // Incase of offset out of range errors, check for remote log manager for non-compacted topics
+          // to fetch from remote storage. `log` instance should not be null here as that would have caught earlier with
+          // NotLeaderForPartitionException or ReplicaNotAvailableException.
+          // If it is from a follower then send the offset metadata but not the records data as that can be fetched
+          // from the remote store.
+          if (remoteLogManager.isDefined && log != null && !log.config.compact) {
+            // For follower fetch requests, throw an error saying that this offset is moved to tiered storage.
+            val highWatermark = log.highWatermark
+            val leaderLogStartOffset = log.logStartOffset
+            val leaderLogEndOffset = log.logEndOffset
+            if (Request.isValidBrokerId(replicaId)) {
+              createLogReadResult(highWatermark, leaderLogStartOffset, leaderLogEndOffset,
+                new OffsetMovedToTieredStorageException("Given offset is moved to tiered storage"))
+            } else {
+              val fetchTimeMs = time.milliseconds
+              val lastStableOffset = Some(log.lastStableOffset)
+              val fetchDataInfo = {
+                // create a dummy FetchDataInfo with the remote storage fetch information
+                // For the first topic-partition that needs remote data, we will use this information to read the data in another thread
+                // For the following topic-partitions, we return an empty record set
+                FetchDataInfo(LogOffsetMetadata(fetchInfo.fetchOffset), MemoryRecords.EMPTY,
+                  delayedRemoteStorageFetch = Some(
+                    RemoteStorageFetchInfo(adjustedMaxBytes, minOneMessage, tp, fetchInfo, fetchIsolation)))
+              }
+
+              LogReadResult(checkFetchDataInfo(partition, fetchDataInfo),
+                divergingEpoch = None,
+                highWatermark,
+                leaderLogStartOffset,
+                leaderLogEndOffset,
+                followerLogStartOffset,
+                fetchTimeMs,
+                lastStableOffset,
+                exception = None)
+            }
+          } else {
+            createLogReadResult(e)
+          }
         case e: Throwable =>
           brokerTopicStats.topicStats(tp.topic).failedFetchRequestRate.mark()
           brokerTopicStats.allTopicsStats.failedFetchRequestRate.mark()
@@ -1194,15 +1312,7 @@ class ReplicaManager(val config: KafkaConfig,
           error(s"Error processing fetch with max size $adjustedMaxBytes from $fetchSource " +
             s"on partition $tp: $fetchInfo", e)
 
-          LogReadResult(info = FetchDataInfo(LogOffsetMetadata.UnknownOffsetMetadata, MemoryRecords.EMPTY),
-            divergingEpoch = None,
-            highWatermark = Log.UnknownOffset,
-            leaderLogStartOffset = Log.UnknownOffset,
-            leaderLogEndOffset = Log.UnknownOffset,
-            followerLogStartOffset = Log.UnknownOffset,
-            fetchTimeMs = -1L,
-            lastStableOffset = None,
-            exception = Some(e))
+          createLogReadResult(e)
       }
     }
 
@@ -1216,6 +1326,13 @@ class ReplicaManager(val config: KafkaConfig,
       if (recordBatchSize > 0)
         minOneMessage = false
       limitBytes = math.max(0, limitBytes - recordBatchSize)
+
+      // Do not read more local data after the first topic-partition that has remote data
+      // Instead of try to estimate how much data is there in remote storage, we assume there is always
+      // enough data to fetch in the remote storage
+      if (readResult.info.delayedRemoteStorageFetch.isDefined)
+        limitBytes = 0
+
       result += (tp -> readResult)
     }
     result
@@ -1444,6 +1561,9 @@ class ReplicaManager(val config: KafkaConfig,
 
           replicaFetcherManager.shutdownIdleFetcherThreads()
           replicaAlterLogDirsManager.shutdownIdleFetcherThreads()
+
+          remoteLogManager.foreach(rlm => rlm.onLeadershipChange(partitionsBecomeLeader, partitionsBecomeFollower, topicIds))
+
           onLeadershipChange(partitionsBecomeLeader, partitionsBecomeFollower)
 
           val data = new LeaderAndIsrResponseData().setErrorCode(Errors.NONE.code)
@@ -1916,6 +2036,7 @@ class ReplicaManager(val config: KafkaConfig,
     delayedProducePurgatory.shutdown()
     delayedDeleteRecordsPurgatory.shutdown()
     delayedElectLeaderPurgatory.shutdown()
+    delayedRemoteFetchPurgatory.shutdown()
     if (checkpointHW)
       checkpointHighWatermarks()
     replicaSelectorOpt.foreach(_.close)

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -58,13 +58,17 @@ class TransactionsTest extends KafkaServerTestHarness {
     TestUtils.createBrokerConfigs(numServers, zkConnect).map(KafkaConfig.fromProps(_, serverProps()))
   }
 
+  def topicConfig(): Properties = {
+    val topicConfig = new Properties()
+    topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
+    topicConfig
+  }
+
   @BeforeEach
   override def setUp(): Unit = {
     super.setUp()
-    val topicConfig = new Properties()
-    topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
-    createTopic(topic1, numPartitions, numServers, topicConfig)
-    createTopic(topic2, numPartitions, numServers, topicConfig)
+    createTopic(topic1, numPartitions, numServers, topicConfig())
+    createTopic(topic2, numPartitions, numServers, topicConfig())
 
     for (_ <- 0 until transactionalProducerCount)
       createTransactionalProducer("transactional-producer")
@@ -567,10 +571,8 @@ class TransactionsTest extends KafkaServerTestHarness {
     val unCommittedConsumer = nonTransactionalConsumers.head
     val topicWith10Partitions = "largeTopic"
     val topicWith10PartitionsAndOneReplica = "largeTopicOneReplica"
-    val topicConfig = new Properties()
-    topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
 
-    createTopic(topicWith10Partitions, 10, numServers, topicConfig)
+    createTopic(topicWith10Partitions, 10, numServers, topicConfig())
     createTopic(topicWith10PartitionsAndOneReplica, 10, 1, new Properties())
 
     firstProducer.initTransactions()
@@ -732,7 +734,7 @@ class TransactionsTest extends KafkaServerTestHarness {
     producer.flush()
   }
 
-  private def serverProps() = {
+  def serverProps() = {
     val serverProps = new Properties()
     serverProps.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
     // Set a smaller value for the number of partitions for the __consumer_offsets topic

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -158,7 +158,7 @@ object AbstractCoordinatorConcurrencyTest {
   }
 
   class TestReplicaManager extends ReplicaManager(
-    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null) {
+    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null) {
 
     @volatile var logs: mutable.Map[TopicPartition, (Log, Long)] = _
     var producePurgatory: DelayedOperationPurgatory[DelayedProduce] = _

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -29,6 +29,7 @@ import kafka.utils.{CoreUtils, MockTime, Scheduler, TestUtils}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.{CompressionType, ControlRecordType, DefaultRecordBatch, MemoryRecords, RecordBatch, RecordVersion, SimpleRecord, TimestampType}
 import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
@@ -64,6 +65,7 @@ class LogLoaderTest {
     val logDir: File = TestUtils.tempDir()
     val logProps = new Properties()
     val logConfig = LogConfig(logProps)
+    val remoteLogManagerConfig = new RemoteLogManagerConfig(new Properties())
     val logDirs = Seq(logDir)
     val topicPartition = new TopicPartition("foo", 0)
     var log: Log = null
@@ -80,7 +82,8 @@ class LogLoaderTest {
         flushCheckMs = 1000L, flushRecoveryOffsetCheckpointMs = 10000L, flushStartOffsetCheckpointMs = 10000L,
         retentionCheckMs = 1000L, maxPidExpirationMs = 60 * 60 * 1000, scheduler = time.scheduler, time = time,
         brokerTopicStats = new BrokerTopicStats, logDirFailureChannel = new LogDirFailureChannel(logDirs.size),
-        keepPartitionMetadataFile = config.usesTopicId, interBrokerProtocolVersion = config.interBrokerProtocolVersion) {
+        keepPartitionMetadataFile = config.usesTopicId, interBrokerProtocolVersion = config.interBrokerProtocolVersion,
+        remoteLogManagerConfig = remoteLogManagerConfig) {
 
         override def loadLog(logDir: File, hadCleanShutdown: Boolean, recoveryPoints: Map[TopicPartition, Long],
                              logStartOffsets: Map[TopicPartition, Long], defaultConfig: LogConfig,

--- a/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
@@ -83,7 +83,8 @@ object LogTestUtils {
                 producerIdExpirationCheckIntervalMs: Int = LogManager.ProducerIdExpirationCheckIntervalMs,
                 lastShutdownClean: Boolean = true,
                 topicId: Option[Uuid] = None,
-                keepPartitionMetadataFile: Boolean = true): Log = {
+                keepPartitionMetadataFile: Boolean = true,
+                remoteLogEnable: Boolean = false): Log = {
     Log(dir = dir,
       config = config,
       logStartOffset = logStartOffset,
@@ -96,7 +97,8 @@ object LogTestUtils {
       logDirFailureChannel = new LogDirFailureChannel(10),
       lastShutdownClean = lastShutdownClean,
       topicId = topicId,
-      keepPartitionMetadataFile = keepPartitionMetadataFile)
+      keepPartitionMetadataFile = keepPartitionMetadataFile,
+      remoteLogEnable = remoteLogEnable)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.log.remote
+
+import java.io.{File, FileInputStream}
+import java.nio.file.Files
+import java.util.Collections
+import kafka.log.{OffsetIndex, OffsetPosition, TimeIndex}
+import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType
+import org.apache.kafka.server.log.remote.storage.{RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteStorageManager}
+import org.easymock.EasyMock
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+
+import org.easymock.EasyMock.anyObject
+import org.easymock.EasyMock.expect
+import org.easymock.EasyMock.reset
+
+class RemoteIndexCacheTest {
+
+  val rlsm: RemoteStorageManager = EasyMock.createMock(classOf[RemoteStorageManager])
+  var rlsMetadata: RemoteLogSegmentMetadata = _
+  var cache: RemoteIndexCache = _
+  var offsetIndex: OffsetIndex = _
+  var timeIndex: TimeIndex = _
+  val maxEntries = 30
+  val baseOffset = 45L
+
+  @BeforeEach
+  def setup(): Unit = {
+    offsetIndex = new OffsetIndex(createTempFile(), baseOffset, maxIndexSize = maxEntries * 8)
+    timeIndex = new TimeIndex(createTempFile(), baseOffset = baseOffset, maxIndexSize = maxEntries * 12)
+
+    appendIndexEntries()
+
+    // fetch indexes only once to build the cache, later it should be available in the cache
+    expect(rlsm.fetchIndex(anyObject(classOf[RemoteLogSegmentMetadata]), EasyMock.eq(IndexType.OFFSET)))
+      .andReturn(new FileInputStream(offsetIndex.file))
+      .times(1)
+    expect(rlsm.fetchIndex(anyObject(classOf[RemoteLogSegmentMetadata]), EasyMock.eq(IndexType.TIMESTAMP)))
+      .andReturn(new FileInputStream(timeIndex.file))
+      .times(1)
+    expect(rlsm.fetchIndex(anyObject(classOf[RemoteLogSegmentMetadata]), EasyMock.eq(IndexType.TRANSACTION)))
+      .andReturn(new FileInputStream(File.createTempFile("kafka-test-", ".txnIndex")))
+      .times(1)
+    expect(rlsm.fetchIndex(anyObject(classOf[RemoteLogSegmentMetadata]), EasyMock.eq(IndexType.PRODUCER_SNAPSHOT)))
+      .andReturn(new FileInputStream(File.createTempFile("kafka-test-", ".snapshot")))
+      .times(1)
+
+    EasyMock.replay(rlsm)
+
+    val logDir = Files.createTempDirectory("kafka-").toString
+    cache = new RemoteIndexCache(remoteStorageManager = rlsm, logDir = logDir)
+
+    val topicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0))
+    rlsMetadata = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid()),
+      baseOffset, offsetIndex.lastOffset, -1L, 1, 1024, 1024,
+      Collections.singletonMap(0, 0L))
+  }
+
+  private def appendIndexEntries(): Unit = {
+    val curTime = System.currentTimeMillis()
+    for (i <- 0 until offsetIndex.maxEntries) {
+      val offset = offsetIndex.baseOffset + i + 1
+      offsetIndex.append(offset, i)
+      timeIndex.maybeAppend(curTime + i, offset, skipFullCheck = true)
+    }
+
+    offsetIndex.flush()
+    timeIndex.flush()
+  }
+
+  private def assertIndexEntries(): Unit = {
+    for (i <- 0 until offsetIndex.maxEntries)
+      assertEquals(OffsetPosition(offsetIndex.baseOffset + i + 1, i), offsetIndex.entry(i))
+    assertTrue(timeIndex.entries > 0)
+    assertTrue(timeIndex.file.exists())
+  }
+
+  def createTempFile(): File = {
+    val file = File.createTempFile("kafka-test-", ".tmp")
+    Files.delete(file.toPath)
+    file
+  }
+
+  @AfterEach
+  def cleanup(): Unit = {
+    reset(rlsm)
+
+    if (offsetIndex != null) offsetIndex.deleteIfExists()
+    if (timeIndex != null) timeIndex.deleteIfExists()
+    cache.close()
+  }
+
+  @Test
+  def testLoadingIndexFromRemoteStorage(): Unit = {
+
+    assertIndexEntries()
+
+    val offsetPosition1 = offsetIndex.entry(1)
+    // this call should have invoked fetchOffsetIndex, fetchTimestampIndex once
+    val resultOffset = cache.lookupOffset(rlsMetadata, offsetPosition1.offset)
+    assertEquals(offsetPosition1.position, resultOffset)
+
+    // this should not cause fetching index from RemoteLogStorageManager as it is already fetched earlier
+    // this is checked by setting expectation times as 1 on the mock
+    val offsetPosition2 = offsetIndex.entry(2)
+    val resultOffset2 = cache.lookupOffset(rlsMetadata, offsetPosition2.offset)
+    assertEquals(offsetPosition2.position, resultOffset2)
+  }
+
+  @Test
+  def testPositionForNonExistingIndexFromRemoteStorage(): Unit = {
+    // offsets beyond this
+    val lastOffsetPosition = cache.lookupOffset(rlsMetadata, offsetIndex.lastOffset)
+    val greaterOffsetThanLastOffset = offsetIndex.lastOffset + 1
+    val resultOffsetPosition1 = cache.lookupOffset(rlsMetadata, greaterOffsetThanLastOffset)
+    assertEquals(lastOffsetPosition, resultOffsetPosition1)
+
+    val nonExistentOffsetPosition = OffsetPosition(baseOffset, 0)
+    val lowerOffsetThanBaseOffset = offsetIndex.baseOffset - 1
+    val resultOffsetPosition2 = cache.lookupOffset(rlsMetadata, lowerOffsetThanBaseOffset)
+    assertEquals(nonExistentOffsetPosition.position, resultOffsetPosition2)
+  }
+}

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -1,0 +1,286 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.log.remote
+
+import java.io.{ByteArrayInputStream, File, InputStream}
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.{Collections, Optional, Properties}
+import java.{lang, util}
+import kafka.log._
+import kafka.server.QuotaFactory.UnboundedQuota
+import kafka.server._
+import kafka.server.checkpoints.LazyOffsetCheckpoints
+import kafka.utils.{MockScheduler, MockTime, TestUtils}
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.common.{Endpoint, TopicIdPartition, TopicPartition}
+import org.apache.kafka.common.config.AbstractConfig
+import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.record._
+import org.apache.kafka.common.requests.FetchRequest.PartitionData
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.server.log.remote.storage.{RemoteLogSegmentMetadata, RemoteStorageManager, _}
+import org.easymock.EasyMock.{anyObject, anyString, createMock, expect, replay, reset}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+
+class RemoteLogManagerTest {
+
+  val brokerId = 101
+  val topicPartition = new TopicPartition("test-topic", 0)
+  val time = new MockTime()
+  val brokerTopicStats = new BrokerTopicStats
+  val metrics = new Metrics
+  val rsmConfigPrefix = "rsm.config."
+  val rlmmConfigPrefix = "rlmm.config."
+
+  val rsmConfig: Map[String, Any] = Map(
+    rsmConfigPrefix + "url" -> "foo.url",
+    rsmConfigPrefix + "timeout.ms" -> 1000L
+  )
+  var logConfig: LogConfig = _
+  var tmpDir: File = _
+  var replicaManager: ReplicaManager = _
+  var logManager: LogManager = _
+  var rlmMock: RemoteLogManager = createMock(classOf[RemoteLogManager])
+
+  val rlmConfig: RemoteLogManagerConfig = {
+    val props = new Properties
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, true.toString)
+    props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP, rsmConfigPrefix)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP, rlmmConfigPrefix)
+    props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, "kafka.log.remote.MockRemoteStorageManager")
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, "kafka.log.remote.MockRemoteLogMetadataManager")
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP, 2.toString)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP, 10.toString)
+    rsmConfig.foreach(config => props.put(config._1, config._2.toString))
+    val config = new AbstractConfig(RemoteLogManagerConfig.CONFIG_DEF, props, false)
+    new RemoteLogManagerConfig(config)
+  }
+
+  @BeforeEach
+  def setup(): Unit = {
+    val logProps = createLogProperties(Map.empty)
+    logConfig = LogConfig(logProps)
+
+    tmpDir = TestUtils.tempDir()
+    val logDir1 = TestUtils.randomPartitionLogDir(tmpDir)
+    val logDir2 = TestUtils.randomPartitionLogDir(tmpDir)
+    logManager = TestUtils.createLogManager(logDirs = Seq(logDir1, logDir2), defaultConfig = logConfig,
+      cleanerConfig = CleanerConfig(enableCleaner = false), time = time, remoteLogManagerConfig = rlmConfig)
+    logManager.startup(Set.empty)
+
+    val brokerProps = TestUtils.createBrokerConfig(brokerId, TestUtils.MockZkConnect)
+    brokerProps.put(KafkaConfig.LogDirsProp, Seq(logDir1, logDir2).map(_.getAbsolutePath).mkString(","))
+    val brokerConfig = KafkaConfig.fromProps(brokerProps)
+    val kafkaZkClient: Option[KafkaZkClient] = Some(createMock(classOf[KafkaZkClient]))
+    val quotaManagers = QuotaFactory.instantiate(brokerConfig, metrics, time, "")
+    val alterIsrManager = TestUtils.createAlterIsrManager()
+    replicaManager = new ReplicaManager(
+       brokerConfig, metrics, time, kafkaZkClient, new MockScheduler(time),
+      logManager, Some(rlmMock), new AtomicBoolean(false), quotaManagers,
+      brokerTopicStats, new ZkMetadataCache(brokerId), new LogDirFailureChannel(brokerConfig.logDirs.size),
+      alterIsrManager)
+
+    expect(kafkaZkClient.get.getEntityConfigs(anyString(), anyString())).andReturn(
+      logProps).anyTimes()
+    expect(
+      kafkaZkClient.get.conditionalUpdatePath(anyObject(), anyObject(), anyObject(),
+        anyObject()))
+      .andReturn((true, 0)).anyTimes()
+    replay(kafkaZkClient.get)
+  }
+
+  @AfterEach
+  def tearDown(): Unit = {
+    reset(rlmMock)
+    brokerTopicStats.close()
+    metrics.close()
+
+    logManager.shutdown()
+    Utils.delete(tmpDir)
+    logManager.liveLogDirs.foreach(Utils.delete)
+    replicaManager.shutdown(checkpointHW = false)
+  }
+
+  private def createLogProperties(overrides: Map[String, String]): Properties = {
+    val logProps = new Properties()
+    logProps.put(LogConfig.SegmentBytesProp, 1024: java.lang.Integer)
+    logProps.put(LogConfig.SegmentIndexBytesProp, 10000: java.lang.Integer)
+    logProps.put(LogConfig.RetentionMsProp, 300000: java.lang.Integer)
+    overrides.foreach { case (k, v) => logProps.put(k, v) }
+    logProps
+  }
+
+  @Test
+  def testRSMConfigInvocation(): Unit = {
+
+    def logFetcher(tp: TopicPartition): Option[Log] = logManager.getLog(tp)
+
+    def lsoUpdater(tp: TopicPartition, los: Long): Unit = {}
+
+    // this should initialize RSM
+    val logsDirTmp = Files.createTempDirectory("kafka-").toString
+    val remoteLogManager = new RemoteLogManager(logFetcher, lsoUpdater, rlmConfig, time, 1, "", logsDirTmp, new BrokerTopicStats)
+    val securityProtocol = SecurityProtocol.PLAINTEXT
+    val listenerName = ListenerName.forSecurityProtocol(securityProtocol)
+    val endpoint = new Endpoint(listenerName.value(), securityProtocol, "localhost", 9092)
+    remoteLogManager.onEndpointCreated(endpoint)
+
+    assertEquals(rsmConfig.size,
+      rsmConfig.count { case (k, v) =>
+        val keyWithoutPrefix = k.split(rsmConfigPrefix)(1)
+        MockRemoteStorageManager.configs.get(keyWithoutPrefix) == v
+      })
+  }
+
+  @Test
+  def testRemoteLogRecordsFetch(): Unit = {
+    // return the lastOffset to verify when out of range offsets are requested.
+    expect(rlmMock.close()).anyTimes()
+    replay(rlmMock)
+
+    val leaderEpoch = 1
+    val partition = replicaManager.createPartition(topicPartition)
+
+    val leaderState = new LeaderAndIsrPartitionState()
+      .setControllerEpoch(1)
+      .setLeader(brokerId)
+      .setLeaderEpoch(leaderEpoch)
+      .setIsr(Collections.singletonList(brokerId))
+      .setZkVersion(1)
+      .setReplicas(Collections.singletonList(brokerId))
+      .setIsNew(true)
+    partition.makeLeader(leaderState, new LazyOffsetCheckpoints(replicaManager.getHighWatermarkCheckpoints), None)
+
+    val recordsArray = Array(
+      new SimpleRecord("k1".getBytes, "v1".getBytes),
+      new SimpleRecord("k2".getBytes, "v2".getBytes),
+      new SimpleRecord("k3".getBytes, "v3".getBytes),
+      new SimpleRecord("k4".getBytes, "v4".getBytes)
+    )
+    val inputRecords: util.List[SimpleRecord] = util.Arrays.asList(recordsArray: _*)
+
+    val inputMemoryRecords = Map(topicPartition -> MemoryRecords.withRecords(0L, CompressionType.NONE, leaderEpoch,
+      recordsArray: _*))
+
+    replicaManager.appendRecords(timeout = 30000, requiredAcks = 1, internalTopicsAllowed = true,
+      origin = AppendOrigin.Client, entriesPerPartition = inputMemoryRecords, responseCallback = _ => ())
+
+    def logReadResultFor(fetchOffset: Long): LogReadResult = {
+      val partitionInfo = Seq((topicPartition, new PartitionData(fetchOffset, 0, 1000,
+        Optional.of(leaderEpoch))))
+      val readRecords = replicaManager.readFromLocalLog(100, fetchOnlyFromLeader = true, FetchTxnCommitted, 1000,
+        hardMaxBytesLimit = false, partitionInfo, UnboundedQuota, None)
+      if (readRecords.isEmpty) null else readRecords.last._2
+    }
+
+    val logReadResult_0 = logReadResultFor(0L)
+    val receivedRecords = logReadResult_0.info.records
+    // check the records are same
+    val result = new util.ArrayList[SimpleRecord]()
+    receivedRecords.records().forEach((t: Record) => result.add(new SimpleRecord(t)))
+    assertEquals(inputRecords, result)
+
+    val outOfRangeOffset = logManager.getLog(topicPartition).get.logEndOffset + 1
+
+    // fetching offsets beyond local log would result in fetching from remote log, it is mocked to return lastOffset,
+    //nextLocalOffset should be lastOffset +1
+    val logReadResult = logReadResultFor(outOfRangeOffset)
+    // fetch response should have no records as it is to indicate that the requested fetch messages are in
+    // remote tier and the next offset available locally is sent as `nextLocalOffset` so that follower replica can
+    // start fetching that for local storage.
+    assertTrue(logReadResult.info.records.sizeInBytes() == 0)
+  }
+
+  @Test
+  def testRLMConfig(): Unit = {
+    val key = "hello"
+    val props: Properties = new Properties()
+    props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP, rsmConfigPrefix)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP, rlmmConfigPrefix)
+    props.put(rlmmConfigPrefix + key, "world")
+    props.put("remote.log.metadata.y", "z")
+    val rlmmConfig = new RemoteLogManagerConfig(new AbstractConfig(RemoteLogManagerConfig.CONFIG_DEF, props))
+      .remoteLogMetadataManagerProps()
+
+    assertEquals(props.get(rlmmConfigPrefix + key), rlmmConfig.get(key))
+    assertFalse(rlmmConfig.containsKey("remote.log.metadata.y"))
+  }
+}
+
+object MockRemoteStorageManager {
+  var configs: util.Map[String, _] = _
+}
+
+class MockRemoteStorageManager extends RemoteStorageManager {
+
+  override def configure(configs: util.Map[String, _]): Unit = {
+    MockRemoteStorageManager.configs = configs
+  }
+
+  override def copyLogSegmentData(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, logSegmentData: LogSegmentData): Unit = {}
+
+  override def fetchLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, startPosition: Int): InputStream = {
+    new ByteArrayInputStream(Array.emptyByteArray)
+  }
+
+  override def fetchLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, startPosition: Int, endPosition: Int): InputStream = {
+    new ByteArrayInputStream(Array.emptyByteArray)
+  }
+
+  override def fetchIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, indexType: RemoteStorageManager.IndexType): InputStream = {
+    new ByteArrayInputStream(Array.emptyByteArray)
+  }
+
+  override def deleteLogSegmentData(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = {}
+
+  override def close(): Unit = {}
+}
+
+class MockRemoteLogMetadataManager extends RemoteLogMetadataManager {
+  override def addRemoteLogSegmentMetadata(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = {}
+
+  override def updateRemoteLogSegmentMetadata(remoteLogSegmentMetadataUpdate: RemoteLogSegmentMetadataUpdate): Unit = {}
+
+  override def remoteLogSegmentMetadata(topicIdPartition: TopicIdPartition, epochForOffset: Int, offset: Long): Optional[RemoteLogSegmentMetadata] = {
+    Optional.empty()
+  }
+
+  override def highestOffsetForEpoch(topicIdPartition: TopicIdPartition, leaderEpoch: Int): Optional[lang.Long] = {
+    Optional.empty()
+  }
+
+  override def putRemotePartitionDeleteMetadata(remotePartitionDeleteMetadata: RemotePartitionDeleteMetadata): Unit = {}
+
+  override def listRemoteLogSegments(topicIdPartition: TopicIdPartition): util.Iterator[RemoteLogSegmentMetadata] = {
+    Collections.emptyIterator()
+  }
+  override def listRemoteLogSegments(topicIdPartition: TopicIdPartition, leaderEpoch: Int): util.Iterator[RemoteLogSegmentMetadata] = {
+    Collections.emptyIterator()
+  }
+  override def onPartitionLeadershipChanges(leaderPartitions: util.Set[TopicIdPartition], followerPartitions: util.Set[TopicIdPartition]): Unit = {}
+
+  override def onStopPartitions(partitions: util.Set[TopicIdPartition]): Unit = {}
+
+  override def configure(configs: util.Map[String, _]): Unit = {}
+
+  override def close(): Unit = {}
+}

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -147,7 +147,7 @@ class RemoteLogManagerTest {
     assertEquals(rsmConfig.size,
       rsmConfig.count { case (k, v) =>
         val keyWithoutPrefix = k.split(rsmConfigPrefix)(1)
-        MockRemoteStorageManager.configs.get(keyWithoutPrefix) == v
+        MockRemoteStorageManager.configs.get(keyWithoutPrefix) == v.toString
       })
   }
 

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogReaderTest.scala
@@ -1,0 +1,175 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.log.remote
+
+import java.nio.file.Files
+import java.util.{Optional, Properties}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import java.util.concurrent.{CompletableFuture, RejectedExecutionException}
+
+import kafka.server.{BrokerTopicStats, FetchDataInfo, FetchTxnCommitted, LogOffsetMetadata, RemoteStorageFetchInfo}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.AbstractConfig
+import org.apache.kafka.common.errors.OffsetOutOfRangeException
+import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.requests.FetchRequest.PartitionData
+import org.apache.kafka.common.utils.SystemTime
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Test
+
+import scala.jdk.CollectionConverters._
+
+class RemoteLogReaderTest {
+
+  @Test
+  def testReadRemoteLog(): Unit = {
+    val rlm = new MockRemoteLogManager(2, 10)
+    val tp = new TopicPartition("test", 0)
+    val fetchInfo = new PartitionData(200, 200, 1000, Optional.of(1))
+    val resultFuture = new CompletableFuture[RemoteLogReadResult]
+    def callback(result: RemoteLogReadResult): Unit = {
+      resultFuture.complete(result)
+    }
+    rlm.asyncRead(RemoteStorageFetchInfo(1000, minOneMessage = true, tp, fetchInfo, FetchTxnCommitted), callback)
+    Thread.sleep(100)
+
+    val dataInfo = resultFuture.get.info.get
+    assertEquals(None, resultFuture.get.error)
+    assertEquals(200, dataInfo.fetchOffsetMetadata.messageOffset)
+    assertEquals(2, dataInfo.records.records.asScala.size)
+    assertEquals(202, dataInfo.records.records.iterator.next.offset)
+  }
+
+  @Test
+  def testTaskQueueFullAndCancelTask(): Unit = {
+    val rlm = new MockRemoteLogManager(5, 20)
+    rlm.pause()
+
+    val tp = new TopicPartition("test", 0)
+    val tasks = new Array[RemoteLogManager#AsyncReadTask](26)
+    val finishedTasks = Array.fill[Boolean](26)(false)
+    val finishCount = new AtomicInteger(0)
+    def callback(result: RemoteLogReadResult): Unit = {
+      assertEquals(None, result.error)
+      finishCount.addAndGet(1)
+      finishedTasks(result.info.get.fetchOffsetMetadata.messageOffset.asInstanceOf[Int]) = true
+    }
+
+    for (i <- 0 to 24) {
+      val fetchInfo = new PartitionData(i, 0, 1000, Optional.of(1))
+      val future = rlm.asyncRead(RemoteStorageFetchInfo(1000, minOneMessage = true, tp, fetchInfo, FetchTxnCommitted), callback)
+      tasks(i) = future
+    }
+    assertEquals(0, finishCount.get)
+
+    assertThrows(classOf[RejectedExecutionException], () => {
+      val fetchInfo = new PartitionData(25, 0, 1000, Optional.of(1))
+      rlm.asyncRead(RemoteStorageFetchInfo(1000, minOneMessage = true, tp, fetchInfo, FetchTxnCommitted), callback)
+    })
+
+    tasks(7).cancel(false)
+    tasks(10).cancel(true)
+
+    val fetchInfo = new PartitionData(25, 0, 1000, Optional.of(1))
+    rlm.asyncRead(RemoteStorageFetchInfo(1000, minOneMessage = true, tp, fetchInfo, FetchTxnCommitted), callback)
+    rlm.resume()
+
+    Thread.sleep(200)
+    assertEquals(24, finishCount.get)
+    assertEquals(24, finishedTasks.count(a => a))
+    assertEquals(false, finishedTasks(7))
+    assertEquals(false, finishedTasks(10))
+  }
+
+  @Test
+  def testErr(): Unit = {
+    val rlm = new MockRemoteLogManager(2, 10) {
+      override def read(remoteStorageFetchInfo: RemoteStorageFetchInfo): FetchDataInfo = {
+        throw new OffsetOutOfRangeException("Offset: %d is out of range"
+          .format(remoteStorageFetchInfo.fetchInfo.fetchOffset))
+      }
+    }
+    val tp = new TopicPartition("test", 1)
+    val fetchInfo = new PartitionData(10000, 0, 1000, Optional.of(1))
+    val resultFuture = new CompletableFuture[RemoteLogReadResult]
+    def callback(result: RemoteLogReadResult): Unit = {
+      resultFuture.complete(result)
+    }
+
+    val task = rlm.asyncRead(RemoteStorageFetchInfo(1000, minOneMessage = true, tp, fetchInfo, FetchTxnCommitted), callback)
+    Thread.sleep(100)
+    assertTrue(task.isDone)
+    assertEquals(None, resultFuture.get.info)
+    assertEquals(classOf[OffsetOutOfRangeException], resultFuture.get.error.get.getClass)
+  }
+}
+
+class MockRemoteLogManager(threads: Int, taskQueueSize: Int)
+  extends RemoteLogManager(
+    _ => None,
+    (_, _) => {},
+    MockRemoteLogManager.rlmConfig(threads, taskQueueSize),
+    new SystemTime,
+    1,
+    "mock-cluster-id",
+    Files.createTempDirectory("kafka-test-").toString,
+    new BrokerTopicStats) {
+
+  private val lock = new ReentrantReadWriteLock
+
+  override def read(remoteStorageFetchInfo: RemoteStorageFetchInfo): FetchDataInfo = {
+    lock.readLock.lock()
+    try {
+      val fetchInfo = remoteStorageFetchInfo.fetchInfo
+      val recordsArray = Array(
+        new SimpleRecord("k1".getBytes, "v1".getBytes),
+        new SimpleRecord("k2".getBytes, "v2".getBytes)
+      )
+      val records = MemoryRecords.withRecords(fetchInfo.fetchOffset + 2, CompressionType.NONE, 1, recordsArray: _*)
+      FetchDataInfo(new LogOffsetMetadata(fetchInfo.fetchOffset), records)
+    } finally {
+      lock.readLock.unlock()
+    }
+  }
+
+  def pause(): Unit = {
+    lock.writeLock.lock()
+  }
+
+  def resume(): Unit = {
+    lock.writeLock.unlock()
+  }
+}
+
+object MockRemoteLogManager {
+
+  def rlmConfig(threads: Int, taskQueueSize: Int): RemoteLogManagerConfig = {
+    val props = new Properties
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, true.toString)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP, "rlmm.config.")
+    props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP, "rsm.config.")
+    props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, "kafka.log.remote.MockRemoteStorageManager")
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, "kafka.log.remote.MockRemoteLogMetadataManager")
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP, threads.toString)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP, taskQueueSize.toString)
+    val config = new AbstractConfig(RemoteLogManagerConfig.CONFIG_DEF, props, false)
+    new RemoteLogManagerConfig(config)
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -521,6 +521,87 @@ class AbstractFetcherThreadTest {
   }
 
   @Test
+  def testFollowerFetchMovedToTieredStore(): Unit = {
+    val partition = new TopicPartition("topic", 0)
+    val fetcher = new MockFetcherThread()
+
+    val replicaLog = Seq(
+      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("a".getBytes)),
+      mkBatch(baseOffset = 1, leaderEpoch = 2, new SimpleRecord("b".getBytes)),
+      mkBatch(baseOffset = 2, leaderEpoch = 4, new SimpleRecord("c".getBytes)))
+
+    val replicaState = MockFetcherThread.PartitionState(replicaLog, leaderEpoch = 5, highWatermark = 0L, rlmEnabled = true)
+    fetcher.setReplicaState(partition, replicaState)
+    fetcher.addPartitions(Map(partition -> initialFetchState(3L, leaderEpoch = 5)))
+
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 5, leaderEpoch = 5, new SimpleRecord("f".getBytes)),
+      mkBatch(baseOffset = 6, leaderEpoch = 5, new SimpleRecord("g".getBytes)),
+      mkBatch(baseOffset = 7, leaderEpoch = 5, new SimpleRecord("h".getBytes)),
+      mkBatch(baseOffset = 8, leaderEpoch = 5, new SimpleRecord("i".getBytes)))
+
+
+    val leaderState = MockFetcherThread.PartitionState(leaderLog, leaderEpoch = 5, highWatermark = 8L, rlmEnabled = true)
+    // Overriding the log start offset to zero to mock the segment 0-4 moved to remote store.
+    leaderState.logStartOffset = 0
+    fetcher.setLeaderState(partition, leaderState)
+
+    assertEquals(3L, replicaState.logEndOffset)
+    val expectedState = if (truncateOnFetch) Option(Fetching) else Option(Truncating)
+    assertEquals(expectedState, fetcher.fetchState(partition).map(_.state))
+
+    fetcher.doWork()
+    // verify that the offset moved to tiered store error triggered and respective states are truncated to expected.
+    assertEquals(0L, replicaState.logStartOffset)
+    assertEquals(5L, replicaState.localLogStartOffset)
+    assertEquals(5L, replicaState.highWatermark)
+    assertEquals(5L, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 4) fetcher.doWork()
+    assertEquals(4, replicaState.log.size)
+    assertEquals(0L, replicaState.logStartOffset)
+    assertEquals(5L, replicaState.localLogStartOffset)
+    assertEquals(8L, replicaState.highWatermark)
+    assertEquals(9L, replicaState.logEndOffset)
+  }
+
+  @Test
+  def testFencedOffsetResetAfterMovedToRemoteTier(): Unit = {
+    val partition = new TopicPartition("topic", 0)
+    var isErrorHandled = false
+    val fetcher = new MockFetcherThread() {
+      override protected def buildRemoteLogAuxState(topicPartition: TopicPartition,
+                                                    leaderEpoch: Int,
+                                                    fetchOffset: Long,
+                                                    leaderLogStartOffset: Long): Unit = {
+        isErrorHandled = true
+        throw new FencedLeaderEpochException(s"Epoch $leaderEpoch is fenced")
+      }
+    }
+
+    val replicaLog = Seq(
+      mkBatch(baseOffset = 1, leaderEpoch = 2, new SimpleRecord("b".getBytes)),
+      mkBatch(baseOffset = 2, leaderEpoch = 4, new SimpleRecord("c".getBytes)))
+    val replicaState = MockFetcherThread.PartitionState(replicaLog, leaderEpoch = 5, highWatermark = 2L, rlmEnabled = true)
+    fetcher.setReplicaState(partition, replicaState)
+    fetcher.addPartitions(Map(partition -> initialFetchState(0L, leaderEpoch = 5)))
+
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 5, leaderEpoch = 5, new SimpleRecord("b".getBytes)),
+      mkBatch(baseOffset = 6, leaderEpoch = 5, new SimpleRecord("c".getBytes)))
+    val leaderState = MockFetcherThread.PartitionState(leaderLog, leaderEpoch = 5, highWatermark = 6L, rlmEnabled = true)
+    fetcher.setLeaderState(partition, leaderState)
+
+    // After the offset moved to tiered storage error, we get a fenced error and remove the partition and mark as failed
+    fetcher.doWork()
+    assertEquals(3, replicaState.logEndOffset)
+    assertTrue(isErrorHandled)
+    assertTrue(fetcher.fetchState(partition).isEmpty)
+    assertTrue(failedPartitions.contains(partition))
+  }
+
+  @Test
   def testFencedOffsetResetAfterOutOfRange(): Unit = {
     val partition = new TopicPartition("topic", 0)
     var fetchedEarliestOffset = false
@@ -892,13 +973,19 @@ class AbstractFetcherThreadTest {
                          var leaderEpoch: Int,
                          var logStartOffset: Long,
                          var logEndOffset: Long,
-                         var highWatermark: Long)
+                         var highWatermark: Long,
+                         var rlmEnabled: Boolean,
+                         var localLogStartOffset: Long)
 
     object PartitionState {
-      def apply(log: Seq[RecordBatch], leaderEpoch: Int, highWatermark: Long): PartitionState = {
+      def apply(log: Seq[RecordBatch], leaderEpoch: Int, highWatermark: Long, rlmEnabled: Boolean): PartitionState = {
         val logStartOffset = log.headOption.map(_.baseOffset).getOrElse(0L)
         val logEndOffset = log.lastOption.map(_.nextOffset).getOrElse(0L)
-        new PartitionState(log.toBuffer, leaderEpoch, logStartOffset, logEndOffset, highWatermark)
+        new PartitionState(log.toBuffer, leaderEpoch, logStartOffset, logEndOffset, highWatermark, rlmEnabled, logStartOffset)
+      }
+
+      def apply(log: Seq[RecordBatch], leaderEpoch: Int, highWatermark: Long): PartitionState = {
+        apply(log, leaderEpoch, highWatermark, rlmEnabled = false)
       }
 
       def apply(leaderEpoch: Int): PartitionState = {
@@ -1016,7 +1103,11 @@ class AbstractFetcherThreadTest {
     override def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit = {
       val state = replicaPartitionState(topicPartition)
       state.log.clear()
-      state.logStartOffset = offset
+      if (state.rlmEnabled) {
+        state.localLogStartOffset = offset
+      } else {
+        state.logStartOffset = offset
+      }
       state.logEndOffset = offset
       state.highWatermark = offset
     }
@@ -1168,8 +1259,12 @@ class AbstractFetcherThreadTest {
 
         val (error, records) = if (epochCheckError.isDefined) {
           (epochCheckError.get, MemoryRecords.EMPTY)
-        } else if (fetchData.fetchOffset > leaderState.logEndOffset || fetchData.fetchOffset < leaderState.logStartOffset) {
-          (Errors.OFFSET_OUT_OF_RANGE, MemoryRecords.EMPTY)
+        } else if (fetchData.fetchOffset > leaderState.logEndOffset || fetchData.fetchOffset < leaderState.localLogStartOffset) {
+          if (leaderState.rlmEnabled && fetchData.fetchOffset < leaderState.localLogStartOffset) {
+            (Errors.OFFSET_MOVED_TO_TIERED_STORAGE, MemoryRecords.EMPTY)
+          } else {
+            (Errors.OFFSET_OUT_OF_RANGE, MemoryRecords.EMPTY)
+          }
         } else if (divergingEpoch.nonEmpty) {
           (Errors.NONE, MemoryRecords.EMPTY)
         } else {
@@ -1209,7 +1304,7 @@ class AbstractFetcherThreadTest {
     override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): Long = {
       val leaderState = leaderPartitionState(topicPartition)
       checkLeaderEpochAndThrow(leaderEpoch, leaderState)
-      leaderState.logStartOffset
+      leaderState.localLogStartOffset
     }
 
     override protected def fetchLatestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): Long = {
@@ -1218,6 +1313,14 @@ class AbstractFetcherThreadTest {
       leaderState.logEndOffset
     }
 
+    override protected def buildRemoteLogAuxState(topicPartition: TopicPartition,
+                                                  currentLeaderEpoch: Int,
+                                                  fetchOffset: Long,
+                                                  leaderLogStartOffset: Long): Unit = {
+      truncateFullyAndStartAt(topicPartition, fetchOffset)
+      replicaPartitionState(topicPartition).logStartOffset = leaderLogStartOffset
+      // skipped building leader epoch cache and producer snapshots as they are not verified.
+    }
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -1260,7 +1260,7 @@ class AbstractFetcherThreadTest {
           (epochCheckError.get, MemoryRecords.EMPTY)
         } else if (fetchData.fetchOffset > leaderState.logEndOffset || fetchData.fetchOffset < leaderState.localLogStartOffset) {
           if (leaderState.rlmEnabled && fetchData.fetchOffset < leaderState.localLogStartOffset) {
-            (Errors.OFFSET_MOVED_TO_TIERED_STORAGE, MemoryRecords.EMPTY)
+            (Errors.LI_OFFSET_MOVED_TO_TIERED_STORAGE, MemoryRecords.EMPTY)
           } else {
             (Errors.OFFSET_OUT_OF_RANGE, MemoryRecords.EMPTY)
           }

--- a/core/src/test/scala/unit/kafka/server/DelayedRemoteFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelayedRemoteFetchTest.scala
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util.Optional
+import java.util.concurrent.CompletableFuture
+
+import kafka.cluster.Partition
+import kafka.log.remote.{MockRemoteLogManager, RemoteLogManager, RemoteLogReadResult}
+import kafka.server.QuotaFactory.UnboundedQuota
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.record.MemoryRecords
+import org.apache.kafka.common.requests.FetchRequest.PartitionData
+import org.easymock.{EasyMock, EasyMockSupport}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import scala.collection.Seq
+import scala.jdk.CollectionConverters._
+
+class DelayedRemoteFetchTest extends EasyMockSupport {
+  val tp = new TopicPartition("test", 0)
+  val tp1 = new TopicPartition("t1", 0)
+  var isRemoteFetchExecuted = false
+
+  @Test
+  def testRemoteFetch(): Unit = {
+    var replied = false
+
+    def responseCallback(r: Seq[(TopicPartition, FetchPartitionData)]): Unit = {
+      replied = true
+      assert(r(0)._1.equals(tp1))
+
+      assert(r(1)._1.equals(tp))
+      assertEquals(None, r(1)._2.error)
+      assertEquals(2, r(1)._2.records.records.asScala.size)
+      assertEquals(102, r(1)._2.records.records.iterator.next.offset)
+      assertEquals(2000, r(1)._2.highWatermark)
+    }
+
+    RemoteFetch(false, responseCallback)
+    assert(replied)
+    assert(isRemoteFetchExecuted)
+  }
+
+  @Test
+  def testRemoteFetchTimeout(): Unit = {
+    var replied = false
+
+    def responseCallback(r: Seq[(TopicPartition, FetchPartitionData)]): Unit = {
+      replied = true
+      assert(r(0)._1.equals(tp1))
+
+      assert(r(1)._1.equals(tp))
+      assertEquals(None, r(1)._2.error)
+      assertEquals(0, r(1)._2.records.records.asScala.size)
+      assertEquals(2000, r(1)._2.highWatermark)
+    }
+
+    RemoteFetch(true, responseCallback)
+    assert(replied)
+    assert(!isRemoteFetchExecuted)
+  }
+
+  def RemoteFetch(timeout: Boolean, responseCallback: (Seq[(TopicPartition, FetchPartitionData)]) => Unit): Unit = {
+    val rlm = new MockRemoteLogManager(5, 20)
+    val fetchInfo = new PartitionData(100, 0, 1000, Optional.of(1))
+    val remoteFetchInfo = RemoteStorageFetchInfo(1000, true, tp, fetchInfo, FetchTxnCommitted)
+
+    val fetchPartitionStatus = FetchPartitionStatus(new LogOffsetMetadata(fetchInfo.fetchOffset), fetchInfo)
+
+    val fetchPartitionStatus1 = FetchPartitionStatus(new LogOffsetMetadata(messageOffset = 50L, segmentBaseOffset = 0L,
+      relativePositionInSegment = 250), new PartitionData(50, 0, 1, Optional.empty()))
+
+    val fetchMetadata = FetchMetadata(fetchMinBytes = 1,
+      fetchMaxBytes = 1000,
+      hardMaxBytesLimit = true,
+      fetchOnlyLeader = true,
+      fetchIsolation = FetchLogEnd,
+      isFromFollower = false,
+      replicaId = 1,
+      fetchPartitionStatus = List((tp1, fetchPartitionStatus1), (tp, fetchPartitionStatus)))
+
+    val localReadResults: Seq[(TopicPartition, LogReadResult)] = List(
+      (tp1, new LogReadResult(info = FetchDataInfo(LogOffsetMetadata.UnknownOffsetMetadata, MemoryRecords.EMPTY),
+        divergingEpoch = None,
+        highWatermark = -1L,
+        leaderLogStartOffset = -1L,
+        leaderLogEndOffset = -1L,
+        followerLogStartOffset = -1L,
+        fetchTimeMs = -1L,
+        lastStableOffset = None,
+        exception = Some(new Exception()))),
+      (tp, new LogReadResult(
+        FetchDataInfo(LogOffsetMetadata(fetchInfo.fetchOffset), MemoryRecords.EMPTY, delayedRemoteStorageFetch = Some(remoteFetchInfo)),
+        divergingEpoch = None,
+        highWatermark = 2000,
+        leaderLogStartOffset = 0,
+        leaderLogEndOffset = 2000,
+        followerLogStartOffset = 0,
+        fetchTimeMs = 0,
+        lastStableOffset = Some(1000),
+        exception = None))
+    )
+
+    val partition: Partition = EasyMock.createMock(classOf[Partition])
+    val replicaManager: ReplicaManager = EasyMock.createMock(classOf[ReplicaManager])
+    EasyMock.expect(replicaManager.getPartitionOrException(EasyMock.anyObject[TopicPartition]))
+      .andReturn(partition).anyTimes()
+    EasyMock.replay(replicaManager)
+
+    val remoteFetchPurgatory = DelayedOperationPurgatory[DelayedRemoteFetch](purgatoryName = "RemoteFetch", brokerId = 1, purgeInterval = 50)
+    val key = new TopicPartitionOperationKey(tp.topic(), tp.partition())
+    val remoteFetchResult = new CompletableFuture[RemoteLogReadResult]
+    var remoteFetchTask: RemoteLogManager#AsyncReadTask = null
+
+    val remoteFetch = new DelayedRemoteFetch(remoteFetchTask = remoteFetchTask,
+      remoteFetchResult = remoteFetchResult,
+      remoteFetchInfo = localReadResults(1)._2.info.delayedRemoteStorageFetch.get,
+      delayMs = 500,
+      fetchMetadata = fetchMetadata,
+      localReadResults = localReadResults,
+      replicaManager = replicaManager,
+      UnboundedQuota,
+      responseCallback = responseCallback)
+
+    assertEquals(false, remoteFetchPurgatory.tryCompleteElseWatch(remoteFetch, Seq(key)))
+
+    if (timeout)
+      rlm.pause()
+
+    remoteFetchTask = rlm.asyncRead(remoteFetchInfo, (result: RemoteLogReadResult) => {
+      isRemoteFetchExecuted = true
+      remoteFetchResult.complete(result)
+      remoteFetchPurgatory.checkAndComplete(key)
+    })
+
+    Thread.sleep(100)
+
+    if (timeout) {
+      assertEquals(false, remoteFetch.isCompleted)
+      Thread.sleep(500)
+    }
+
+    assertEquals(true, remoteFetch.isCompleted)
+  }
+}
+
+

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -13,7 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 package kafka.server
 
 import kafka.log._
@@ -64,7 +64,7 @@ class HighwatermarkPersistenceTest {
     val quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, None, scheduler,
-      logManagers.head, new AtomicBoolean(false), quotaManager,
+      logManagers.head, None, new AtomicBoolean(false), quotaManager,
       new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager)
     replicaManager.startup()
     try {
@@ -113,7 +113,7 @@ class HighwatermarkPersistenceTest {
     val quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, None,
-      scheduler, logManagers.head, new AtomicBoolean(false), quotaManager,
+      scheduler, logManagers.head, None, new AtomicBoolean(false), quotaManager,
       new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager)
     replicaManager.startup()
     try {

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -65,9 +65,10 @@ class IsrExpirationTest {
 
     alterIsrManager = TestUtils.createAlterIsrManager()
     quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
-    replicaManager = new ReplicaManager(configs.head, metrics, time, None, null, logManager, new AtomicBoolean(false),
-      quotaManager, new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId),
-      new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager)
+    replicaManager = new ReplicaManager(configs.head, metrics, time, None, null, logManager, None,
+      new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
+      MetadataCache.zkMetadataCache(configs.head.brokerId), new LogDirFailureChannel(configs.head.logDirs.size),
+      alterIsrManager)
   }
 
   @AfterEach

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -189,7 +189,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
     TestUtils.produceMessage(servers, topic, "test-10", System.currentTimeMillis() + 10L)
 
     assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, 0L, -1))
-    assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, version = -1))
+    assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP, version = -1))
     assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, -1))
     assertEquals((10L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, -1))
     assertEquals((9L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.MAX_TIMESTAMP, -1))
@@ -204,7 +204,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
 
     // No changes to written data
     assertEquals((0L, 0), fetchOffsetAndEpoch(secondLeaderId, 0L, -1))
-    assertEquals((0L, -1), fetchOffsetAndEpoch(secondLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, -1))
+    assertEquals((0L, -1), fetchOffsetAndEpoch(secondLeaderId, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP, -1))
 
     assertEquals((0L, 0), fetchOffsetAndEpoch(secondLeaderId, 0L, -1))
     assertEquals((0L, 0), fetchOffsetAndEpoch(secondLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, -1))
@@ -226,12 +226,12 @@ class ListOffsetsRequestTest extends BaseRequestTest {
       if (version == 0) {
         assertEquals((-1L, -1), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
         assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, version.toShort))
-        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, version.toShort))
+        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP, version.toShort))
         assertEquals((10L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, version.toShort))
       } else if (version >= 1 && version <= 3) {
         assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
         assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, version.toShort))
-        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, version.toShort))
+        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP, version.toShort))
         assertEquals((10L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, version.toShort))
       } else if (version >= 4  && version <= 6) {
         assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
@@ -240,7 +240,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
       } else if (version >= 7) {
         assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
         assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, version.toShort))
-        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, version.toShort))
+        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP, version.toShort))
         assertEquals((10L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, version.toShort))
         assertEquals((9L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.MAX_TIMESTAMP, version.toShort))
       }

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -21,17 +21,28 @@ import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartit
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{ListOffsetsRequest, ListOffsetsResponse}
-import org.apache.kafka.common.{IsolationLevel, TopicPartition}
+import org.apache.kafka.common.{IsolationLevel, TopicIdPartition, TopicPartition}
+import org.apache.kafka.server.log.remote.storage.{LogSegmentData, RemoteLogManagerConfig, RemoteLogMetadataManager, RemoteLogSegmentMetadata, RemoteLogSegmentMetadataUpdate, RemotePartitionDeleteMetadata, RemoteStorageManager}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
-import java.util.Optional
+import java.util.{Collections, Optional, Properties}
+import java.io.InputStream
+import java.{lang, util}
 import scala.jdk.CollectionConverters._
 
 class ListOffsetsRequestTest extends BaseRequestTest {
 
   val topic = "topic"
   val partition = new TopicPartition(topic, 0)
+
+  override def brokerPropertyOverrides(props: Properties): Unit = {
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
+    props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP, "remote.storage.config.")
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP, "rlmm.config.")
+    props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, classOf[DummyRemoteStorageManager].getName)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, classOf[DummyRemoteLogMetadataManager].getName)
+  }
 
   @Test
   def testListOffsetsErrorCodes(): Unit = {
@@ -178,6 +189,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
     TestUtils.produceMessage(servers, topic, "test-10", System.currentTimeMillis() + 10L)
 
     assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, 0L, -1))
+    assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, version = -1))
     assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, -1))
     assertEquals((10L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, -1))
     assertEquals((9L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.MAX_TIMESTAMP, -1))
@@ -192,7 +204,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
 
     // No changes to written data
     assertEquals((0L, 0), fetchOffsetAndEpoch(secondLeaderId, 0L, -1))
-    assertEquals((0L, 0), fetchOffsetAndEpoch(secondLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, -1))
+    assertEquals((0L, -1), fetchOffsetAndEpoch(secondLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, -1))
 
     assertEquals((0L, 0), fetchOffsetAndEpoch(secondLeaderId, 0L, -1))
     assertEquals((0L, 0), fetchOffsetAndEpoch(secondLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, -1))
@@ -214,10 +226,12 @@ class ListOffsetsRequestTest extends BaseRequestTest {
       if (version == 0) {
         assertEquals((-1L, -1), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
         assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, version.toShort))
+        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, version.toShort))
         assertEquals((10L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, version.toShort))
       } else if (version >= 1 && version <= 3) {
         assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
         assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, version.toShort))
+        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, version.toShort))
         assertEquals((10L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, version.toShort))
       } else if (version >= 4  && version <= 6) {
         assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
@@ -226,6 +240,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
       } else if (version >= 7) {
         assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, 0L, version.toShort))
         assertEquals((0L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_TIMESTAMP, version.toShort))
+        assertEquals((0L, -1), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, version.toShort))
         assertEquals((10L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.LATEST_TIMESTAMP, version.toShort))
         assertEquals((9L, 0), fetchOffsetAndEpoch(firstLeaderId, ListOffsetsRequest.MAX_TIMESTAMP, version.toShort))
       }
@@ -245,4 +260,28 @@ class ListOffsetsRequestTest extends BaseRequestTest {
   private def sendRequest(leaderId: Int, request: ListOffsetsRequest): ListOffsetsResponse = {
     connectAndReceive[ListOffsetsResponse](request, destination = brokerSocketServer(leaderId))
   }
+}
+
+private class DummyRemoteStorageManager extends RemoteStorageManager {
+  override def copyLogSegmentData(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, logSegmentData: LogSegmentData): Unit = {}
+  override def fetchLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, startPosition: Int): InputStream = {null}
+  override def fetchLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, startPosition: Int, endPosition: Int): InputStream = {null}
+  override def fetchIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, indexType: RemoteStorageManager.IndexType): InputStream = {null}
+  override def deleteLogSegmentData(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = {}
+  override def close(): Unit = {}
+  override def configure(configs: util.Map[String, _]): Unit = {}
+}
+
+private class DummyRemoteLogMetadataManager extends RemoteLogMetadataManager {
+  override def addRemoteLogSegmentMetadata(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = {}
+  override def updateRemoteLogSegmentMetadata(remoteLogSegmentMetadataUpdate: RemoteLogSegmentMetadataUpdate): Unit = {}
+  override def remoteLogSegmentMetadata(topicIdPartition: TopicIdPartition, epochForOffset: Int, offset: Long): Optional[RemoteLogSegmentMetadata] = {Optional.empty()}
+  override def highestOffsetForEpoch(topicIdPartition: TopicIdPartition, leaderEpoch: Int): Optional[lang.Long] = {Optional.empty()}
+  override def putRemotePartitionDeleteMetadata(remotePartitionDeleteMetadata: RemotePartitionDeleteMetadata): Unit = {}
+  override def listRemoteLogSegments(topicIdPartition: TopicIdPartition): util.Iterator[RemoteLogSegmentMetadata] = {null}
+  override def listRemoteLogSegments(topicIdPartition: TopicIdPartition, leaderEpoch: Int): util.Iterator[RemoteLogSegmentMetadata] = {Collections.emptyIterator()}
+  override def onPartitionLeadershipChanges(leaderPartitions: util.Set[TopicIdPartition], followerPartitions: util.Set[TopicIdPartition]): Unit = {}
+  override def onStopPartitions(partitions: util.Set[TopicIdPartition]): Unit = {}
+  override def close(): Unit = {}
+  override def configure(configs: util.Map[String, _]): Unit = {}
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -241,7 +241,7 @@ class ReplicaManagerQuotasTest {
 
     val leaderBrokerId = configs.head.brokerId
     quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
-    replicaManager = new ReplicaManager(configs.head, metrics, time, None, scheduler, logManager,
+    replicaManager = new ReplicaManager(configs.head, metrics, time, None, scheduler, logManager, None,
       new AtomicBoolean(false), quotaManager,
       new BrokerTopicStats, MetadataCache.zkMetadataCache(leaderBrokerId), new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager)
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -95,7 +95,7 @@ class ReplicaManagerTest {
   @Test
   def testHighWaterMarkDirectoryMapping(): Unit = {
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)))
-    val rm = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr,
+    val rm = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr, None,
       new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
     try {
@@ -115,7 +115,7 @@ class ReplicaManagerTest {
     props.put("log.dir", TestUtils.tempRelativeDir("data").getAbsolutePath)
     val config = KafkaConfig.fromProps(props)
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)))
-    val rm = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr,
+    val rm = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr, None,
       new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
     try {
@@ -132,7 +132,7 @@ class ReplicaManagerTest {
   @Test
   def testIllegalRequiredAcks(): Unit = {
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)))
-    val rm = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr,
+    val rm = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr, None,
       new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager, Option(this.getClass.getName))
     try {
@@ -179,7 +179,7 @@ class ReplicaManagerTest {
     val aliveBrokers = Seq(new Node(0, "host0", 0), new Node(1, "host1", 1))
     val metadataCache: MetadataCache = Mockito.mock(classOf[MetadataCache])
     mockGetAliveBrokerFunctions(metadataCache, aliveBrokers)
-    val rm = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr,
+    val rm = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr, None,
       new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
       metadataCache, new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
 
@@ -1647,6 +1647,8 @@ class ReplicaManagerTest {
       purgatoryName = "DeleteRecords", timer, reaperEnabled = false)
     val mockElectLeaderPurgatory = new DelayedOperationPurgatory[DelayedElectLeader](
       purgatoryName = "ElectLeader", timer, reaperEnabled = false)
+    val mockDelayedRemoteFetchPurgatory = new DelayedOperationPurgatory[DelayedRemoteFetch](
+      purgatoryName = "RemoteFetch", timer, reaperEnabled = false)
 
     // Mock network client to show leader offset of 5
     val blockingSend = new ReplicaFetcherMockBlockingSend(
@@ -1656,10 +1658,10 @@ class ReplicaManagerTest {
         .setLeaderEpoch(leaderEpochFromLeader)
         .setEndOffset(offsetFromLeader)).asJava,
       BrokerEndPoint(1, "host1" ,1), time)
-    val replicaManager = new ReplicaManager(config, metrics, time, None, mockScheduler, mockLogMgr,
+    val replicaManager = new ReplicaManager(config, metrics, time, None, mockScheduler, mockLogMgr, None,
       new AtomicBoolean(false), quotaManager, mockBrokerTopicStats,
       metadataCache, mockLogDirFailureChannel, mockProducePurgatory, mockFetchPurgatory,
-      mockDeleteRecordsPurgatory, mockElectLeaderPurgatory, Option(this.getClass.getName),
+      mockDeleteRecordsPurgatory, mockElectLeaderPurgatory, mockDelayedRemoteFetchPurgatory, Option(this.getClass.getName),
       alterIsrManager) {
 
       override protected def createReplicaFetcherManager(metrics: Metrics,
@@ -1831,13 +1833,15 @@ class ReplicaManagerTest {
       purgatoryName = "Fetch", timer, reaperEnabled = false)
     val mockDeleteRecordsPurgatory = new DelayedOperationPurgatory[DelayedDeleteRecords](
       purgatoryName = "DeleteRecords", timer, reaperEnabled = false)
+    val mockDelayedRemoteFetchPurgatory = new DelayedOperationPurgatory[DelayedRemoteFetch](
+      purgatoryName = "RemoteFetch", timer, reaperEnabled = false)
     val mockDelayedElectLeaderPurgatory = new DelayedOperationPurgatory[DelayedElectLeader](
       purgatoryName = "DelayedElectLeader", timer, reaperEnabled = false)
 
-    new ReplicaManager(config, metrics, time, None, scheduler, mockLogMgr,
+    new ReplicaManager(config, metrics, time, None, scheduler, mockLogMgr, None,
       new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
       metadataCache, new LogDirFailureChannel(config.logDirs.size), mockProducePurgatory, mockFetchPurgatory,
-      mockDeleteRecordsPurgatory, mockDelayedElectLeaderPurgatory, Option(this.getClass.getName),
+      mockDeleteRecordsPurgatory, mockDelayedElectLeaderPurgatory, mockDelayedRemoteFetchPurgatory, Option(this.getClass.getName),
       alterIsrManager) {
 
       override protected def createReplicaFetcherManager(
@@ -2062,10 +2066,10 @@ class ReplicaManagerTest {
     mockGetAliveBrokerFunctions(metadataCache1, aliveBrokers)
 
     // each replica manager is for a broker
-    val rm0 = new ReplicaManager(config0, metrics, time, None, new MockScheduler(time), mockLogMgr0,
+    val rm0 = new ReplicaManager(config0, metrics, time, None, new MockScheduler(time), mockLogMgr0, None,
       new AtomicBoolean(false), quotaManager,
       brokerTopicStats1, metadataCache0, new LogDirFailureChannel(config0.logDirs.size), alterIsrManager)
-    val rm1 = new ReplicaManager(config1, metrics, time, None, new MockScheduler(time), mockLogMgr1,
+    val rm1 = new ReplicaManager(config1, metrics, time, None, new MockScheduler(time), mockLogMgr1, None,
       new AtomicBoolean(false), quotaManager,
       brokerTopicStats2, metadataCache1, new LogDirFailureChannel(config1.logDirs.size), alterIsrManager)
 
@@ -2308,7 +2312,7 @@ class ReplicaManagerTest {
       val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
       val config = KafkaConfig.fromProps(props)
       val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)))
-      new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr,
+      new ReplicaManager(config, metrics, time, None, new MockScheduler(time), mockLogMgr, None,
         new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
         MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager) {
         override def getPartitionOrException(topicPartition: TopicPartition): Partition = {

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
@@ -578,4 +578,19 @@ class LeaderEpochFileCacheTest {
     //Then
     cache.truncateFromEnd(7)
   }
+
+  @Test
+  def shouldFetchEpochForGivenOffset(): Unit = {
+    cache.assign(0, 10L)
+    cache.assign(1, 20L)
+    cache.assign(5, 30L)
+
+    assertEquals(1, cache.epochForOffset(25L).get)
+    assertEquals(1, cache.epochForOffset(20L).get)
+    assertEquals(5, cache.epochForOffset(30L).get)
+    assertEquals(5, cache.epochForOffset(50L).get)
+    assertEquals(0, cache.epochForOffset(5L).get)
+    cache.clearAndFlush()
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -65,7 +65,7 @@ class OffsetsForLeaderEpochTest {
     replay(mockLog, logManager)
 
     // create a replica manager with 1 partition that has 1 replica
-    replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, new AtomicBoolean(false),
+    replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
     val partition = replicaManager.createPartition(tp)
@@ -88,7 +88,7 @@ class OffsetsForLeaderEpochTest {
     replay(logManager)
 
     //create a replica manager with 1 partition that has 0 replica
-    replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, new AtomicBoolean(false),
+    replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
     replicaManager.createPartition(tp)
@@ -113,7 +113,7 @@ class OffsetsForLeaderEpochTest {
     replay(logManager)
 
     //create a replica manager with 0 partition
-    replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, new AtomicBoolean(false),
+    replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -66,6 +66,7 @@ import org.apache.kafka.common.utils.Utils._
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{KafkaFuture, TopicPartition}
 import org.apache.kafka.server.authorizer.{Authorizer => JAuthorizer}
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.zookeeper.KeeperException.SessionExpiredException
 import org.apache.zookeeper.ZooDefs._
@@ -1092,7 +1093,8 @@ object TestUtils extends Logging {
                        configRepository: ConfigRepository = new MockConfigRepository,
                        cleanerConfig: CleanerConfig = CleanerConfig(enableCleaner = false),
                        time: MockTime = new MockTime(),
-                       interBrokerProtocolVersion: ApiVersion = ApiVersion.latestVersion): LogManager = {
+                       interBrokerProtocolVersion: ApiVersion = ApiVersion.latestVersion,
+                       remoteLogManagerConfig: RemoteLogManagerConfig = new RemoteLogManagerConfig(new Properties())): LogManager = {
     new LogManager(logDirs = logDirs.map(_.getAbsoluteFile),
                    initialOfflineDirs = Array.empty[File],
                    configRepository = configRepository,
@@ -1109,7 +1111,8 @@ object TestUtils extends Logging {
                    brokerTopicStats = new BrokerTopicStats,
                    logDirFailureChannel = new LogDirFailureChannel(logDirs.size),
                    keepPartitionMetadataFile = true,
-                   interBrokerProtocolVersion = interBrokerProtocolVersion)
+                   interBrokerProtocolVersion = interBrokerProtocolVersion,
+                   remoteLogManagerConfig = remoteLogManagerConfig)
   }
 
   class MockAlterIsrManager extends AlterIsrManager {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -58,6 +58,7 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.mockito.Mockito;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -118,6 +119,7 @@ public class ReplicaFetcherThreadBenchmark {
         props.put("zookeeper.connect", "127.0.0.1:9999");
         KafkaConfig config = new KafkaConfig(props);
         LogConfig logConfig = createLogConfig();
+        RemoteLogManagerConfig rlmConfig = createRemoteLogManagerConfig();
 
         List<File> logDirs = Collections.singletonList(logDir);
         BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
@@ -138,7 +140,8 @@ public class ReplicaFetcherThreadBenchmark {
                 brokerTopicStats,
                 logDirFailureChannel,
                 Time.SYSTEM,
-                true);
+                true,
+                rlmConfig);
 
         LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> initialFetched = new LinkedHashMap<>();
         scala.collection.mutable.Map<TopicPartition, InitialFetchState> initialFetchStates = new scala.collection.mutable.HashMap<>();
@@ -235,6 +238,9 @@ public class ReplicaFetcherThreadBenchmark {
         return LogConfig.apply(logProps, new scala.collection.immutable.HashSet<>());
     }
 
+    private static RemoteLogManagerConfig createRemoteLogManagerConfig() {
+        return new RemoteLogManagerConfig(new Properties());
+    }
 
     static class ReplicaFetcherBenchThread extends ReplicaFetcherThread {
         private final Pool<TopicPartition, Partition> pool;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.mockito.Mockito;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -97,6 +98,7 @@ public class PartitionMakeFollowerBenchmark {
 
         scheduler.startup();
         LogConfig logConfig = createLogConfig();
+        RemoteLogManagerConfig rlmConfig = createRemoteLogManagerConfig();
 
         List<File> logDirs = Collections.singletonList(logDir);
         BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
@@ -117,7 +119,8 @@ public class PartitionMakeFollowerBenchmark {
             brokerTopicStats,
             logDirFailureChannel,
             Time.SYSTEM,
-            true);
+            true,
+                rlmConfig);
 
         TopicPartition tp = new TopicPartition("topic", 0);
         topicId = OptionConverters.toScala(Optional.of(Uuid.randomUuid()));
@@ -178,5 +181,9 @@ public class PartitionMakeFollowerBenchmark {
         logProps.put(LogConfig.SegmentIndexBytesProp(), Defaults.MaxIndexSize());
         logProps.put(LogConfig.FileDeleteDelayMsProp(), Defaults.FileDeleteDelayMs());
         return LogConfig.apply(logProps, new scala.collection.immutable.HashSet<>());
+    }
+
+    private static RemoteLogManagerConfig createRemoteLogManagerConfig() {
+        return new RemoteLogManagerConfig(new Properties());
     }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.mockito.Mockito;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -85,6 +86,7 @@ public class UpdateFollowerFetchStateBenchmark {
     public void setUp() {
         scheduler.startup();
         LogConfig logConfig = createLogConfig();
+        RemoteLogManagerConfig rlmConfig = createRemoteLogManagerConfig();
         List<File> logDirs = Collections.singletonList(logDir);
         logManager = new LogManager(JavaConverters.asScalaIteratorConverter(logDirs.iterator()).asScala().toSeq(),
                 JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
@@ -102,7 +104,8 @@ public class UpdateFollowerFetchStateBenchmark {
                 brokerTopicStats,
                 logDirFailureChannel,
                 Time.SYSTEM,
-                true);
+                true,
+                rlmConfig);
         OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
         Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), topicPartition)).thenReturn(Option.apply(0L));
         DelayedOperations delayedOperations = new DelayedOperationsMock();
@@ -160,6 +163,10 @@ public class UpdateFollowerFetchStateBenchmark {
         logProps.put(LogConfig.SegmentIndexBytesProp(), Defaults.MaxIndexSize());
         logProps.put(LogConfig.FileDeleteDelayMsProp(), Defaults.FileDeleteDelayMs());
         return LogConfig.apply(logProps, new scala.collection.immutable.HashSet<>());
+    }
+
+    private static RemoteLogManagerConfig createRemoteLogManagerConfig() {
+        return new RemoteLogManagerConfig(new Properties());
     }
 
     @Benchmark

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
@@ -54,6 +55,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -107,7 +109,8 @@ public class CheckpointBench {
         this.logManager = TestUtils.createLogManager(JavaConverters.asScalaBuffer(files),
                 LogConfig.apply(), new MockConfigRepository(), CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
                         1024 * 1024, 32 * 1024 * 1024,
-                        Double.MAX_VALUE, 15 * 1000, true, "MD5"), time, ApiVersion.latestVersion());
+                        Double.MAX_VALUE, 15 * 1000, true, "MD5"), time,
+                    ApiVersion.latestVersion(), new RemoteLogManagerConfig(new Properties()));
         scheduler.startup();
         final BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
         final MetadataCache metadataCache =
@@ -125,6 +128,7 @@ public class CheckpointBench {
                 Option.empty(),
                 this.scheduler,
                 this.logManager,
+                Option.empty(),
                 new AtomicBoolean(false),
                 this.quotaManagers,
                 brokerTopicStats,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -45,6 +45,7 @@ import org.apache.kafka.common.message.LeaderAndIsrRequestData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -138,7 +139,8 @@ public class PartitionCreationBench {
                 brokerTopicStats,
                 failureChannel,
                 Time.SYSTEM,
-                true);
+                true,
+                createRemoteLogManagerConfig());
         scheduler.startup();
         final MetadataCache metadataCache =
                 new ZkMetadataCache(this.brokerProperties.brokerId());
@@ -161,6 +163,7 @@ public class PartitionCreationBench {
                 Option.apply(zkClient),
                 this.scheduler,
                 this.logManager,
+                Option.empty(),
                 new AtomicBoolean(false),
                 this.quotaManagers,
                 brokerTopicStats,
@@ -197,6 +200,10 @@ public class PartitionCreationBench {
         logProps.put(LogConfig.SegmentIndexBytesProp(), Defaults.MaxIndexSize());
         logProps.put(LogConfig.FileDeleteDelayMsProp(), Defaults.FileDeleteDelayMs());
         return LogConfig.apply(logProps, new scala.collection.immutable.HashSet<>());
+    }
+
+    private static RemoteLogManagerConfig createRemoteLogManagerConfig() {
+        return new RemoteLogManagerConfig(new Properties());
     }
 
     @Benchmark


### PR DESCRIPTION
Source commit: https://github.com/satishd/kafka/commit/54d84789c655b3268afccffa0d974213ad99cfed
Original Authors: Authors: satishd@uber.com, yingz@uber.com, kchandraprakash@uber.com

Summary:
RemoteLogManager implemented to read/copy data from/to remote tier.

- This patch contains all the required changes in core module to be able to read/fetch and write/copy log segments from remote store.
- Updated the follower fetch protocol to read only the local data available in the leader. On starting a new replica, leader epoch cache gets updated from remote store.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
