### PR TITLE
[LI-HOTFIX] Add test case for describe maintenance broker config

### DIFF
--- a/core/src/test/scala/integration/kafka/tools/MaintenanceBrokerTestUtils.scala
+++ b/core/src/test/scala/integration/kafka/tools/MaintenanceBrokerTestUtils.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package integration.kafka.tools
 
 import kafka.server.{DynamicConfig, KafkaServer}

--- a/core/src/test/scala/integration/kafka/tools/MaintenanceBrokerTestUtils.scala
+++ b/core/src/test/scala/integration/kafka/tools/MaintenanceBrokerTestUtils.scala
@@ -1,0 +1,24 @@
+package integration.kafka.tools
+
+import kafka.server.{DynamicConfig, KafkaServer}
+import kafka.utils.CoreUtils.propsWith
+import kafka.utils.TestUtils
+import kafka.zk.{AdminZkClient, KafkaZkClient}
+
+object MaintenanceBrokerTestUtils {
+
+  def setMaintenanceBrokers(adminZkClient: AdminZkClient,
+                            zkClient: KafkaZkClient,
+                            brokers: Seq[KafkaServer],
+                            maintenanceBrokerIds: Seq[Int]): Unit = {
+    val propstring = maintenanceBrokerIds.mkString(",")
+    adminZkClient.changeBrokerConfig(None,
+      propsWith((DynamicConfig.Broker.MaintenanceBrokerListProp, propstring)))
+
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+
+    TestUtils.waitUntilTrue(() => brokers(controllerId).config.getMaintenanceBrokerList == maintenanceBrokerIds,
+      s"wait until broker $propstring is masked as maintenance broker not taking new partitions", 5000)
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/server/MaintenanceBrokerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MaintenanceBrokerTest.scala
@@ -17,22 +17,20 @@
 
 package kafka.server
 
-import java.util.{Optional, Properties}
+import java.util.Properties
 
 import integration.kafka.tools.MaintenanceBrokerTestUtils
 import kafka.server.KafkaConfig.fromProps
-import kafka.utils.CoreUtils._
 import kafka.utils.TestUtils
 import kafka.utils.TestUtils._
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
-
-import scala.collection.JavaConverters._
 import org.junit.Assert._
 import org.junit.{After, Test}
 
+import scala.collection.JavaConverters._
 import scala.collection.Map
 
 /**
@@ -204,4 +202,5 @@ class MaintenanceBrokerTest extends ZooKeeperTestHarness {
   def setMaintenanceBrokers(brokerIds: Seq[Int]): Unit = {
     MaintenanceBrokerTestUtils.setMaintenanceBrokers(adminZkClient, zkClient, brokers, brokerIds)
   }
+
 }

--- a/core/src/test/scala/unit/kafka/server/MaintenanceBrokerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MaintenanceBrokerTest.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import java.util.{Optional, Properties}
 
+import integration.kafka.tools.MaintenanceBrokerTestUtils
 import kafka.server.KafkaConfig.fromProps
 import kafka.utils.CoreUtils._
 import kafka.utils.TestUtils
@@ -201,15 +202,6 @@ class MaintenanceBrokerTest extends ZooKeeperTestHarness {
   }
 
   def setMaintenanceBrokers(brokerIds: Seq[Int]): Unit = {
-    var propstring = brokerIds.mkString(",")
-    adminZkClient.changeBrokerConfig(None,
-      propsWith((DynamicConfig.Broker.MaintenanceBrokerListProp, propstring)))
-
-    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
-
-    TestUtils.waitUntilTrue(() => brokers(controllerId).config.getMaintenanceBrokerList == brokerIds,
-      s"wait until broker $propstring is masked as maintenance broker not taking new partitions", 5000)
-
+    MaintenanceBrokerTestUtils.setMaintenanceBrokers(adminZkClient, zkClient, brokers, brokerIds)
   }
-
 }


### PR DESCRIPTION
TICKET = KAFKA-8527
LI_DESCRIPTION =
In the commit 6b93c274b9 `[LI-HOTFIX] Add dynamic maintenance broker
config`, the test cases didn't cover the describe config API.
Adding this to protect the code path and facilitate the future rebase process.

EXIT_CRITERIA = TICKET [KAFKA-8527] or the patch is dropped

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
