### PR TITLE
[LI-HOTFIX] Implementation of memory pool based on weak references. (#49)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/memory/WeakMemoryPool.java
+++ b/clients/src/main/java/org/apache/kafka/common/memory/WeakMemoryPool.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.memory;
+
+import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+
+/**
+ * An implementation of memory pool with weak references.
+ *
+ * Note: This will be a no-op for all the other clients.
+ *
+ * If and when the GC runs, the buffers will be reclaimed and no side effects will be seen.
+ */
+public class WeakMemoryPool implements MemoryPool {
+    private final NavigableMap<Integer, LinkedList<WeakReference<ByteBuffer>>> cache;
+    private final Object lock = new Object();
+
+    public WeakMemoryPool() {
+        cache = new TreeMap<>();
+    }
+
+    /**
+     * Tries to acquire a ByteBuffer of the specified size
+     * @param sizeBytes size required
+     * @return a ByteBuffer (which later needs to be release()ed), or null if no memory available.
+     *         the buffer will be of the exact size requested, even if backed by a larger chunk of memory
+     */
+    @Override
+    public ByteBuffer tryAllocate(int sizeBytes) {
+        if (sizeBytes < 0) {
+            throw new IllegalArgumentException("The buffer size cannot be less than 0");
+        }
+        ByteBuffer buffer = null;
+        synchronized (lock) {
+            NavigableMap<Integer, LinkedList<WeakReference<ByteBuffer>>> tailMap = cache.tailMap(sizeBytes, true);
+            LinkedList<Integer> keysToDelete = new LinkedList<>();
+            for (Map.Entry<Integer, LinkedList<WeakReference<ByteBuffer>>> entry : tailMap.entrySet()) {
+
+                LinkedList<WeakReference<ByteBuffer>> queue = entry.getValue();
+                while (!queue.isEmpty() && buffer == null) {
+                    buffer = queue.pop().get();
+                }
+
+                if (queue.isEmpty()) {
+                    keysToDelete.add(entry.getKey());
+                }
+
+                // If buffer is non-null; break out of the loop!
+                if (buffer != null) {
+                    break;
+                }
+            }
+
+            // Remove all keys from the map which have zero queue lengths
+            for (Integer key : keysToDelete) {
+                cache.remove(key);
+            }
+        }
+
+        // If buffer is non-null, clear it before returning back to the user!
+        if (buffer != null) {
+            buffer.clear();
+            return buffer;
+        }
+
+        return ByteBuffer.allocate(sizeBytes);
+    }
+
+    /**
+     * Returns a previously allocated buffer to the pool.
+     * @param previouslyAllocated a buffer previously returned from tryAllocate()
+     */
+    @Override
+    public void release(ByteBuffer previouslyAllocated) {
+        if (previouslyAllocated == null) {
+            throw new IllegalArgumentException("the buffer to be released cannot be null!");
+        }
+
+        synchronized (lock) {
+            LinkedList<WeakReference<ByteBuffer>> queue =
+                cache.computeIfAbsent(previouslyAllocated.capacity(), k -> new LinkedList<>());
+            queue.add(new WeakReference<>(previouslyAllocated));
+        }
+    }
+
+    /**
+     * Returns the total size of this pool
+     * @return total size, in bytes
+     */
+    @Override
+    public long size() {
+        return Long.MAX_VALUE;
+    }
+
+    /**
+     * Returns the amount of memory available for allocation by this pool.
+     * NOTE: result may be negative (pools may over allocate to avoid starvation issues)
+     * @return bytes available
+     */
+    @Override
+    public long availableMemory() {
+        return Long.MAX_VALUE;
+    }
+
+    /**
+     * Returns true if the pool cannot currently allocate any more buffers
+     * - meaning total outstanding buffers meets or exceeds pool size and
+     * some would need to be released before further allocations are possible.
+     *
+     * This is equivalent to availableMemory() <= 0
+     * @return true if out of memory
+     */
+    @Override
+    public boolean isOutOfMemory() {
+        return false;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/memory/WeakMemoryPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/WeakMemoryPoolTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.memory;
+
+import java.nio.ByteBuffer;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class WeakMemoryPoolTest {
+    private static final int FORTY_MEGABYTES = 40 * 1024 * 1024;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeAllocation() {
+        WeakMemoryPool memoryPool = new WeakMemoryPool();
+        memoryPool.tryAllocate(-1);
+    }
+
+    @Test
+    public void testZeroAllocation() {
+        WeakMemoryPool memoryPool = new WeakMemoryPool();
+        memoryPool.tryAllocate(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullRelease() {
+        WeakMemoryPool memoryPool = new WeakMemoryPool();
+        memoryPool.release(null);
+    }
+
+    @Test
+    public void testAllocationMemorySize() {
+        WeakMemoryPool pool = new WeakMemoryPool();
+        long freeMemory = Runtime.getRuntime().freeMemory();
+        ByteBuffer buffer1 = pool.tryAllocate(FORTY_MEGABYTES + 1);
+        ByteBuffer buffer2 = pool.tryAllocate(FORTY_MEGABYTES + 2);
+        ByteBuffer buffer3 = pool.tryAllocate(FORTY_MEGABYTES + 3);
+        Assert.assertTrue(Runtime.getRuntime().freeMemory()
+            <= freeMemory - buffer1.capacity() - buffer2.capacity() - buffer3.capacity());
+
+        pool.release(buffer1);
+        ByteBuffer reuse1 = pool.tryAllocate(FORTY_MEGABYTES);
+        // Compare the references
+        Assert.assertTrue(reuse1 == buffer1);
+
+        pool.release(buffer2);
+        pool.release(buffer3);
+        ByteBuffer reuse3 = pool.tryAllocate(FORTY_MEGABYTES + 3);
+        ByteBuffer reuse2 = pool.tryAllocate(FORTY_MEGABYTES + 2);
+
+        Assert.assertTrue(reuse3 == buffer3);
+        Assert.assertTrue(reuse2 == buffer2);
+    }
+
+    @Test
+    public void testAllocation() {
+        WeakMemoryPool pool = new WeakMemoryPool();
+        ByteBuffer buffer1 = pool.tryAllocate(FORTY_MEGABYTES + 1);
+        ByteBuffer buffer2 = pool.tryAllocate(FORTY_MEGABYTES + 2);
+        ByteBuffer buffer3 = pool.tryAllocate(FORTY_MEGABYTES + 3);
+
+        pool.release(buffer1);
+        ByteBuffer reuse1 = pool.tryAllocate(FORTY_MEGABYTES);
+        // Compare the references
+        Assert.assertEquals(System.identityHashCode(reuse1), System.identityHashCode(buffer1));
+
+        pool.release(buffer2);
+        pool.release(buffer3);
+        ByteBuffer reuse3 = pool.tryAllocate(FORTY_MEGABYTES + 3);
+        ByteBuffer reuse2 = pool.tryAllocate(FORTY_MEGABYTES + 2);
+
+        Assert.assertEquals(System.identityHashCode(reuse3), System.identityHashCode(buffer3));
+        Assert.assertEquals(System.identityHashCode(reuse2), System.identityHashCode(buffer2));
+    }
+
+    @Test
+    public void testAllocationGC() {
+        // Clean all garbage before we begin!
+        System.gc();
+
+        WeakMemoryPool pool = new WeakMemoryPool();
+
+        ByteBuffer buffer1 = ByteBuffer.allocate(FORTY_MEGABYTES + 1);
+        ByteBuffer buffer2 = ByteBuffer.allocate(FORTY_MEGABYTES + 5);
+        ByteBuffer buffer3 = ByteBuffer.allocate(FORTY_MEGABYTES + 9);
+
+        // The byte buffers are not reachable from gc-roots
+        int identifier1 = System.identityHashCode(buffer1);
+        int identifier2 = System.identityHashCode(buffer2);
+        int identifier3 = System.identityHashCode(buffer3);
+
+        pool.release(buffer1);
+        pool.release(buffer2);
+        pool.release(buffer3);
+
+        Assert.assertEquals(identifier2, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 3)));
+        Assert.assertEquals(identifier3, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 7)));
+        Assert.assertEquals(identifier1, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 0)));
+
+        pool.release(buffer1);
+        pool.release(buffer2);
+        pool.release(buffer3);
+
+        buffer1 = null;
+        buffer2 = null;
+        buffer3 = null;
+
+        // Reclaim all the objects
+        System.gc();
+
+        // Assert that the object is a different one!
+        Assert.assertNotEquals(identifier2, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 3)));
+        Assert.assertNotEquals(identifier3, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 7)));
+        Assert.assertNotEquals(identifier1, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 0)));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/memory/WeakMemoryPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/WeakMemoryPoolTest.java
@@ -18,17 +18,21 @@
 package org.apache.kafka.common.memory;
 
 import java.nio.ByteBuffer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class WeakMemoryPoolTest {
     private static final int FORTY_MEGABYTES = 40 * 1024 * 1024;
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNegativeAllocation() {
         WeakMemoryPool memoryPool = new WeakMemoryPool();
-        memoryPool.tryAllocate(-1);
+        assertThrows(IllegalArgumentException.class, () -> memoryPool.tryAllocate(-1));
     }
 
     @Test
@@ -37,34 +41,31 @@ public class WeakMemoryPoolTest {
         memoryPool.tryAllocate(0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNullRelease() {
         WeakMemoryPool memoryPool = new WeakMemoryPool();
-        memoryPool.release(null);
+        assertThrows(IllegalArgumentException.class, () -> memoryPool.release(null));
     }
 
     @Test
     public void testAllocationMemorySize() {
         WeakMemoryPool pool = new WeakMemoryPool();
-        long freeMemory = Runtime.getRuntime().freeMemory();
         ByteBuffer buffer1 = pool.tryAllocate(FORTY_MEGABYTES + 1);
         ByteBuffer buffer2 = pool.tryAllocate(FORTY_MEGABYTES + 2);
         ByteBuffer buffer3 = pool.tryAllocate(FORTY_MEGABYTES + 3);
-        Assert.assertTrue(Runtime.getRuntime().freeMemory()
-            <= freeMemory - buffer1.capacity() - buffer2.capacity() - buffer3.capacity());
 
         pool.release(buffer1);
         ByteBuffer reuse1 = pool.tryAllocate(FORTY_MEGABYTES);
         // Compare the references
-        Assert.assertTrue(reuse1 == buffer1);
+        assertTrue(reuse1 == buffer1);
 
         pool.release(buffer2);
         pool.release(buffer3);
         ByteBuffer reuse3 = pool.tryAllocate(FORTY_MEGABYTES + 3);
         ByteBuffer reuse2 = pool.tryAllocate(FORTY_MEGABYTES + 2);
 
-        Assert.assertTrue(reuse3 == buffer3);
-        Assert.assertTrue(reuse2 == buffer2);
+        assertTrue(reuse3 == buffer3);
+        assertTrue(reuse2 == buffer2);
     }
 
     @Test
@@ -77,15 +78,15 @@ public class WeakMemoryPoolTest {
         pool.release(buffer1);
         ByteBuffer reuse1 = pool.tryAllocate(FORTY_MEGABYTES);
         // Compare the references
-        Assert.assertEquals(System.identityHashCode(reuse1), System.identityHashCode(buffer1));
+        assertEquals(System.identityHashCode(reuse1), System.identityHashCode(buffer1));
 
         pool.release(buffer2);
         pool.release(buffer3);
         ByteBuffer reuse3 = pool.tryAllocate(FORTY_MEGABYTES + 3);
         ByteBuffer reuse2 = pool.tryAllocate(FORTY_MEGABYTES + 2);
 
-        Assert.assertEquals(System.identityHashCode(reuse3), System.identityHashCode(buffer3));
-        Assert.assertEquals(System.identityHashCode(reuse2), System.identityHashCode(buffer2));
+        assertEquals(System.identityHashCode(reuse3), System.identityHashCode(buffer3));
+        assertEquals(System.identityHashCode(reuse2), System.identityHashCode(buffer2));
     }
 
     @Test
@@ -108,9 +109,9 @@ public class WeakMemoryPoolTest {
         pool.release(buffer2);
         pool.release(buffer3);
 
-        Assert.assertEquals(identifier2, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 3)));
-        Assert.assertEquals(identifier3, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 7)));
-        Assert.assertEquals(identifier1, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 0)));
+        assertEquals(identifier2, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 3)));
+        assertEquals(identifier3, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 7)));
+        assertEquals(identifier1, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 0)));
 
         pool.release(buffer1);
         pool.release(buffer2);
@@ -124,8 +125,8 @@ public class WeakMemoryPoolTest {
         System.gc();
 
         // Assert that the object is a different one!
-        Assert.assertNotEquals(identifier2, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 3)));
-        Assert.assertNotEquals(identifier3, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 7)));
-        Assert.assertNotEquals(identifier1, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 0)));
+        assertNotEquals(identifier2, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 3)));
+        assertNotEquals(identifier3, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 7)));
+        assertNotEquals(identifier1, System.identityHashCode(pool.tryAllocate(FORTY_MEGABYTES + 0)));
     }
 }


### PR DESCRIPTION
LI_DESCRIPTION =
* Implementation of memory pool based on weak references.

This will act as a NO-OP memory pool (current behavior) in all the clients and kafka broker except
when there is an opportunity to reuse buffer before it could have been garbage collected.
EXIT_CRITERIA =

Note: It is possible that if we allocate buffers in a strictly increasing order, we may accumulate certain keys over time with their weak references set to null. The idea is that allocation distribution is usually uniform and eventually an allocation for a smaller byte buffer would kick out these keys from the cache.