### PR TITLE
[LI-HOTFIX] Move info-level consumer logs on seeking to an offset to debug-level. (#89)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1582,7 +1582,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
         acquireAndEnsureOpen();
         try {
-            log.info("Seeking to offset {} for partition {}", offset, partition);
+            log.debug("Seeking to offset {} for partition {}", offset, partition);
             SubscriptionState.FetchPosition newPosition = new SubscriptionState.FetchPosition(
                     offset,
                     Optional.empty(), // This will ensure we skip validation
@@ -1612,10 +1612,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         acquireAndEnsureOpen();
         try {
             if (offsetAndMetadata.leaderEpoch().isPresent()) {
-                log.info("Seeking to offset {} for partition {} with epoch {}",
+                log.debug("Seeking to offset {} for partition {} with epoch {}",
                         offset, partition, offsetAndMetadata.leaderEpoch().get());
             } else {
-                log.info("Seeking to offset {} for partition {}", offset, partition);
+                log.debug("Seeking to offset {} for partition {}", offset, partition);
             }
             Metadata.LeaderAndEpoch currentLeaderAndEpoch = this.metadata.currentLeader(partition);
             SubscriptionState.FetchPosition newPosition = new SubscriptionState.FetchPosition(


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
Info-level logs cause a line to be logged for each partition seek. This leads to an excessive number of logs in Kafka consumer users with frequent seek operations.
Pre-2.3 versions of Kafka use debug-level logs for seek operations. This patch brings this behavior back.

EXIT_CRITERIA = TICKET [KAFKA-8883]