### PR TITLE
[LI-HOTFIX]  Add log brokerid for admin client listTopics failure (#131)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1893,6 +1893,14 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             void handleResponse(AbstractResponse abstractResponse) {
                 MetadataResponse response = (MetadataResponse) abstractResponse;
+
+                // Check if any topic's metadata failed to get updated
+                Map<String, Errors> errors = response.errors();
+                if (!errors.isEmpty()) {
+                    String destination = this.curNode().idString();
+                    log.warn("Error while fetching metadata with from source {} with errors : {}", destination, errors);
+                }
+
                 Map<String, TopicListing> topicListing = new HashMap<>();
                 for (MetadataResponse.TopicMetadata topicMetadata : response.topicMetadata()) {
                     String topicName = topicMetadata.topic();


### PR DESCRIPTION
[LI-HOTFIX] Add log brokerid for admin client listTopics failure (#131)
TICKET = N/A
LI_DESCRIPTION = VENG-7361
In VENG-7361, sometimes KafkaAdminClient#listTopics will time out. This patch adds logs to help show the broker that served the listTopic request, which can help us understand the timeout.
EXIT_CRITERIA = N/A