### PR TITLE
[LI-HOTFIX] add 2 more algorithms for least loaded node selection

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/LeastLoadedNodeAlgorithm.java
+++ b/clients/src/main/java/org/apache/kafka/clients/LeastLoadedNodeAlgorithm.java
@@ -24,15 +24,30 @@ package org.apache.kafka.clients;
 public enum LeastLoadedNodeAlgorithm {
   /**
    * default upstream kafka selection algorithm.
-   * attempts to minimize latency, but may resuult in stickiness
+   * attempts to minimize latency, but may result in stickiness
    * and hammering of dedicated controllers and brokers down
    * for maintenance
    */
   VANILLA,
   /**
-   * selects a random broker out of 3 candidates. candidates are preferrably
+   * selects a random broker out of 3 candidates. candidates are preferably
    * brokers with existing connections, but new connections will be initiated
    * to get the candidate pool up to 3.
    */
-  AT_LEAST_THREE
+  AT_LEAST_THREE,
+  /**
+   * selects a random broker out of all nodes except those for which the number
+   * of requests in flight is already at max.
+   * NOTE - this is expected to result in a lot of open sockets per client
+   * (worst case being one per broker)
+   */
+  RANDOM,
+  /**
+   * designed by an esteemed kafka SRE, this algorithm selects a broker out
+   * of the top 15 brokers EXCEPT the top 5 (so random broker out of brokers
+   * 5 to 15 in the best candidates structure). the idea is that the top 5
+   * may be dedicated controllers and/or brokers in maintenance mode, both
+   * of which we want to avoid hitting from clients
+   */
+  RANDOM_BETWEEN_5_TO_15
 }


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION = vanilla logic can lead to clients being sticky to the same broker, which can cause issues. added new mode to spread out the MD requests a bit more.
EXIT_CRITERIA = N/A

Co-authored-by: Radai Rosenblatt <rrosenbl@rrosenbl-mn1.linkedin.biz>
fix merge conflicts
(cherry picked from commit 0d2abca68cda56d899fefbb3fa8568c00d379423)
