### PR TITLE
[LI-TIERING] When secondary consumer consumes, update readOffsetsByPartition map in PrimaryConsumerTask.

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/PrimaryConsumerTask.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/PrimaryConsumerTask.java
@@ -285,6 +285,7 @@ class PrimaryConsumerTask implements Runnable, Closeable {
         consumer.assign(assignedMetaTopicPartitions);
         offsetsByPartition.forEach((partition, offset) ->
                 consumer.seek(new TopicPartition(REMOTE_LOG_METADATA_TOPIC_NAME, partition), offset + 1));
+        readOffsetsByPartition.putAll(offsetsByPartition);
     }
 
     public void addAssignmentsForPartitions(Set<TopicIdPartition> partitions) {


### PR DESCRIPTION
This is a bugfix for the following scenario -

1. Topic A with remote storage is created. Let us say it corresponds to RLMM Topic Partition 0 (using the Murmur logic).
1. First segment (say, of size = 1 byte) gets ready for offloading to remote tier.

1. Inside an RLMTask thread
    1. RLMTask thread calls RLMM to create a RemoteLogSegmentMetadata with status = COPYING_STARTED.
    1. RLMM produces record indicating metadata change. https://github.com/linkedin/kafka/blob/cd465f92f2613250d12020f1bd2118132ff3c156/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java#L168
    1. RLMM starts waiting for this record to be processed https://github.com/linkedin/kafka/blob/cd465f92f2613250d12020f1bd2118132ff3c156/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java#L171
    1. `ConsumerManager` keeps waiting for the result from `PrimaryConsumerTask::receivedOffsetForPartition(0)` to increase.
https://github.com/linkedin/kafka/blob/cd465f92f2613250d12020f1bd2118132ff3c156/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java#L94-L98
    1. This method keeps returning the value in the `readOffsetsByPartition` field inside PrimaryConsumerTask.
https://github.com/linkedin/kafka/blob/cd465f92f2613250d12020f1bd2118132ff3c156/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/PrimaryConsumerTask.java#L355

1. Inside the request processing thread
    1. At around the same time as **2**, the leader receives a `LeaderAndIsrRequest` from the controller. These methods gets called in order
    ```
    RLM::onLeadershipChange
    RLMM::onPartitionLeadershipChanges
    TopicBasedRLMM::onPartitionLeadershipChanges
    ConsumerManager::addAssignmentsForPartitions
    PrimaryConsumerTask::addAssignmentsForPartitions
    PrimaryConsumerTask::updateAssignmentsForPartitions
    SecondaryConsumerTask::addPartitions
    ```

1. Inside the PrimaryConsumerTask thread known as `RLMMConsumerTask`,
    1. `SecondaryConsumerTask::maybeConsumeFromSecondaryConsumer` is called.
    2. This reads the record produced in **3.ii**. This calls back `PrimaryConsumerTask` with the list of offsets from which the `PrimaryConsumerTask` should consume.
https://github.com/linkedin/kafka/blob/cd465f92f2613250d12020f1bd2118132ff3c156/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/SecondaryConsumerTask.java#L146-L151
    3. `PrimaryConsumerTask::resumePartitionsForPrimaryConsumption` is called, which in turn calls `PrimaryConsumerTask::executeReassignmentAndSeek`.
https://github.com/linkedin/kafka/blob/cd465f92f2613250d12020f1bd2118132ff3c156/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/PrimaryConsumerTask.java#L196-L201
    4. This seeks the consumer to the offset to read from next. However, the `readOffsetsByPartition` map never gets updated. Hence, the RLMTask thread above keeps waiting and eventually fails unless a new message is produced on that metadata partition.
https://github.com/linkedin/kafka/blob/cd465f92f2613250d12020f1bd2118132ff3c156/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/PrimaryConsumerTask.java#L286-L287

In this PR, I have added code to update the offsets map, so that the RLMTask can confirm that the offset has been read.

This scenario can be replicated unreliably (only happens sometimes), when executing the `TransactionsTestWithTieredStore`.

This PR has also been raised against Satish's 2.8.x-tiered-storage branch https://github.com/satishd/kafka/pull/10

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
