### PR TITLE
[LI-HOTFIX] Retry failed tests for integrationTest and unitTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,6 +329,10 @@ subprojects {
       includeCategories 'org.apache.kafka.test.IntegrationTest'
     }
 
+    retry {
+      maxRetries = userMaxTestRetries
+      maxFailures = userMaxTestRetryFailures
+    }
   }
 
   task unitTest(type: Test, dependsOn: compileJava) {
@@ -348,6 +352,11 @@ subprojects {
       useJUnit {
         excludeCategories 'org.apache.kafka.test.IntegrationTest'
       }
+    }
+
+    retry {
+      maxRetries = userMaxTestRetries
+      maxFailures = userMaxTestRetryFailures
     }
   }
 


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
The previous PR #259 added logic to retry failed tests for the `test` gradle task.
This PR adds the retries for the `integrationTest` and `unitTest` tasks as well.
EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

This change is tested by adding a test that always fails,
and verifying that the command below will retry the test for 3 times after the failure.
`export SCALA_VERSION=2.12 && ./gradlew -PmaxTestRetries=3 -PscalaVersion="$SCALA_VERSION" -PtestLoggingEvents=started,passed,skipped,failed --no-daemon core:integrationTest --rerun-tasks --tests '*.lucasTest'
`
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
