### PR TITLE
[LI-HOTFIX] Populate the metadata cache before processing LeaderAndIsr

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3117,19 +3117,19 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     val responseData = new LiCombinedControlResponseData()
 
+    decomposedRequest.updateMetadataRequest match {
+      case Some(updateMetadataRequest) => {
+        val updateMetadataResponse = doHandleUpdateMetadataRequest(request, correlationId, updateMetadataRequest)
+        responseData.setUpdateMetadataErrorCode(updateMetadataResponse.errorCode())
+      }
+      case _ => // do nothing
+    }
+
     decomposedRequest.leaderAndIsrRequest match {
       case Some(leaderAndIsrRequest) => {
         val leaderAndIsrResponse = doHandleLeaderAndIsrRequest(request, correlationId, leaderAndIsrRequest)
         responseData.setLeaderAndIsrErrorCode(leaderAndIsrResponse.errorCode())
           .setLeaderAndIsrPartitionErrors(LiCombinedControlTransformer.transformLeaderAndIsrPartitionErrors(leaderAndIsrResponse.partitions()))
-      }
-      case _ => // do nothing
-    }
-
-    decomposedRequest.updateMetadataRequest match {
-      case Some(updateMetadataRequest) => {
-        val updateMetadataResponse = doHandleUpdateMetadataRequest(request, correlationId, updateMetadataRequest)
-        responseData.setUpdateMetadataErrorCode(updateMetadataResponse.errorCode())
       }
       case _ => // do nothing
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3117,6 +3117,9 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     val responseData = new LiCombinedControlResponseData()
 
+    // The LeaderAndIsr section depends on the UpdateMetadata section, which implies that
+    // the UpdateMetadataRequest section should be processed before the LeaderAndIsr section.
+    // If the order is reversed, a broker will fail to become the follower
     decomposedRequest.updateMetadataRequest match {
       case Some(updateMetadataRequest) => {
         val updateMetadataResponse = doHandleUpdateMetadataRequest(request, correlationId, updateMetadataRequest)


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
When processing a LiCombinedControl request, we found that sometimes the LeaderAndIsr section
depends on the UpdateMetadata section, which implies that the UpdateMetadataRequest section
should be processed before the LeaderAndIsr section.

If the order is reversed, a broker will fail to become the follower, and result in the following error message
`
Received LeaderAndIsrRequest with correlation id ... from controller ... epoch ...
for partition ... (last update controller epoch ...) but cannot become follower
since the new leader ... is unavailable.
`

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
