### PR TITLE
[LI-HOTFIX] Use max broker epoch in controller requests

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -101,7 +101,7 @@
               files="RequestResponseTest.java|FetcherTest.java|KafkaAdminClientTest.java"/>
 
     <suppress checks="NPathComplexity"
-              files="MemoryRecordsTest|MetricsTest|RequestResponseTest|TestSslUtils|AclAuthorizerBenchmark"/>
+              files="MemoryRecordsTest|MetricsTest|RequestResponseTest|TestSslUtils|UpdateMetadataRequestTest|AclAuthorizerBenchmark"/>
 
     <suppress checks="(WhitespaceAround|LocalVariableName|ImportControl|AvoidStarImport)"
               files="Murmur3Test.java"/>

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractControlRequest.java
@@ -27,12 +27,14 @@ public abstract class AbstractControlRequest extends AbstractRequest {
         protected final int controllerId;
         protected final int controllerEpoch;
         protected final long brokerEpoch;
+        protected final long maxBrokerEpoch;
 
-        protected Builder(ApiKeys api, short version, int controllerId, int controllerEpoch, long brokerEpoch) {
+        protected Builder(ApiKeys api, short version, int controllerId, int controllerEpoch, long brokerEpoch, long maxBrokerEpoch) {
             super(api, version);
             this.controllerId = controllerId;
             this.controllerEpoch = controllerEpoch;
             this.brokerEpoch = brokerEpoch;
+            this.maxBrokerEpoch = maxBrokerEpoch;
         }
 
     }
@@ -46,5 +48,7 @@ public abstract class AbstractControlRequest extends AbstractRequest {
     public abstract int controllerEpoch();
 
     public abstract long brokerEpoch();
+
+    public abstract long maxBrokerEpoch();
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
@@ -48,10 +48,10 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
         private final Map<String, Uuid> topicIds;
         private final Collection<Node> liveLeaders;
 
-        public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch,
+        public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch, long maxBrokerEpoch,
                        List<LeaderAndIsrPartitionState> partitionStates, Map<String, Uuid> topicIds,
                        Collection<Node> liveLeaders) {
-            super(ApiKeys.LEADER_AND_ISR, version, controllerId, controllerEpoch, brokerEpoch);
+            super(ApiKeys.LEADER_AND_ISR, version, controllerId, controllerEpoch, brokerEpoch, maxBrokerEpoch);
             this.partitionStates = partitionStates;
             this.topicIds = topicIds;
             this.liveLeaders = liveLeaders;
@@ -69,6 +69,7 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
                 .setControllerId(controllerId)
                 .setControllerEpoch(controllerEpoch)
                 .setBrokerEpoch(brokerEpoch)
+                .setMaxBrokerEpoch(maxBrokerEpoch)
                 .setLiveLeaders(leaders);
 
             if (version >= 2) {
@@ -101,6 +102,7 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
                 .append(", controllerId=").append(controllerId)
                 .append(", controllerEpoch=").append(controllerEpoch)
                 .append(", brokerEpoch=").append(brokerEpoch)
+                .append(", maxBrokerEpoch=").append(maxBrokerEpoch)
                 .append(", partitionStates=").append(partitionStates)
                 .append(", topicIds=").append(topicIds)
                 .append(", liveLeaders=(").append(Utils.join(liveLeaders, ", ")).append(")")
@@ -136,7 +138,7 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
         Errors error = Errors.forException(e);
         responseData.setErrorCode(error.code());
 
-        if (version() < 5) {
+        if (version() < 6) {
             List<LeaderAndIsrPartitionError> partitions = new ArrayList<>();
             for (LeaderAndIsrPartitionState partition : partitionStates()) {
                 partitions.add(new LeaderAndIsrPartitionError()
@@ -176,6 +178,11 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
     @Override
     public long brokerEpoch() {
         return data.brokerEpoch();
+    }
+
+    @Override
+    public long maxBrokerEpoch() {
+        return data.maxBrokerEpoch();
     }
 
     public Iterable<LeaderAndIsrPartitionState> partitionStates() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrResponse.java
@@ -60,13 +60,13 @@ public class LeaderAndIsrResponse extends AbstractResponse {
         Errors error = error();
         if (error != Errors.NONE) {
             // Minor optimization since the top-level error applies to all partitions
-            if (version < 5) 
+            if (version < 6)
                 return Collections.singletonMap(error, data.partitionErrors().size() + 1);
-            return Collections.singletonMap(error, 
+            return Collections.singletonMap(error,
                     data.topics().stream().mapToInt(t -> t.partitionErrors().size()).sum() + 1);
         }
         Map<Errors, Integer> errors;
-        if (version < 5)
+        if (version < 6)
             errors = errorCounts(data.partitionErrors().stream().map(l -> Errors.forCode(l.errorCode())));
         else
             errors = errorCounts(data.topics().stream().flatMap(t -> t.partitionErrors().stream()).map(l ->
@@ -77,7 +77,7 @@ public class LeaderAndIsrResponse extends AbstractResponse {
 
     public Map<TopicPartition, Errors> partitionErrors(Map<Uuid, String> topicNames) {
         Map<TopicPartition, Errors> errors = new HashMap<>();
-        if (version < 5) {
+        if (version < 6) {
             data.partitionErrors().forEach(partition ->
                     errors.put(new TopicPartition(partition.topicName(), partition.partitionIndex()),
                             Errors.forCode(partition.errorCode())));

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -48,10 +48,10 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
         private final List<UpdateMetadataBroker> liveBrokers;
         private final Map<String, Uuid> topicIds;
 
-        public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch,
+        public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch, long maxBrokerEpoch,
                        List<UpdateMetadataPartitionState> partitionStates, List<UpdateMetadataBroker> liveBrokers,
                        Map<String, Uuid> topicIds) {
-            super(ApiKeys.UPDATE_METADATA, version, controllerId, controllerEpoch, brokerEpoch);
+            super(ApiKeys.UPDATE_METADATA, version, controllerId, controllerEpoch, brokerEpoch, maxBrokerEpoch);
             this.partitionStates = partitionStates;
             this.liveBrokers = liveBrokers;
             this.topicIds = topicIds;
@@ -84,6 +84,7 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
                     .setControllerId(controllerId)
                     .setControllerEpoch(controllerEpoch)
                     .setBrokerEpoch(brokerEpoch)
+                    .setMaxBrokerEpoch(maxBrokerEpoch)
                     .setLiveBrokers(liveBrokers);
 
             if (version >= 5) {
@@ -122,6 +123,7 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
                 append(", controllerId=").append(controllerId).
                 append(", controllerEpoch=").append(controllerEpoch).
                 append(", brokerEpoch=").append(brokerEpoch).
+                append(", maxBrokerEpoch=").append(maxBrokerEpoch).
                 append(", liveBrokers=").append(Utils.join(liveBrokers, ", ")).
                 append(")");
 
@@ -198,6 +200,11 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
     @Override
     public long brokerEpoch() {
         return data.brokerEpoch();
+    }
+
+    @Override
+    public long maxBrokerEpoch() {
+        return data.maxBrokerEpoch();
     }
 
     @Override

--- a/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+++ b/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
@@ -22,24 +22,28 @@
   //
   // Version 2 adds broker epoch and reorganizes the partitions by topic.
   //
-  // Version 3 adds AddingReplicas and RemovingReplicas.
+  // Version 3 adds the max broker epoch to make the UpdateMetadataRequest cacheable
   //
-  // Version 4 is the first flexible version.
+  // Version 4 adds AddingReplicas and RemovingReplicas.
   //
-  // Version 5 adds Topic ID and Type to the TopicStates, as described in KIP-516.
-  "validVersions": "0-5",
-  "flexibleVersions": "4+",
+  // Version 5 is the first flexible version.
+  //
+  // Version 6 adds Topic ID and Type to the TopicStates, as described in KIP-516.
+  "validVersions": "0-6",
+  "flexibleVersions": "5+",
   "fields": [
     { "name": "ControllerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
       "about": "The current controller ID." },
     { "name": "ControllerEpoch", "type": "int32", "versions": "0+",
       "about": "The current controller epoch." },
-    { "name": "BrokerEpoch", "type": "int64", "versions": "2+", "ignorable": true, "default": "-1",
+    { "name": "BrokerEpoch", "type": "int64", "versions": "2", "ignorable": true, "default": "-1",
       "about": "The current broker epoch." },
-    { "name": "Type", "type": "int8", "versions": "5+",
+    { "name": "Type", "type": "int8", "versions": "6+",
       "about": "The type that indicates whether all topics are included in the request"},
     { "name": "UngroupedPartitionStates", "type": "[]LeaderAndIsrPartitionState", "versions": "0-1",
       "about": "The state of each partition, in a v0 or v1 message." },
+    { "name": "MaxBrokerEpoch", "type": "int64", "versions": "3+", "ignorable": true, "default": "-1",
+      "about": "The max broker epoch." },
     // In v0 or v1 requests, each partition is listed alongside its topic name.
     // In v2+ requests, partitions are organized by topic, so that each topic name
     // only needs to be listed once.
@@ -47,7 +51,7 @@
       "about": "Each topic.", "fields": [
       { "name": "TopicName", "type": "string", "versions": "2+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "TopicId", "type": "uuid", "versions": "5+", "ignorable": true,
+      { "name": "TopicId", "type": "uuid", "versions": "6+", "ignorable": true,
         "about": "The unique topic ID." },
       { "name": "PartitionStates", "type": "[]LeaderAndIsrPartitionState", "versions": "2+",
         "about": "The state of each partition" }
@@ -80,9 +84,9 @@
         "about": "The ZooKeeper version." },
       { "name": "Replicas", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
         "about": "The replica IDs." },
-      { "name": "AddingReplicas", "type": "[]int32", "versions": "3+", "ignorable": true, "entityType": "brokerId",
+      { "name": "AddingReplicas", "type": "[]int32", "versions": "4+", "ignorable": true, "entityType": "brokerId",
         "about": "The replica IDs that we are adding this partition to, or null if no replicas are being added." },
-      { "name": "RemovingReplicas", "type": "[]int32", "versions": "3+", "ignorable": true, "entityType": "brokerId",
+      { "name": "RemovingReplicas", "type": "[]int32", "versions": "4+", "ignorable": true, "entityType": "brokerId",
         "about": "The replica IDs that we are removing this partition from, or null if no replicas are being removed." },
       { "name": "IsNew", "type": "bool", "versions": "1+", "default": "false", "ignorable": true,
         "about": "Whether the replica should have existed on the broker or not." }

--- a/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+++ b/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
@@ -23,28 +23,30 @@
   //
   // Version 3 is the same as version 2.
   //
-  // Version 4 is the first flexible version.
+  // Version 4 is the same as version 3
   //
-  // Version 5 removes TopicName and replaces it with TopicId and reorganizes 
+  // Version 5 is is the first flexible version
+  //
+  // Version 6 removes TopicName and replaces it with TopicId and reorganizes
   // the partitions by topic, as described by KIP-516.
-  "validVersions": "0-5",
-  "flexibleVersions": "4+",
+  "validVersions": "0-6",
+  "flexibleVersions": "5+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
-    { "name": "PartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "0-4",
+    { "name": "PartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "0-5",
       "about": "Each partition in v0 to v4 message."},
-    { "name":  "Topics", "type": "[]LeaderAndIsrTopicError", "versions": "5+",
+    { "name":  "Topics", "type": "[]LeaderAndIsrTopicError", "versions": "6+",
       "about": "Each topic", "fields": [
-      { "name": "TopicId", "type": "uuid", "versions": "5+", "mapKey": true,
+      { "name": "TopicId", "type": "uuid", "versions": "6+", "mapKey": true,
         "about": "The unique topic ID" },
-      { "name": "PartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "5+",
+      { "name": "PartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "6+",
         "about": "Each partition."}
       ]}
     ],
     "commonStructs": [
     { "name": "LeaderAndIsrPartitionError", "versions": "0+", "fields": [
-      { "name": "TopicName", "type": "string", "versions": "0-4", "entityType": "topicName", "ignorable": true,
+      { "name": "TopicName", "type": "string", "versions": "0-5", "entityType": "topicName", "ignorable": true,
         "about": "The topic name."},
       { "name": "PartitionIndex", "type": "int32", "versions": "0+",
         "about": "The partition index." },

--- a/clients/src/main/resources/common/message/StopReplicaRequest.json
+++ b/clients/src/main/resources/common/message/StopReplicaRequest.json
@@ -21,19 +21,23 @@
   // Version 1 adds the broker epoch and reorganizes the partitions to be stored
   // per topic.
   //
-  // Version 2 is the first flexible version.
+  // Version 2 adds the max broker epoch to make the UpdateMetadataRequest cacheable
   //
-  // Version 3 adds the leader epoch per partition (KIP-570).
-  "validVersions": "0-3",
-  "flexibleVersions": "2+",
+  // Version 3 is the first flexible version.
+  //
+  // Version 4 adds the leader epoch per partition (KIP-570).
+  "validVersions": "0-4",
+  "flexibleVersions": "3+",
   "fields": [
     { "name": "ControllerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
       "about": "The controller id." },
     { "name": "ControllerEpoch", "type": "int32", "versions": "0+",
       "about": "The controller epoch." },
-    { "name": "BrokerEpoch", "type": "int64", "versions": "1+", "default": "-1", "ignorable": true,
+    { "name": "BrokerEpoch", "type": "int64", "versions": "1", "default": "-1", "ignorable": true,
       "about": "The broker epoch." },
-    { "name": "DeletePartitions", "type": "bool", "versions": "0-2",
+    { "name": "MaxBrokerEpoch", "type": "int64", "versions": "2+", "default": "-1", "ignorable": true,
+      "about": "The max broker epoch." },
+    { "name": "DeletePartitions", "type": "bool", "versions": "0-3",
       "about": "Whether these partitions should be deleted." },
     { "name": "UngroupedPartitions", "type": "[]StopReplicaPartitionV0", "versions": "0",
       "about": "The partitions to stop.", "fields": [
@@ -42,24 +46,24 @@
       { "name": "PartitionIndex", "type": "int32", "versions": "0",
         "about": "The partition index." }
     ]},
-    { "name": "Topics", "type": "[]StopReplicaTopicV1", "versions": "1-2",
+    { "name": "Topics", "type": "[]StopReplicaTopicV1", "versions": "1-3",
       "about": "The topics to stop.", "fields": [
-      { "name": "Name", "type": "string", "versions": "1-2", "entityType": "topicName",
+      { "name": "Name", "type": "string", "versions": "1-3", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "PartitionIndexes", "type": "[]int32", "versions": "1-2",
+      { "name": "PartitionIndexes", "type": "[]int32", "versions": "1-3",
         "about": "The partition indexes." }
     ]},
-    { "name": "TopicStates", "type": "[]StopReplicaTopicState", "versions": "3+",
+    { "name": "TopicStates", "type": "[]StopReplicaTopicState", "versions": "4+",
       "about": "Each topic.", "fields": [
-      { "name": "TopicName", "type": "string", "versions": "3+", "entityType": "topicName",
+      { "name": "TopicName", "type": "string", "versions": "4+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "PartitionStates", "type": "[]StopReplicaPartitionState", "versions": "3+",
+      { "name": "PartitionStates", "type": "[]StopReplicaPartitionState", "versions": "4+",
         "about": "The state of each partition", "fields": [
-        { "name": "PartitionIndex", "type": "int32", "versions": "3+",
+        { "name": "PartitionIndex", "type": "int32", "versions": "4+",
           "about": "The partition index." },
-        { "name": "LeaderEpoch", "type": "int32", "versions": "3+", "default": "-1",
+        { "name": "LeaderEpoch", "type": "int32", "versions": "4+", "default": "-1",
           "about": "The leader epoch." },
-        { "name": "DeletePartition", "type": "bool", "versions": "3+",
+        { "name": "DeletePartition", "type": "bool", "versions": "4+",
           "about": "Whether this partition should be deleted." }
       ]}
     ]}

--- a/clients/src/main/resources/common/message/StopReplicaResponse.json
+++ b/clients/src/main/resources/common/message/StopReplicaResponse.json
@@ -19,11 +19,13 @@
   "name": "StopReplicaResponse",
   // Version 1 is the same as version 0.
   //
-  // Version 2 is the first flexible version.
+  // Version 2 is the same as version 1.
   //
-  // Version 3 returns FENCED_LEADER_EPOCH if the epoch of the leader is stale (KIP-570).
-  "validVersions": "0-3",
-  "flexibleVersions": "2+",
+  // Version 3 is the first flexible version.
+  //
+  // Version 4 returns FENCED_LEADER_EPOCH if the epoch of the leader is stale (KIP-570).
+  "validVersions": "0-4",
+  "flexibleVersions": "3+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The top-level error code, or 0 if there was no top-level error." },

--- a/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+++ b/clients/src/main/resources/common/message/UpdateMetadataRequest.json
@@ -27,23 +27,30 @@
   // Version 4 adds the offline replica list.
   //
   // Version 5 adds the broker epoch field and normalizes partitions by topic.
-  // Version 7 adds topicId
-  "validVersions": "0-7",
-  "flexibleVersions": "6+",
+  //
+  // Version 6 adds the max broker epoch to make the UpdateMetadataRequest cacheable
+  //
+  // Version 7 is the first flexible version.
+  //
+  // Version 8 adds topicId
+  "validVersions": "0-8",
+  "flexibleVersions": "7+",
   "fields": [
     { "name": "ControllerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
       "about": "The controller id." },
     { "name": "ControllerEpoch", "type": "int32", "versions": "0+",
       "about": "The controller epoch." },
-    { "name": "BrokerEpoch", "type": "int64", "versions": "5+", "ignorable": true, "default": "-1",
+    { "name": "BrokerEpoch", "type": "int64", "versions": "5", "ignorable": true, "default": "-1",
       "about": "The broker epoch." },
     { "name": "UngroupedPartitionStates", "type": "[]UpdateMetadataPartitionState", "versions": "0-4",
       "about": "In older versions of this RPC, each partition that we would like to update." },
+    { "name": "MaxBrokerEpoch", "type": "int64", "versions": "6+", "ignorable": true, "default": "-1",
+      "about": "The max broker epoch." },
     { "name": "TopicStates", "type": "[]UpdateMetadataTopicState", "versions": "5+",
       "about": "In newer versions of this RPC, each topic that we would like to update.", "fields": [
       { "name": "TopicName", "type": "string", "versions": "5+", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "TopicId", "type": "uuid", "versions": "7+", "ignorable": true, "about": "The topic id."},
+      { "name": "TopicId", "type": "uuid", "versions": "8+", "ignorable": true, "about": "The topic id."},
       { "name": "PartitionStates", "type": "[]UpdateMetadataPartitionState", "versions": "5+",
         "about": "The partition that we would like to update." }
     ]},

--- a/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+++ b/clients/src/main/resources/common/message/UpdateMetadataResponse.json
@@ -17,9 +17,11 @@
   "apiKey": 6,
   "type": "response",
   "name": "UpdateMetadataResponse",
-  // Versions 1, 2, 3, 4, and 5 are the same as version 0
-  "validVersions": "0-7",
-  "flexibleVersions": "6+",
+  // Versions 1, 2, 3, 4, 5 and 6 are the same as version 0
+  //
+  // Version 7 is the first flexible version.
+  "validVersions": "0-8",
+  "flexibleVersions": "7+",
   "fields": [
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The error code, or 0 if there was no error." }

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -424,7 +424,7 @@ public final class MessageTest {
             (short) 3,
             new LeaderAndIsrRequestData().setTopicStates(Collections.singletonList(partitionStateWithAddingRemovingReplicas)),
             new LeaderAndIsrRequestData().setTopicStates(Collections.singletonList(partitionStateNoAddingRemovingReplicas)));
-        testAllMessageRoundTripsFromVersion((short) 3, new LeaderAndIsrRequestData().setTopicStates(Collections.singletonList(partitionStateWithAddingRemovingReplicas)));
+        testAllMessageRoundTripsFromVersion((short) 4, new LeaderAndIsrRequestData().setTopicStates(Collections.singletonList(partitionStateWithAddingRemovingReplicas)));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrRequestTest.java
@@ -54,7 +54,7 @@ public class LeaderAndIsrRequestTest {
     @Test
     public void testUnsupportedVersion() {
         LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder(
-                (short) (LEADER_AND_ISR.latestVersion() + 1), 0, 0, 0,
+                (short) (LEADER_AND_ISR.latestVersion() + 1), 0, 0, 0, 0,
                 Collections.emptyList(), Collections.emptyMap(), Collections.emptySet());
         assertThrows(UnsupportedVersionException.class, builder::build);
     }
@@ -65,7 +65,7 @@ public class LeaderAndIsrRequestTest {
         String topicName = "topic";
         int partition = 0;
         for (short version : LEADER_AND_ISR.allVersions()) {
-            LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(version, 0, 0, 0,
+            LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(version, 0, 0, 0, 0,
                 Collections.singletonList(new LeaderAndIsrPartitionState()
                     .setTopicName(topicName)
                     .setPartitionIndex(partition)),
@@ -78,7 +78,7 @@ public class LeaderAndIsrRequestTest {
 
             assertEquals(Errors.CLUSTER_AUTHORIZATION_FAILED, response.error());
 
-            if (version < 5) {
+            if (version < 6) {
                 assertEquals(
                     Collections.singletonList(new LeaderAndIsrPartitionError()
                         .setTopicName(topicName)
@@ -153,7 +153,7 @@ public class LeaderAndIsrRequestTest {
             topicIds.put("topic0", Uuid.randomUuid());
             topicIds.put("topic1", Uuid.randomUuid());
 
-            LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(version, 1, 2, 3, partitionStates,
+            LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(version, 1, 2, 3, 3, partitionStates,
                 topicIds, liveNodes).build();
 
             List<LeaderAndIsrLiveLeader> liveLeaders = liveNodes.stream().map(n -> new LeaderAndIsrLiveLeader()
@@ -170,9 +170,9 @@ public class LeaderAndIsrRequestTest {
             LeaderAndIsrRequest deserializedRequest = new LeaderAndIsrRequest(new LeaderAndIsrRequestData(
                 new ByteBufferAccessor(byteBuffer), version), version);
 
-            // Adding/removing replicas is only supported from version 3, so the deserialized request won't have
+            // Adding/removing replicas is only supported from version 4, so the deserialized request won't have
             // them for earlier versions.
-            if (version < 3) {
+            if (version < 4) {
                 partitionStates.get(0)
                     .setAddingReplicas(emptyList())
                     .setRemovingReplicas(emptyList());
@@ -184,9 +184,9 @@ public class LeaderAndIsrRequestTest {
                 topicIds = new HashMap<>();
             }
 
-            //  In versions 2-4 there are TopicStates, but no topicIds, so deserialized requests will have
+            //  In versions 2-5 there are TopicStates, but no topicIds, so deserialized requests will have
             //  Zero Uuids in place.
-            if (version > 1 && version < 5) {
+            if (version > 1 && version < 6) {
                 topicIds.put("topic0", Uuid.ZERO_UUID);
                 topicIds.put("topic1", Uuid.ZERO_UUID);
             }
@@ -211,7 +211,7 @@ public class LeaderAndIsrRequestTest {
                 .setPartitionIndex(tp.partition()));
             topicIds.put(tp.topic(), Uuid.randomUuid());
         }
-        LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder((short) 2, 0, 0, 0,
+        LeaderAndIsrRequest.Builder builder = new LeaderAndIsrRequest.Builder((short) 2, 0, 0, 0, 0,
             partitionStates, topicIds, Collections.emptySet());
 
         LeaderAndIsrRequest v2 = builder.build((short) 2);

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrResponseTest.java
@@ -64,7 +64,7 @@ public class LeaderAndIsrResponseTest {
         Map<String, Uuid> topicIds = Collections.singletonMap("foo", Uuid.randomUuid());
 
         LeaderAndIsrRequest request = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion(),
-                15, 20, 0, partitionStates, topicIds, Collections.emptySet()).build();
+                15, 20, 0, 0, partitionStates, topicIds, Collections.emptySet()).build();
         LeaderAndIsrResponse response = request.getErrorResponse(0, Errors.CLUSTER_AUTHORIZATION_FAILED.exception());
         assertEquals(Collections.singletonMap(Errors.CLUSTER_AUTHORIZATION_FAILED, 3), response.errorCounts());
     }
@@ -73,7 +73,7 @@ public class LeaderAndIsrResponseTest {
     public void testErrorCountsWithTopLevelError() {
         for (short version : LEADER_AND_ISR.allVersions()) {
             LeaderAndIsrResponse response;
-            if (version < 5) {
+            if (version < 6) {
                 List<LeaderAndIsrPartitionError> partitions = createPartitions("foo",
                         asList(Errors.NONE, Errors.NOT_LEADER_OR_FOLLOWER));
                 response = new LeaderAndIsrResponse(new LeaderAndIsrResponseData()
@@ -84,7 +84,7 @@ public class LeaderAndIsrResponseTest {
                 LeaderAndIsrTopicErrorCollection topics = createTopic(id, asList(Errors.NONE, Errors.NOT_LEADER_OR_FOLLOWER));
                 response = new LeaderAndIsrResponse(new LeaderAndIsrResponseData()
                         .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code())
-                        .setTopics(topics), version); 
+                        .setTopics(topics), version);
             }
             assertEquals(Collections.singletonMap(Errors.UNKNOWN_SERVER_ERROR, 3), response.errorCounts());
         }
@@ -94,7 +94,7 @@ public class LeaderAndIsrResponseTest {
     public void testErrorCountsNoTopLevelError() {
         for (short version : LEADER_AND_ISR.allVersions()) {
             LeaderAndIsrResponse response;
-            if (version < 5) {
+            if (version < 6) {
                 List<LeaderAndIsrPartitionError> partitions = createPartitions("foo",
                         asList(Errors.NONE, Errors.CLUSTER_AUTHORIZATION_FAILED));
                 response = new LeaderAndIsrResponse(new LeaderAndIsrResponseData()
@@ -118,7 +118,7 @@ public class LeaderAndIsrResponseTest {
     public void testToString() {
         for (short version : LEADER_AND_ISR.allVersions()) {
             LeaderAndIsrResponse response;
-            if (version < 5) {
+            if (version < 6) {
                 List<LeaderAndIsrPartitionError> partitions = createPartitions("foo",
                         asList(Errors.NONE, Errors.CLUSTER_AUTHORIZATION_FAILED));
                 response = new LeaderAndIsrResponse(new LeaderAndIsrResponseData()

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -356,7 +356,7 @@ public class RequestResponseTest {
             checkErrorResponse(createLeaderAndIsrRequest(version), unknownServerException, false);
             checkResponse(createLeaderAndIsrResponse(version), version, true);
         }
-        
+
         checkRequest(createSaslHandshakeRequest(), true);
         checkErrorResponse(createSaslHandshakeRequest(), unknownServerException, true);
         checkResponse(createSaslHandshakeResponse(), 0, true);
@@ -1782,7 +1782,7 @@ public class RequestResponseTest {
                 .setDeletePartition(deletePartitions)));
         topicStates.add(topic2);
 
-        return new StopReplicaRequest.Builder((short) version, 0, 1, 0,
+        return new StopReplicaRequest.Builder((short) version, 0, 1, 0, 0,
             deletePartitions, topicStates).build((short) version);
     }
 
@@ -1875,12 +1875,12 @@ public class RequestResponseTest {
         topicIds.put("topic5", Uuid.randomUuid());
         topicIds.put("topic20", Uuid.randomUuid());
 
-        return new LeaderAndIsrRequest.Builder((short) version, 1, 10, 0,
+        return new LeaderAndIsrRequest.Builder((short) version, 1, 10, 0, 0,
                 partitionStates, topicIds, leaders).build();
     }
 
     private LeaderAndIsrResponse createLeaderAndIsrResponse(int version) {
-        if (version < 5) {
+        if (version < 6) {
             List<LeaderAndIsrResponseData.LeaderAndIsrPartitionError> partitions = new ArrayList<>();
             partitions.add(new LeaderAndIsrResponseData.LeaderAndIsrPartitionError()
                     .setTopicName("test")
@@ -1982,7 +1982,7 @@ public class RequestResponseTest {
                 .setEndpoints(endpoints2)
                 .setRack(rack)
         );
-        return new UpdateMetadataRequest.Builder((short) version, 1, 10, 0, partitionStates,
+        return new UpdateMetadataRequest.Builder((short) version, 1, 10, 0, 0, partitionStates,
             liveBrokers, Collections.emptyMap()).build();
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaRequestTest.java
@@ -118,7 +118,7 @@ public class StopReplicaRequestTest {
                 Map<TopicPartition, StopReplicaPartitionState> partitionStates =
                     StopReplicaRequestTest.partitionStates(data.topicStates());
                 assertEquals(expectedPartitionStates, partitionStates);
-                // Always false from V3 on
+                // Always false from V4 on
                 assertFalse(data.deletePartitions());
             }
         }
@@ -183,7 +183,7 @@ public class StopReplicaRequestTest {
                     assertEquals(expectedPartitionState.partitionIndex(), partitionState.partitionIndex());
                     assertTrue(partitionState.deletePartition());
 
-                    if (version >= 3) {
+                    if (version >= 4) {
                         assertEquals(expectedPartitionState.leaderEpoch(), partitionState.leaderEpoch());
                     } else {
                         assertEquals(-1, partitionState.leaderEpoch());

--- a/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaRequestTest.java
@@ -48,7 +48,7 @@ public class StopReplicaRequestTest {
     public void testUnsupportedVersion() {
         StopReplicaRequest.Builder builder = new StopReplicaRequest.Builder(
                 (short) (STOP_REPLICA.latestVersion() + 1),
-                0, 0, 0L, false, Collections.emptyList());
+                0, 0, 0L, 0L, false, Collections.emptyList());
         assertThrows(UnsupportedVersionException.class, builder::build);
     }
 
@@ -68,7 +68,7 @@ public class StopReplicaRequestTest {
 
         for (short version : STOP_REPLICA.allVersions()) {
             StopReplicaRequest.Builder builder = new StopReplicaRequest.Builder(version,
-                    0, 0, 0L, false, topicStates);
+                    0, 0, 0L, 0L, false, topicStates);
             StopReplicaRequest request = builder.build();
             StopReplicaResponse response = request.getErrorResponse(0,
                     new ClusterAuthorizationException("Not authorized"));
@@ -94,7 +94,7 @@ public class StopReplicaRequestTest {
             StopReplicaRequestTest.partitionStates(topicStates);
 
         for (short version : STOP_REPLICA.allVersions()) {
-            StopReplicaRequest request = new StopReplicaRequest.Builder(version, 0, 1, 0,
+            StopReplicaRequest request = new StopReplicaRequest.Builder(version, 0, 1, 0, 0,
                 deletePartitions, topicStates).build(version);
             StopReplicaRequestData data = request.data();
 
@@ -105,7 +105,7 @@ public class StopReplicaRequestTest {
                 }
                 assertEquals(expectedPartitionStates.keySet(), partitions);
                 assertEquals(deletePartitions, data.deletePartitions());
-            } else if (version < 3) {
+            } else if (version < 4) {
                 Set<TopicPartition> partitions = new HashSet<>();
                 for (StopReplicaTopicV1 topic : data.topics()) {
                     for (Integer partition : topic.partitionIndexes()) {
@@ -130,7 +130,7 @@ public class StopReplicaRequestTest {
 
         for (short version : STOP_REPLICA.allVersions()) {
             // Create a request for version to get its serialized form
-            StopReplicaRequest baseRequest = new StopReplicaRequest.Builder(version, 0, 1, 0,
+            StopReplicaRequest baseRequest = new StopReplicaRequest.Builder(version, 0, 1, 0, 0,
                 true, topicStates).build(version);
 
             // Construct the request from the buffer
@@ -149,7 +149,7 @@ public class StopReplicaRequestTest {
                     assertEquals(expectedPartitionState.partitionIndex(), partitionState.partitionIndex());
                     assertTrue(partitionState.deletePartition());
 
-                    if (version >= 3) {
+                    if (version >= 4) {
                         assertEquals(expectedPartitionState.leaderEpoch(), partitionState.leaderEpoch());
                     } else {
                         assertEquals(-1, partitionState.leaderEpoch());
@@ -165,7 +165,7 @@ public class StopReplicaRequestTest {
 
         for (short version : STOP_REPLICA.allVersions()) {
             // Create a request for version to get its serialized form
-            StopReplicaRequest baseRequest = new StopReplicaRequest.Builder(version, 0, 1, 0,
+            StopReplicaRequest baseRequest = new StopReplicaRequest.Builder(version, 0, 1, 0, 0,
                 true, topicStates).build(version);
 
             // Construct the request from the buffer

--- a/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaResponseTest.java
@@ -46,7 +46,7 @@ public class StopReplicaResponseTest {
 
         for (short version : STOP_REPLICA.allVersions()) {
             StopReplicaRequest request = new StopReplicaRequest.Builder(version,
-                15, 20, 0, false, topicStates).build(version);
+                15, 20, 0, 0, false, topicStates).build(version);
             StopReplicaResponse response = request
                 .getErrorResponse(0, Errors.CLUSTER_AUTHORIZATION_FAILED.exception());
             assertEquals(Collections.singletonMap(Errors.CLUSTER_AUTHORIZATION_FAILED, 3),

--- a/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
@@ -54,7 +54,7 @@ public class UpdateMetadataRequestTest {
     @Test
     public void testUnsupportedVersion() {
         UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder(
-                (short) (UPDATE_METADATA.latestVersion() + 1), 0, 0, 0,
+                (short) (UPDATE_METADATA.latestVersion() + 1), 0, 0, 0, 0,
                 Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
         assertThrows(UnsupportedVersionException.class, builder::build);
     }
@@ -63,7 +63,7 @@ public class UpdateMetadataRequestTest {
     public void testGetErrorResponse() {
         for (short version : UPDATE_METADATA.allVersions()) {
             UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder(
-                    version, 0, 0, 0, Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
+                    version, 0, 0, 0, 0, Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
             UpdateMetadataRequest request = builder.build();
             UpdateMetadataResponse response = request.getErrorResponse(0,
                     new ClusterAuthorizationException("Not authorized"));
@@ -156,7 +156,7 @@ public class UpdateMetadataRequestTest {
             topicIds.put(topic0, Uuid.randomUuid());
             topicIds.put(topic1, Uuid.randomUuid());
 
-            UpdateMetadataRequest request = new UpdateMetadataRequest.Builder(version, 1, 2, 3,
+            UpdateMetadataRequest request = new UpdateMetadataRequest.Builder(version, 1, 2, 3, 3,
                 partitionStates, liveBrokers, topicIds).build();
 
             assertEquals(new HashSet<>(partitionStates), iterableToSet(request.partitionStates()));
@@ -204,7 +204,7 @@ public class UpdateMetadataRequestTest {
             long topicIdCount = deserializedRequest.data().topicStates().stream()
                     .map(UpdateMetadataRequestData.UpdateMetadataTopicState::topicId)
                     .filter(topicId -> topicId != Uuid.ZERO_UUID).count();
-            if (version >= 7)
+            if (version >= 8)
                 assertEquals(2, topicIdCount);
             else
                 assertEquals(0, topicIdCount);
@@ -220,7 +220,7 @@ public class UpdateMetadataRequestTest {
                 .setTopicName(tp.topic())
                 .setPartitionIndex(tp.partition()));
         }
-        UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder((short) 5, 0, 0, 0,
+        UpdateMetadataRequest.Builder builder = new UpdateMetadataRequest.Builder((short) 5, 0, 0, 0, 0,
                 partitionStates, Collections.emptyList(), Collections.emptyMap());
 
         assertTrue(builder.build((short) 5).sizeInBytes() <  builder.build((short) 4).sizeInBytes());

--- a/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
@@ -164,6 +164,7 @@ public class UpdateMetadataRequestTest {
             assertEquals(1, request.controllerId());
             assertEquals(2, request.controllerEpoch());
             assertEquals(3, request.brokerEpoch());
+            assertEquals(3, request.maxBrokerEpoch());
 
             ByteBuffer byteBuffer = request.serialize();
             UpdateMetadataRequest deserializedRequest = new UpdateMetadataRequest(new UpdateMetadataRequestData(
@@ -196,10 +197,15 @@ public class UpdateMetadataRequestTest {
             assertEquals(1, deserializedRequest.controllerId());
             assertEquals(2, deserializedRequest.controllerEpoch());
             // Broker epoch is only supported from version 5
-            if (version >= 5)
+            if (version == 5)
                 assertEquals(3, deserializedRequest.brokerEpoch());
             else
                 assertEquals(-1, deserializedRequest.brokerEpoch());
+
+            if (version >= 6)
+                assertEquals(3, deserializedRequest.maxBrokerEpoch());
+            else
+                assertEquals(-1, deserializedRequest.maxBrokerEpoch());
 
             long topicIdCount = deserializedRequest.data().topicStates().stream()
                     .map(UpdateMetadataRequestData.UpdateMetadataTopicState::topicId)

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -100,6 +100,8 @@ object ApiVersion {
     KAFKA_2_3_IV0,
     // Add rack_id to FetchRequest, preferred_read_replica to FetchResponse, and replica_id to OffsetsForLeaderRequest
     KAFKA_2_3_IV1,
+    // Add cacheable broker epoch to UpdateMetadataRequest
+    KAFKA_2_3_IV2,
     // Add adding_replicas and removing_replicas fields to LeaderAndIsrRequest
     KAFKA_2_4_IV0,
     // Flexible version support in inter-broker APIs
@@ -437,81 +439,88 @@ case object KAFKA_2_3_IV1 extends DefaultApiVersion {
   val id: Int = 23
 }
 
+case object KAFKA_2_3_IV2 extends DefaultApiVersion {
+  val shortVersion: String = "2.3"
+  val subVersion = "IV2"
+  val recordVersion = RecordVersion.V2
+  val id: Int = 24
+}
+
 case object KAFKA_2_4_IV0 extends DefaultApiVersion {
   val shortVersion: String = "2.4"
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
-  val id: Int = 24
+  val id: Int = 25
 }
 
 case object KAFKA_2_4_IV1 extends DefaultApiVersion {
   val shortVersion: String = "2.4"
   val subVersion = "IV1"
   val recordVersion = RecordVersion.V2
-  val id: Int = 25
+  val id: Int = 26
 }
 
 case object KAFKA_2_5_IV0 extends DefaultApiVersion {
   val shortVersion: String = "2.5"
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
-  val id: Int = 26
+  val id: Int = 27
 }
 
 case object KAFKA_2_6_IV0 extends DefaultApiVersion {
   val shortVersion: String = "2.6"
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
-  val id: Int = 27
+  val id: Int = 28
 }
 
 case object KAFKA_2_7_IV0 extends DefaultApiVersion {
   val shortVersion: String = "2.7"
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
-  val id: Int = 28
+  val id: Int = 29
 }
 
 case object KAFKA_2_7_IV1 extends DefaultApiVersion {
   val shortVersion: String = "2.7"
   val subVersion = "IV1"
   val recordVersion = RecordVersion.V2
-  val id: Int = 29
+  val id: Int = 30
 }
 
 case object KAFKA_2_7_IV2 extends DefaultApiVersion {
   val shortVersion: String = "2.7"
   val subVersion = "IV2"
   val recordVersion = RecordVersion.V2
-  val id: Int = 30
+  val id: Int = 31
 }
 
 case object KAFKA_2_8_IV0 extends DefaultApiVersion {
   val shortVersion: String = "2.8"
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
-  val id: Int = 31
+  val id: Int = 32
 }
 
 case object KAFKA_2_8_IV1 extends DefaultApiVersion {
   val shortVersion: String = "2.8"
   val subVersion = "IV1"
   val recordVersion = RecordVersion.V2
-  val id: Int = 32
+  val id: Int = 33
 }
 
 case object KAFKA_3_0_IV0 extends DefaultApiVersion {
   val shortVersion: String = "3.0"
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
-  val id: Int = 33
+  val id: Int = 34
 }
 
 case object KAFKA_3_0_IV1 extends DefaultApiVersion {
   val shortVersion: String = "3.0"
   val subVersion = "IV1"
   val recordVersion = RecordVersion.V2
-  val id: Int = 34
+  val id: Int = 35
 }
 
 object ApiVersionValidator extends Validator {

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -617,7 +617,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
           }
 
         val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(brokerId)
-        if (stopReplicaRequestVersion >= 3) {
+        if (stopReplicaRequestVersion >= 4) {
           val stopReplicaTopicState = mutable.Map.empty[String, StopReplicaTopicState]
           partitionStates.forKeyValue { (topicPartition, partitionState) =>
             val topicState = stopReplicaTopicState.getOrElseUpdate(topicPartition.topic,

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -475,13 +475,15 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
 
   private def sendLeaderAndIsrRequest(controllerEpoch: Int, stateChangeLog: StateChangeLogger): Unit = {
     val leaderAndIsrRequestVersion: Short =
-      if (config.interBrokerProtocolVersion >= KAFKA_2_8_IV1) 5
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 4
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV0) 3
+      if (config.interBrokerProtocolVersion >= KAFKA_2_8_IV1) 6
+      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 5
+      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV0) 4
+      else if (config.interBrokerProtocolVersion >= KAFKA_2_3_IV2) 3
       else if (config.interBrokerProtocolVersion >= KAFKA_2_2_IV0) 2
       else if (config.interBrokerProtocolVersion >= KAFKA_1_0_IV0) 1
       else 0
 
+    val maxBrokerEpoch = controllerContext.maxBrokerEpoch
     leaderAndIsrRequestMap.forKeyValue { (broker, leaderAndIsrPartitionStates) =>
       if (controllerContext.liveOrShuttingDownBrokerIds.contains(broker)) {
         val leaderIds = mutable.Set.empty[Int]
@@ -509,7 +511,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
           .map(topic => (topic, controllerContext.topicIds.getOrElse(topic, Uuid.ZERO_UUID)))
           .toMap
         val leaderAndIsrRequestBuilder = new LeaderAndIsrRequest.Builder(leaderAndIsrRequestVersion, controllerId,
-          controllerEpoch, brokerEpoch, leaderAndIsrPartitionStates.values.toBuffer.asJava, topicIds.asJava, leaders.asJava)
+          controllerEpoch, brokerEpoch, maxBrokerEpoch, leaderAndIsrPartitionStates.values.toBuffer.asJava, topicIds.asJava, leaders.asJava)
         sendRequest(broker, leaderAndIsrRequestBuilder, (r: AbstractResponse) => {
           val leaderAndIsrResponse = r.asInstanceOf[LeaderAndIsrResponse]
           sendEvent(LeaderAndIsrResponseReceived(leaderAndIsrResponse, broker))
@@ -525,8 +527,9 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
 
     val partitionStates = updateMetadataRequestPartitionInfoMap.values.toBuffer
     val updateMetadataRequestVersion: Short =
-      if (config.interBrokerProtocolVersion >= KAFKA_2_8_IV1) 7
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 6
+      if (config.interBrokerProtocolVersion >= KAFKA_2_8_IV1) 8
+      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 7
+      else if (config.interBrokerProtocolVersion >= KAFKA_2_3_IV2) 6
       else if (config.interBrokerProtocolVersion >= KAFKA_2_2_IV0) 5
       else if (config.interBrokerProtocolVersion >= KAFKA_1_0_IV0) 4
       else if (config.interBrokerProtocolVersion >= KAFKA_0_10_2_IV0) 3
@@ -560,6 +563,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
         .setRack(broker.rack.orNull)
     }.toBuffer
 
+    val maxBrokerEpoch = controllerContext.maxBrokerEpoch
     updateMetadataRequestBrokerSet.intersect(controllerContext.liveOrShuttingDownBrokerIds).foreach { broker =>
       val brokerEpoch = controllerContext.liveBrokerIdAndEpochs(broker)
       val topicIds = partitionStates.map(_.topicName())
@@ -567,7 +571,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
         .filter(controllerContext.topicIds.contains)
         .map(topic => (topic, controllerContext.topicIds(topic))).toMap
       val updateMetadataRequestBuilder = new UpdateMetadataRequest.Builder(updateMetadataRequestVersion,
-        controllerId, controllerEpoch, brokerEpoch, partitionStates.asJava, liveBrokers.asJava, topicIds.asJava)
+        controllerId, controllerEpoch, brokerEpoch, maxBrokerEpoch, partitionStates.asJava, liveBrokers.asJava, topicIds.asJava)
       sendRequest(broker, updateMetadataRequestBuilder, (r: AbstractResponse) => {
         val updateMetadataResponse = r.asInstanceOf[UpdateMetadataResponse]
         sendEvent(UpdateMetadataResponseReceived(updateMetadataResponse, broker))
@@ -581,8 +585,9 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
   private def sendStopReplicaRequests(controllerEpoch: Int, stateChangeLog: StateChangeLogger): Unit = {
     val traceEnabled = stateChangeLog.isTraceEnabled
     val stopReplicaRequestVersion: Short =
-      if (config.interBrokerProtocolVersion >= KAFKA_2_6_IV0) 3
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 2
+      if (config.interBrokerProtocolVersion >= KAFKA_2_6_IV0) 4
+      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 3
+      else if (config.interBrokerProtocolVersion >= KAFKA_2_3_IV2) 2
       else if (config.interBrokerProtocolVersion >= KAFKA_2_2_IV0) 1
       else 0
 
@@ -602,6 +607,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
           partitionErrorsForDeletingTopics))
     }
 
+    val maxBrokerEpoch = controllerContext.maxBrokerEpoch
     stopReplicaRequestMap.forKeyValue { (brokerId, partitionStates) =>
       if (controllerContext.liveOrShuttingDownBrokerIds.contains(brokerId)) {
         if (traceEnabled)
@@ -623,7 +629,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
             s"replicas to broker $brokerId")
           val stopReplicaRequestBuilder = new StopReplicaRequest.Builder(
             stopReplicaRequestVersion, controllerId, controllerEpoch, brokerEpoch,
-            false, stopReplicaTopicState.values.toBuffer.asJava)
+            maxBrokerEpoch, false, stopReplicaTopicState.values.toBuffer.asJava)
           sendRequest(brokerId, stopReplicaRequestBuilder,
             responseCallback(brokerId, tp => partitionStates.get(tp).exists(_.deletePartition)))
         } else {
@@ -650,7 +656,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
               s"$numPartitionStateWithDelete replicas to broker $brokerId")
             val stopReplicaRequestBuilder = new StopReplicaRequest.Builder(
               stopReplicaRequestVersion, controllerId, controllerEpoch, brokerEpoch,
-              true, topicStatesWithDelete.values.toBuffer.asJava)
+              maxBrokerEpoch, true, topicStatesWithDelete.values.toBuffer.asJava)
             sendRequest(brokerId, stopReplicaRequestBuilder, responseCallback(brokerId, _ => true))
           }
 
@@ -659,7 +665,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
               s"$numPartitionStateWithoutDelete replicas to broker $brokerId")
             val stopReplicaRequestBuilder = new StopReplicaRequest.Builder(
               stopReplicaRequestVersion, controllerId, controllerEpoch, brokerEpoch,
-              false, topicStatesWithoutDelete.values.toBuffer.asJava)
+              maxBrokerEpoch, false, topicStatesWithoutDelete.values.toBuffer.asJava)
             sendRequest(brokerId, stopReplicaRequestBuilder)
           }
         }

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -218,6 +218,7 @@ class ControllerContext {
   def liveOrShuttingDownBrokerIds: Set[Int] = liveBrokerEpochs.keySet
   def liveOrShuttingDownBrokers: Set[Broker] = liveBrokers
   def liveBrokerIdAndEpochs: Map[Int, Long] = liveBrokerEpochs
+  def maxBrokerEpoch: Long = liveBrokerEpochs.values.max
   def liveOrShuttingDownBroker(brokerId: Int): Option[Broker] = liveOrShuttingDownBrokers.find(_.id == brokerId)
 
   def partitionsOnBroker(brokerId: Int): Set[TopicPartition] = {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -419,7 +419,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
         .setSecurityProtocol(securityProtocol.id)
         .setListener(ListenerName.forSecurityProtocol(securityProtocol).value)).asJava)).asJava
     val version = ApiKeys.UPDATE_METADATA.latestVersion
-    new requests.UpdateMetadataRequest.Builder(version, brokerId, Int.MaxValue, Long.MaxValue, partitionStates,
+    new requests.UpdateMetadataRequest.Builder(version, brokerId, Int.MaxValue, Long.MaxValue, Long.MaxValue, partitionStates,
       brokers, Collections.emptyMap()).build()
   }
 
@@ -509,7 +509,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   ).build()
 
   private def leaderAndIsrRequest: LeaderAndIsrRequest = {
-    new requests.LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,
+    new requests.LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue, Long.MaxValue,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp.topic)
         .setPartitionIndex(tp.partition)
@@ -534,7 +534,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
           .setDeletePartition(true)).asJava)
     ).asJava
     new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion, brokerId, Int.MaxValue,
-      Long.MaxValue, false, topicStates).build()
+      Long.MaxValue, Long.MaxValue, false, topicStates).build()
   }
 
   private def controlledShutdownRequest: ControlledShutdownRequest = {

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -98,9 +98,10 @@ class ApiVersionTest {
     assertEquals(KAFKA_2_2_IV0, ApiVersion("2.2-IV0"))
     assertEquals(KAFKA_2_2_IV1, ApiVersion("2.2-IV1"))
 
-    assertEquals(KAFKA_2_3_IV1, ApiVersion("2.3"))
+    assertEquals(KAFKA_2_3_IV2, ApiVersion("2.3"))
     assertEquals(KAFKA_2_3_IV0, ApiVersion("2.3-IV0"))
     assertEquals(KAFKA_2_3_IV1, ApiVersion("2.3-IV1"))
+    assertEquals(KAFKA_2_3_IV2, ApiVersion("2.3-IV2"))
 
     assertEquals(KAFKA_2_4_IV1, ApiVersion("2.4"))
     assertEquals(KAFKA_2_4_IV0, ApiVersion("2.4-IV0"))

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -17,7 +17,7 @@
 package kafka.controller
 
 import java.util.Properties
-import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, KAFKA_0_10_2_IV0, KAFKA_0_9_0, KAFKA_1_0_IV0, KAFKA_2_2_IV0, KAFKA_2_4_IV0, KAFKA_2_4_IV1, KAFKA_2_6_IV0, KAFKA_2_8_IV1, LeaderAndIsr}
+import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, KAFKA_0_10_2_IV0, KAFKA_0_9_0, KAFKA_1_0_IV0, KAFKA_2_2_IV0, KAFKA_2_3_IV2, KAFKA_2_4_IV0, KAFKA_2_4_IV1, KAFKA_2_6_IV0, KAFKA_2_8_IV1, LeaderAndIsr}
 import kafka.cluster.{Broker, EndPoint}
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
@@ -161,9 +161,10 @@ class ControllerChannelManagerTest {
 
     for (apiVersion <- ApiVersion.allVersions) {
       val leaderAndIsrRequestVersion: Short =
-        if (apiVersion >= KAFKA_2_8_IV1) 5
-        else if (apiVersion >= KAFKA_2_4_IV1) 4
-        else if (apiVersion >= KAFKA_2_4_IV0) 3
+        if (apiVersion >= KAFKA_2_8_IV1) 6
+        else if (apiVersion >= KAFKA_2_4_IV1) 5
+        else if (apiVersion >= KAFKA_2_4_IV0) 4
+        else if (apiVersion >= KAFKA_2_3_IV2) 3
         else if (apiVersion >= KAFKA_2_2_IV0) 2
         else if (apiVersion >= KAFKA_1_0_IV0) 1
         else 0
@@ -192,11 +193,11 @@ class ControllerChannelManagerTest {
     assertEquals(1, leaderAndIsrRequests.size)
     assertEquals(expectedLeaderAndIsrVersion, leaderAndIsrRequests.head.version,
       s"IBP $interBrokerProtocolVersion should use version $expectedLeaderAndIsrVersion")
-    
+
     val request = leaderAndIsrRequests.head
     val byteBuffer = request.serialize
     val deserializedRequest = LeaderAndIsrRequest.parse(byteBuffer, expectedLeaderAndIsrVersion)
-    
+
     if (interBrokerProtocolVersion >= KAFKA_2_8_IV1) {
       assertFalse(request.topicIds().get("foo").equals(Uuid.ZERO_UUID))
       assertFalse(deserializedRequest.topicIds().get("foo").equals(Uuid.ZERO_UUID))
@@ -362,8 +363,9 @@ class ControllerChannelManagerTest {
 
     for (apiVersion <- ApiVersion.allVersions) {
       val updateMetadataRequestVersion: Short =
-        if (apiVersion >= KAFKA_2_8_IV1) 7
-        else if (apiVersion >= KAFKA_2_4_IV1) 6
+        if (apiVersion >= KAFKA_2_8_IV1) 8
+        else if (apiVersion >= KAFKA_2_4_IV1) 7
+        else if (apiVersion >= KAFKA_2_3_IV2) 6
         else if (apiVersion >= KAFKA_2_2_IV0) 5
         else if (apiVersion >= KAFKA_1_0_IV0) 4
         else if (apiVersion >= KAFKA_0_10_2_IV0) 3
@@ -758,12 +760,14 @@ class ControllerChannelManagerTest {
     for (apiVersion <- ApiVersion.allVersions) {
       if (apiVersion < KAFKA_2_2_IV0)
         testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, 0.toShort)
-      else if (apiVersion < KAFKA_2_4_IV1)
+      else if (apiVersion < KAFKA_2_3_IV2)
         testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, 1.toShort)
-      else if (apiVersion < KAFKA_2_6_IV0)
+      else if (apiVersion < KAFKA_2_4_IV1)
         testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, 2.toShort)
-      else
+      else if (apiVersion < KAFKA_2_6_IV0)
         testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, 3.toShort)
+      else
+        testStopReplicaFollowsInterBrokerProtocolVersion(apiVersion, 4.toShort)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -813,7 +813,7 @@ class ControllerChannelManagerTest {
           .setPartitionIndex(topicPartition.partition)
           .setDeletePartition(deletePartition)
 
-        if (version >= 3) {
+        if (version >= 4) {
           partitionState.setLeaderEpoch(if (topicsQueuedForDeletion.contains(topicPartition.topic))
             LeaderAndIsr.EpochDuringDelete
           else

--- a/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
@@ -156,6 +156,7 @@ class BrokerEpochIntegrationTest extends ZooKeeperTestHarness {
         val requestBuilder = new LeaderAndIsrRequest.Builder(
           ApiKeys.LEADER_AND_ISR.latestVersion, controllerId, controllerEpoch,
           epochInRequest,
+          epochInRequest,
           partitionStates.asJava, topicIds, nodes.toSet.asJava)
 
         if (epochInRequestDiffFromCurrentEpoch < 0) {
@@ -197,7 +198,7 @@ class BrokerEpochIntegrationTest extends ZooKeeperTestHarness {
         }.toBuffer
         val requestBuilder = new UpdateMetadataRequest.Builder(
           ApiKeys.UPDATE_METADATA.latestVersion, controllerId, controllerEpoch,
-          epochInRequest,
+          epochInRequest, epochInRequest,
           partitionStates.asJava, liveBrokers.asJava, Collections.emptyMap())
 
         if (epochInRequestDiffFromCurrentEpoch < 0) {
@@ -225,6 +226,7 @@ class BrokerEpochIntegrationTest extends ZooKeeperTestHarness {
         ).asJava
         val requestBuilder = new StopReplicaRequest.Builder(
           ApiKeys.STOP_REPLICA.latestVersion, controllerId, controllerEpoch,
+          epochInRequest, // Correct broker epoch
           epochInRequest, // Correct broker epoch
           false, topicStates)
 

--- a/core/src/test/scala/unit/kafka/server/CacheableBrokerEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CacheableBrokerEpochIntegrationTest.scala
@@ -1,0 +1,73 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import java.util.Properties
+import kafka.api.KAFKA_2_3_IV1
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Test
+
+class CacheableBrokerEpochIntegrationTest extends ZooKeeperTestHarness {
+  @Test
+  def testNewControllerConfig(): Unit = {
+    testControlRequests(true)
+  }
+
+  @Test
+  def testOldControllerConfig(): Unit = {
+    testControlRequests(false)
+  }
+
+  def testControlRequests(controllerUseNewConfig: Boolean): Unit = {
+    val controllerId = 0
+    val controllerConfig: Properties =
+      if (controllerUseNewConfig) {
+        TestUtils.createBrokerConfig(controllerId, zkConnect)
+      } else {
+        val oldConfig = TestUtils.createBrokerConfig(controllerId, zkConnect)
+        oldConfig.put(KafkaConfig.InterBrokerProtocolVersionProp, KAFKA_2_3_IV1.toString)
+        oldConfig
+      }
+    val controller = TestUtils.createServer(KafkaConfig.fromProps(controllerConfig))
+
+    // Note that broker side logic does not depend on the InterBrokerProtocolVersion config
+    val brokerId = 1
+    val brokerConfig = TestUtils.createBrokerConfig(brokerId, zkConnect)
+    val broker = TestUtils.createServer(KafkaConfig.fromProps(brokerConfig))
+    val servers = Seq(controller, broker)
+
+    val tp = new TopicPartition("new-topic", 0)
+
+    try {
+      // Use topic creation to test the LeaderAndIsr and UpdateMetadata requests
+      TestUtils.createTopic(zkClient, tp.topic(), partitionReplicaAssignment = Map(0 -> Seq(brokerId, controllerId)),
+        servers = servers)
+      TestUtils.waitUntilLeaderIsKnown(Seq(broker), tp, 10000)
+      TestUtils.waitForPartitionMetadata(Seq(broker), tp.topic(), tp.partition())
+
+      // Use topic deletion to test StopReplica requests
+      adminZkClient.deleteTopic(tp.topic())
+      TestUtils.verifyTopicDeletion(zkClient, tp.topic(), 1, servers)
+    } finally {
+      TestUtils.shutdownServers(servers)
+    }
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1799,6 +1799,7 @@ class KafkaApisTest {
       controllerId,
       controllerEpoch,
       brokerEpoch,
+      brokerEpoch,
       false,
       topicStates
     ).build()
@@ -2976,6 +2977,7 @@ class KafkaApisTest {
       controllerId,
       controllerEpoch,
       brokerEpochInRequest,
+      brokerEpochInRequest,
       partitionStates,
       Collections.singletonMap("topicW", Uuid.randomUuid()),
       asList(new Node(0, "host0", 9090), new Node(1, "host1", 9091))
@@ -3042,6 +3044,7 @@ class KafkaApisTest {
       ApiKeys.STOP_REPLICA.latestVersion,
       controllerId,
       controllerEpoch,
+      brokerEpochInRequest,
       brokerEpochInRequest,
       false,
       topicStates
@@ -3142,7 +3145,7 @@ class KafkaApisTest {
             .setListener(plaintextListener.value)).asJava)
     )
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
-      0, 0, Seq.empty[UpdateMetadataPartitionState].asJava, brokers.asJava, Collections.emptyMap()).build()
+      0, 0, 0, Seq.empty[UpdateMetadataPartitionState].asJava, brokers.asJava, Collections.emptyMap()).build()
     MetadataCacheTest.updateCache(metadataCache, updateMetadataRequest)
 
     val describeClusterRequest = new DescribeClusterRequest.Builder(new DescribeClusterRequestData()
@@ -3196,7 +3199,7 @@ class KafkaApisTest {
             .setListener(plaintextListener.value)).asJava)
     )
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
-      0, 0, Seq.empty[UpdateMetadataPartitionState].asJava, brokers.asJava, Collections.emptyMap()).build()
+      0, 0, 0, Seq.empty[UpdateMetadataPartitionState].asJava, brokers.asJava, Collections.emptyMap()).build()
     MetadataCacheTest.updateCache(metadataCache, updateMetadataRequest)
     (plaintextListener, anotherListener)
   }
@@ -3311,7 +3314,7 @@ class KafkaApisTest {
     val liveBrokers = (0 until numBrokers).map(
       brokerId => createMetadataBroker(brokerId, plaintextListener))
     new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
-      0, brokerEpoch, partitionStates.asJava, liveBrokers.asJava, Collections.emptyMap()).build()
+      0, brokerEpoch, brokerEpoch, partitionStates.asJava, liveBrokers.asJava, Collections.emptyMap()).build()
   }
 
   private def addTopicToMetadataCache(topic: String, numPartitions: Int, numBrokers: Int = 1): Unit = {

--- a/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
@@ -18,6 +18,9 @@
 package kafka.server
 
 import java.util.Collections
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import org.apache.kafka.common.TopicPartition
 
 import org.apache.kafka.common.{TopicPartition, Uuid}
 
@@ -30,6 +33,7 @@ import kafka.cluster.Broker
 import kafka.controller.{ControllerChannelManager, ControllerContext, StateChangeLogger}
 import kafka.utils.TestUtils._
 import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.common.message.LeaderAndIsrRequestData
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ListenerName
@@ -157,8 +161,8 @@ class LeaderElectionTest extends ZooKeeperTestHarness {
       )
       val requestBuilder = new LeaderAndIsrRequest.Builder(
         ApiKeys.LEADER_AND_ISR.latestVersion, controllerId, staleControllerEpoch,
-        servers(brokerId2).kafkaController.brokerEpoch, partitionStates.asJava,
-        Collections.singletonMap(topic, Uuid.randomUuid()), nodes.toSet.asJava)
+        servers(brokerId2).kafkaController.brokerEpoch, servers(brokerId2).kafkaController.brokerEpoch,
+        partitionStates.asJava, Collections.singletonMap(topic, Uuid.randomUuid()), nodes.toSet.asJava)
 
       controllerChannelManager.sendRequest(brokerId2, requestBuilder, staleControllerEpochCallback)
       TestUtils.waitUntilTrue(() => staleControllerEpochDetected, "Controller epoch should be stale")

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -201,7 +201,7 @@ class MetadataCacheTest {
     topicIds.put(topic1, Uuid.randomUuid())
 
     val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch, brokerEpoch,
       partitionStates.asJava, brokers.asJava, topicIds).build()
     MetadataCacheTest.updateCache(cache, updateMetadataRequest)
 
@@ -323,7 +323,7 @@ class MetadataCacheTest {
       .setReplicas(asList(0)))
 
     val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch, brokerEpoch,
       partitionStates.asJava, brokers.asJava, util.Collections.emptyMap()).build()
     MetadataCacheTest.updateCache(cache, updateMetadataRequest)
 
@@ -379,7 +379,7 @@ class MetadataCacheTest {
         .setReplicas(replicas))
 
     val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch, brokerEpoch,
       partitionStates.asJava, brokers.asJava, util.Collections.emptyMap()).build()
     MetadataCacheTest.updateCache(cache, updateMetadataRequest)
 
@@ -452,7 +452,7 @@ class MetadataCacheTest {
       .setReplicas(replicas))
 
     val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch, brokerEpoch, brokerEpoch,
       partitionStates.asJava, brokers.asJava, util.Collections.emptyMap()).build()
     MetadataCacheTest.updateCache(cache, updateMetadataRequest)
 
@@ -517,7 +517,7 @@ class MetadataCacheTest {
       .setZkVersion(3)
       .setReplicas(replicas))
     val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, partitionStates.asJava,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, brokerEpoch, partitionStates.asJava,
       brokers.asJava, util.Collections.emptyMap()).build()
     MetadataCacheTest.updateCache(cache, updateMetadataRequest)
 
@@ -559,7 +559,7 @@ class MetadataCacheTest {
         .setZkVersion(3)
         .setReplicas(replicas))
       val version = ApiKeys.UPDATE_METADATA.latestVersion
-      val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, partitionStates.asJava,
+      val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, brokerEpoch, partitionStates.asJava,
         brokers.asJava, util.Collections.emptyMap()).build()
       MetadataCacheTest.updateCache(cache, updateMetadataRequest)
     }
@@ -612,7 +612,7 @@ class MetadataCacheTest {
       .setReplicas(replicas)
       .setOfflineReplicas(offline))
     val version = ApiKeys.UPDATE_METADATA.latestVersion
-    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, partitionStates.asJava,
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, brokerEpoch, partitionStates.asJava,
       brokers.asJava, Collections.emptyMap()).build()
     MetadataCacheTest.updateCache(cache, updateMetadataRequest)
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -191,7 +191,7 @@ class ReplicaManagerTest {
       partition.createLogIfNotExists(isNew = false, isFutureReplica = false,
         new LazyOffsetCheckpoints(rm.highWatermarkCheckpoints), None)
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -214,7 +214,7 @@ class ReplicaManagerTest {
       }
 
       // Make this replica the follower
-      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -251,7 +251,7 @@ class ReplicaManagerTest {
         .createLogIfNotExists(isNew = false, isFutureReplica = false,
           new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints), None)
 
-      def leaderAndIsrRequest(epoch: Int): LeaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      def leaderAndIsrRequest(epoch: Int): LeaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -311,7 +311,7 @@ class ReplicaManagerTest {
         new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints), None)
 
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -372,7 +372,7 @@ class ReplicaManagerTest {
         new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints), None)
 
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -479,7 +479,7 @@ class ReplicaManagerTest {
         new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints), None)
 
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -556,7 +556,7 @@ class ReplicaManagerTest {
         new LazyOffsetCheckpoints(rm.highWatermarkCheckpoints), None)
 
       // Make this replica the leader.
-      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -623,7 +623,7 @@ class ReplicaManagerTest {
         .setZkVersion(0)
         .setReplicas(replicas)
         .setIsNew(true)
-      val leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(leaderAndIsrPartitionState).asJava,
         Collections.singletonMap(topic, Uuid.randomUuid()),
         Set(new Node(0, "host1", 0), new Node(1, "host2", 1)).asJava).build()
@@ -740,7 +740,7 @@ class ReplicaManagerTest {
       val partition0Replicas = Seq[Integer](0, 1).asJava
       val partition1Replicas = Seq[Integer](0, 2).asJava
       val topicIds = Map(tp0.topic -> Uuid.randomUuid(), tp1.topic -> Uuid.randomUuid()).asJava
-      val leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, 0, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
             .setTopicName(tp0.topic)
@@ -877,7 +877,7 @@ class ReplicaManagerTest {
       // trigger even though leader does not change
       leaderEpoch += leaderEpochIncrement
       val leaderAndIsrRequest0 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
-        controllerId, controllerEpoch, brokerEpoch,
+        controllerId, controllerEpoch, brokerEpoch, brokerEpoch,
         Seq(leaderAndIsrPartitionState(tp, leaderEpoch, leaderBrokerId, aliveBrokerIds)).asJava,
         Collections.singletonMap(topic, topicId),
         Set(new Node(followerBrokerId, "host1", 0),
@@ -952,7 +952,7 @@ class ReplicaManagerTest {
       initializeLogAndTopicId(replicaManager, tp0, topicId)
 
       // Make this replica the follower
-      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -1009,7 +1009,7 @@ class ReplicaManagerTest {
       initializeLogAndTopicId(replicaManager, tp0, topicId)
 
       // Make this replica the follower
-      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -1066,7 +1066,7 @@ class ReplicaManagerTest {
     initializeLogAndTopicId(replicaManager, tp0, topicId)
 
     // Make this replica the follower
-    val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(topic)
         .setPartitionIndex(0)
@@ -1157,7 +1157,7 @@ class ReplicaManagerTest {
       val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints)
       replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
       val partition0Replicas = Seq[Integer](0, 1).asJava
-      val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(tp0.topic)
           .setPartitionIndex(tp0.partition)
@@ -1203,7 +1203,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1251,7 +1251,7 @@ class ReplicaManagerTest {
       val partition0Replicas = Seq[Integer](0, 1).asJava
       val topicId = Uuid.randomUuid()
 
-      val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(tp0.topic)
           .setPartitionIndex(tp0.partition)
@@ -1272,7 +1272,7 @@ class ReplicaManagerTest {
       assertNull(fetchResult.get)
 
       // Become a follower and ensure that the delayed fetch returns immediately
-      val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(tp0.topic)
           .setPartitionIndex(tp0.partition)
@@ -1308,7 +1308,7 @@ class ReplicaManagerTest {
       val partition0Replicas = Seq[Integer](0, 1).asJava
       val topicId = Uuid.randomUuid()
 
-      val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(tp0.topic)
           .setPartitionIndex(tp0.partition)
@@ -1330,7 +1330,7 @@ class ReplicaManagerTest {
       assertNull(fetchResult.get)
 
       // Become a follower and ensure that the delayed fetch returns immediately
-      val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      val becomeFollowerRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(tp0.topic)
           .setPartitionIndex(tp0.partition)
@@ -1361,9 +1361,10 @@ class ReplicaManagerTest {
     val tp0 = new TopicPartition(topic, 0)
     val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints)
     replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
+
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1406,7 +1407,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1449,7 +1450,7 @@ class ReplicaManagerTest {
     replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
     val partition0Replicas = Seq[Integer](0, 1).asJava
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
       Seq(new LeaderAndIsrPartitionState()
         .setTopicName(tp0.topic)
         .setPartitionIndex(tp0.partition)
@@ -1881,7 +1882,7 @@ class ReplicaManagerTest {
       val topicIds = Map(tp0.topic -> Uuid.randomUuid(), tp1.topic -> Uuid.randomUuid()).asJava
 
       val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
-        controllerId, 0, brokerEpoch,
+        controllerId, 0, brokerEpoch, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
             .setTopicName(tp0.topic)
@@ -1912,7 +1913,7 @@ class ReplicaManagerTest {
 
       // make broker 0 the leader of partition 1 so broker 1 loses its leadership position
       val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, controllerId,
-        controllerEpoch, brokerEpoch,
+        controllerEpoch, brokerEpoch, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
             .setTopicName(tp0.topic)
@@ -1973,7 +1974,7 @@ class ReplicaManagerTest {
       val topicIds = Map(tp0.topic -> Uuid.randomUuid(), tp1.topic -> Uuid.randomUuid()).asJava
 
       val leaderAndIsrRequest1 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
-        controllerId, 0, brokerEpoch,
+        controllerId, 0, brokerEpoch, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
             .setTopicName(tp0.topic)
@@ -2004,7 +2005,7 @@ class ReplicaManagerTest {
 
       // make broker 0 the leader of partition 1 so broker 1 loses its leadership position
       val leaderAndIsrRequest2 = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, controllerId,
-        controllerEpoch, brokerEpoch,
+        controllerEpoch, brokerEpoch, brokerEpoch,
         Seq(
           new LeaderAndIsrPartitionState()
             .setTopicName(tp0.topic)
@@ -2081,7 +2082,7 @@ class ReplicaManagerTest {
     val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints)
     replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 10, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 10, brokerEpoch, brokerEpoch,
       Seq(leaderAndIsrPartitionState(tp0, 1, 0, Seq(0, 1), true)).asJava,
       Collections.singletonMap(topic, Uuid.randomUuid()),
       Set(new Node(0, "host1", 0), new Node(1, "host2", 1)).asJava
@@ -2108,7 +2109,7 @@ class ReplicaManagerTest {
     val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints)
     replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
       Seq(leaderAndIsrPartitionState(tp0, 1, 0, Seq(0, 1), true)).asJava,
       Collections.singletonMap(topic, Uuid.randomUuid()),
       Set(new Node(0, "host1", 0), new Node(1, "host2", 1)).asJava
@@ -2258,7 +2259,7 @@ class ReplicaManagerTest {
         logDirFailureChannel).read()
     }
 
-    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+    val becomeLeaderRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
       Seq(leaderAndIsrPartitionState(tp0, 1, 0, Seq(0, 1), true)).asJava,
       Collections.singletonMap(tp0.topic(), Uuid.randomUuid()),
       Set(new Node(0, "host1", 0), new Node(1, "host2", 1)).asJava
@@ -2338,7 +2339,7 @@ class ReplicaManagerTest {
       val topicNames = topicIds.asScala.map(_.swap).asJava
 
       def leaderAndIsrRequest(epoch: Int, topicIds: java.util.Map[String, Uuid]): LeaderAndIsrRequest =
-        new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+        new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
           Seq(new LeaderAndIsrPartitionState()
             .setTopicName(topic)
             .setPartitionIndex(0)
@@ -2383,7 +2384,7 @@ class ReplicaManagerTest {
       val topicIds = Collections.singletonMap(topic, Uuid.randomUuid())
       val topicNames = topicIds.asScala.map(_.swap).asJava
 
-      def leaderAndIsrRequest(epoch: Int): LeaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+      def leaderAndIsrRequest(epoch: Int): LeaderAndIsrRequest = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -2423,7 +2424,7 @@ class ReplicaManagerTest {
       val topicPartition2 = new TopicPartition(topic, 1)
 
       def leaderAndIsrRequest(topicIds: util.Map[String, Uuid], version: Short, partition: Int = 0, leaderEpoch: Int = 0): LeaderAndIsrRequest =
-        new LeaderAndIsrRequest.Builder(version, 0, 0, brokerEpoch,
+        new LeaderAndIsrRequest.Builder(version, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(partition)
@@ -2486,7 +2487,7 @@ class ReplicaManagerTest {
       val invalidTopicNames = invalidTopicIds.asScala.map(_.swap).asJava
 
       def leaderAndIsrRequest(epoch: Int, topicIds: java.util.Map[String, Uuid]): LeaderAndIsrRequest =
-        new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch,
+        new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(topic)
           .setPartitionIndex(0)
@@ -2527,7 +2528,7 @@ class ReplicaManagerTest {
       val topicNames = topicIds.asScala.map(_.swap).asJava
 
       def leaderAndIsrRequest(epoch: Int, name: String, version: Short): LeaderAndIsrRequest = LeaderAndIsrRequest.parse(
-        new LeaderAndIsrRequest.Builder(version, 0, 0, brokerEpoch,
+        new LeaderAndIsrRequest.Builder(version, 0, 0, brokerEpoch, brokerEpoch,
         Seq(new LeaderAndIsrPartitionState()
           .setTopicName(name)
           .setPartitionIndex(0)
@@ -2603,6 +2604,7 @@ class ReplicaManagerTest {
       version,
       controllerId,
       controllerEpoch,
+      brokerEpoch,
       brokerEpoch,
       Seq(partitionState).asJava,
       Map(topicPartition.topic -> topicId).asJava,

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -244,7 +244,7 @@ class RequestQuotaTest extends BaseRequestTest {
             .setTargetTimes(List(topic).asJava)
 
         case ApiKeys.LEADER_AND_ISR =>
-          new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,
+          new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, brokerId, Int.MaxValue, Long.MaxValue, Long.MaxValue,
             Seq(new LeaderAndIsrPartitionState()
               .setTopicName(tp.topic)
               .setPartitionIndex(tp.partition)
@@ -268,7 +268,7 @@ class RequestQuotaTest extends BaseRequestTest {
                 .setDeletePartition(true)).asJava)
           ).asJava
           new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion, brokerId,
-            Int.MaxValue, Long.MaxValue, false, topicStates)
+            Int.MaxValue, Long.MaxValue, Long.MaxValue, false, topicStates)
 
         case ApiKeys.UPDATE_METADATA =>
           val partitionState = Seq(new UpdateMetadataPartitionState()
@@ -289,7 +289,7 @@ class RequestQuotaTest extends BaseRequestTest {
               .setSecurityProtocol(securityProtocol.id)
               .setListener(ListenerName.forSecurityProtocol(securityProtocol).value)).asJava)).asJava
           new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, brokerId, Int.MaxValue, Long.MaxValue,
-            partitionState, brokers, Collections.emptyMap())
+            Long.MaxValue, partitionState, brokers, Collections.emptyMap())
 
         case ApiKeys.CONTROLLED_SHUTDOWN =>
           new ControlledShutdownRequest.Builder(

--- a/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerShutdownTest.scala
@@ -235,7 +235,7 @@ class ServerShutdownTest extends ZooKeeperTestHarness {
 
       // Initiate a sendRequest and wait until connection is established and one byte is received by the peer
       val requestBuilder = new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion,
-        controllerId, 1, 0L, Seq.empty.asJava, Collections.singletonMap(topic, Uuid.randomUuid()),
+        controllerId, 1, 0L, 0L, Seq.empty.asJava, Collections.singletonMap(topic, Uuid.randomUuid()),
         brokerAndEpochs.keys.map(_.node(listenerName)).toSet.asJava)
       controllerChannelManager.sendRequest(1, requestBuilder)
       receiveFuture.get(10, TimeUnit.SECONDS)

--- a/core/src/test/scala/unit/kafka/server/StopReplicaRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StopReplicaRequestTest.scala
@@ -66,7 +66,7 @@ class StopReplicaRequestTest extends BaseRequestTest {
     for (_ <- 1 to 2) {
       val request1 = new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion,
         server.config.brokerId, server.replicaManager.controllerEpoch, server.kafkaController.brokerEpoch,
-        false, topicStates).build()
+        server.kafkaController.brokerEpoch, false, topicStates).build()
       val response1 = connectAndReceive[StopReplicaResponse](request1, destination = controllerSocketServer)
       val partitionErrors1 = response1.partitionErrors.asScala
       assertEquals(Some(Errors.NONE.code),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -156,7 +156,7 @@ public class MetadataRequestBenchmark {
 
         UpdateMetadataRequest updateMetadataRequest = new UpdateMetadataRequest.Builder(
             ApiKeys.UPDATE_METADATA.latestVersion(),
-            1, 1, 1,
+            1, 1, 1, 1,
             partitionStates, liveBrokers, Collections.emptyMap()).build();
         metadataCache.updateMetadata(100, updateMetadataRequest);
     }


### PR DESCRIPTION
TICKET = KAFKA-7186
LI_DESCERIPTION = Currently the controller is creating a separate copy of UpdateMetadataRequest for
each broker in the cluster, which may cause OOMs upon controller startup. This patch is the first step
toward making the UpdateMetadataRequests cacheable. We change the broker-specific epoch in control
requests to a common maximum broker epoch seen in all brokers, such that all UpdateMetadataRequests have
the same payload.

EXIT_CRITERIA = KAFKA-7186

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
