### PR TITLE
Remove incorrect filtering logic in ControllerContext::removeLiveBrokers

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -193,8 +193,6 @@ class ControllerContext {
   def removeLiveBrokers(brokerIds: Set[Int]): Unit = {
     liveBrokers = liveBrokers.filter(broker => !brokerIds.contains(broker.id))
     liveBrokerEpochs = liveBrokerEpochs.filter { case (id, _) => !brokerIds.contains(id) }
-
-    shuttingDownBrokerIds = shuttingDownBrokerIds.filterKeys(brokerIds.contains)
   }
 
   def updateBrokerMetadata(oldMetadata: Broker, newMetadata: Broker): Unit = {


### PR DESCRIPTION
We already have logic to remove broker IDs from `shuttingDownBrokerIds` here -

https://github.com/linkedin/kafka/blob/2.4-li/core/src/main/scala/kafka/controller/KafkaController.scala#L546

This method `onBrokerFailure` is called for both bounced and dead brokers, after the call to `ControllerContext::removeLiveBroker`. See here -
https://github.com/linkedin/kafka/blob/2.4-li/core/src/main/scala/kafka/controller/KafkaController.scala#L1655-L1664

Also, the logic inside `removeLiveBroker` seems to be incorrect. Instead of filtering out entries from `shuttingDownBrokerIds` that are in the `brokerIds` set, it filters out any entries that are not in the set. This is a bug.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
