### PR TITLE
[LI-HOTFIX] Replace Java stream api usages with non-functional old style in ZkMetadata request/response path

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -26,10 +26,10 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class MetadataRequest extends AbstractRequest {
 
@@ -56,7 +56,9 @@ public class MetadataRequest extends AbstractRequest {
             if (topics == null)
                 data.setTopics(null);
             else {
-                topics.forEach(topic -> data.topics().add(new MetadataRequestTopic().setName(topic)));
+                for (String topic: topics) {
+                    data.topics().add(new MetadataRequestTopic().setName(topic));
+                }
             }
 
             data.setAllowAutoTopicCreation(allowAutoTopicCreation);
@@ -85,11 +87,16 @@ public class MetadataRequest extends AbstractRequest {
             return data.topics() == null;
         }
 
+        // Used for testing only
         public List<String> topics() {
-            return data.topics()
-                .stream()
-                .map(MetadataRequestTopic::name)
-                .collect(Collectors.toList());
+            if (data.topics() == null) {
+                return Collections.emptyList();
+            }
+            List<String> topicList = new ArrayList<>(data.topics().size());
+            for (MetadataRequestData.MetadataRequestTopic mdTopic: data.topics()) {
+                topicList.add(mdTopic.name());
+            }
+            return topicList;
         }
 
         @Override
@@ -160,11 +167,13 @@ public class MetadataRequest extends AbstractRequest {
     public List<String> topics() {
         if (isAllTopics()) //In version 0, we return null for empty topic list
             return null;
-        else
-            return data.topics()
-                .stream()
-                .map(MetadataRequestTopic::name)
-                .collect(Collectors.toList());
+        else {
+            List<String> topics = new ArrayList<>(data.topics().size());
+            for (MetadataRequestTopic topic: data.topics()) {
+                topics.add(topic.name());
+            }
+            return topics;
+        }
     }
 
     public boolean allowAutoTopicCreation() {
@@ -180,8 +189,10 @@ public class MetadataRequest extends AbstractRequest {
     }
 
     public static List<MetadataRequestTopic> convertToMetadataRequestTopic(final Collection<String> topics) {
-        return topics.stream().map(topic -> new MetadataRequestTopic()
-            .setName(topic))
-            .collect(Collectors.toList());
+        List<MetadataRequestTopic> metadataRequestTopicList = new ArrayList<>(topics.size());
+        for (String topicName: topics) {
+            metadataRequestTopicList.add(new MetadataRequestTopic().setName(topicName));
+        }
+        return metadataRequestTopicList;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -41,8 +41,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Possible topic-level error codes:
@@ -418,8 +416,19 @@ public class MetadataResponse extends AbstractResponse {
         }
 
         private Map<Integer, Node> createBrokers(MetadataResponseData data) {
-            return data.brokers().valuesList().stream().map(b -> new Node(b.nodeId(), b.host(), b.port(), b.rack()))
-                    .collect(Collectors.toMap(Node::id, Function.identity()));
+            final Map<Integer, Node> brokerMap = new HashMap<>(data.brokers().size());
+            for (MetadataResponseData.MetadataResponseBroker brokerMetadata: data.brokers().valuesList()) {
+                brokerMap.put(
+                    brokerMetadata.nodeId(),
+                    new Node(
+                        brokerMetadata.nodeId(),
+                        brokerMetadata.host(),
+                        brokerMetadata.port(),
+                        brokerMetadata.rack()
+                    )
+                );
+            }
+            return brokerMap;
         }
 
         private Collection<TopicMetadata> createTopicMetadata(MetadataResponseData data) {
@@ -474,19 +483,21 @@ public class MetadataResponse extends AbstractResponse {
                                                    int clusterAuthorizedOperations) {
         MetadataResponseData responseData = new MetadataResponseData();
         responseData.setThrottleTimeMs(throttleTimeMs);
-        brokers.forEach(broker ->
+        for (Node broker: brokers) {
             responseData.brokers().add(new MetadataResponseBroker()
                 .setNodeId(broker.id())
                 .setHost(broker.host())
                 .setPort(broker.port())
-                .setRack(broker.rack()))
-        );
-
+                .setRack(broker.rack()));
+        }
         responseData.setClusterId(clusterId);
         responseData.setControllerId(controllerId);
         responseData.setClusterAuthorizedOperations(clusterAuthorizedOperations);
 
-        topics.forEach(topicMetadata -> responseData.topics().add(topicMetadata));
+        for (MetadataResponseTopic topicMetadata: topics) {
+            responseData.topics().add(topicMetadata);
+        }
+
         return new MetadataResponse(responseData, hasReliableEpoch);
     }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1301,6 +1301,11 @@ class KafkaApis(val requestChannel: RequestChannel,
     trace("Sending topic metadata %s and brokers %s for correlation id %d to client %s".format(completeTopicMetadata.mkString(","),
       brokers.mkString(","), request.header.correlationId, request.header.clientId))
 
+    val brokersAsJava: java.util.List[Node] = new java.util.ArrayList[Node](brokers.size)
+    for (b: Node <- brokers) {
+      brokersAsJava.add(b)
+    }
+
     requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
        MetadataResponse.prepareResponse(
          requestVersion,

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -41,6 +41,8 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{MetadataResponse, UpdateMetadataRequest}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 
+import scala.collection.mutable.ArrayBuffer
+
 /**
  *  A cache for the state (e.g., current leader) of each partition. This cache is updated through
  *  UpdateMetadataRequest from the controller. Every broker maintains the same cache, asynchronously.
@@ -83,9 +85,12 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
   // Otherwise, return LEADER_NOT_AVAILABLE for broker unavailable and missing listener (Metadata response v5 and below).
   private def getPartitionMetadata(snapshot: MetadataSnapshot, topic: String, listenerName: ListenerName, errorUnavailableEndpoints: Boolean,
                                    errorUnavailableListeners: Boolean): Option[Iterable[MetadataResponsePartition]] = {
-    snapshot.partitionStates.get(topic).map { partitions =>
-      partitions.map { case (partitionId, partitionState) =>
-        val topicPartition = new TopicPartition(topic, partitionId.toInt)
+    val result = new ArrayBuffer[MetadataResponsePartition]
+    for (partitionsMap <- snapshot.partitionStates.get(topic)) {
+      for (partitionEntry <- partitionsMap) {
+        val partitionId = partitionEntry._1.toInt
+        val partitionState = partitionEntry._2
+        val topicPartition = new TopicPartition(topic, partitionId)
         val leaderBrokerId = partitionState.leader
         val leaderEpoch = partitionState.leaderEpoch
         val maybeLeader = getAliveEndpoint(snapshot, leaderBrokerId, listenerName)
@@ -109,7 +114,7 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
               if (errorUnavailableListeners) Errors.LISTENER_NOT_FOUND else Errors.LEADER_NOT_AVAILABLE
             }
 
-            new MetadataResponsePartition()
+            result += new MetadataResponsePartition()
               .setErrorCode(error.code)
               .setPartitionIndex(partitionId.toInt)
               .setLeaderId(MetadataResponse.NO_LEADER_ID)
@@ -131,7 +136,7 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
               Errors.NONE
             }
 
-            new MetadataResponsePartition()
+            result += new MetadataResponsePartition()
               .setErrorCode(error.code)
               .setPartitionIndex(partitionId.toInt)
               .setLeaderId(maybeLeader.map(_.id()).getOrElse(MetadataResponse.NO_LEADER_ID))
@@ -142,6 +147,10 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
         }
       }
     }
+    if (result.isEmpty)
+      None
+    else
+      Option(result)
   }
 
   /**
@@ -169,9 +178,11 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
                        errorUnavailableEndpoints: Boolean = false,
                        errorUnavailableListeners: Boolean = false): Seq[MetadataResponseTopic] = {
     val snapshot = metadataSnapshot
-    topics.toSeq.flatMap { topic =>
-      getPartitionMetadata(snapshot, topic, listenerName, errorUnavailableEndpoints, errorUnavailableListeners).map { partitionMetadata =>
-        new MetadataResponseTopic()
+    val topicMetadata = new ArrayBuffer[MetadataResponseTopic]
+    for (topic <- topics) {
+      val partitionMetadataSet = getPartitionMetadata(snapshot, topic, listenerName, errorUnavailableEndpoints, errorUnavailableListeners)
+      for (partitionMetadata <- partitionMetadataSet) {
+        topicMetadata += new MetadataResponseTopic()
           .setErrorCode(Errors.NONE.code)
           .setName(topic)
           .setTopicId(snapshot.topicIds.getOrElse(topic, Uuid.ZERO_UUID))
@@ -179,6 +190,7 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
           .setPartitions(partitionMetadata.toBuffer.asJava)
       }
     }
+    topicMetadata
   }
 
   override def getAllTopics(): Set[String] = {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/requests/MetadataRequestResponseBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/requests/MetadataRequestResponseBenchmark.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.jmh.common.requests;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+public class MetadataRequestResponseBenchmark {
+    @State(Scope.Thread)
+    public static class BenchState {
+
+        public void populateBrokerNodeList(int numNodes) {
+            brokerNodeList = new ArrayList<>();
+            for (int i = 0; i < numNodes; i++) {
+                brokerNodeList.add(new Node(i, "localhost", 2194));
+            }
+        }
+
+        public void populateTopicMetadataList(int maxTopics, int maxPartitionsPerTopic) {
+            topicMetadataList = new ArrayList<>();
+            for (int topicCount = 0; topicCount < maxTopics; topicCount++) {
+                final String topic = "topic-" + topicCount;
+                final List<MetadataResponsePartition> topicPartitionMetadata = new ArrayList<>();
+                for (int i = 0; i < maxPartitionsPerTopic; i++) {
+                    topicPartitionMetadata.add(
+                        new MetadataResponsePartition()
+                            .setErrorCode(Errors.NONE.code())
+                            .setLeaderEpoch(100)
+                            .setLeaderId(1000)
+                            .setReplicaNodes(Arrays.asList(1000, 1001, 1002))
+                            .setIsrNodes(Arrays.asList(1001, 1002))
+                            .setOfflineReplicas(Collections.singletonList(1000))
+                            .setPartitionIndex(i)
+                    );
+                }
+                topicMetadataList.add(
+                    new MetadataResponseTopic()
+                        .setIsInternal(false)
+                        .setName(topic)
+                        .setTopicId(Uuid.randomUuid())
+                        .setTopicAuthorizedOperations(MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED)
+                        .setPartitions(topicPartitionMetadata)
+                        .setErrorCode(Errors.NONE.code())
+                );
+            }
+        }
+
+        @Setup(Level.Iteration)
+        public void setUp() {
+            populateBrokerNodeList(10);
+            populateTopicMetadataList(20, 8);
+        }
+
+        public List<Node> brokerNodeList;
+        public List<MetadataResponseTopic> topicMetadataList;
+        public String clusterId = "XYZ";
+        int controllerId = 290230;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void responseConstructor(Blackhole blackhole, BenchState state) {
+        blackhole.consume(MetadataResponse.prepareResponse(ApiKeys.METADATA.latestVersion(), -1, state.brokerNodeList, state.clusterId, state.controllerId,
+            state.topicMetadataList, MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED));
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/ZkMetadataCacheBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/ZkMetadataCacheBenchmark.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.server;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import kafka.server.ZkMetadataCache;
+import org.apache.kafka.common.message.UpdateMetadataRequestData;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.requests.UpdateMetadataRequest;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import scala.collection.JavaConverters;
+
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 10, time = 60, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 60, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+public class ZkMetadataCacheBenchmark {
+
+    @State(Scope.Thread)
+    public static class BenchState {
+        public static final int BROKER_ID = 1;
+        public static final String TOPIC_NAME = "topic";
+        public static final String TOPIC1_NAME = "topic1";
+
+        @Setup(Level.Iteration)
+        public void setUp() {
+            UpdateMetadataRequest request =
+                new UpdateMetadataRequest.Builder(
+                    ApiKeys.UPDATE_METADATA.latestVersion(), 2, 1, 0, 0,
+                    getPartitionStates(), getUpdateMetadataBroker(), Collections.emptyMap()
+                ).build();
+            metadataCache.updateMetadata(15, request);
+        }
+
+        private List<UpdateMetadataRequestData.UpdateMetadataBroker> getUpdateMetadataBroker() {
+            List<UpdateMetadataRequestData.UpdateMetadataBroker> result = new LinkedList<>();
+            for (int i = 0; i < 5; i++) {
+                result.add(new UpdateMetadataRequestData.UpdateMetadataBroker().setId(i)
+                    .setEndpoints(getEndPoints(i))
+                    .setRack("rack1"));
+            }
+            return result;
+        }
+
+        private List<UpdateMetadataRequestData.UpdateMetadataEndpoint> getEndPoints(int brokerId) {
+            return new LinkedList<UpdateMetadataRequestData.UpdateMetadataEndpoint>() {
+                {
+                    add(new UpdateMetadataRequestData.UpdateMetadataEndpoint().setHost("host-" + brokerId)
+                        .setPort(9092)
+                        .setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)
+                        .setListener(ListenerName.forSecurityProtocol(
+                            org.apache.kafka.common.security.auth.SecurityProtocol.PLAINTEXT).value()));
+                }
+
+                {
+                    add(new UpdateMetadataRequestData.UpdateMetadataEndpoint().setHost("host-" + brokerId)
+                        .setPort(9093)
+                        .setSecurityProtocol(SecurityProtocol.SSL.id)
+                        .setListener(
+                            ListenerName.forSecurityProtocol(org.apache.kafka.common.security.auth.SecurityProtocol.SSL)
+                                .value()));
+                }
+            };
+        }
+
+        private List<UpdateMetadataRequestData.UpdateMetadataPartitionState> getPartitionStates() {
+            List<UpdateMetadataRequestData.UpdateMetadataPartitionState> result = new LinkedList<>();
+            int controllerEpoch = 1;
+            int zkVersion = 3;
+
+            result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState().setTopicName(TOPIC_NAME)
+                .setPartitionIndex(0)
+                .setControllerEpoch(controllerEpoch)
+                .setLeader(0)
+                .setLeaderEpoch(0)
+                .setIsr(Arrays.asList(0, 1, 3))
+                .setZkVersion(zkVersion)
+                .setReplicas(Arrays.asList(0, 1, 3)));
+            result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState().setTopicName(TOPIC_NAME)
+                .setPartitionIndex(1)
+                .setControllerEpoch(controllerEpoch)
+                .setLeader(1)
+                .setLeaderEpoch(1)
+                .setIsr(Arrays.asList(1, 0))
+                .setZkVersion(zkVersion)
+                .setReplicas(Arrays.asList(1, 2, 0, 4)));
+            result.add(new UpdateMetadataRequestData.UpdateMetadataPartitionState().setTopicName(TOPIC1_NAME)
+                .setPartitionIndex(0)
+                .setControllerEpoch(controllerEpoch)
+                .setLeader(2)
+                .setLeaderEpoch(2)
+                .setIsr(Arrays.asList(2, 1))
+                .setZkVersion(zkVersion)
+                .setReplicas(Arrays.asList(2, 1, 3)));
+            return result;
+        }
+
+        public final ZkMetadataCache metadataCache = new ZkMetadataCache(BROKER_ID);
+        public final ListenerName listenerName = ListenerName.normalised("PLAINTEXT");
+        public final scala.collection.Set<String> topicScalaSetInQuery =
+            JavaConverters.asScalaSet(Collections.singleton(TOPIC_NAME));
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void benchmarkGetTopicMetadata(BenchState state, Blackhole blackhole) {
+        state.metadataCache.getTopicMetadata(state.topicScalaSetInQuery, state.listenerName, false, false);
+    }
+}


### PR DESCRIPTION
EXIT_CRITERIA = After KIP-500 and we're not using ZK for metadata

Changes
=======

This is a combination porting of the 2 commits from 2.4-li branch to 3.0:
- def7e89 Replace java.util.stream.* api usages with non-functional old style code in Metadata request/response (#163)
- 5b170af [LI-HOTFIX] Fix a spotbugs warning in JMH benchmark code (#194)

- Replaced java.util.stream.* api usages with non-functional old style code in
  - `MetadataRequest`
  - `MetadataResponse`
  - `MetadataCache`
- Added a JMH benchmark code for `MetadataResponse.prepareResponse` codepath.

Tests
=====

In the original 2.4 PR (linkedin#163), the benchmark shows ~3x improvement in GC allocation rates for Metadata request/response.
However, after porting to the 3.0 branch, the improvment is not that significant or even worse.

**Baseline**
```
MetadataRequestResponseBenchmark.responseConstructor:·gc.alloc.rate.norm               thrpt   10  824.005 ±  0.001    B/op
MetadataRequestResponseBenchmark.responseConstructor:·gc.time                          thrpt   10  885.000               ms
```

**Test**
```
MetadataRequestResponseBenchmark.responseConstructor:·gc.alloc.rate.norm               thrpt   10   904.005 ±  0.001    B/op
MetadataRequestResponseBenchmark.responseConstructor:·gc.time                          thrpt   10   874.000               ms
```

Minor (< 1%) improvements in `ZkMetadataCache` GC allocation rates.
Same as the original test results in 2.4

**Baseline**
```
ZkMetadataCacheBenchmark.benchmarkGetTopicMetadata:·gc.alloc.rate.norm               thrpt   10   960.000 ±  0.001    B/op
ZkMetadataCacheBenchmark.benchmarkGetTopicMetadata:·gc.time                          thrpt   10  5187.000               ms
```

**Test**
```
ZkMetadataCacheBenchmark.benchmarkGetTopicMetadata:·gc.alloc.rate.norm               thrpt   10   840.000 ±  0.001    B/op
ZkMetadataCacheBenchmark.benchmarkGetTopicMetadata:·gc.time                          thrpt   10  5269.000               ms
```
