### PR TITLE
[LI-HOTFX] Allow passing client software name and version from producer/consumer to network client

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -66,6 +66,9 @@ public class CommonClientConfigs {
     public static final String CLIENT_ID_CONFIG = "client.id";
     public static final String CLIENT_ID_DOC = "An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.";
 
+    public static final String LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG = "li.client.software.name.and.commit";
+    public static final String LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_DOC = "A name string to indicate client software name and corresponding commit hash. The purpose of this is to be able to track/analyze clients beyond just client id";
+
     public static final String CLIENT_RACK_CONFIG = "client.rack";
     public static final String CLIENT_RACK_DOC = "A rack identifier for this client. This can be any string value which indicates where this client is physically located. It corresponds with the broker config 'broker.rack'";
 

--- a/clients/src/main/java/org/apache/kafka/clients/StaleClusterMetadataException.java
+++ b/clients/src/main/java/org/apache/kafka/clients/StaleClusterMetadataException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.errors.InvalidMetadataException;
+
+/**
+ * Thrown when current metadata is from a stale cluster that has a different cluster id
+ * than original cluster.
+ *
+ * Note: this is not a public API.
+ */
+public class StaleClusterMetadataException extends InvalidMetadataException {
+    private static final long serialVersionUID = 1L;
+
+    public StaleClusterMetadataException() {}
+
+    public StaleClusterMetadataException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -197,6 +197,11 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
 
     /**
+     * <code>li.client.software.name.and.commit</code>
+     * */
+    public static final String LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG = CommonClientConfigs.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG;
+
+    /**
      * <code>client.rack</code>
      */
     public static final String CLIENT_RACK_CONFIG = CommonClientConfigs.CLIENT_RACK_CONFIG;
@@ -401,6 +406,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         "",
                                         Importance.LOW,
                                         CommonClientConfigs.CLIENT_ID_DOC)
+                                .define(LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG,
+                                        Type.STRING,
+                                        "li-oss-consumer-java",
+                                        Importance.LOW,
+                                        CommonClientConfigs.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_DOC)
                                 .define(CLIENT_RACK_CONFIG,
                                         Type.STRING,
                                         "",

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -757,7 +757,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     true,
                     apiVersions,
                     throttleTimeSensor,
-                    logContext);
+                    logContext,
+                    config.getString(ConsumerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG));
+
             this.client = new ConsumerNetworkClient(
                     logContext,
                     netClient,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -466,7 +466,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 true,
                 apiVersions,
                 throttleTimeSensor,
-                logContext);
+                logContext,
+                producerConfig.getString(ProducerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG));
         short acks = configureAcks(producerConfig, log);
         return new Sender(logContext,
                 client,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -134,6 +134,9 @@ public class ProducerConfig extends AbstractConfig {
     /** <code>client.id</code> */
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
 
+    /** <code>li.client.software.name.and.commit</code> */
+    public static final String LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG = CommonClientConfigs.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG;
+
     /** <code>send.buffer.bytes</code> */
     public static final String SEND_BUFFER_CONFIG = CommonClientConfigs.SEND_BUFFER_CONFIG;
 
@@ -302,6 +305,7 @@ public class ProducerConfig extends AbstractConfig {
                                 .define(LINGER_MS_CONFIG, Type.LONG, 0, atLeast(0), Importance.MEDIUM, LINGER_MS_DOC)
                                 .define(DELIVERY_TIMEOUT_MS_CONFIG, Type.INT, 120 * 1000, atLeast(0), Importance.MEDIUM, DELIVERY_TIMEOUT_MS_DOC)
                                 .define(CLIENT_ID_CONFIG, Type.STRING, "", Importance.MEDIUM, CommonClientConfigs.CLIENT_ID_DOC)
+                                .define(LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG, Type.STRING, "li-oss-producer-java", Importance.LOW, CommonClientConfigs.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_DOC)
                                 .define(SEND_BUFFER_CONFIG, Type.INT, 128 * 1024, atLeast(CommonClientConfigs.SEND_BUFFER_LOWER_BOUND), Importance.MEDIUM, CommonClientConfigs.SEND_BUFFER_DOC)
                                 .define(RECEIVE_BUFFER_CONFIG, Type.INT, 32 * 1024, atLeast(CommonClientConfigs.RECEIVE_BUFFER_LOWER_BOUND), Importance.MEDIUM, CommonClientConfigs.RECEIVE_BUFFER_DOC)
                                 .define(MAX_REQUEST_SIZE_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -30,28 +30,54 @@ import java.nio.ByteBuffer;
 public class ApiVersionsRequest extends AbstractRequest {
 
     public static class Builder extends AbstractRequest.Builder<ApiVersionsRequest> {
-        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
+        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "linkedin-kafka-java";
 
-        private static final ApiVersionsRequestData DATA = new ApiVersionsRequestData()
-            .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
-            .setClientSoftwareVersion(AppInfoParser.getVersion());
+        private final ApiVersionsRequestData apiVersionsRequestData;
 
         public Builder() {
             super(ApiKeys.API_VERSIONS);
+            apiVersionsRequestData = new ApiVersionsRequestData()
+                .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(AppInfoParser.getVersion());
         }
 
         public Builder(short version) {
             super(ApiKeys.API_VERSIONS, version);
+            apiVersionsRequestData = new ApiVersionsRequestData()
+                .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(AppInfoParser.getVersion());
+        }
+
+        public Builder(String clientName) {
+            super(ApiKeys.API_VERSIONS);
+            if (clientName != null) {
+                apiVersionsRequestData = new ApiVersionsRequestData().setClientSoftwareName(clientName).setClientSoftwareVersion(AppInfoParser.getVersion());
+            } else {
+                apiVersionsRequestData = new ApiVersionsRequestData()
+                    .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
+                    .setClientSoftwareVersion(AppInfoParser.getVersion());
+            }
+        }
+
+        public Builder(short version, String clientName) {
+            super(ApiKeys.API_VERSIONS, version);
+            if (clientName != null) {
+                apiVersionsRequestData = new ApiVersionsRequestData().setClientSoftwareName(clientName).setClientSoftwareVersion(AppInfoParser.getVersion());
+            } else {
+                apiVersionsRequestData = new ApiVersionsRequestData()
+                    .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
+                    .setClientSoftwareVersion(AppInfoParser.getVersion());
+            }
         }
 
         @Override
         public ApiVersionsRequest build(short version) {
-            return new ApiVersionsRequest(DATA, version);
+            return new ApiVersionsRequest(apiVersionsRequestData, version);
         }
 
         @Override
         public String toString() {
-            return DATA.toString();
+            return apiVersionsRequestData.toString();
         }
     }
 


### PR DESCRIPTION


TICKET = N/A
LI_DESCRIPTION = Add config to pass customized client name from producer/consumer to ApiVersionsRequest

Starting from kafka 2.4, brokers are able to collect clients' version and name, see KIP-511 for more details.
With kafka 2.4 and linkedin-kafka-clients 10, we should make this name
unique so that in future when collecting user metrics, we can
distinguish supported clients from those using unsupported clients.

EXIT_CRITERIA = N/A
