### PR TITLE
[LI-HOTFIX] Avoid triggering CI workflows on push

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -19,7 +19,6 @@ name: Code analysis
 
 on:
   pull_request:
-  push:
     # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
     branches: ['2.4-li']
 

--- a/.github/workflows/int-test.yml
+++ b/.github/workflows/int-test.yml
@@ -19,7 +19,6 @@ name: intTest
 
 on:
   pull_request:
-  push:
     # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
     branches: ['2.4-li']
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,7 +19,6 @@ name: unitTest
 
 on:
   pull_request:
-  push:
     # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
     branches: ['2.4-li']
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For security issues with this branch please review
 Guidelines](https://www.linkedin.com/help/linkedin/answer/62924/security-vulnerabilities?lang=en).
 General Kafka issues should be communicated via the Kafka community.
 
+
 Apache Kafka
 =================
 See our [web site](https://kafka.apache.org) for details on the project.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ For security issues with this branch please review
 Guidelines](https://www.linkedin.com/help/linkedin/answer/62924/security-vulnerabilities?lang=en).
 General Kafka issues should be communicated via the Kafka community.
 
-
 Apache Kafka
 =================
 See our [web site](https://kafka.apache.org) for details on the project.


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
Currently, the CI workflows are triggered when there is a push event, e.g.
when a PR is merged. Running the workflows upon push events are not required
and thus waste computation power. This PR removes the push event trigger.

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

I've tested that the CI workflows can still be triggered when there are
subsequent commits to a PR. This type of commit is called `synchorize` in Github Actions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
