### PR TITLE
[LI-HOTFIX] Update README with the correct jfrog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You are encouraged to check out other Kafka projects from LinkedIn:
 We are currently using Github Actions as the CI framework, and the testing results can be found [here](https://github.com/linkedin/kafka/actions).
 To publish a release, go to [the release page](https://github.com/linkedin/kafka/releases) and manually create a new release.
 Once the release tag is created, a test job will be triggered to run the necessary tests. And once the test passes, the artifacts
-will be published to [the bintray hosting LinkedIn projects](https://dl.bintray.com/linkedin/maven/com/linkedin/kafka/kafka_2.12/).
+will be published to [jfrog](https://linkedin.jfrog.io/ui/native/kafka/com/linkedin/kafka/kafka_2.12/).
 
 ### Contributing ###
 


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
We are publishing artifacts to Jfrog instead of Bintray now.
This PR updates README with the correct jfrog link.
EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
