### PR TITLE
[LI-HOTFIX] Modified github actions to generate JARs and run tests for new components

### DIFF
--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -56,4 +56,4 @@ jobs:
           JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
         run: |
-          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} :clients:uploadArchives :core:uploadArchives :metadata:uploadArchives :raft:uploadArchives :server-common:uploadArchives :storage:uploadArchives :storage:api:uploadArchives --no-daemon
+          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} :clients:publish :core:publish :metadata:publish :raft:publish :server-common:publish :storage:publish :storage:api:publish --no-daemon

--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -50,10 +50,12 @@ jobs:
       - name: Build with Gradle and run all tests
         # exclude the streams test and connect test
         # Set maxTestRetries for flaky tests.  This is the setup in upstream Jenkinsfile
-        run: ./gradlew -PmaxTestRetries=3 cleanTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest :generator:test :clients:test :core:test :metadata:test :raft:test :server-common:test :storage:test :storage:api:test :shell:test --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
+        # Maintain lexicographical order for subprojects
+        run: ./gradlew -PmaxTestRetries=3 cleanTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest :clients:test :core:test :generator:test :metadata:test :raft:test :server-common:test :shell:test :storage:test :storage:api:test --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
       - name: Upload archive
         env:
           JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
+        # Maintain lexicographical order for subprojects
         run: |
           ./gradlew -Pversion=${{ env.RELEASE_VERSION }} :clients:publish :core:publish :metadata:publish :raft:publish :server-common:publish :storage:publish :storage:api:publish --no-daemon

--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -50,10 +50,10 @@ jobs:
       - name: Build with Gradle and run all tests
         # exclude the streams test and connect test
         # Set maxTestRetries for flaky tests.  This is the setup in upstream Jenkinsfile
-        run: ./gradlew -PmaxTestRetries=3 cleanTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest :clients:test :core:test --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
+        run: ./gradlew -PmaxTestRetries=3 cleanTest rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest :generator:test :clients:test :core:test :metadata:test :raft:test :server-common:test :storage:test :storage:api:test :shell:test --no-daemon -PxmlFindBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed
       - name: Upload archive
         env:
           JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
         run: |
-          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} :clients:uploadArchives :core:uploadArchives --no-daemon
+          ./gradlew -Pversion=${{ env.RELEASE_VERSION }} :clients:uploadArchives :core:uploadArchives :metadata:uploadArchives :raft:uploadArchives :server-common:uploadArchives :storage:uploadArchives :storage:api:uploadArchives --no-daemon

--- a/.github/workflows/int-test.yml
+++ b/.github/workflows/int-test.yml
@@ -34,15 +34,15 @@ jobs:
     strategy:
       fail-fast: false  # We still want to see all jobs' build result to the end
       matrix:
-        module:
-          - generator
+        module: # Maintain lexicographical order
           - clients
+          - generator
           - metadata
           - raft
           - server-common
+          - shell
           - storage
           - storage:api
-          - shell
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code

--- a/.github/workflows/int-test.yml
+++ b/.github/workflows/int-test.yml
@@ -26,11 +26,23 @@ on:
       - 3.0-li-dev**
 
 jobs:
-  clients:
+  test:
     # Name the Job
-    name: clients
+    name: ${{ matrix.module }}
     # Set the type of machine to run on
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # We still want to see all jobs' build result to the end
+      matrix:
+        module:
+          - generator
+          - clients
+          - metadata
+          - raft
+          - server-common
+          - storage
+          - storage:api
+          - shell
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
@@ -44,7 +56,9 @@ jobs:
         with:
           java-version: '11'
       - name: Run tests
-        run: ./gradlew -PmaxTestRetries=3 cleanTest clients:integrationTest --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
+        env:
+          MODULE: ${{ matrix.module }}
+        run: ./gradlew -PmaxTestRetries=3 cleanTest "$MODULE:integrationTest" --no-daemon -PtestLoggingEvents=started,passed,skipped,failed
   core:
     # Name the Job
     name: core (${{ matrix.prefixes }})

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -34,16 +34,16 @@ jobs:
     strategy:
       fail-fast: false  # We still want to see all jobs' build result to the end
       matrix:
-        module:
-          - generator
-          - core
+        module: # Maintain lexicographical order
           - clients
+          - core
+          - generator
           - metadata
           - raft
           - server-common
+          - shell
           - storage
           - storage:api
-          - shell
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -35,8 +35,15 @@ jobs:
       fail-fast: false  # We still want to see all jobs' build result to the end
       matrix:
         module:
+          - generator
           - core
           - clients
+          - metadata
+          - raft
+          - server-common
+          - storage
+          - storage:api
+          - shell
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION = Modified github actions to generate JARs and run tests for new components. 
EXIT_CRITERIA = Never. We want to have custom github actions for publishing the artifact for linkedin.

In 2.4, we only used to upload JARs for `clients` and `core` subprojects into the artifactory. This is not enough to build `kafka`, and we observed a failure when building it internally.

This review adds the JARs for `storage`, `raft`, `server-common`, `storage:api` subprojects.
We also add these subprojects (and also `shell` used for CLI tools and `generator` used for generating request and response classes) to the unit test and integration test github actions.

We also switch from using `uploadArchive` to `publish` as recommended. Kafka 3.0 moved to using the `maven-publish` plugin, that provides the `publish` target. `uploadArchive` is an alias that points to it, and has been kept for backwards compatibility.  According to the README.md file, `publish` is the recommended target.

We could also just run the top-level `publish` target, but that would also publish artifacts for `connect` and `streams` which we do not use.

**Testing**
Tested the github actions for unit and integration tests on personal repo
https://github.com/wyuka/kafka/actions/runs/1747749281
https://github.com/wyuka/kafka/actions/runs/1747749282
https://github.com/wyuka/kafka/actions/runs/1747749289

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
