### PR TITLE
[LI-HOTFIX] Add the move controller RPC

### DIFF
--- a/bin/kafka-li-cluster.sh
+++ b/bin/kafka-li-cluster.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.LiClusterCommand "$@"

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1176,6 +1176,15 @@ public interface Admin extends AutoCloseable {
     ListOffsetsResult listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets, ListOffsetsOptions options);
 
     /**
+     * Move the kafka controller to a different host.
+     * When the active controller is elected via Zookeeper, this API will send
+     * an LiMoveControllerRequest to a kafka broker, which will delete the /controller znode.
+     *
+     * @param options The options to use when moving the controller.
+     */
+    MoveControllerResult moveController(MoveControllerOptions options);
+
+    /**
      * Describes all entities matching the provided filter that have at least one client quota configuration
      * value defined.
      * <p>

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerOptions.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#moveController(MoveControllerOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class MoveControllerOptions extends AbstractOptions<MoveControllerOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link Admin#moveController()}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class MoveControllerResult {
+    private final KafkaFuture<Void> future;
+
+    MoveControllerResult(KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
@@ -214,6 +214,11 @@ public class NoOpAdminClient extends AdminClient {
     }
 
     @Override
+    public MoveControllerResult moveController(MoveControllerOptions options) {
+        return null;
+    }
+
+    @Override
     public DescribeClientQuotasResult describeClientQuotas(ClientQuotaFilter filter,
         DescribeClientQuotasOptions options) {
         return null;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -112,7 +112,8 @@ public enum ApiKeys {
 
     // LinkedIn API keys for APIs not yet upstreamed.
     LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK(ApiMessageType.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, true, true),
-    LI_COMBINED_CONTROL(ApiMessageType.LI_COMBINED_CONTROL, true);
+    LI_COMBINED_CONTROL(ApiMessageType.LI_COMBINED_CONTROL, true),
+    LI_MOVE_CONTROLLER(ApiMessageType.LI_MOVE_CONTROLLER, true);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -307,6 +307,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return LiControlledShutdownSkipSafetyCheckRequest.parse(buffer, apiVersion);
             case LI_COMBINED_CONTROL:
                 return LiCombinedControlRequest.parse(buffer, apiVersion);
+            case LI_MOVE_CONTROLLER:
+                return LiMoveControllerRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -251,6 +251,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return LiControlledShutdownSkipSafetyCheckResponse.parse(responseBuffer, version);
             case LI_COMBINED_CONTROL:
                 return LiCombinedControlResponse.parse(responseBuffer, version);
+            case LI_MOVE_CONTROLLER:
+                return LiMoveControllerResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiMoveControllerRequestData;
+import org.apache.kafka.common.message.LiMoveControllerResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+public class LiMoveControllerRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiMoveControllerRequest> {
+        private final LiMoveControllerRequestData data;
+
+        public Builder(LiMoveControllerRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_MOVE_CONTROLLER, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiMoveControllerRequest build(short version) {
+            return new LiMoveControllerRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiMoveControllerRequestData data;
+
+    LiMoveControllerRequest(LiMoveControllerRequestData data, short version) {
+        super(ApiKeys.LI_MOVE_CONTROLLER, version);
+        this.data = data;
+    }
+
+    public static LiMoveControllerRequest parse(ByteBuffer buffer, short version) {
+        return new LiMoveControllerRequest(new LiMoveControllerRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiMoveControllerResponseData data = new LiMoveControllerResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiMoveControllerResponse(data, version());
+    }
+
+    public LiMoveControllerRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerResponse.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.message.LiMoveControllerResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+public class LiMoveControllerResponse extends AbstractResponse {
+    private final LiMoveControllerResponseData data;
+    private final short version;
+
+    public LiMoveControllerResponse(LiMoveControllerResponseData data, short version) {
+        super(ApiKeys.LI_MOVE_CONTROLLER);
+        this.data = data;
+        this.version = version;
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    public LiMoveControllerResponseData data() {
+        return data;
+    }
+
+    public static LiMoveControllerResponse prepareResponse(Errors error, short version) {
+        LiMoveControllerResponseData data = new LiMoveControllerResponseData();
+        data.setErrorCode(error.code());
+        return new LiMoveControllerResponse(data, version);
+    }
+
+    public static LiMoveControllerResponse parse(ByteBuffer buffer, short version) {
+        return new LiMoveControllerResponse(new LiMoveControllerResponseData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return 0;
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/resources/common/message/LiMoveControllerRequest.json
+++ b/clients/src/main/resources/common/message/LiMoveControllerRequest.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1002,
+  "type": "request",
+  "listeners": ["zkBroker"],
+  "name": "LiMoveControllerRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+  ]
+}

--- a/clients/src/main/resources/common/message/LiMoveControllerResponse.json
+++ b/clients/src/main/resources/common/message/LiMoveControllerResponse.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1002,
+  "type": "response",
+  "name": "LiMoveControllerResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -983,6 +983,11 @@ public class MockAdminClient extends AdminClient {
         return null;
     }
 
+    @Override
+    public MoveControllerResult moveController(MoveControllerOptions options) {
+        return null;
+    }
+
     synchronized public void setFetchesRemainingUntilVisible(String topicName, int fetchesRemainingUntilVisible) {
         TopicMetadata metadata = allTopics.get(topicName);
         if (metadata == null) {

--- a/core/src/main/scala/kafka/admin/LiClusterCommand.scala
+++ b/core/src/main/scala/kafka/admin/LiClusterCommand.scala
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.admin
+
+import joptsimple.OptionSpec
+import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Exit, Logging}
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.admin.{Admin, MoveControllerOptions, AdminClient => JAdminClient}
+import org.apache.kafka.common.utils.Utils
+import java.util.Properties
+
+object LiClusterCommand extends Logging {
+  def createAdminClient(commandConfig: Properties, bootstrapServer: Option[String]): Admin = {
+    bootstrapServer match {
+      case Some(serverList) => commandConfig.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, serverList)
+      case None =>
+    }
+    JAdminClient.create(commandConfig)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val opts = new ControllerCommandOptions(args)
+    opts.checkArgs()
+
+    val adminClient = createAdminClient(opts.commandConfig, opts.bootstrapServer)
+
+    var exitCode = 0
+    try {
+      if (opts.hasMoveControllerOption) {
+        val moveControllerResult = adminClient.moveController(new MoveControllerOptions())
+        moveControllerResult.all().get()
+        println("The move-controller request has completed successfully.")
+      }
+    } catch {
+      case throwable: Throwable =>
+        println("Error while executing cluster command: " + throwable.getMessage)
+        error(Utils.stackTrace(throwable))
+        exitCode = 1
+    } finally {
+      adminClient.close()
+      Exit.exit(exitCode)
+    }
+  }
+
+  class ControllerCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
+    private val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED: The Kafka server to connect to. In case of providing this, a direct Zookeeper connection won't be required.")
+      .withRequiredArg
+      .describedAs("server to connect to")
+      .ofType(classOf[String])
+    private val commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client. " +
+      "This is used only with --bootstrap-server option for describing and altering broker configs.")
+      .withRequiredArg
+      .describedAs("command config property file")
+      .ofType(classOf[String])
+    private val moveControllerOpt = parser.accepts("move-controller", "Move the controller to a different host.")
+
+    options = parser.parse(args : _*)
+    def has(builder: OptionSpec[_]): Boolean = options.has(builder)
+    def valueAsOption[A](option: OptionSpec[A], defaultValue: Option[A] = None): Option[A] = if (has(option)) Some(options.valueOf(option)) else defaultValue
+    def hasMoveControllerOption: Boolean = has(moveControllerOpt)
+    def bootstrapServer: Option[String] = valueAsOption(bootstrapServerOpt)
+    def commandConfig: Properties = if (has(commandConfigOpt)) Utils.loadProps(options.valueOf(commandConfigOpt)) else new Properties()
+
+    def checkArgs(): Unit = {
+      if (args.length == 0)
+        CommandLineUtils.printUsageAndDie(parser, "move a controller")
+
+      CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps to move a controller.")
+
+      // should have exactly one action
+      val actions = Seq(moveControllerOpt).count(options.has)
+      if (actions != 1)
+        CommandLineUtils.printUsageAndDie(parser, "Command must include exactly one action: --move-controller")
+      if (!has(bootstrapServerOpt)) {
+        throw new IllegalArgumentException("The --bootstrap-server option must be set")
+      }
+    }
+  }
+}

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -97,6 +97,7 @@ object RequestConvertToJson {
       case req: ListTransactionsRequest => ListTransactionsRequestDataJsonConverter.write(req.data, request.version)
       case req: LiControlledShutdownSkipSafetyCheckRequest => LiControlledShutdownSkipSafetyCheckRequestDataJsonConverter.write(req.data, request.version)
       case req: LiCombinedControlRequest => LiCombinedControlRequestDataJsonConverter.write(req.data, request.version())
+      case req: LiMoveControllerRequest => LiMoveControllerRequestDataJsonConverter.write(req.data, request.version())
       case _ => throw new IllegalStateException(s"ApiKey ${request.apiKey} is not currently handled in `request`, the " +
         "code should be updated to do so.");
     }
@@ -174,6 +175,7 @@ object RequestConvertToJson {
       case res: ListTransactionsResponse => ListTransactionsResponseDataJsonConverter.write(res.data, version)
       case res: LiControlledShutdownSkipSafetyCheckResponse => LiControlledShutdownSkipSafetyCheckResponseDataJsonConverter.write(res.data, version)
       case res: LiCombinedControlResponse => LiCombinedControlResponseDataJsonConverter.write(res.data, version)
+      case res: LiMoveControllerResponse => LiMoveControllerResponseDataJsonConverter.write(res.data, version)
       case _ => throw new IllegalStateException(s"ApiKey ${response.apiKey} is not currently handled in `response`, the " +
         "code should be updated to do so.");
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -236,6 +236,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         // LinkedIn internal request types
         case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => handleLiControlledShutdownSkipSafetyCheck(request)
         case ApiKeys.LI_COMBINED_CONTROL => handleLiCombinedControlRequest(request, requestLocal)
+        case ApiKeys.LI_MOVE_CONTROLLER => handleMoveControllerRequest(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -3561,6 +3562,22 @@ class KafkaApis(val requestChannel: RequestChannel,
     responseData.setStopReplicaPartitionErrors(stopReplicaPartitionErrors)
 
     requestHelper.sendResponseExemptThrottle(request, new LiCombinedControlResponse(responseData, liCombinedControlRequest.version()))
+  }
+
+  def handleMoveControllerRequest(request: RequestChannel.Request): Unit = {
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val moveControllerRequest = request.body[LiMoveControllerRequest]
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+
+    val moveControllerResponse = try {
+      zkSupport.zkClient.deleteControllerRaw()
+      LiMoveControllerResponse.prepareResponse(Errors.NONE, moveControllerRequest.version())
+    } catch {
+      case throwable: Throwable  =>
+        moveControllerRequest.getErrorResponse(throwable)
+    }
+
+    requestHelper.sendResponseExemptThrottle(request, moveControllerResponse)
   }
 }
 

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -1266,6 +1266,16 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
   }
 
   /**
+   * Deletes the controller znode without checking the expectedControllerEpochZkVersion
+   * This is used to force a controller switch from the cli.
+   * @param expectedControllerEpochZkVersion expected controller epoch zkVersion.
+   */
+  def deleteControllerRaw(): Unit = {
+    val deleteRequest = DeleteRequest(ControllerZNode.path, ZkVersion.MatchAnyVersion)
+    retryRequestUntilConnected(deleteRequest, ZkVersion.MatchAnyVersion)
+  }
+
+  /**
    * Gets the controller epoch.
    * @return optional (Int, Stat) that is Some if the controller epoch path exists and None otherwise.
    */

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -657,6 +657,9 @@ class RequestQuotaTest extends BaseRequestTest {
             new util.ArrayList[Node](), new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataPartitionState](), new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataBroker](),
             new util.ArrayList[LiCombinedControlRequestData.StopReplicaPartitionState](), Collections.emptyMap())
 
+        case ApiKeys.LI_MOVE_CONTROLLER =>
+          new LiMoveControllerRequest.Builder(new LiMoveControllerRequestData(), ApiKeys.LI_MOVE_CONTROLLER.latestVersion)
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }


### PR DESCRIPTION
This is a squash of 2 commits in 2.4-li
- 782005008e [LI-HOTFIX] Add the move controller RPC (#211)
- 8c0345aef7 [LI-HOTFIX] Fixing the broken tests in RequestQuotaTest caused by the new moveController API (#212)

TICKET = LIKAFKA-37769
LI_DESCRIPTION =
In order to make Kafka SOX compliant, all of the znodes need to be protected with ACLS and become writable only by kafka-server. This means the ktool cluster move-controller command will be rejected.

To continue supporting the ktool command above, this PR adds a new moveController API to the KafkaAdminClient.
EXIT_CRITERIA = We can deprecate this PR if either of the following two conditions is met
1. This change is merged in upstream
2. A new equivalent API is added upstream that works based on the Raft-based controller quorum, and we are deprecating zookeeper

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
