### PR TITLE
[LI-HOTFIX] Add rate metrics for metadata request sent by Kafka clients

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
@@ -41,6 +41,8 @@ public class FetcherMetricsRegistry {
     public MetricNameTemplate recordsLeadMin;
     public MetricNameTemplate fetchThrottleTimeAvg;
     public MetricNameTemplate fetchThrottleTimeMax;
+    public MetricNameTemplate metadataRequestRate;
+    public MetricNameTemplate metadataRequestTotal;
     public MetricNameTemplate topicFetchSizeAvg;
     public MetricNameTemplate topicFetchSizeMax;
     public MetricNameTemplate topicBytesConsumedRate;
@@ -94,7 +96,10 @@ public class FetcherMetricsRegistry {
                 "The number of fetch requests per second.", tags);
         this.fetchRequestTotal = new MetricNameTemplate("fetch-total", groupName,
                 "The total number of fetch requests.", tags);
-
+        this.metadataRequestTotal = new MetricNameTemplate("consumer-metadata-request-total",
+            "consumer-metrics", "The total number of metadata requests sent by the consumer", tags);
+        this.metadataRequestRate = new MetricNameTemplate("consumer-metadata-request-rate", "consumer-metrics",
+            "The average per-second number of metadata request sent by the consumer", tags);
         this.recordsLagMax = new MetricNameTemplate("records-lag-max", groupName,
                 "The maximum lag in terms of number of records for any partition in this window", tags);
         this.recordsLeadMin = new MetricNameTemplate("records-lead-min", groupName,
@@ -175,7 +180,9 @@ public class FetcherMetricsRegistry {
             partitionRecordsLead,
             partitionRecordsLeadMin,
             partitionRecordsLeadAvg,
-            partitionPreferredReadReplica
+            partitionPreferredReadReplica,
+            metadataRequestRate,
+            metadataRequestTotal
         );
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/KafkaConsumerMetrics.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.metrics.stats.Max;
 
 import java.util.concurrent.TimeUnit;
 
+
 public class KafkaConsumerMetrics implements AutoCloseable {
     private final MetricName lastPollMetricName;
     private final Sensor timeBetweenPollSensor;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -436,7 +436,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         logContext,
                         clusterResourceListeners,
                         Time.SYSTEM,
-                        config.getBoolean(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG));
+                        config.getBoolean(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
+                        metrics);
                 this.metadata.bootstrap(addresses);
             }
             this.errors = this.metrics.sensor("errors");
@@ -1067,6 +1068,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             }
             metadata.add(topic, nowMs + elapsed);
             int version = metadata.requestUpdateForTopic(topic);
+            metadata.recordMetadataRequest();
             sender.wakeup();
             try {
                 metadata.awaitUpdate(version, remainingWaitMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -344,6 +344,8 @@ public class Sender implements Runnable {
             log.debug("Requesting metadata update due to unknown leader topics from the batched records: {}",
                 result.unknownLeaderTopics);
             this.metadata.requestUpdate();
+            this.metadata.recordMetadataRequest();
+
         }
 
         // remove any nodes we aren't ready to send to
@@ -487,6 +489,7 @@ public class Sender implements Runnable {
             // For non-coordinator requests, sleep here to prevent a tight loop when no node is available
             time.sleep(retryBackoffMs);
             metadata.requestUpdate();
+            metadata.recordMetadataRequest();
         }
 
         transactionManager.retry(nextRequestHandler);
@@ -644,6 +647,7 @@ public class Sender implements Runnable {
                             error.exception(response.errorMessage).toString());
                 }
                 metadata.requestUpdate();
+                metadata.recordMetadataRequest();
             }
         } else {
             completeBatch(batch, response);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/SenderMetricsRegistry.java
@@ -41,7 +41,7 @@ public class SenderMetricsRegistry {
     public final MetricName recordQueueTimeAvg;
     public final MetricName recordQueueTimeMax;
     public final MetricName requestLatencyAvg;
-    public final MetricName requestLatencyMax;   
+    public final MetricName requestLatencyMax;
     public final MetricName produceThrottleTimeAvg;
     public final MetricName produceThrottleTimeMax;
     public final MetricName recordSendRate;
@@ -67,7 +67,7 @@ public class SenderMetricsRegistry {
     private final MetricNameTemplate topicRecordRetryTotal;
     private final MetricNameTemplate topicRecordErrorRate;
     private final MetricNameTemplate topicRecordErrorTotal;
-    
+
     private final Metrics metrics;
     private final Set<String> tags;
     private final LinkedHashSet<String> topicTags;
@@ -76,9 +76,9 @@ public class SenderMetricsRegistry {
         this.metrics = metrics;
         this.tags = this.metrics.config().tags().keySet();
         this.allTemplates = new ArrayList<>();
-        
+
         /***** Client level *****/
-        
+
         this.batchSizeAvg = createMetricName("batch-size-avg",
                 "The average number of bytes sent per partition per-request.");
         this.batchSizeMax = createMetricName("batch-size-max",
@@ -90,35 +90,35 @@ public class SenderMetricsRegistry {
                 "The average time in ms record batches spent in the send buffer.");
         this.recordQueueTimeMax = createMetricName("record-queue-time-max",
                 "The maximum time in ms record batches spent in the send buffer.");
-        this.requestLatencyAvg = createMetricName("request-latency-avg", 
+        this.requestLatencyAvg = createMetricName("request-latency-avg",
                 "The average request latency in ms");
-        this.requestLatencyMax = createMetricName("request-latency-max", 
+        this.requestLatencyMax = createMetricName("request-latency-max",
                 "The maximum request latency in ms");
-        this.recordSendRate = createMetricName("record-send-rate", 
+        this.recordSendRate = createMetricName("record-send-rate",
                 "The average number of records sent per second.");
-        this.recordSendTotal = createMetricName("record-send-total", 
+        this.recordSendTotal = createMetricName("record-send-total",
                 "The total number of records sent.");
         this.recordsPerRequestAvg = createMetricName("records-per-request-avg",
                 "The average number of records per request.");
         this.recordRetryRate = createMetricName("record-retry-rate",
                 "The average per-second number of retried record sends");
-        this.recordRetryTotal = createMetricName("record-retry-total", 
+        this.recordRetryTotal = createMetricName("record-retry-total",
                 "The total number of retried record sends");
         this.recordErrorRate = createMetricName("record-error-rate",
                 "The average per-second number of record sends that resulted in errors");
         this.recordErrorTotal = createMetricName("record-error-total",
                 "The total number of record sends that resulted in errors");
-        this.recordSizeMax = createMetricName("record-size-max", 
+        this.recordSizeMax = createMetricName("record-size-max",
                 "The maximum record size");
-        this.recordSizeAvg = createMetricName("record-size-avg", 
+        this.recordSizeAvg = createMetricName("record-size-avg",
                 "The average record size");
         this.requestsInFlight = createMetricName("requests-in-flight",
                 "The current number of in-flight requests awaiting a response.");
         this.metadataAge = createMetricName("metadata-age",
                 "The age in seconds of the current producer metadata being used.");
-        this.batchSplitRate = createMetricName("batch-split-rate", 
+        this.batchSplitRate = createMetricName("batch-split-rate",
                 "The average number of batch splits per second");
-        this.batchSplitTotal = createMetricName("batch-split-total", 
+        this.batchSplitTotal = createMetricName("batch-split-total",
                 "The total number of batch splits");
 
         this.produceThrottleTimeAvg = createMetricName("produce-throttle-time-avg",
@@ -137,7 +137,7 @@ public class SenderMetricsRegistry {
                 "The total number of records sent for a topic.");
         this.topicByteRate = createTopicTemplate("byte-rate",
                 "The average number of bytes sent per second for a topic.");
-        this.topicByteTotal = createTopicTemplate("byte-total", 
+        this.topicByteTotal = createTopicTemplate("byte-total",
                 "The total number of bytes sent for a topic.");
         this.topicCompressionRate = createTopicTemplate("compression-rate",
                 "The average compression rate of record batches for a topic, defined as the average ratio " +

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2316,7 +2316,7 @@ public class KafkaConsumerTest {
 
     private ConsumerMetadata createMetadata(SubscriptionState subscription) {
         return new ConsumerMetadata(0, Long.MAX_VALUE, false, false,
-                                    subscription, new LogContext(), new ClusterResourceListeners());
+                                    subscription, new LogContext(), new ClusterResourceListeners(), new Metrics());
     }
 
     private Node prepareRebalance(MockClient client, Node node, final Set<String> subscribedTopics, ConsumerPartitionAssignor assignor, List<TopicPartition> partitions, Node coordinator) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -124,9 +124,10 @@ public class AbstractCoordinatorTest {
     private void setupCoordinator(int retryBackoffMs, int rebalanceTimeoutMs, Optional<String> groupInstanceId) {
         LogContext logContext = new LogContext();
         this.mockTime = new MockTime();
+        metrics = new Metrics(mockTime);
         ConsumerMetadata metadata = new ConsumerMetadata(retryBackoffMs, 60 * 60 * 1000L,
                 false, false, new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST),
-                logContext, new ClusterResourceListeners());
+                logContext, new ClusterResourceListeners(), metrics);
 
         this.mockClient = new MockClient(mockTime, metadata);
         this.consumerClient = new ConsumerNetworkClient(logContext,
@@ -136,7 +137,6 @@ public class AbstractCoordinatorTest {
                                                         retryBackoffMs,
                                                         REQUEST_TIMEOUT_MS,
                                                         HEARTBEAT_INTERVAL_MS);
-        metrics = new Metrics(mockTime);
 
         mockClient.updateMetadata(RequestTestUtils.metadataUpdateWith(1, emptyMap()));
         this.node = metadata.fetch().nodes().get(0);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -187,13 +187,13 @@ public abstract class ConsumerCoordinatorTest {
     public void setup() {
         LogContext logContext = new LogContext();
         this.subscriptions = new SubscriptionState(logContext, OffsetResetStrategy.EARLIEST);
+        this.metrics = new Metrics(time);
         this.metadata = new ConsumerMetadata(0, Long.MAX_VALUE, false,
-                false, subscriptions, logContext, new ClusterResourceListeners());
+            false, subscriptions, logContext, new ClusterResourceListeners(), metrics);
         this.client = new MockClient(time, metadata);
         this.client.updateMetadata(metadataResponse);
         this.consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time, 100,
                 requestTimeoutMs, Integer.MAX_VALUE);
-        this.metrics = new Metrics(time);
         this.rebalanceListener = new MockRebalanceListener();
         this.mockOffsetCommitCallback = new MockCommitCallback();
         this.partitionAssignor.clear();
@@ -1748,7 +1748,7 @@ public abstract class ConsumerCoordinatorTest {
 
     private void testInternalTopicInclusion(boolean includeInternalTopics) {
         metadata = new ConsumerMetadata(0, Long.MAX_VALUE, includeInternalTopics,
-                false, subscriptions, new LogContext(), new ClusterResourceListeners());
+                false, subscriptions, new LogContext(), new ClusterResourceListeners(), metrics);
         client = new MockClient(time, metadata);
         try (ConsumerCoordinator coordinator = buildCoordinator(rebalanceConfig, new Metrics(), assignors, false, subscriptions)) {
             subscriptions.subscribe(Pattern.compile(".*"), rebalanceListener);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
@@ -178,7 +179,7 @@ public class ConsumerMetadataTest {
         long refreshBackoffMs = 50;
         long expireMs = 50000;
         return new ConsumerMetadata(refreshBackoffMs, expireMs, includeInternalTopics, false,
-                subscription, new LogContext(), new ClusterResourceListeners());
+                subscription, new LogContext(), new ClusterResourceListeners(), new Metrics());
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -4753,11 +4753,11 @@ public class FetcherTest {
                                    SubscriptionState subscriptionState,
                                    LogContext logContext) {
         time = new MockTime(1);
+        metrics = new Metrics(metricConfig, time);
         subscriptions = subscriptionState;
         metadata = new ConsumerMetadata(0, metadataExpireMs, false, false,
-                subscriptions, logContext, new ClusterResourceListeners());
+            subscriptions, logContext, new ClusterResourceListeners(), metrics);
         client = new MockClient(time, metadata);
-        metrics = new Metrics(metricConfig, time);
         consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time,
                 100, 1000, Integer.MAX_VALUE);
         metricsRegistry = new FetcherMetricsRegistry(metricConfig.tags().keySet(), "consumer" + groupId);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.utils.LogContext;
@@ -159,7 +160,7 @@ public class OffsetForLeaderEpochClientTest {
         time = new MockTime(1);
         subscriptions = new SubscriptionState(logContext, offsetResetStrategy);
         metadata = new ConsumerMetadata(0, Long.MAX_VALUE, false, false,
-                subscriptions, logContext, new ClusterResourceListeners());
+                subscriptions, logContext, new ClusterResourceListeners(), new Metrics());
         client = new MockClient(time, metadata);
         consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time,
                 100, 1000, Integer.MAX_VALUE);


### PR DESCRIPTION
TICKET = LIKAFKA-37080
LI_DESCRIPTION =
Added rate metrics for metadata requests sent by producer/consumer/kafka admin clients.

EXIT_CRITERIA = When this feature is merged into upstream kafka and pulled into this repo.

(cherry picked from commit 77cad71d223efa210627f045ea3a0b97d70110c3)