### PR TITLE
[LI-HOTFIX] Resolve the bootstrap server when cluster metadata hasn't been refreshed for a long timeq

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -119,7 +119,7 @@
     </module>
     <module name="ClassDataAbstractionCoupling">
       <!-- default is 7 -->
-      <property name="max" value="25"/>
+      <property name="max" value="26"/>
       <property name="excludeClassesRegexps" value="AtomicInteger|PriorityQueue"/>
     </module>
     <module name="BooleanExpressionComplexity">

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -196,6 +196,12 @@ public class CommonClientConfigs {
                                                                  + "of 3 lowest-expected-latency nodes)";
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = LeastLoadedNodeAlgorithm.VANILLA.name();
 
+    public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG = "li.client.cluster.metadata.expire.time.ms";
+    public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_DOC = "The configuration controls the max time the client cluster metadata can remain idle/unchanged before "
+        + "trying to resolve the bootstrap servers from given url again; different from the other metadata.max.age.ms config, "
+        + "which will try to refresh metadata by choosing from existing resolved node set, this config will force resolving "
+        + "the bootstrap url again to get new node set and use the new node set to send update metadata request";
+
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -55,6 +55,10 @@ public class CommonClientConfigs {
     public static final String METADATA_MAX_AGE_CONFIG = "metadata.max.age.ms";
     public static final String METADATA_MAX_AGE_DOC = "The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions.";
 
+
+    public static final String METADATA_TOPIC_EXPIRY_MS_CONFIG = "metadata.topic.expiry.ms";
+    public static final String METADATA_TOPIC_EXPIRY_MS_DOC = "The period of time in milliseconds before we expire topic from metadata cache";
+
     public static final String SEND_BUFFER_CONFIG = "send.buffer.bytes";
     public static final String SEND_BUFFER_DOC = "The size of the TCP send buffer (SO_SNDBUF) to use when sending data. If the value is -1, the OS default will be used.";
     public static final int SEND_BUFFER_LOWER_BOUND = -1;

--- a/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
@@ -61,6 +61,11 @@ public class ManualMetadataUpdater implements MetadataUpdater {
     }
 
     @Override
+    public boolean isUpdateClusterMetadataDue(long now) {
+        return false;
+    }
+
+    @Override
     public long maybeUpdate(long now) {
         return Long.MAX_VALUE;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -76,6 +76,10 @@ public class Metadata implements Closeable {
     private boolean isClosed;
     private final Map<TopicPartition, Integer> lastSeenLeaderEpochs;
 
+    private final long maxClusterMetadataExpireTimeMs;
+    private int nodesTriedSinceLastSuccessfulRefresh;
+    private boolean forceClusterMetadataUpdateFromBootstrap;
+
     /**
      * Create a new Metadata instance
      *
@@ -89,6 +93,14 @@ public class Metadata implements Closeable {
                     long metadataExpireMs,
                     LogContext logContext,
                     ClusterResourceListeners clusterResourceListeners) {
+        this(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, Long.MAX_VALUE);
+    }
+
+    public Metadata(long refreshBackoffMs,
+        long metadataExpireMs,
+        LogContext logContext,
+        ClusterResourceListeners clusterResourceListeners,
+        long metadataClusterMetadataExpireTimeMs) {
         this.log = logContext.logger(Metadata.class);
         this.refreshBackoffMs = refreshBackoffMs;
         this.metadataExpireMs = metadataExpireMs;
@@ -103,6 +115,9 @@ public class Metadata implements Closeable {
         this.lastSeenLeaderEpochs = new HashMap<>();
         this.invalidTopics = Collections.emptySet();
         this.unauthorizedTopics = Collections.emptySet();
+        this.maxClusterMetadataExpireTimeMs = metadataClusterMetadataExpireTimeMs;
+        this.nodesTriedSinceLastSuccessfulRefresh = 0;
+        this.forceClusterMetadataUpdateFromBootstrap = false;
     }
 
     /**
@@ -110,6 +125,26 @@ public class Metadata implements Closeable {
      */
     public synchronized Cluster fetch() {
         return cache.cluster();
+    }
+
+    /**
+     * Increment the nodesTriedSinceLastSuccessfulRefresh
+     */
+    public synchronized void incrementNodesTriedSinceLastSuccessfulRefresh() {
+        this.nodesTriedSinceLastSuccessfulRefresh++;
+    }
+
+    /**
+     * Whether the client should update the cluster metadata by resolving the bootstrap server again
+     * @param nowMs
+     * @return true if client hasn't refreshed cluster metadata for maxClusterMetadataExpireTimeMs and
+     * has tried connecting to at least one node in current node set; or forceClusterMetadataUpdateFromBootstrap
+     * has been set by receiving stale metadata from a different cluster
+     */
+    public synchronized boolean shouldUpdateClusterMetadataFromBootstrap(long nowMs) {
+        return (this.nodesTriedSinceLastSuccessfulRefresh >= 1 &&
+            this.lastSuccessfulRefreshMs + this.maxClusterMetadataExpireTimeMs <= nowMs) ||
+            this.forceClusterMetadataUpdateFromBootstrap;
     }
 
     /**
@@ -153,6 +188,15 @@ public class Metadata implements Closeable {
         this.needPartialUpdate = true;
         this.requestVersion++;
         return this.updateVersion;
+    }
+
+    /**
+     * Request an update of the current cluster metadata info by resolving the bootstrap server and randomly pick
+     * a node from the resolved node set. This happens when client receives stale metadata response from brokers in
+     * a different cluster and need to refresh the cluster metadata without waiting for maxClusterMetadataExpireTimeMs
+     */
+    public synchronized void requestClusterMetadataUpdateFromBootstrap() {
+        this.forceClusterMetadataUpdateFromBootstrap = true;
     }
 
     /**
@@ -268,12 +312,26 @@ public class Metadata implements Closeable {
         this.lastRefreshMs = nowMs;
         this.updateVersion += 1;
         if (!isPartialUpdate) {
-            validateCluster(response.clusterId());
+            if (!validateCluster(response.clusterId())) {
+                //if validateCluster fails, do not update metadataCache with the wrong cluster information,
+                //just return and wait for next update
+                //
+                //here we don't blacklist this node from the cluster's
+                //node set since we don't have enough information from the response to map to the actual node,
+                //and since there are usually hours to days interval before we put a removed broker to a different
+                //cluster, clients should either find another node in cached node set or resolved bootstrap server
+                //again and find a new node to send update metadata request, it should be ok to not blacklist this node
+                requestClusterMetadataUpdateFromBootstrap();
+                return;
+            }
             this.needFullUpdate = false;
             this.lastSuccessfulRefreshMs = nowMs;
         }
 
         String previousClusterId = cache.clusterResource().clusterId();
+
+        this.nodesTriedSinceLastSuccessfulRefresh = 0;
+        this.forceClusterMetadataUpdateFromBootstrap = false;
 
         this.cache = handleMetadataResponse(response, isPartialUpdate, nowMs);
 
@@ -291,8 +349,9 @@ public class Metadata implements Closeable {
         log.debug("Updated cluster metadata updateVersion {} to {}", this.updateVersion, this.cache);
     }
 
-    private void validateCluster(String newClusterId) {
+    private boolean validateCluster(String newClusterId) {
         String previousClusterId = this.cache.cluster().clusterResource().clusterId();
+        boolean validateResult = true;
 
         if (previousClusterId != null && newClusterId != null && !previousClusterId.equals(newClusterId)) {
             // kafka cluster id is unique.
@@ -314,10 +373,10 @@ public class Metadata implements Closeable {
             log.error("Received metadata from a different cluster {}, current cluster {} has no valid brokers anymore,"
                 + "please reboot the producer/consumer", newClusterId, previousClusterId);
 
-            throw new StaleClusterMetadataException(
-                "Trying to access a different cluster " + newClusterId + ", previous connected cluster " + previousClusterId);
-
+            validateResult = false;
         }
+
+        return validateResult;
     }
 
     private void maybeSetMetadataError(Cluster cluster) {

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -46,6 +46,12 @@ public interface MetadataUpdater extends Closeable {
     boolean isUpdateDue(long now);
 
     /**
+     * Returns true if the cluster metadata hasn't refreshed for li.client.cluster.metadata.expire.time.ms
+     * and has tried at least one node in the cached metadata node set
+     */
+    boolean isUpdateClusterMetadataDue(long now);
+
+    /**
      * Starts a cluster metadata update if needed and possible. Returns the time until the metadata update (which would
      * be 0 if an update has been started as a result of this call).
      *

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients;
 
+import java.util.Collections;
 import java.util.PriorityQueue;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
@@ -127,6 +128,8 @@ public class NetworkClient implements KafkaClient {
     private final Map<String, ApiVersionsRequest.Builder> nodesNeedingApiVersionsFetch = new HashMap<>();
 
     private final List<ClientResponse> abortedSends = new LinkedList<>();
+
+    private final List<String> bootstrapServers = new LinkedList<>();
 
     private final Sensor throttleTimeSensor;
 
@@ -282,8 +285,51 @@ public class NetworkClient implements KafkaClient {
              logContext,
              new DefaultHostResolver(),
              clientSoftwareNameAndCommit,
-             leastLoadedNodeAlgorithm);
+             leastLoadedNodeAlgorithm,
+             Collections.emptyList());
     }
+
+    public NetworkClient(Selectable selector,
+                         Metadata metadata,
+                         String clientId,
+                         int maxInFlightRequestsPerConnection,
+                         long reconnectBackoffMs,
+                         long reconnectBackoffMax,
+                         int socketSendBuffer,
+                         int socketReceiveBuffer,
+                         int defaultRequestTimeoutMs,
+                         long connectionSetupTimeoutMs,
+                         long connectionSetupTimeoutMaxMs,
+                         Time time,
+                         boolean discoverBrokerVersions,
+                         ApiVersions apiVersions,
+                         Sensor throttleTimeSensor,
+                         LogContext logContext,
+                         String clientSoftwareNameAndCommit,
+                         LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm,
+                         List<String> bootstrapServerUrls) {
+        this(null,
+             metadata,
+             selector,
+             clientId,
+             maxInFlightRequestsPerConnection,
+             reconnectBackoffMs,
+             reconnectBackoffMax,
+             socketSendBuffer,
+             socketReceiveBuffer,
+             defaultRequestTimeoutMs,
+             connectionSetupTimeoutMs,
+             connectionSetupTimeoutMaxMs,
+             time,
+             discoverBrokerVersions,
+             apiVersions,
+             throttleTimeSensor,
+             logContext,
+             new DefaultHostResolver(),
+             clientSoftwareNameAndCommit,
+             leastLoadedNodeAlgorithm,
+             bootstrapServerUrls);
+  }
 
     public NetworkClient(Selectable selector,
                          MetadataUpdater metadataUpdater,
@@ -357,43 +403,43 @@ public class NetworkClient implements KafkaClient {
     }
 
     public NetworkClient(MetadataUpdater metadataUpdater,
-        Metadata metadata,
-        Selectable selector,
-        String clientId,
-        int maxInFlightRequestsPerConnection,
-        long reconnectBackoffMs,
-        long reconnectBackoffMax,
-        int socketSendBuffer,
-        int socketReceiveBuffer,
-        int defaultRequestTimeoutMs,
-        long connectionSetupTimeoutMs,
-        long connectionSetupTimeoutMaxMs,
-        Time time,
-        boolean discoverBrokerVersions,
-        ApiVersions apiVersions,
-        Sensor throttleTimeSensor,
-        LogContext logContext,
-        HostResolver hostResolver) {
+                         Metadata metadata,
+                         Selectable selector,
+                         String clientId,
+                         int maxInFlightRequestsPerConnection,
+                         long reconnectBackoffMs,
+                         long reconnectBackoffMax,
+                         int socketSendBuffer,
+                         int socketReceiveBuffer,
+                         int defaultRequestTimeoutMs,
+                         long connectionSetupTimeoutMs,
+                         long connectionSetupTimeoutMaxMs,
+                         Time time,
+                         boolean discoverBrokerVersions,
+                         ApiVersions apiVersions,
+                         Sensor throttleTimeSensor,
+                         LogContext logContext,
+                         HostResolver hostResolver) {
         this(metadataUpdater,
-            metadata,
-            selector,
-            clientId,
-            maxInFlightRequestsPerConnection,
-            reconnectBackoffMs,
-            reconnectBackoffMax,
-            socketSendBuffer,
-            socketReceiveBuffer,
-            defaultRequestTimeoutMs,
-            connectionSetupTimeoutMs,
-            connectionSetupTimeoutMaxMs,
-            time,
-            discoverBrokerVersions,
-            apiVersions,
-            throttleTimeSensor,
-            logContext,
-            hostResolver,
-            null,
-            LeastLoadedNodeAlgorithm.VANILLA);
+             metadata,
+             selector,
+             clientId,
+             maxInFlightRequestsPerConnection,
+             reconnectBackoffMs,
+             reconnectBackoffMax,
+             socketSendBuffer,
+             socketReceiveBuffer,
+             defaultRequestTimeoutMs,
+             connectionSetupTimeoutMs,
+             connectionSetupTimeoutMaxMs,
+             time,
+             discoverBrokerVersions,
+             apiVersions,
+             throttleTimeSensor,
+             logContext,
+             hostResolver,
+             null,
+             LeastLoadedNodeAlgorithm.VANILLA);
     }
 
     public NetworkClient(MetadataUpdater metadataUpdater,
@@ -416,6 +462,50 @@ public class NetworkClient implements KafkaClient {
                          HostResolver hostResolver,
                          String clientSoftwareNameAndCommit,
                          LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm) {
+        this(metadataUpdater,
+             metadata,
+             selector,
+             clientId,
+             maxInFlightRequestsPerConnection,
+             reconnectBackoffMs,
+             reconnectBackoffMax,
+             socketSendBuffer,
+             socketReceiveBuffer,
+             defaultRequestTimeoutMs,
+             connectionSetupTimeoutMs,
+             connectionSetupTimeoutMaxMs,
+             time,
+             discoverBrokerVersions,
+             apiVersions,
+             throttleTimeSensor,
+             logContext,
+             hostResolver,
+             clientSoftwareNameAndCommit,
+             leastLoadedNodeAlgorithm,
+             Collections.emptyList());
+    }
+
+  public NetworkClient(MetadataUpdater metadataUpdater,
+                       Metadata metadata,
+                       Selectable selector,
+                       String clientId,
+                       int maxInFlightRequestsPerConnection,
+                       long reconnectBackoffMs,
+                       long reconnectBackoffMax,
+                       int socketSendBuffer,
+                       int socketReceiveBuffer,
+                       int defaultRequestTimeoutMs,
+                       long connectionSetupTimeoutMs,
+                       long connectionSetupTimeoutMaxMs,
+                       Time time,
+                       boolean discoverBrokerVersions,
+                       ApiVersions apiVersions,
+                       Sensor throttleTimeSensor,
+                       LogContext logContext,
+                       HostResolver hostResolver,
+                       String clientSoftwareNameAndCommit,
+                       LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm,
+                       List<String> bootstrapServersConfig) {
         /* It would be better if we could pass `DefaultMetadataUpdater` from the public constructor, but it's not
          * possible because `DefaultMetadataUpdater` is an inner class and it can only be instantiated after the
          * super constructor is invoked.
@@ -450,6 +540,7 @@ public class NetworkClient implements KafkaClient {
             throw new IllegalArgumentException("must specify leastLoadedNodeAlgorithm");
         }
         this.leastLoadedNodeAlgorithm = leastLoadedNodeAlgorithm;
+        this.bootstrapServers.addAll(bootstrapServersConfig);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -542,7 +542,8 @@ public class KafkaAdminClient extends AdminClient {
                 logContext,
                 (hostResolver == null) ? new DefaultHostResolver() : hostResolver,
                 null,
-                leastLoadedNodeAlgorithm);
+                leastLoadedNodeAlgorithm,
+                Collections.emptyList());
             return new KafkaAdminClient(config, clientId, time, metadataManager, metrics, networkClient,
                 timeoutProcessorFactory, logContext);
         } catch (Throwable exc) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -91,6 +91,11 @@ public class AdminMetadataManager {
         }
 
         @Override
+        public boolean isUpdateClusterMetadataDue(long now) {
+            return false;
+        }
+
+        @Override
         public boolean isUpdateDue(long now) {
             return false;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -362,6 +362,8 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
 
+    public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG = CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                                         Type.LIST,
@@ -404,6 +406,12 @@ public class ConsumerConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.LOW,
                                         CommonClientConfigs.METADATA_MAX_AGE_DOC)
+                                .define(LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG,
+                                        Type.LONG,
+                                        60 * 60 * 1000,
+                                        atLeast(0),
+                                        Importance.LOW,
+                                        CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_DOC)
                                 .define(ENABLE_AUTO_COMMIT_CONFIG,
                                         Type.BOOLEAN,
                                         true,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -728,7 +728,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     config.getLong(ConsumerConfig.METADATA_MAX_AGE_CONFIG),
                     !config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
                     config.getBoolean(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
-                    subscriptions, logContext, clusterResourceListeners, metrics);
+                    subscriptions, logContext, clusterResourceListeners, metrics,
+                    config.getLong(ConsumerConfig.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG));
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
                     config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG), config.getString(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG));
             this.metadata.bootstrap(addresses);
@@ -764,7 +765,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     throttleTimeSensor,
                     logContext,
                     config.getString(ConsumerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG),
-                    leastLoadedNodeAlgorithm);
+                    leastLoadedNodeAlgorithm,
+                    config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
 
             this.client = new ConsumerNetworkClient(
                     logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadata.java
@@ -46,7 +46,20 @@ public class ConsumerMetadata extends Metadata {
                             LogContext logContext,
                             ClusterResourceListeners clusterResourceListeners,
                             Metrics metrics) {
-        super(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners);
+        this(refreshBackoffMs, metadataExpireMs, includeInternalTopics, allowAutoTopicCreation, subscription,
+            logContext, clusterResourceListeners, metrics, Long.MAX_VALUE);
+    }
+
+    public ConsumerMetadata(long refreshBackoffMs,
+        long metadataExpireMs,
+        boolean includeInternalTopics,
+        boolean allowAutoTopicCreation,
+        SubscriptionState subscription,
+        LogContext logContext,
+        ClusterResourceListeners clusterResourceListeners,
+        Metrics metrics,
+        long clusterMetadataExpireMs) {
+        super(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, clusterMetadataExpireMs);
         this.includeInternalTopics = includeInternalTopics;
         this.allowAutoTopicCreation = allowAutoTopicCreation;
         this.subscription = subscription;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -436,8 +436,10 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         logContext,
                         clusterResourceListeners,
                         Time.SYSTEM,
+                        config.getLong(ProducerConfig.METADATA_TOPIC_EXPIRY_MS_CONFIG),
                         config.getBoolean(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
-                        metrics);
+                        metrics,
+                        config.getLong(ProducerConfig.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG));
                 this.metadata.bootstrap(addresses);
             }
             this.errors = this.metrics.sensor("errors");
@@ -485,7 +487,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 throttleTimeSensor,
                 logContext,
                 producerConfig.getString(ProducerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG),
-                leastLoadedNodeAlgorithm);
+                leastLoadedNodeAlgorithm,
+                producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
         short acks = configureAcks(producerConfig, log);
         return new Sender(logContext,
                 client,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.LeastLoadedNodeAlgorithm;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
+import org.apache.kafka.clients.producer.internals.ProducerMetadata;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -59,6 +60,9 @@ public class ProducerConfig extends AbstractConfig {
 
     /** <code>client.dns.lookup</code> */
     public static final String CLIENT_DNS_LOOKUP_CONFIG = CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG;
+
+    public static final String METADATA_TOPIC_EXPIRY_MS_CONFIG = CommonClientConfigs.METADATA_TOPIC_EXPIRY_MS_CONFIG;
+    private static final String METADATA_TOPIC_EXPIRY_MS_DOC = CommonClientConfigs.METADATA_TOPIC_EXPIRY_MS_DOC;
 
     /** <code>metadata.max.age.ms</code> */
     public static final String METADATA_MAX_AGE_CONFIG = CommonClientConfigs.METADATA_MAX_AGE_CONFIG;
@@ -437,6 +441,11 @@ public class ProducerConfig extends AbstractConfig {
                                         60000,
                                         Importance.LOW,
                                         TRANSACTION_TIMEOUT_DOC)
+                                .define(METADATA_TOPIC_EXPIRY_MS_CONFIG,
+                                    Type.LONG,
+                                    ProducerMetadata.TOPIC_EXPIRY_MS,
+                                    Importance.LOW,
+                                    METADATA_TOPIC_EXPIRY_MS_DOC)
                                 .define(TRANSACTIONAL_ID_CONFIG,
                                         Type.STRING,
                                         null,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -290,6 +290,8 @@ public class ProducerConfig extends AbstractConfig {
     public static final String LEAST_LOADED_NODE_ALGORITHM_DOC = CommonClientConfigs.LEAST_LOADED_NODE_ALGORITHM_DOC;
     public static final String DEFAULT_LEAST_LOADED_NODE_ALGORITHM = CommonClientConfigs.DEFAULT_LEAST_LOADED_NODE_ALGORITHM;
 
+    public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG = CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Collections.emptyList(), new ConfigDef.NonNullValidator(), Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
                                 .define(CLIENT_DNS_LOOKUP_CONFIG,
@@ -343,6 +345,12 @@ public class ProducerConfig extends AbstractConfig {
                                         atLeast(5000),
                                         Importance.LOW,
                                         METADATA_MAX_IDLE_DOC)
+                                .define(LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG,
+                                        Type.LONG,
+                                        60 * 60 * 1000,
+                                        atLeast(0),
+                                        Importance.LOW,
+                                        CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_DOC)
                                 .define(METRICS_SAMPLE_WINDOW_MS_CONFIG,
                                         Type.LONG,
                                         30000,

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -76,6 +76,8 @@ public class MetadataTest {
 
     private long refreshBackoffMs = 100;
     private long metadataExpireMs = 1000;
+    private final long connectionSetupTimeoutMsTest = 5 * 1000;
+    private final long connectionSetupTimeoutMaxMsTest = 127 * 1000;
     private Metadata metadata = new Metadata(refreshBackoffMs, metadataExpireMs, new LogContext(),
             new ClusterResourceListeners());
 
@@ -84,7 +86,8 @@ public class MetadataTest {
 
     private NetworkClient clusterClient = new NetworkClient(selector, clusterMetadata, "mock-cluster-md", Integer.MAX_VALUE,
         0, 0, 64 * 1024, 64 * 1024,
-        defaultRequestTimeoutMs, ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), null, new LogContext(),
+        defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true,
+        new ApiVersions(), null, new LogContext(), null,
         LeastLoadedNodeAlgorithm.VANILLA, Collections.singletonList("some.invalid.hostname.foo.bar.local:9999"));
 
     private static MetadataResponse emptyMetadataResponse() {

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
@@ -41,6 +42,8 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.MockClusterResourceListener;
 import org.junit.jupiter.api.Test;
+import org.apache.kafka.test.MockSelector;
+import org.apache.kafka.test.TestUtils;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -66,10 +69,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetadataTest {
 
+    protected final int defaultRequestTimeoutMs = 1000;
+    protected final MockTime time = new MockTime();
+    protected final MockSelector selector = new MockSelector(time);
+    protected final Node node = TestUtils.singletonCluster().nodes().iterator().next();
+
     private long refreshBackoffMs = 100;
     private long metadataExpireMs = 1000;
     private Metadata metadata = new Metadata(refreshBackoffMs, metadataExpireMs, new LogContext(),
             new ClusterResourceListeners());
+
+    private Metadata clusterMetadata = new Metadata(refreshBackoffMs, metadataExpireMs, new LogContext(),
+        new ClusterResourceListeners(), 0);
+
+    private NetworkClient clusterClient = new NetworkClient(selector, clusterMetadata, "mock-cluster-md", Integer.MAX_VALUE,
+        0, 0, 64 * 1024, 64 * 1024,
+        defaultRequestTimeoutMs, ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), null, new LogContext(),
+        LeastLoadedNodeAlgorithm.VANILLA, Collections.singletonList("some.invalid.hostname.foo.bar.local:9999"));
 
     private static MetadataResponse emptyMetadataResponse() {
         return RequestTestUtils.metadataResponse(
@@ -88,6 +104,23 @@ public class MetadataTest {
     public void testMetadataUpdateAfterClose() {
         metadata.close();
         assertThrows(IllegalStateException.class, () -> metadata.updateWithCurrentRequestVersion(emptyMetadataResponse(), false, 1000));
+    }
+
+    @Test
+    public void testResolveBootstrapAfterClusterMetadataTimeout() {
+        List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(Collections.singletonList("example.com:10000"));
+        //bootstrap the metadata cache with some valid nodes
+        clusterMetadata.bootstrap(addresses);
+
+        //first time call leastLoadedNode on the created NetworkClient should pass since nodesTriedSinceLastSuccessfulRefresh is 0
+        clusterClient.leastLoadedNode(time.milliseconds());
+
+        //simulate metadata refresh attempt by incrementing the nodesTriedSinceLastSuccessfulRefresh by 1
+        clusterMetadata.incrementNodesTriedSinceLastSuccessfulRefresh();
+
+        //now second call to leastLoadedNode on the NetworkClient should fail since we passed an invalid bootstrap server to it
+        //it should throw a ConfigException of no resolvable bootstrap server in provided urls
+        assertThrows(ConfigException.class, () -> clusterClient.leastLoadedNode(time.milliseconds()));
     }
 
     private static void checkTimeToNextUpdate(long refreshBackoffMs, long metadataExpireMs) {

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -86,10 +86,12 @@ public class NetworkClientTest {
     protected final long connectionSetupTimeoutMsTest = 5 * 1000;
     protected final long connectionSetupTimeoutMaxMsTest = 127 * 1000;
     private final TestMetadataUpdater metadataUpdater = new TestMetadataUpdater(Collections.singletonList(node));
+    private final TestClusterMetadataUpdater clusterMetadataUpdater = new TestClusterMetadataUpdater(Collections.singletonList(node));
     private final NetworkClient client = createNetworkClient(reconnectBackoffMaxMsTest);
     private final NetworkClient clientWithNoExponentialBackoff = createNetworkClient(reconnectBackoffMsTest);
     private final NetworkClient clientWithStaticNodes = createNetworkClientWithStaticNodes();
     private final NetworkClient clientWithNoVersionDiscovery = createNetworkClientWithNoVersionDiscovery();
+    private final NetworkClient clusterClient = createClusterNetworkClient();
 
     private static ArrayList<InetAddress> initialAddresses;
     private static ArrayList<InetAddress> newAddresses;
@@ -144,6 +146,13 @@ public class NetworkClientTest {
                 connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, false, new ApiVersions(), new LogContext());
     }
 
+    private NetworkClient createClusterNetworkClient() {
+        return new NetworkClient(selector, clusterMetadataUpdater, "mock-cluster-md", Integer.MAX_VALUE,
+            0, 0, 64 * 1024, 64 * 1024,
+            defaultRequestTimeoutMs, ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), new LogContext(),
+            LeastLoadedNodeAlgorithm.VANILLA, Collections.singletonList("example.com:10000"));
+    }
+    
     @BeforeEach
     public void setup() {
         selector.reset();
@@ -613,6 +622,13 @@ public class NetworkClientTest {
     private void sendThrottledProduceResponse(int correlationId, int throttleMs, short version) {
         ProduceResponse response = new ProduceResponse(new ProduceResponseData().setThrottleTimeMs(throttleMs));
         sendResponse(response, version, correlationId);
+    }
+
+    @Test
+    public void testResolveBootstrapInLeastLoadedNode() {
+        clusterClient.ready(node, time.milliseconds());
+        assertFalse(clusterClient.isReady(node, time.milliseconds()));
+        assertNotEquals(node, clusterClient.leastLoadedNode(time.milliseconds()));
     }
 
     @Test
@@ -1181,6 +1197,40 @@ public class NetworkClientTest {
 
         public TestMetadataUpdater(List<Node> nodes) {
             super(nodes);
+        }
+
+        @Override
+        public void handleServerDisconnect(long now, String destinationId, Optional<AuthenticationException> maybeAuthException) {
+            maybeAuthException.ifPresent(exception -> {
+                failure = exception;
+            });
+            super.handleServerDisconnect(now, destinationId, maybeAuthException);
+        }
+
+        @Override
+        public void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException) {
+            maybeFatalException.ifPresent(exception -> {
+                failure = exception;
+            });
+        }
+
+        public KafkaException getAndClearFailure() {
+            KafkaException failure = this.failure;
+            this.failure = null;
+            return failure;
+        }
+    }
+
+    private static class TestClusterMetadataUpdater extends ManualMetadataUpdater {
+        KafkaException failure;
+
+        public TestClusterMetadataUpdater(List<Node> nodes) {
+            super(nodes);
+        }
+
+        @Override
+        public boolean isUpdateClusterMetadataDue(long now) {
+            return true;
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -149,10 +149,10 @@ public class NetworkClientTest {
     private NetworkClient createClusterNetworkClient() {
         return new NetworkClient(selector, clusterMetadataUpdater, "mock-cluster-md", Integer.MAX_VALUE,
             0, 0, 64 * 1024, 64 * 1024,
-            defaultRequestTimeoutMs, ClientDnsLookup.DEFAULT, time, true, new ApiVersions(), new LogContext(),
+            defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true, new ApiVersions(), new LogContext(),
             LeastLoadedNodeAlgorithm.VANILLA, Collections.singletonList("example.com:10000"));
     }
-    
+
     @BeforeEach
     public void setup() {
         selector.reset();


### PR DESCRIPTION
This patch adds a config li.client.cluster.metadata.expire.time.ms which controls the max time cluster metadata can remain unchanged. On NetworkClient.poll, if this timeout has been reached and the client has tried half of the nodes in the original cached node set and failed, it will try to resolve the bootstrap servers again and use the newly resolved nodes to pick a leastLoadedNode to send updateMetadataRequest.

This is to avoid following two scenarios:

consumer has been idle for a long time, and whole cluster has been swapped. This case, all the cached nodes are invalid and resolve bootstrap is needed.
consumer hasn't refreshed metadata for a long time and some brokers in the cluster had been moved to another cluster, and the client randomly picks up the moved broker to send md request and get a response for a different cluster. In this case, we simply reject the stale md response and resolve bootstrap when conditions are met.
TICKET =
LI_DESCRIPTION = LIKAFKA-40759,
EXIT_CRITERIA = MANUAL this is not going to merged with upstream

Co-authored-by: Ke Hu <kehu@kehu-mn2.linkedin.biz>
(cherry picked from commit ec1d353f344bee8fded1bc855c52e5943b242ac8)