### PR TITLE
[LI-TIERING] Moved highest remote offset fetching to RLMTask::run() method.

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -478,7 +478,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
                   .remoteBytesOutRate.mark(remoteLogSegmentMetadata.segmentSizeInBytes())
                 readOffsetOption = Some(endOffset)
                 //todo-tier-storage
-                log.updateRemoteIndexHighestOffset(readOffset)
+                log.updateRemoteIndexHighestOffset(endOffset)
                 info(s"Copied $fileName to remote storage.")
               }
             }

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -325,7 +325,9 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
 
     private def isLeader(): Boolean = leaderEpoch >= 0
 
-    private var readOffset: Long = -1
+    // The readOffset is None initially for a new leader RLMTask,
+    // and needs to be fetched inside the task's run() method.
+    private var readOffsetOption: Option[Long] = None
 
     //todo-updating log with remote index highest offset -- should this be required?
     // fetchLog(tp.topicPartition()).foreach { log => log.updateRemoteIndexHighestOffset(readOffset) }
@@ -336,9 +338,9 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
       }
       if (this.leaderEpoch != leaderEpochVal) {
         leaderEpoch = leaderEpochVal
-        info(s"Find the highest remote offset for partition: $tp after becoming leader, leaderEpoch: $leaderEpoch")
-        readOffset = findHighestRemoteOffset(tp)
       }
+      // Reset readOffset, so that it is set in next run of RLMTask
+      readOffsetOption = None
     }
 
     def convertToFollower(): Unit = {
@@ -346,7 +348,21 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     }
 
     def copyLogSegmentsToRemote(): Unit = {
+      def maybeUpdateReadOffset(): Unit = {
+        if (readOffsetOption.isEmpty) {
+          info(s"Find the highest remote offset for partition: $tp after becoming leader, leaderEpoch: $leaderEpoch")
+
+          // This is found by traversing from the latest leader epoch from leader epoch history and find the highest offset
+          // of a segment with that epoch copied into remote storage. If it can not find an entry then it checks for the
+          // previous leader epoch till it finds an entry, If there are no entries till the earliest leader epoch in leader
+          // epoch cache then it starts copying the segments from the earliest epoch entry’s offset.
+          readOffsetOption = Some(findHighestRemoteOffset(tp))
+        }
+      }
+
       try {
+        maybeUpdateReadOffset()
+        val readOffset = readOffsetOption.get
         fetchLog(tp.topicPartition()).foreach { log => {
           if (isCancelled()) {
             info(s"Skipping copying log segments as the current task is cancelled")
@@ -460,7 +476,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
                 remoteLogMetadataManager.updateRemoteLogSegmentMetadata(rlsmAfterCreate)
                 brokerTopicStats.topicStats(tp.topicPartition().topic())
                   .remoteBytesOutRate.mark(remoteLogSegmentMetadata.segmentSizeInBytes())
-                readOffset = endOffset
+                readOffsetOption = Some(endOffset)
                 //todo-tier-storage
                 log.updateRemoteIndexHighestOffset(readOffset)
                 info(s"Copied $fileName to remote storage.")
@@ -600,10 +616,6 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     }
   }
 
-  // This is found by traversing from the latest leader epoch from leader epoch history and find the highest offset
-  // of a segment with that epoch copied into remote storage. If it can not find an entry then it checks for the
-  // previous leader epoch till it finds an entry, If there are no entries till the earliest leader epoch in leader
-  // epoch cache then it returns -1.
   def findHighestRemoteOffset(topicIdPartition: TopicIdPartition): Long = {
     var offset: Optional[lang.Long] = Optional.empty()
     fetchLog(topicIdPartition.topicPartition()).foreach { log =>


### PR DESCRIPTION
The leader `RLMTask` needs to know the highest offset that is consistent with the leader's epoch history and is already copied to the remote tier. This is done by calling the findHighestRemoteOffset method inside the `RLMTask::convertToLeader()` until now. This call can fail if the RLMM is still initializing, and is not yet ready to take requests. In this scenario, `findHighestRemoteOffset()` throws an exception, causing the LeaderAndIsrRequest to fail and not be processed.

After this change, the method will be called inside an execution of the `RLMTask`, and if an exception occurs, it will be retried again in the next execution. The task will succeed eventually once the RLMM is available to respond to thehighestOffsetForEpoch method.

This bug was observed when we increase the value of `INITIALIZATION_RETRY_INTERVAL_MS` inside `TopicBasedRemoteLogMetadataManager` to `5000`, and run the `OffloadAndConsumeFromLeaderTest` test (if the `__remote_log_metadata` topic doesn't get created in the first go because of start-up delays).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
