### PR TITLE
Fixed the API version check when building LeaderAndIsrResponse in ReplicaManager.

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -229,10 +229,11 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.LIST_TRANSACTIONS => handleListTransactionsRequest(request)
         case ApiKeys.ALLOCATE_PRODUCER_IDS => handleAllocateProducerIdsRequest(request)
         case ApiKeys.DESCRIBE_QUORUM => forwardToControllerOrFail(request)
-        case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
 
         // LinkedIn internal request types
         case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => handleLiControlledShutdownSkipSafetyCheck(request)
+
+        case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
       case e: FatalExitError => throw e

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1574,7 +1574,7 @@ class ReplicaManager(val config: KafkaConfig,
           onLeadershipChange(partitionsBecomeLeader, partitionsBecomeFollower)
 
           val data = new LeaderAndIsrResponseData().setErrorCode(Errors.NONE.code)
-          if (leaderAndIsrRequest.version < 5) {
+          if (leaderAndIsrRequest.version < 6) {
             responseMap.forKeyValue { (tp, error) =>
               data.partitionErrors.add(new LeaderAndIsrPartitionError()
                 .setTopicName(tp.topic)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1574,6 +1574,9 @@ class ReplicaManager(val config: KafkaConfig,
           onLeadershipChange(partitionsBecomeLeader, partitionsBecomeFollower)
 
           val data = new LeaderAndIsrResponseData().setErrorCode(Errors.NONE.code)
+          /* In version 5 and below, response contains a list of topic-partitions with
+          their corresponding errors. In version 6 and up, partitions and corresponding
+          errors are grouped by topicId. */
           if (leaderAndIsrRequest.version < 6) {
             responseMap.forKeyValue { (tp, error) =>
               data.partitionErrors.add(new LeaderAndIsrPartitionError()


### PR DESCRIPTION
In PR #247, we changed the response versions for LeaderAndIsrResponse. Version 5 became version 6. We missed changing this check that actually transforms the response and groups it by TopicId if the version >= 5 (which should now become version 6).

Also moved the catch-all clause for the case inside KafkaApis to maintain consistency.

https://github.com/linkedin/kafka/pull/247/files#diff-e7cce238d48a1918a4c35d38ccaf1ea6821003f3e0c85a4cd9af6e804f9ef024

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
