### PR TITLE
[LI-HOTFIX] Parallelize async fetcher shutdown

### DIFF
--- a/core/src/main/scala/kafka/server/AsyncAbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AsyncAbstractFetcherManager.scala
@@ -25,7 +25,6 @@ import org.apache.kafka.common.{KafkaFuture, TopicPartition}
 import org.apache.kafka.common.utils.Utils
 
 import scala.collection.{Map, Set, mutable}
-import scala.collection.mutable.ArrayBuffer
 
 abstract class AsyncAbstractFetcherManager[T <: FetcherEventManager](val name: String, clientId: String, numFetchers: Int)
   extends FetcherManagerTrait with Logging with KafkaMetricsGroup {
@@ -241,9 +240,11 @@ abstract class AsyncAbstractFetcherManager[T <: FetcherEventManager](val name: S
   def closeAllFetchers(): Unit = {
     lock synchronized {
       for ( (_, fetcher) <- fetcherThreadMap) {
-        fetcher.close()
+        fetcher.initShutdown()
       }
-
+      for ( (_, fetcher) <- fetcherThreadMap) {
+        fetcher.awaitShutdown()
+      }
       fetcherThreadMap.clear()
     }
   }

--- a/core/src/main/scala/kafka/server/FetcherEventManager.scala
+++ b/core/src/main/scala/kafka/server/FetcherEventManager.scala
@@ -118,10 +118,13 @@ class FetcherEventManager(name: String,
     future
   }
 
-  def close(): Unit = {
+  def initShutdown(): Unit = {
+    thread.initiateShutdown()
+    fetcherEventBus.close()
+  }
+
+  def awaitShutdown(): Unit = {
     try {
-      thread.initiateShutdown()
-      fetcherEventBus.close()
       thread.awaitShutdown()
     } finally {
       removeMetric(EventQueueTimeMetricName)
@@ -132,6 +135,10 @@ class FetcherEventManager(name: String,
     processor.close()
   }
 
+  def close(): Unit = {
+    initShutdown()
+    awaitShutdown()
+  }
 
   class FetcherEventThread(name: String) extends ShutdownableThread(name = name, isInterruptible = false) {
     logIdent = s"[FetcherEventThread fetcherId=$name] "


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
We found that the shutdown process may be slow due to
the sequential shutdown of async fetcher threads.
This PR addresses this problem by parallelizing async fetcher shutdowns.

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
