### PR TITLE
  [LI-HOTFIX] Allow skipping metadata cache update when topic partition is unassigned

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -342,6 +342,13 @@ public class ConsumerConfig extends AbstractConfig {
             " be set to `false` when using brokers older than 0.11.0";
     public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = false;
 
+    /** <code>skip.metadata.cache.update.upon.unassign</code> */
+    public static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN = "linkedin.skip.metadata.cache.update.upon.unassign";
+    private static final String SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN_DOC = "Skip metadata cache update if the new " +
+            "partition assignment passed to the <code>assign</code> method is a subset of the current assignment since " +
+            "the consumer instance should already have metadata for assigned partitions.";
+    public static final boolean DEFAULT_SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN = false;
+
     /**
      * <code>security.providers</code>
      */
@@ -600,6 +607,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
                                         Importance.MEDIUM,
                                         ALLOW_AUTO_CREATE_TOPICS_DOC)
+                                .define(SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN,
+                                        Type.BOOLEAN,
+                                        DEFAULT_SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN,
+                                        Importance.LOW,
+                                        SKIP_METADATA_CACHE_UPDATE_UPON_UNASSIGN_DOC)
                                 // security support
                                 .define(SECURITY_PROVIDERS_CONFIG,
                                         Type.STRING,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -718,6 +718,10 @@ public class SubscriptionState {
         return assignment.contains(tp);
     }
 
+    public synchronized boolean areAllAssigned(Collection<TopicPartition> tps) {
+        return assignment.containsAll(tps);
+    }
+
     public synchronized boolean isPaused(TopicPartition tp) {
         TopicPartitionState assignedOrNull = assignedStateOrNull(tp);
         return assignedOrNull != null && assignedOrNull.isPaused();

--- a/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.internals;
 
+import java.util.Collection;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.ArrayList;
@@ -84,6 +85,10 @@ public class PartitionStates<S> {
 
     public boolean contains(TopicPartition topicPartition) {
         return map.containsKey(topicPartition);
+    }
+
+    public boolean containsAll(Collection<TopicPartition> topicPartitions) {
+        return map.keySet().containsAll(topicPartitions);
     }
 
     public Iterator<S> stateIterator() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -755,7 +755,7 @@ public class KafkaConsumerTest {
 
         // Case 1: Default behavior. Metadata cache updated requested upon every topic assignment change.
         KafkaConsumer<String, String> consumer = newConsumer(time, client, subscription, mockConsumerMetadata, assignor,
-                true, groupId, groupInstanceId, Optional.of(new StringDeserializer()),false,
+                true, groupId, groupInstanceId, Optional.of(new StringDeserializer()), false,
                  skipMetadataCacheUpdateUponUnassignment);
         consumer.assign(Arrays.asList(tp0, tp1));
         verify(mockConsumerMetadata, times(1)).requestUpdateForNewTopics();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -144,6 +144,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 
 public class KafkaConsumerTest {
     private final String topic = "test";
@@ -737,6 +741,42 @@ public class KafkaConsumerTest {
         // lookup committed offset and find nothing
         client.prepareResponseFrom(offsetResponse(Collections.singletonMap(tp0, -1L), Errors.NONE), coordinator);
         assertThrows(NoOffsetForPartitionException.class, () -> consumer.poll(Duration.ZERO));
+    }
+
+    @Test
+    public void testSkipMetadataCacheUpdate() {
+        Time time = new MockTime();
+        SubscriptionState subscription = new SubscriptionState(new LogContext(), OffsetResetStrategy.NONE);
+        ConsumerMetadata mockConsumerMetadata = mock(ConsumerMetadata.class);
+        MockClient client = new MockClient(time, mockConsumerMetadata);
+
+        ConsumerPartitionAssignor assignor = new RoundRobinAssignor();
+        boolean skipMetadataCacheUpdateUponUnassignment = false;
+
+        // Case 1: Default behavior. Metadata cache updated requested upon every topic assignment change.
+        KafkaConsumer<String, String> consumer = newConsumer(time, client, subscription, mockConsumerMetadata, assignor,
+                true, groupId, groupInstanceId, Optional.of(new StringDeserializer()),false,
+                 skipMetadataCacheUpdateUponUnassignment);
+        consumer.assign(Arrays.asList(tp0, tp1));
+        verify(mockConsumerMetadata, times(1)).requestUpdateForNewTopics();
+        consumer.assign(Arrays.asList(tp0, tp1, t2p0));
+        verify(mockConsumerMetadata, times(2)).requestUpdateForNewTopics();
+        consumer.assign(Arrays.asList(tp0, tp1));
+        verify(mockConsumerMetadata, times(3)).requestUpdateForNewTopics();
+
+        // Case 2: Skip metadata cache update.
+        skipMetadataCacheUpdateUponUnassignment = true;
+        subscription = new SubscriptionState(new LogContext(), OffsetResetStrategy.NONE);
+        mockConsumerMetadata = mock(ConsumerMetadata.class);
+        consumer = newConsumer(time, client, subscription, mockConsumerMetadata, assignor,
+                true, groupId, groupInstanceId, Optional.of(new StringDeserializer()), false,
+                skipMetadataCacheUpdateUponUnassignment);
+        consumer.assign(Arrays.asList(tp0, tp1));
+        verify(mockConsumerMetadata, times(1)).requestUpdateForNewTopics();
+        consumer.assign(Arrays.asList(tp0, tp1, t2p0));
+        verify(mockConsumerMetadata, times(2)).requestUpdateForNewTopics();
+        consumer.assign(Arrays.asList(tp0, tp1)); // Not trigger metadata cache update in this case
+        verify(mockConsumerMetadata, times(2)).requestUpdateForNewTopics();
     }
 
     @Test
@@ -1738,7 +1778,7 @@ public class KafkaConsumerTest {
         client.prepareResponseFrom(joinGroupFollowerResponse(assignor, 1, memberId, leaderId, Errors.NONE), coordinator);
         client.prepareResponseFrom(syncGroupResponse(singletonList(tp0), Errors.NONE), coordinator);
 
-        client.prepareResponseFrom(body -> body instanceof FetchRequest 
+        client.prepareResponseFrom(body -> body instanceof FetchRequest
             && ((FetchRequest) body).fetchData().containsKey(tp0), fetchResponse(tp0, 1, 1), node);
         time.sleep(heartbeatIntervalMs);
         Thread.sleep(heartbeatIntervalMs);
@@ -2493,6 +2533,21 @@ public class KafkaConsumerTest {
                                                       Optional<String> groupInstanceId,
                                                       Optional<Deserializer<String>> valueDeserializer,
                                                       boolean throwOnStableOffsetNotSupported) {
+        return newConsumer(time, client, subscription, metadata, assignor, autoCommitEnabled, groupId, groupInstanceId,
+            valueDeserializer, throwOnStableOffsetNotSupported, false);
+    }
+
+    private KafkaConsumer<String, String> newConsumer(Time time,
+                                                      KafkaClient client,
+                                                      SubscriptionState subscription,
+                                                      ConsumerMetadata metadata,
+                                                      ConsumerPartitionAssignor assignor,
+                                                      boolean autoCommitEnabled,
+                                                      String groupId,
+                                                      Optional<String> groupInstanceId,
+                                                      Optional<Deserializer<String>> valueDeserializer,
+                                                      boolean throwOnStableOffsetNotSupported,
+                                                      boolean skipMetadataCacheUpdateUponUnassignment) {
         String clientId = "mock-consumer";
         String metricGroupPrefix = "consumer";
         long retryBackoffMs = 100;
@@ -2580,7 +2635,8 @@ public class KafkaConsumerTest {
                 requestTimeoutMs,
                 defaultApiTimeoutMs,
                 assignors,
-                groupId);
+                groupId,
+                skipMetadataCacheUpdateUponUnassignment);
     }
 
     private static class FetchInfo {


### PR DESCRIPTION
  TICKET = KAFKA-12854
  LI_DESCRIPTION = Introduce a config to allow skipping metadata cache update when a topic partition is un-assigned from the current consumer consuming assignment. The purpose is to reduce the rate of metadata requests sent from consumer instances to Kafka server when there are a significant number of consumer instances. See the description section of LIKAFKA-36680 for more context.

 (cherry picked from commit ad4cf85842db8fe4e743a2b42404a5a28599dd5a)
 Resolved merge conflicts
EXIT_CRITERIA = TICKET [KAFKA-12854]
