### PR TITLE
[LI-TIERING] Load pending partitions into metadata store during RLMM init

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -270,7 +270,6 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                 // when it is initialized successfully in initializeResources().
                 this.pendingAssignPartitions.addAll(allPartitions);
             } else {
-                this.pendingAssignPartitions.clear();
                 assignPartitions(allPartitions);
             }
         } finally {
@@ -362,7 +361,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
                     }
 
                     if (!pendingAssignPartitions.isEmpty()) {
-                        consumerManager.addAssignmentsForPartitions(pendingAssignPartitions);
+                        assignPartitions(pendingAssignPartitions);
                         pendingAssignPartitions.clear();
                     }
 


### PR DESCRIPTION
Currently, when `onPartitionLeadershipChanges` is called before initialzation, it adds the partitions to a `pendingAssignPartitions` set. Then, when `TopicBasedRemoteLogMetadataManager` gets initialized, it adds the partitions in the `pendingAssignPartitions` set to the `ConsumerManager` to consume from, but does not store them in the `remotePartitionMetadataStore`.

https://github.com/linkedin/kafka/blob/c3a084e84cbf9582327f81b80413b2c275e20b6f/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java#L367

This behavior is different from when `addRemoteLogSegmentMetadata` is called after initialization, and it calls remotePartitionMetadataStore.maybeLoadPartition(partition).

https://github.com/linkedin/kafka/blob/c3a084e84cbf9582327f81b80413b2c275e20b6f/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java#L274
https://github.com/linkedin/kafka/blob/c3a084e84cbf9582327f81b80413b2c275e20b6f/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java#L283

This change makes the behavior consistent, so that the `RemotePartitionMetadataStore` does not miss any partitions that were added before initialization.

This causes the `OffloadAndConsumeFromLeaderTest` to fail intermittently.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
