### PR TITLE
[LI-HOTFIX] Exclude the partitions info in the MetadataResponse for listTopics() API

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1887,7 +1887,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             MetadataRequest.Builder createRequest(int timeoutMs) {
-                return MetadataRequest.Builder.allTopics();
+                return MetadataRequest.Builder.allTopicsOnly();
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -36,6 +36,8 @@ public class MetadataRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<MetadataRequest> {
         private static final MetadataRequestData ALL_TOPICS_REQUEST_DATA = new MetadataRequestData().
             setTopics(null).setAllowAutoTopicCreation(true);
+        private static final MetadataRequestData ALL_TOPICS_ONLY_REQUEST_DATA = new MetadataRequestData().
+                setTopics(null).setAllowAutoTopicCreation(false).setExcludePartitions(true);
 
         private final MetadataRequestData data;
 
@@ -69,6 +71,10 @@ public class MetadataRequest extends AbstractRequest {
             // This never causes auto-creation, but we set the boolean to true because that is the default value when
             // deserializing V2 and older. This way, the value is consistent after serialization and deserialization.
             return new Builder(ALL_TOPICS_REQUEST_DATA);
+        }
+
+        public static Builder allTopicsOnly() {
+            return new Builder(ALL_TOPICS_ONLY_REQUEST_DATA);
         }
 
         public boolean emptyTopicList() {
@@ -163,6 +169,10 @@ public class MetadataRequest extends AbstractRequest {
 
     public boolean allowAutoTopicCreation() {
         return data.allowAutoTopicCreation();
+    }
+
+    public boolean excludePartitions() {
+        return data.excludePartitions();
     }
 
     public static MetadataRequest parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -282,6 +282,14 @@ public class MetadataResponse extends AbstractResponse {
             this(error, topic, Uuid.ZERO_UUID, isInternal, partitionMetadata, AUTHORIZED_OPERATIONS_OMITTED);
         }
 
+        private static final List<PartitionMetadata> EMPTY_PARTITION_METADATA = Collections.emptyList();
+
+        public TopicMetadata(Errors error,
+                             String topic,
+                             boolean isInternal) {
+            this(error, topic, isInternal, EMPTY_PARTITION_METADATA);
+        }
+
         public Errors error() {
             return error;
         }

--- a/clients/src/main/resources/common/message/MetadataRequest.json
+++ b/clients/src/main/resources/common/message/MetadataRequest.json
@@ -49,6 +49,8 @@
     { "name": "IncludeClusterAuthorizedOperations", "type": "bool", "versions": "8-10",
       "about": "Whether to include cluster authorized operations." },
     { "name": "IncludeTopicAuthorizedOperations", "type": "bool", "versions": "8+",
-      "about": "Whether to include topic authorized operations." }
+      "about": "Whether to include topic authorized operations." },
+    { "name": "ExcludePartitions", "type": "bool", "tag": 0, "taggedVersions": "9+", "versions": "9+", "default": "false",
+      "about": "Whether to exclude partitions in the MetadataResponse." }
   ]
 }


### PR DESCRIPTION
Compared to the original implementation, which uses the topic names directly during `excludePartitions = true`, this new implementation will still visit the metadata cache in order to obtain the topic Id info.


This is a squash of 2 commits:
* [LI-HOTFIX] Exclude the partitions info in the MetadataResponse for the listTopics() API (#183)
* [LI-HOTFIX] Making the ExcludePartitions field in MetadataRequest an optional field (#193)

==1st commit message==

[LI-HOTFIX] Exclude the partitions info in the MetadataResponse for the listTopics() API (#183)

TICKET = LIKAFKA-37320
LI_DESCRIPTION = Making the listTopics() API more light-weight so that a kafka broker would only return the topic names in the MetadataResponse. The partitions and replicas info would not be included in the MetadataResponse for the listTopics() API.

EXIT_CRITERIA = When this change is merged in upstream and the corresponding change is pulled into a future release.

==2nd commit message==

[LI-HOTFIX] Making the ExcludePartitions field in MetadataRequest an optional field (#193)

TICKET = LIKAFKA-37320
LI_DESCRIPTION =
After the change made in b28666d5d8ff72f3cc595dcafbc17383253749a4,
an old client version sending a MetadataRequest without the "ExcludePartitions"
field to a new kafka server version expecting the field will result in the exception below.
This PR turns the "ExcludePartitions" field into an optional one introduced in KIP-482.

org.apache.kafka.common.errors.InvalidRequestException: Error getting request for apiKey: METADATA, apiVersion: 9, connectionId: 10.154.165.183:16637-10.154.87.109:44876-2848, listenerName: ListenerName(SSL), principal: User:likafka-cruise-control:None:prod-ltx1
        at org.apache.kafka.common.requests.RequestContext.parseRequest(RequestContext.java:70) ~[kafka-clients-2.4.1.26.jar:?]
        at kafka.network.RequestChannel$Request.<init>(RequestChannel.scala:89) ~[kafka_2.12-2.4.1.26.jar:?]
        at kafka.network.Processor.$anonfun$processCompletedReceives$1(SocketServer.scala:928) ~[kafka_2.12-2.4.1.26.jar:?]
        at kafka.network.Processor.$anonfun$processCompletedReceives$1$adapted(SocketServer.scala:909) ~[kafka_2.12-2.4.1.26.jar:?]
        at scala.collection.Iterator.foreach(Iterator.scala:941) [scala-library-2.12.10.jar:?]
        at scala.collection.Iterator.foreach$(Iterator.scala:941) [scala-library-2.12.10.jar:?]
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1429) [scala-library-2.12.10.jar:?]
        at scala.collection.IterableLike.foreach(IterableLike.scala:74) [scala-library-2.12.10.jar:?]
        at scala.collection.IterableLike.foreach$(IterableLike.scala:73) [scala-library-2.12.10.jar:?]
        at scala.collection.AbstractIterable.foreach(Iterable.scala:56) [scala-library-2.12.10.jar:?]
        at kafka.network.Processor.processCompletedReceives(SocketServer.scala:909) [kafka_2.12-2.4.1.26.jar:?]
        at kafka.network.Processor.run(SocketServer.scala:799) [kafka_2.12-2.4.1.26.jar:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: org.apache.kafka.common.protocol.types.SchemaException: Error reading field '_tagged_fields': java.nio.BufferUnderflowException
        at org.apache.kafka.common.protocol.types.Schema.read(Schema.java:118) ~[kafka-clients-2.4.1.26.jar:?]
        at org.apache.kafka.common.protocol.ApiKeys.parseRequest(ApiKeys.java:327) ~[kafka-clients-2.4.1.26.jar:?]
        at org.apache.kafka.common.requests.RequestContext.parseRequest(RequestContext.java:65) ~[kafka-clients-2.4.1.26.jar:?]
        ... 12 more

EXIT_CRITERIA = When this change is merged in upstream and the corresponding change is pulled into a future release.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
