### PR TITLE
[LI-HOTFX] Allow passing client software name and version from producer/consumer to network client

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -66,6 +66,9 @@ public class CommonClientConfigs {
     public static final String CLIENT_ID_CONFIG = "client.id";
     public static final String CLIENT_ID_DOC = "An id string to pass to the server when making requests. The purpose of this is to be able to track the source of requests beyond just ip/port by allowing a logical application name to be included in server-side request logging.";
 
+    public static final String LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG = "li.client.software.name.and.commit";
+    public static final String LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_DOC = "A name string to indicate client software name and corresponding commit hash. The purpose of this is to be able to track/analyze clients beyond just client id";
+
     public static final String CLIENT_RACK_CONFIG = "client.rack";
     public static final String CLIENT_RACK_DOC = "A rack identifier for this client. This can be any string value which indicates where this client is physically located. It corresponds with the broker config 'broker.rack'";
 

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -102,6 +102,9 @@ public class NetworkClient implements KafkaClient {
     /* the client id used to identify this client in requests to the server */
     private final String clientId;
 
+    /* the client software name and commit hash */
+    private final String clientSoftwareNameAndCommit;
+
     /* the current correlation id to use when sending requests to servers */
     private int correlation;
 
@@ -158,7 +161,8 @@ public class NetworkClient implements KafkaClient {
              discoverBrokerVersions,
              apiVersions,
              null,
-             logContext);
+             logContext,
+             null);
     }
 
     public NetworkClient(Selectable selector,
@@ -194,7 +198,46 @@ public class NetworkClient implements KafkaClient {
              apiVersions,
              throttleTimeSensor,
              logContext,
-             new DefaultHostResolver());
+             new DefaultHostResolver(),
+             null);
+    }
+
+    public NetworkClient(Selectable selector,
+                         Metadata metadata,
+                         String clientId,
+                         int maxInFlightRequestsPerConnection,
+                         long reconnectBackoffMs,
+                         long reconnectBackoffMax,
+                         int socketSendBuffer,
+                         int socketReceiveBuffer,
+                         int defaultRequestTimeoutMs,
+                         long connectionSetupTimeoutMs,
+                         long connectionSetupTimeoutMaxMs,
+                         Time time,
+                         boolean discoverBrokerVersions,
+                         ApiVersions apiVersions,
+                         Sensor throttleTimeSensor,
+                         LogContext logContext,
+                         String clientSoftwareNameAndCommit) {
+        this(null,
+            metadata,
+            selector,
+            clientId,
+            maxInFlightRequestsPerConnection,
+            reconnectBackoffMs,
+            reconnectBackoffMax,
+            socketSendBuffer,
+            socketReceiveBuffer,
+            defaultRequestTimeoutMs,
+            connectionSetupTimeoutMs,
+            connectionSetupTimeoutMaxMs,
+            time,
+            discoverBrokerVersions,
+            apiVersions,
+            throttleTimeSensor,
+            logContext,
+            new DefaultHostResolver(),
+            clientSoftwareNameAndCommit);
     }
 
     public NetworkClient(Selectable selector,
@@ -229,7 +272,46 @@ public class NetworkClient implements KafkaClient {
              apiVersions,
              null,
              logContext,
-             new DefaultHostResolver());
+             new DefaultHostResolver(),
+             null);
+    }
+    public NetworkClient(MetadataUpdater metadataUpdater,
+        Metadata metadata,
+        Selectable selector,
+        String clientId,
+        int maxInFlightRequestsPerConnection,
+        long reconnectBackoffMs,
+        long reconnectBackoffMax,
+        int socketSendBuffer,
+        int socketReceiveBuffer,
+        int defaultRequestTimeoutMs,
+        long connectionSetupTimeoutMs,
+        long connectionSetupTimeoutMaxMs,
+        Time time,
+        boolean discoverBrokerVersions,
+        ApiVersions apiVersions,
+        Sensor throttleTimeSensor,
+        LogContext logContext,
+        HostResolver hostResolver) {
+        this(metadataUpdater,
+            metadata,
+            selector,
+            clientId,
+            maxInFlightRequestsPerConnection,
+            reconnectBackoffMs,
+            reconnectBackoffMax,
+            socketSendBuffer,
+            socketReceiveBuffer,
+            defaultRequestTimeoutMs,
+            connectionSetupTimeoutMs,
+            connectionSetupTimeoutMaxMs,
+            time,
+            discoverBrokerVersions,
+            apiVersions,
+            throttleTimeSensor,
+            logContext,
+            hostResolver,
+            null);
     }
 
     public NetworkClient(MetadataUpdater metadataUpdater,
@@ -249,7 +331,8 @@ public class NetworkClient implements KafkaClient {
                          ApiVersions apiVersions,
                          Sensor throttleTimeSensor,
                          LogContext logContext,
-                         HostResolver hostResolver) {
+                         HostResolver hostResolver,
+                         String clientSoftwareNameAndCommit) {
         /* It would be better if we could pass `DefaultMetadataUpdater` from the public constructor, but it's not
          * possible because `DefaultMetadataUpdater` is an inner class and it can only be instantiated after the
          * super constructor is invoked.
@@ -263,6 +346,7 @@ public class NetworkClient implements KafkaClient {
         }
         this.selector = selector;
         this.clientId = clientId;
+        this.clientSoftwareNameAndCommit = clientSoftwareNameAndCommit;
         this.inFlightRequests = new InFlightRequests(maxInFlightRequestsPerConnection);
         this.connectionStates = new ClusterConnectionStates(
                 reconnectBackoffMs, reconnectBackoffMax,
@@ -911,7 +995,7 @@ public class NetworkClient implements KafkaClient {
                         maxApiVersion = apiVersion.maxVersion();
                     }
                 }
-                nodesNeedingApiVersionsFetch.put(node, new ApiVersionsRequest.Builder(maxApiVersion));
+                nodesNeedingApiVersionsFetch.put(node, new ApiVersionsRequest.Builder(maxApiVersion, this.clientSoftwareNameAndCommit));
             }
             return;
         }
@@ -948,7 +1032,7 @@ public class NetworkClient implements KafkaClient {
             // connection.
             if (discoverBrokerVersions) {
                 this.connectionStates.checkingApiVersions(node);
-                nodesNeedingApiVersionsFetch.put(node, new ApiVersionsRequest.Builder());
+                nodesNeedingApiVersionsFetch.put(node, new ApiVersionsRequest.Builder(this.clientSoftwareNameAndCommit));
                 log.debug("Completed connection to node {}. Fetching API versions.", node);
             } else {
                 this.connectionStates.ready(node);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -197,6 +197,11 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
 
     /**
+     * <code>li.client.software.name.and.commit</code>
+     * */
+    public static final String LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG = CommonClientConfigs.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG;
+
+    /**
      * <code>client.rack</code>
      */
     public static final String CLIENT_RACK_CONFIG = CommonClientConfigs.CLIENT_RACK_CONFIG;
@@ -401,6 +406,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         "",
                                         Importance.LOW,
                                         CommonClientConfigs.CLIENT_ID_DOC)
+                                .define(LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG,
+                                        Type.STRING,
+                                        "li-oss-consumer-java",
+                                        Importance.LOW,
+                                        CommonClientConfigs.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_DOC)
                                 .define(CLIENT_RACK_CONFIG,
                                         Type.STRING,
                                         "",

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -757,7 +757,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     true,
                     apiVersions,
                     throttleTimeSensor,
-                    logContext);
+                    logContext,
+                    config.getString(ConsumerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG));
+
             this.client = new ConsumerNetworkClient(
                     logContext,
                     netClient,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -479,7 +479,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 apiVersions,
                 throttleTimeSensor,
                 logContext,
-            producerConfig.getString(ProducerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG));
+                producerConfig.getString(ProducerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG));
         short acks = configureAcks(producerConfig, log);
         return new Sender(logContext,
                 client,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -478,7 +478,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 true,
                 apiVersions,
                 throttleTimeSensor,
-                logContext);
+                logContext,
+            producerConfig.getString(ProducerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG));
         short acks = configureAcks(producerConfig, log);
         return new Sender(logContext,
                 client,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -134,6 +134,9 @@ public class ProducerConfig extends AbstractConfig {
     /** <code>client.id</code> */
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
 
+    /** <code>li.client.software.name.and.commit</code> */
+    public static final String LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG = CommonClientConfigs.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG;
+
     /** <code>send.buffer.bytes</code> */
     public static final String SEND_BUFFER_CONFIG = CommonClientConfigs.SEND_BUFFER_CONFIG;
 
@@ -302,6 +305,7 @@ public class ProducerConfig extends AbstractConfig {
                                 .define(LINGER_MS_CONFIG, Type.LONG, 0, atLeast(0), Importance.MEDIUM, LINGER_MS_DOC)
                                 .define(DELIVERY_TIMEOUT_MS_CONFIG, Type.INT, 120 * 1000, atLeast(0), Importance.MEDIUM, DELIVERY_TIMEOUT_MS_DOC)
                                 .define(CLIENT_ID_CONFIG, Type.STRING, "", Importance.MEDIUM, CommonClientConfigs.CLIENT_ID_DOC)
+                                .define(LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG, Type.STRING, "li-oss-producer-java", Importance.LOW, CommonClientConfigs.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_DOC)
                                 .define(SEND_BUFFER_CONFIG, Type.INT, 128 * 1024, atLeast(CommonClientConfigs.SEND_BUFFER_LOWER_BOUND), Importance.MEDIUM, CommonClientConfigs.SEND_BUFFER_DOC)
                                 .define(RECEIVE_BUFFER_CONFIG, Type.INT, 32 * 1024, atLeast(CommonClientConfigs.RECEIVE_BUFFER_LOWER_BOUND), Importance.MEDIUM, CommonClientConfigs.RECEIVE_BUFFER_DOC)
                                 .define(MAX_REQUEST_SIZE_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -30,28 +30,54 @@ import java.nio.ByteBuffer;
 public class ApiVersionsRequest extends AbstractRequest {
 
     public static class Builder extends AbstractRequest.Builder<ApiVersionsRequest> {
-        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "apache-kafka-java";
+        private static final String DEFAULT_CLIENT_SOFTWARE_NAME = "linkedin-kafka-java";
 
-        private static final ApiVersionsRequestData DATA = new ApiVersionsRequestData()
-            .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
-            .setClientSoftwareVersion(AppInfoParser.getVersion());
+        private final ApiVersionsRequestData apiVersionsRequestData;
 
         public Builder() {
             super(ApiKeys.API_VERSIONS);
+            apiVersionsRequestData = new ApiVersionsRequestData()
+                .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(AppInfoParser.getVersion());
         }
 
         public Builder(short version) {
             super(ApiKeys.API_VERSIONS, version);
+            apiVersionsRequestData = new ApiVersionsRequestData()
+                .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
+                .setClientSoftwareVersion(AppInfoParser.getVersion());
+        }
+
+        public Builder(String clientName) {
+            super(ApiKeys.API_VERSIONS);
+            if (clientName != null) {
+                apiVersionsRequestData = new ApiVersionsRequestData().setClientSoftwareName(clientName).setClientSoftwareVersion(AppInfoParser.getVersion());
+            } else {
+                apiVersionsRequestData = new ApiVersionsRequestData()
+                    .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
+                    .setClientSoftwareVersion(AppInfoParser.getVersion());
+            }
+        }
+
+        public Builder(short version, String clientName) {
+            super(ApiKeys.API_VERSIONS, version);
+            if (clientName != null) {
+                apiVersionsRequestData = new ApiVersionsRequestData().setClientSoftwareName(clientName).setClientSoftwareVersion(AppInfoParser.getVersion());
+            } else {
+                apiVersionsRequestData = new ApiVersionsRequestData()
+                    .setClientSoftwareName(DEFAULT_CLIENT_SOFTWARE_NAME)
+                    .setClientSoftwareVersion(AppInfoParser.getVersion());
+            }
         }
 
         @Override
         public ApiVersionsRequest build(short version) {
-            return new ApiVersionsRequest(DATA, version);
+            return new ApiVersionsRequest(apiVersionsRequestData, version);
         }
 
         @Override
         public String toString() {
-            return DATA.toString();
+            return apiVersionsRequestData.toString();
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -114,7 +114,7 @@ public class SaslServerAuthenticatorTest {
     @Test
     public void testLatestApiVersionsRequest() throws IOException {
         testApiVersionsRequest(ApiKeys.API_VERSIONS.latestVersion(),
-            "apache-kafka-java", AppInfoParser.getVersion());
+            "linkedin-kafka-java", AppInfoParser.getVersion());
     }
 
     private void testApiVersionsRequest(short version, String expectedSoftwareName,

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -270,7 +270,7 @@ class SocketServerTest {
   def testClientInformationWithLatestApiVersionsRequest(): Unit = {
     testClientInformation(
       ApiKeys.API_VERSIONS.latestVersion,
-      "apache-kafka-java",
+      "linkedin-kafka-java",
       AppInfoParser.getVersion
     )
   }


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION = Add config to pass customized client name from producer/consumer to ApiVersionsRequest.

Starting from kafka 2.4, brokers are able to collect clients' version and name, see KIP-511 for more details.
With kafka 2.4 and linkedin-kafka-clients 10, we should make this name unique so that in future when collecting user metrics, we can distinguish supported clients from those using unsupported clients.
Fixed tests and merged conflicts
EXIT_CRITERIA = N/A

Co-authored-by: Ke Hu <kehu@kehu-mn2.linkedin.biz>
(cherry picked from commit 011ebf8107985ecfea5d850c662702652b3dde7f)

