### PR TITLE
Add tag for brokerId on metric maxRequestAge

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -271,8 +271,10 @@ extends ShutdownableThread(name = name) with KafkaMetricsGroup {
         if (latestRequestStatus.isInFlight || latestRequestStatus.isInQueue) time.milliseconds() - latestRequestStatus.enqueueTimeMs
         else 0
     },
-    Map("broker-id" -> brokerNode.id.toString)
+    brokerMetricTags(brokerNode.id())
   )
+
+  private def brokerMetricTags(brokerId: Int) = Map("broker-id" -> brokerId.toString)
 
   def backoff(): Unit = pause(100, TimeUnit.MILLISECONDS)
 
@@ -436,7 +438,7 @@ extends ShutdownableThread(name = name) with KafkaMetricsGroup {
   override def initiateShutdown(): Boolean = {
     if (super.initiateShutdown()) {
       networkClient.initiateClose()
-      removeMetric(MaxRequestAgeMetricName)
+      removeMetric(MaxRequestAgeMetricName, brokerMetricTags(brokerNode.id()))
       true
     } else
       false

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -270,7 +270,8 @@ extends ShutdownableThread(name = name) with KafkaMetricsGroup {
       def value: Long =
         if (latestRequestStatus.isInFlight || latestRequestStatus.isInQueue) time.milliseconds() - latestRequestStatus.enqueueTimeMs
         else 0
-    }
+    },
+    Map("broker-id" -> brokerNode.id.toString)
   )
 
   def backoff(): Unit = pause(100, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
In the precious commit 26a24fd2 we add a metric called "MaxRequestAge". Before create a sensor for it, we realized that we didn't attach a tag with broker id to id. This PR is to add brokerId as a tag for the metric.

Test will be run on tango cluster once this change is merged.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
