### PR TITLE
Add request enqueue time metric in RequestSendThread

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -270,7 +270,7 @@ extends ShutdownableThread(name = name) with KafkaMetricsGroup {
       def value: Long =
         if (latestRequestStatus.isInFlight || latestRequestStatus.isInQueue) time.milliseconds() - latestRequestStatus.enqueueTimeMs
         else 0
-    },
+    }
   )
 
   def backoff(): Unit = pause(100, TimeUnit.MILLISECONDS)

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -232,6 +232,8 @@ class ControllerChannelManager(controllerContext: ControllerContext,
 case class QueueItem(apiKey: ApiKeys, request: AbstractControlRequest.Builder[_ <: AbstractControlRequest],
                      callback: AbstractResponse => Unit, enqueueTimeMs: Long)
 
+case class LatestRequestStatus(isInFlight: Boolean, isInQueue: Boolean, enqueueTimeMs: Long)
+
 class RequestSendThread(val controllerId: Int,
                         val controllerContext: ControllerContext,
                         val queue: BlockingQueue[QueueItem],
@@ -255,12 +257,19 @@ extends ShutdownableThread(name = name) with KafkaMetricsGroup {
 
   private var firstUpdateMetadataWithPartitionsSent = false
 
-  private var requestEnqueueTimeMs = time.milliseconds()
+  @volatile private var latestRequestStatus = LatestRequestStatus(isInFlight = false, isInQueue = false, 0)
 
-  val queueSizeGauge = newGauge(
+  // This metric reports the queued time of the latest request from the queue
+  // Case 1: if there is an inflight request, the metric need to report the age of the inflight request.
+  // Case 2: if there is no inflight request and there are requests inside the queue, the metric need to report
+  //         the age of the oldest item in the queue, which is the one that should be dequeued next.
+  // Case 3: if there is no inflight request and there are no requests inside the queue, the metric should report 0.
+  val queueTimeGauge = newGauge(
     QueueTimeMetricName,
     new Gauge[Long] {
-      def value: Long = time.milliseconds() - requestEnqueueTimeMs
+      def value: Long =
+        if (latestRequestStatus.isInFlight || latestRequestStatus.isInQueue) time.milliseconds() - latestRequestStatus.enqueueTimeMs
+        else 0
     },
   )
 
@@ -289,7 +298,7 @@ extends ShutdownableThread(name = name) with KafkaMetricsGroup {
       // handle case 4 first
       if (!controllerRequestMerger.hasPendingRequests()) {
         val QueueItem(apiKey, requestBuilder, callback, enqueueTimeMs) = queue.take()
-        requestEnqueueTimeMs = enqueueTimeMs
+        latestRequestStatus = LatestRequestStatus(isInFlight = true, isInQueue = false, enqueueTimeMs)
         mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
       }
 
@@ -308,7 +317,7 @@ extends ShutdownableThread(name = name) with KafkaMetricsGroup {
     } else {
       // use the old behavior of sending each item in the queue as a separate request
       val QueueItem(apiKey, requestBuilder, callback, enqueueTimeMs) = queue.take()
-      requestEnqueueTimeMs = enqueueTimeMs
+      latestRequestStatus = LatestRequestStatus(isInFlight = true, isInQueue = false, enqueueTimeMs)
       updateMetrics(apiKey, enqueueTimeMs)
       (requestBuilder, callback)
     }
@@ -338,6 +347,13 @@ extends ShutdownableThread(name = name) with KafkaMetricsGroup {
             clientResponse = NetworkClientUtils.sendAndReceive(networkClient, clientRequest, time)
             isSendSuccessful = true
             remoteTimeMs = time.milliseconds() - remoteTimeStartMs
+
+            val nextRequest = queue.peek()
+            if (nextRequest != null) {
+              latestRequestStatus = LatestRequestStatus(isInFlight = false, isInQueue = true, nextRequest.enqueueTimeMs)
+            } else {
+              latestRequestStatus = LatestRequestStatus(isInFlight = false, isInQueue = false, 0)
+            }
           }
         } catch {
           case e: Throwable => // if the send was not successful, reconnect to broker and resend the message


### PR DESCRIPTION
this PR also adds a requestEnqueueTime metric, to indicates how long is it since a request be added to the queue but not completed yet. This metric can provide a more clear view when requests are stuck. To monitor this metric, we'll need another PR in kafka-server mp.

Testing: N/A

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
