### PR TITLE
[LI-HOTFIX] Preallocate maps with exact size instead of the default(which is 16) 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Schema.java
@@ -55,7 +55,7 @@ public class Schema extends Type {
      */
     public Schema(boolean tolerateMissingFieldsWithDefaults, Field... fs) {
         this.fields = new BoundField[fs.length];
-        this.fieldsByName = new HashMap<>();
+        this.fieldsByName = new HashMap<>(fs.length);
         this.tolerateMissingFieldsWithDefaults = tolerateMissingFieldsWithDefaults;
         for (int i = 0; i < this.fields.length; i++) {
             Field def = fs[i];


### PR DESCRIPTION


LI_DESCRIPTION =
EXIT_CRITERIA =

(cherry picked from commit d2f66fa8f3b6fdff468b031418ed240d5d6d04ec)
