### PR TITLE
[LI-HOTFIX] Add fetchState information in NoOffsetForPartitionException (#238)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/NoOffsetForPartitionException.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/NoOffsetForPartitionException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.internals.SubscriptionState;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collection;
@@ -32,15 +35,24 @@ public class NoOffsetForPartitionException extends InvalidOffsetException {
     private static final long serialVersionUID = 1L;
 
     private final Set<TopicPartition> partitions;
+    private final Map<TopicPartition, SubscriptionState.FetchState> partitionFetchStates;
 
     public NoOffsetForPartitionException(TopicPartition partition) {
         super("Undefined offset with no reset policy for partition: " + partition);
         this.partitions = Collections.singleton(partition);
+        this.partitionFetchStates = Collections.emptyMap();
     }
 
     public NoOffsetForPartitionException(Collection<TopicPartition> partitions) {
         super("Undefined offset with no reset policy for partitions: " + partitions);
         this.partitions = Collections.unmodifiableSet(new HashSet<>(partitions));
+        this.partitionFetchStates = Collections.emptyMap();
+    }
+
+    public NoOffsetForPartitionException(Map<TopicPartition, SubscriptionState.FetchState> partitionFetchStates) {
+        super("Undefined offset with no reset policy for partitionss with states: " + partitionFetchStates);
+        this.partitionFetchStates = Collections.unmodifiableMap(new HashMap<>(partitionFetchStates));
+        this.partitions = Collections.emptySet();
     }
 
     /**
@@ -51,4 +63,11 @@ public class NoOffsetForPartitionException extends InvalidOffsetException {
         return partitions;
     }
 
+    /**
+     * returns a map of all partitions for which no offset are defined, and their respective fetch states
+     * @return all partitions with no offset and their respective fetch states
+     */
+    public Map<TopicPartition, SubscriptionState.FetchState> partitionFetchStates() {
+        return partitionFetchStates;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -692,18 +692,18 @@ public class SubscriptionState {
 
 
     public synchronized void resetInitializingPositions() {
-        final Set<TopicPartition> partitionsWithNoOffsets = new HashSet<>();
+        final Map<TopicPartition, FetchState> partitionsWithNoOffsetsAndStates = new HashMap<>();
         assignment.forEach((tp, partitionState) -> {
             if (partitionState.fetchState.equals(FetchStates.INITIALIZING)) {
                 if (defaultResetStrategy == OffsetResetStrategy.NONE)
-                    partitionsWithNoOffsets.add(tp);
+                    partitionsWithNoOffsetsAndStates.put(tp, partitionState.fetchState);
                 else
                     requestOffsetReset(tp);
             }
         });
 
-        if (!partitionsWithNoOffsets.isEmpty())
-            throw new NoOffsetForPartitionException(partitionsWithNoOffsets);
+        if (!partitionsWithNoOffsetsAndStates.isEmpty())
+            throw new NoOffsetForPartitionException(partitionsWithNoOffsetsAndStates);
     }
 
     public synchronized Set<TopicPartition> partitionsNeedingReset(long nowMs) {
@@ -773,7 +773,7 @@ public class SubscriptionState {
         private Integer preferredReadReplica;
         private Long preferredReadReplicaExpireTimeMs;
         private boolean endOffsetRequested;
-        
+
         TopicPartitionState() {
             this.paused = false;
             this.endOffsetRequested = false;
@@ -793,6 +793,10 @@ public class SubscriptionState {
 
         public void requestEndOffset() {
             endOffsetRequested = true;
+        }
+
+        public FetchState getFetchState() {
+            return fetchState;
         }
 
         private void transitionState(FetchState newState, Runnable runIfTransitioned) {
@@ -996,7 +1000,7 @@ public class SubscriptionState {
      * The fetch state of a partition. This class is used to determine valid state transitions and expose the some of
      * the behavior of the current fetch state. Actual state variables are stored in the {@link TopicPartitionState}.
      */
-    interface FetchState {
+    public interface FetchState {
         default FetchState transitionTo(FetchState newState) {
             if (validTransitions().contains(newState)) {
                 return newState;


### PR DESCRIPTION
TICKET = LIKAFKA-40747
LI_DESCRIPTION =
A potential reason for NoOffsetForPartitionException is the transition of FetchState for partitions to any state other than INITIALIZING (e.g. offset_reset). However, there are not enough logs on the client side to see if that was the case. Add logs in the exception message to track the actual fetch state of partitions when a NoOffsetForPartitionException is thrown.

(cherry picked from commit aaf8c8d76f2a5d3eced83e8bf6265d7243d6278b)