### PR TITLE
[LI-HOTFIX] Basic server-side support for multi-cluster integration tests

### DIFF
--- a/core/src/test/scala/integration/kafka/api/MultiClusterAbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MultiClusterAbstractConsumerTest.scala
@@ -1,0 +1,449 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.api
+
+import java.time.Duration
+import java.util
+import java.util.Properties
+
+import kafka.server.{KafkaConfig, MultiClusterBaseRequestTest}
+import kafka.utils.{ShutdownableThread, TestUtils}
+import org.apache.kafka.clients.consumer._
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.WakeupException
+import org.apache.kafka.common.record.TimestampType
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.BeforeEach
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.collection.mutable.{ArrayBuffer, Buffer}
+
+/**
+ * Extension point for consumer integration tests.
+ */
+abstract class MultiClusterAbstractConsumerTest extends MultiClusterBaseRequestTest {
+
+  val epsilon = 0.1
+  override def brokerCountPerCluster: Int = 3
+
+  val topicBaseName = "TestTopic"
+  val topicNameCluster0 = "Cluster0" + topicBaseName
+  val topicNameCluster1 = "Cluster1" + topicBaseName
+  val tp1c0 = new TopicPartition(topicNameCluster0, 0)
+  val tp2c0 = new TopicPartition(topicNameCluster0, 1)  // not actually used currently...
+  val tp1c1 = new TopicPartition(topicNameCluster1, 0)
+  // limit the test topics to no more than two brokers per partition as replicas
+  val replicaCount = if (brokerCountPerCluster > 2) 2 else brokerCountPerCluster
+
+  val producerClientId = "MultiClusterTestProducerID"  // all three of these are fine to be the same across physical
+  val consumerClientId = "MultiClusterTestConsumerID"  // clusters even in the federated case since physical clusters
+  val groupId = "MultiClusterTestConsumerGroupID"      // are invisible to clients; federated looks monolithic
+  val groupMaxSessionTimeoutMs = 30000L
+
+
+  override protected def brokerPropertyOverrides(properties: Properties): Unit = {
+    properties.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false") // speed up shutdown
+    properties.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp, "3") // don't want to lose offset
+    properties.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "1")
+    properties.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, "100") // set small enough session timeout
+    properties.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, groupMaxSessionTimeoutMs.toString)
+    properties.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "10")
+  }
+
+  @BeforeEach
+  override def setUp(): Unit = {
+    super.setUp()
+
+    (0 until numClusters).foreach { i =>
+      this.producerConfigs(i).setProperty(ProducerConfig.ACKS_CONFIG, "all")
+      this.producerConfigs(i).setProperty(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)
+
+      this.consumerConfigs(i).setProperty(ConsumerConfig.CLIENT_ID_CONFIG, consumerClientId)
+      this.consumerConfigs(i).setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+      this.consumerConfigs(i).setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+      this.consumerConfigs(i).setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      this.consumerConfigs(i).setProperty(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "100")
+      this.consumerConfigs(i).setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "6000")
+    }
+
+    // create the test topics
+    createTopic(topicNameCluster0, numPartitions = 2, replicaCount, clusterIndex = 0)
+    createTopic(topicNameCluster1, 1, replicaCount, clusterIndex = 1)  // single-partition topic in 2nd cluster for simplicity
+  }
+
+  protected class TestConsumerReassignmentListener extends ConsumerRebalanceListener {
+    var callsToAssigned = 0
+    var callsToRevoked = 0
+
+    def onPartitionsAssigned(partitions: java.util.Collection[TopicPartition]): Unit = {
+      info("onPartitionsAssigned called.")
+      callsToAssigned += 1
+    }
+
+    def onPartitionsRevoked(partitions: java.util.Collection[TopicPartition]): Unit = {
+      info("onPartitionsRevoked called.")
+      callsToRevoked += 1
+    }
+  }
+
+  protected def createConsumerWithGroupId(groupId: String): KafkaConsumer[Array[Byte], Array[Byte]] = {
+    val groupOverrideConfig = new Properties
+    groupOverrideConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+    createConsumer(configOverrides = groupOverrideConfig)
+  }
+
+  protected def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]],
+                            numRecords: Int,
+                            tp: TopicPartition):
+                            Seq[ProducerRecord[Array[Byte], Array[Byte]]] = {
+    val records = (0 until numRecords).map { i =>
+      val record = new ProducerRecord(tp.topic(), tp.partition(), i.toLong, s"key $i".getBytes, s"value $i".getBytes)
+      producer.send(record)
+      record
+    }
+    producer.flush()
+
+    records
+  }
+
+  protected def consumeAndVerifyRecords(consumer: Consumer[Array[Byte], Array[Byte]],
+                                        numRecords: Int,
+                                        startingOffset: Int,
+                                        startingKeyAndValueIndex: Int = 0,
+                                        startingTimestamp: Long = 0L,
+                                        timestampType: TimestampType = TimestampType.CREATE_TIME,
+                                        tp: TopicPartition = tp1c0,
+                                        maxPollRecords: Int = Int.MaxValue): Unit = {
+    val records = consumeRecords(consumer, numRecords, maxPollRecords = maxPollRecords)
+    val now = System.currentTimeMillis()
+    for (i <- 0 until numRecords) {
+      val record = records(i)
+      val offset = startingOffset + i
+      assertEquals(tp.topic, record.topic)
+      assertEquals(tp.partition, record.partition)
+      if (timestampType == TimestampType.CREATE_TIME) {
+        assertEquals(timestampType, record.timestampType)
+        val timestamp = startingTimestamp + i
+        assertEquals(timestamp.toLong, record.timestamp)
+      } else
+        assertTrue(record.timestamp >= startingTimestamp && record.timestamp <= now,
+          s"Got unexpected timestamp ${record.timestamp}. Timestamp should be between [$startingTimestamp, $now}]")
+      assertEquals(offset.toLong, record.offset)
+      val keyAndValueIndex = startingKeyAndValueIndex + i
+      assertEquals(s"key $keyAndValueIndex", new String(record.key))
+      assertEquals(s"value $keyAndValueIndex", new String(record.value))
+      // this is true only because K and V are byte arrays
+      assertEquals(s"key $keyAndValueIndex".length, record.serializedKeySize)
+      assertEquals(s"value $keyAndValueIndex".length, record.serializedValueSize)
+    }
+  }
+
+  protected def consumeRecords[K, V](consumer: Consumer[K, V],
+                                     numRecords: Int,
+                                     maxPollRecords: Int = Int.MaxValue): ArrayBuffer[ConsumerRecord[K, V]] = {
+    val records = new ArrayBuffer[ConsumerRecord[K, V]]
+    def pollAction(polledRecords: ConsumerRecords[K, V]): Boolean = {
+      assertTrue(polledRecords.asScala.size <= maxPollRecords)
+      records ++= polledRecords.asScala
+      records.size >= numRecords
+    }
+    TestUtils.pollRecordsUntilTrue(consumer, pollAction, waitTimeMs = 60000,
+      msg = s"Timed out before consuming expected $numRecords records. " +
+        s"The number consumed was ${records.size}.")
+    records
+  }
+
+  protected def sendAndAwaitAsyncCommit[K, V](consumer: Consumer[K, V],
+                                              offsetsOpt: Option[Map[TopicPartition, OffsetAndMetadata]] = None): Unit = {
+
+    def sendAsyncCommit(callback: OffsetCommitCallback) = {
+      offsetsOpt match {
+        case Some(offsets) => consumer.commitAsync(offsets.asJava, callback)
+        case None => consumer.commitAsync(callback)
+      }
+    }
+
+    class RetryCommitCallback extends OffsetCommitCallback {
+      var isComplete = false
+      var error: Option[Exception] = None
+
+      override def onComplete(offsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
+        exception match {
+          case e: RetriableCommitFailedException =>
+            sendAsyncCommit(this)
+          case e =>
+            isComplete = true
+            error = Option(e)
+        }
+      }
+    }
+
+    val commitCallback = new RetryCommitCallback
+
+    sendAsyncCommit(commitCallback)
+    TestUtils.pollUntilTrue(consumer, () => commitCallback.isComplete,
+      "Failed to observe commit callback before timeout", waitTimeMs = 10000)
+
+    assertEquals(None, commitCallback.error)
+  }
+
+  /**
+    * Create 'numConsumersToAdd' consumers add then to the consumer group 'consumerGroup', and create corresponding
+    * pollers for these consumers. Wait for partition re-assignment and validate.
+    *
+    * Currently, assignment validation requires that total number of partitions is greater or equal to
+    * number of consumers, so subscriptions.size must be greater or equal the resulting number of consumers in the group
+    *
+    * @param numConsumersToAdd number of consumers to create and add to the consumer group
+    * @param consumerGroup current consumer group
+    * @param consumerPollers current consumer pollers
+    * @param topicsToSubscribe topics to which new consumers will subscribe to
+    * @param subscriptions set of all topic partitions
+    */
+  def addConsumersToGroupAndWaitForGroupAssignment(numConsumersToAdd: Int,
+                                                   consumerGroup: mutable.Buffer[KafkaConsumer[Array[Byte], Array[Byte]]],
+                                                   consumerPollers: mutable.Buffer[ConsumerAssignmentPoller],
+                                                   topicsToSubscribe: List[String],
+                                                   subscriptions: Set[TopicPartition],
+                                                   group: String = groupId): (mutable.Buffer[KafkaConsumer[Array[Byte], Array[Byte]]], mutable.Buffer[ConsumerAssignmentPoller]) = {
+    assertTrue(consumerGroup.size + numConsumersToAdd <= subscriptions.size)
+    addConsumersToGroup(numConsumersToAdd, consumerGroup, consumerPollers, topicsToSubscribe, subscriptions, group)
+    // wait until topics get re-assigned and validate assignment
+    validateGroupAssignment(consumerPollers, subscriptions)
+
+    (consumerGroup, consumerPollers)
+  }
+
+  /**
+    * Create 'numConsumersToAdd' consumers add then to the consumer group 'consumerGroup', and create corresponding
+    * pollers for these consumers.
+    *
+    *
+    * @param numConsumersToAdd number of consumers to create and add to the consumer group
+    * @param consumerGroup current consumer group
+    * @param consumerPollers current consumer pollers
+    * @param topicsToSubscribe topics to which new consumers will subscribe to
+    * @param subscriptions set of all topic partitions
+    */
+  def addConsumersToGroup(numConsumersToAdd: Int,
+                          consumerGroup: mutable.Buffer[KafkaConsumer[Array[Byte], Array[Byte]]],
+                          consumerPollers: mutable.Buffer[ConsumerAssignmentPoller],
+                          topicsToSubscribe: List[String],
+                          subscriptions: Set[TopicPartition],
+                          group: String = groupId): (mutable.Buffer[KafkaConsumer[Array[Byte], Array[Byte]]], mutable.Buffer[ConsumerAssignmentPoller]) = {
+    for (_ <- 0 until numConsumersToAdd) {
+      val consumer = createConsumerWithGroupId(group)
+      consumerGroup += consumer
+      consumerPollers += subscribeConsumerAndStartPolling(consumer, topicsToSubscribe)
+    }
+
+    (consumerGroup, consumerPollers)
+  }
+
+  /**
+    * Wait for consumers to get partition assignment and validate it.
+    *
+    * @param consumerPollers consumer pollers corresponding to the consumer group we are testing
+    * @param subscriptions set of all topic partitions
+    * @param msg message to print when waiting for/validating assignment fails
+    */
+  def validateGroupAssignment(consumerPollers: mutable.Buffer[ConsumerAssignmentPoller],
+                              subscriptions: Set[TopicPartition],
+                              msg: Option[String] = None,
+                              waitTime: Long = 10000L): Unit = {
+    val assignments = mutable.Buffer[Set[TopicPartition]]()
+    TestUtils.waitUntilTrue(() => {
+      assignments.clear()
+      consumerPollers.foreach(assignments += _.consumerAssignment())
+      isPartitionAssignmentValid(assignments, subscriptions)
+    }, msg.getOrElse(s"Did not get valid assignment for partitions $subscriptions. Instead, got $assignments"), waitTime)
+  }
+
+  /**
+    * Subscribes consumer 'consumer' to a given list of topics 'topicsToSubscribe', creates
+    * consumer poller and starts polling.
+    * Assumes that the consumer is not subscribed to any topics yet
+    *
+    * @param consumer consumer
+    * @param topicsToSubscribe topics that this consumer will subscribe to
+    * @return consumer poller for the given consumer
+    */
+  def subscribeConsumerAndStartPolling(consumer: Consumer[Array[Byte], Array[Byte]],
+                                       topicsToSubscribe: List[String],
+                                       partitionsToAssign: Set[TopicPartition] = Set.empty[TopicPartition]): ConsumerAssignmentPoller = {
+    assertEquals(0, consumer.assignment().size)
+    val consumerPoller = if (topicsToSubscribe.nonEmpty)
+      new ConsumerAssignmentPoller(consumer, topicsToSubscribe)
+    else
+      new ConsumerAssignmentPoller(consumer, partitionsToAssign)
+
+    consumerPoller.start()
+    consumerPoller
+  }
+
+  protected def awaitRebalance(consumer: Consumer[_, _], rebalanceListener: TestConsumerReassignmentListener): Unit = {
+    val numReassignments = rebalanceListener.callsToAssigned
+    TestUtils.pollUntilTrue(consumer, () => rebalanceListener.callsToAssigned > numReassignments,
+      "Timed out before expected rebalance completed")
+  }
+
+  protected def ensureNoRebalance(consumer: Consumer[_, _], rebalanceListener: TestConsumerReassignmentListener): Unit = {
+    // The best way to verify that the current membership is still active is to commit offsets.
+    // This would fail if the group had rebalanced.
+    val initialRevokeCalls = rebalanceListener.callsToRevoked
+    sendAndAwaitAsyncCommit(consumer)
+    assertEquals(initialRevokeCalls, rebalanceListener.callsToRevoked)
+  }
+
+  protected class CountConsumerCommitCallback extends OffsetCommitCallback {
+    var successCount = 0
+    var failCount = 0
+    var lastError: Option[Exception] = None
+
+    override def onComplete(offsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
+      if (exception == null) {
+        successCount += 1
+      } else {
+        failCount += 1
+        lastError = Some(exception)
+      }
+    }
+  }
+
+  protected class ConsumerAssignmentPoller(consumer: Consumer[Array[Byte], Array[Byte]],
+                                           topicsToSubscribe: List[String],
+                                           partitionsToAssign: Set[TopicPartition])
+    extends ShutdownableThread("daemon-consumer-assignment", false) {
+
+    def this(consumer: Consumer[Array[Byte], Array[Byte]], topicsToSubscribe: List[String]) {
+      this(consumer, topicsToSubscribe, Set.empty[TopicPartition])
+    }
+
+    def this(consumer: Consumer[Array[Byte], Array[Byte]], partitionsToAssign: Set[TopicPartition]) {
+      this(consumer, List.empty[String], partitionsToAssign)
+    }
+
+    @volatile var thrownException: Option[Throwable] = None
+    @volatile var receivedMessages = 0
+
+    private val partitionAssignment = mutable.Set[TopicPartition]()
+    @volatile private var subscriptionChanged = false
+    private var topicsSubscription = topicsToSubscribe
+
+    val rebalanceListener: ConsumerRebalanceListener = new ConsumerRebalanceListener {
+      override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]) = {
+        partitionAssignment ++= partitions.toArray(new Array[TopicPartition](0))
+      }
+
+      override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]) = {
+        partitionAssignment --= partitions.toArray(new Array[TopicPartition](0))
+      }
+    }
+
+    if (partitionsToAssign.isEmpty) {
+      consumer.subscribe(topicsToSubscribe.asJava, rebalanceListener)
+    } else {
+      consumer.assign(partitionsToAssign.asJava)
+    }
+
+    def consumerAssignment(): Set[TopicPartition] = {
+      partitionAssignment.toSet
+    }
+
+    /**
+     * Subscribe consumer to a new set of topics.
+     * Since this method most likely be called from a different thread, this function
+     * just "schedules" the subscription change, and actual call to consumer.subscribe is done
+     * in the doWork() method
+     *
+     * This method does not allow to change subscription until doWork processes the previous call
+     * to this method. This is just to avoid race conditions and enough functionality for testing purposes
+     * @param newTopicsToSubscribe
+     */
+    def subscribe(newTopicsToSubscribe: List[String]): Unit = {
+      if (subscriptionChanged)
+        throw new IllegalStateException("Do not call subscribe until the previous subscribe request is processed.")
+      if (partitionsToAssign.nonEmpty)
+        throw new IllegalStateException("Cannot call subscribe when configured to use manual partition assignment")
+
+      topicsSubscription = newTopicsToSubscribe
+      subscriptionChanged = true
+    }
+
+    def isSubscribeRequestProcessed: Boolean = {
+      !subscriptionChanged
+    }
+
+    override def initiateShutdown(): Boolean = {
+      val res = super.initiateShutdown()
+      consumer.wakeup()
+      res
+    }
+
+    override def doWork(): Unit = {
+      if (subscriptionChanged) {
+        consumer.subscribe(topicsSubscription.asJava, rebalanceListener)
+        subscriptionChanged = false
+      }
+      try {
+        receivedMessages += consumer.poll(Duration.ofMillis(50)).count()
+      } catch {
+        case _: WakeupException => // ignore for shutdown
+        case e: Throwable =>
+          thrownException = Some(e)
+          throw e
+      }
+    }
+  }
+
+  /**
+   * Check whether partition assignment is valid
+   * Assumes partition assignment is valid iff
+   * 1. Every consumer got assigned at least one partition
+   * 2. Each partition is assigned to only one consumer
+   * 3. Every partition is assigned to one of the consumers
+   *
+   * @param assignments set of consumer assignments; one per each consumer
+   * @param partitions set of partitions that consumers subscribed to
+   * @return true if partition assignment is valid
+   */
+  def isPartitionAssignmentValid(assignments: Buffer[Set[TopicPartition]],
+                                 partitions: Set[TopicPartition]): Boolean = {
+    val allNonEmptyAssignments = assignments.forall(assignment => assignment.nonEmpty)
+    if (!allNonEmptyAssignments) {
+      // at least one consumer got empty assignment
+      return false
+    }
+
+    // make sure that sum of all partitions to all consumers equals total number of partitions
+    val totalPartitionsInAssignments = assignments.foldLeft(0)(_ + _.size)
+    if (totalPartitionsInAssignments != partitions.size) {
+      // either same partitions got assigned to more than one consumer or some
+      // partitions were not assigned
+      return false
+    }
+
+    // The above checks could miss the case where one or more partitions were assigned to more
+    // than one consumer and the same number of partitions were missing from assignments.
+    // Make sure that all unique assignments are the same as 'partitions'
+    val uniqueAssignedPartitions = assignments.foldLeft(Set.empty[TopicPartition])(_ ++ _)
+    uniqueAssignedPartitions == partitions
+  }
+
+}

--- a/core/src/test/scala/integration/kafka/api/MultiClusterIntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/MultiClusterIntegrationTestHarness.scala
@@ -1,0 +1,175 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.api
+
+import java.time.Duration
+import java.util.Properties
+
+import kafka.integration.MultiClusterKafkaServerTestHarness
+import kafka.server.KafkaConfig
+import kafka.utils.Implicits._
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
+import org.apache.kafka.common.network.{ListenerName, Mode}
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, Deserializer, Serializer}
+import org.junit.jupiter.api.{AfterEach, BeforeEach}
+
+import scala.collection.{Seq, mutable}
+import scala.collection.mutable.{ArrayBuffer, Buffer}
+
+/**
+ * A helper class for writing integration tests that involve producers, consumers, and servers
+ */
+abstract class MultiClusterIntegrationTestHarness extends MultiClusterKafkaServerTestHarness {
+  protected def brokerCountPerCluster: Int
+  protected def logDirCount: Int = 1
+
+  val producerConfigs: Buffer[Properties] = new ArrayBuffer(numClusters) // referenced in MultiClusterAbstractConsumerTest
+  val consumerConfigs: Buffer[Properties] = new ArrayBuffer(numClusters) // ditto
+  val adminClientConfigs: Buffer[Properties] = new ArrayBuffer(numClusters)
+  val serverConfig = new Properties // unconditional extra configs for all brokers
+
+  private val consumers = mutable.Buffer[KafkaConsumer[_, _]]()
+  private val producers = mutable.Buffer[KafkaProducer[_, _]]()
+  private val adminClients = mutable.Buffer[Admin]()
+
+  override def generateConfigsByCluster(clusterIndex: Int): Seq[KafkaConfig] = {
+    val cfgs = TestUtils.createBrokerConfigs(brokerCountPerCluster, zkConnect(clusterIndex),
+      interBrokerSecurityProtocol = Some(securityProtocol), trustStoreFile = trustStoreFile,
+      saslProperties = serverSaslProperties, logDirCount = logDirCount)
+    modifyConfigs(cfgs, clusterIndex)
+    cfgs.map(KafkaConfig.fromProps)
+  }
+
+  protected def modifyConfigs(props: Seq[Properties], clusterIndex: Int): Unit = {
+    configureListeners(props)
+    props.foreach(_ ++= serverConfig)
+  }
+
+  protected def configureListeners(props: Seq[Properties]): Unit = {
+    props.foreach { config =>
+      config.remove(KafkaConfig.InterBrokerSecurityProtocolProp)
+      config.setProperty(KafkaConfig.InterBrokerListenerNameProp, interBrokerListenerName.value)
+
+      val listenerNames = Set(listenerName, interBrokerListenerName)
+      val listeners = listenerNames.map(listenerName => s"${listenerName.value}://localhost:${TestUtils.RandomPort}").mkString(",")
+      val listenerSecurityMap = listenerNames.map(listenerName => s"${listenerName.value}:${securityProtocol.name}").mkString(",")
+
+      config.setProperty(KafkaConfig.ListenersProp, listeners)
+      config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, listenerSecurityMap)
+    }
+  }
+
+  protected def interBrokerListenerName: ListenerName = listenerName
+
+  @BeforeEach
+  override def setUp(): Unit = {
+    doSetup(createOffsetsTopic = true)
+  }
+
+  def doSetup(createOffsetsTopic: Boolean): Unit = {
+    super.setUp()
+
+    (0 until numClusters).foreach { i =>
+      producerConfigs += new Properties
+      consumerConfigs += new Properties
+      adminClientConfigs += new Properties
+
+      producerConfigs(i) ++= clientSecurityProps("producer")
+      consumerConfigs(i) ++= clientSecurityProps("consumer")
+      adminClientConfigs(i) ++= clientSecurityProps("adminClient")
+
+      producerConfigs(i).put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList(i))
+      producerConfigs(i).putIfAbsent(ProducerConfig.ACKS_CONFIG, "-1")
+      producerConfigs(i).putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+      producerConfigs(i).putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer].getName)
+      producerConfigs(i).putIfAbsent(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, boolean2Boolean(true))
+
+      consumerConfigs(i).put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList(i))
+      consumerConfigs(i).putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+      consumerConfigs(i).putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, "group")
+      consumerConfigs(i).putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+      consumerConfigs(i).putIfAbsent(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+      consumerConfigs(i).putIfAbsent(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, boolean2Boolean(true))
+
+      adminClientConfigs(i).put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList(i))
+
+      if (createOffsetsTopic)
+        TestUtils.createOffsetsTopic(zkClient(i), serversByCluster(i))
+    }
+  }
+
+  def clientSecurityProps(certAlias: String): Properties = {
+    TestUtils.securityConfigs(Mode.CLIENT, securityProtocol, trustStoreFile, certAlias, TestUtils.SslCertificateCn,
+      clientSaslProperties)
+  }
+
+  // TODO:  currently cluster 0 only
+  def createProducer[K, V](keySerializer: Serializer[K] = new ByteArraySerializer,
+                           valueSerializer: Serializer[V] = new ByteArraySerializer,
+                           configOverrides: Properties = new Properties): KafkaProducer[K, V] = {
+    val props = new Properties
+    props ++= producerConfigs(0)
+    props ++= configOverrides
+    val producer = new KafkaProducer[K, V](props, keySerializer, valueSerializer)
+    producers += producer
+    producer
+  }
+
+  // TODO:  currently cluster 0 only
+  def createConsumer[K, V](keyDeserializer: Deserializer[K] = new ByteArrayDeserializer,
+                           valueDeserializer: Deserializer[V] = new ByteArrayDeserializer,
+                           configOverrides: Properties = new Properties,
+                           configsToRemove: List[String] = List()): KafkaConsumer[K, V] = {
+    val props = new Properties
+    props ++= consumerConfigs(0)
+    props ++= configOverrides
+    configsToRemove.foreach(props.remove(_))
+    val consumer = new KafkaConsumer[K, V](props, keyDeserializer, valueDeserializer)
+    consumers += consumer
+    consumer
+  }
+
+  // TODO:  currently cluster 0 only
+  def createAdminClient(configOverrides: Properties = new Properties): Admin = {
+    val props = new Properties
+    props ++= adminClientConfigs(0)
+    props ++= configOverrides
+    val adminClient = AdminClient.create(props)
+    adminClients += adminClient
+    adminClient
+  }
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    // TODO:  figure out how want to store and shut down per-cluster clients
+    producers.foreach(_.close(Duration.ZERO))
+    consumers.foreach(_.wakeup())
+    consumers.foreach(_.close(Duration.ZERO))
+    adminClients.foreach(_.close(Duration.ZERO))
+
+    producers.clear()
+    consumers.clear()
+    adminClients.clear()
+
+    super.tearDown()
+  }
+
+}

--- a/core/src/test/scala/integration/kafka/api/ProxyBasedFederationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProxyBasedFederationTest.scala
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright
+ * ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package kafka.api
+
+import org.junit.jupiter.api.Test
+
+import scala.collection.JavaConverters._
+
+/**
+ * Currently a simple proof of concept of a multi-cluster integration test, but ultimately intended
+ * as a feasibility test for proxy-based federation:  specifically, can a vanilla client (whether
+ * consumer, producer, or admin) talk to a federated set of two or more physical clusters and
+ * successfully execute all parts of its API?
+ */
+class ProxyBasedFederationTest extends MultiClusterAbstractConsumerTest {
+  override def numClusters: Int = 2  // need one ZK instance for each Kafka cluster  [TODO: can we "chroot" instead?]
+  override def brokerCountPerCluster: Int = 3  // three _per Kafka cluster_, i.e., six total
+
+  @Test
+  def testBasicMultiClusterSetup(): Unit = {
+    val numRecords = 1000
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp1c0)
+
+    val consumer = createConsumer()
+    consumer.assign(List(tp1c0).asJava)
+    consumer.seek(tp1c0, 0)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, startingOffset = 0)
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/integration/MultiClusterKafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/MultiClusterKafkaServerTestHarness.scala
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.integration
+
+import java.io.File
+import java.util.Properties
+
+import kafka.server._
+import kafka.utils.TestUtils
+import kafka.zk.MultiClusterZooKeeperTestHarness
+import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
+import org.apache.kafka.common.utils.Time
+import org.junit.jupiter.api.{AfterEach, BeforeEach}
+
+import scala.collection.Seq
+import scala.collection.mutable.{ArrayBuffer, Buffer}
+
+/**
+ * A test harness that brings up some number of broker nodes
+ */
+abstract class MultiClusterKafkaServerTestHarness extends MultiClusterZooKeeperTestHarness {
+  private val brokerLists: Buffer[String] = new ArrayBuffer(numClusters)
+  private val instanceServers: Buffer[Buffer[KafkaServer]] = new ArrayBuffer(numClusters)
+  private val instanceConfigs: Buffer[Seq[KafkaConfig]] = new ArrayBuffer(numClusters)
+
+  val kafkaPrincipalType = KafkaPrincipal.USER_TYPE
+
+  def brokerList(clusterIndex: Int): String = {
+    brokerLists(clusterIndex)
+  }
+
+  // We avoid naming this method servers() since that conflicts with the existing indexed addressing of
+  // Buffer[KafkaServer] (i.e., of specific brokers within a single cluster) used in our sub-sub-subclass
+  // AbstractConsumerTest.
+  def serversByCluster(clusterIndex: Int): Buffer[KafkaServer] = {
+    instanceServers(clusterIndex)
+  }
+
+  private def configsByCluster(clusterIndex: Int): Seq[KafkaConfig] = {
+    if (clusterIndex >= numClusters)
+      throw new KafkaException("clusterIndex (" + clusterIndex + ") is out of range: must be less than " + numClusters)
+    if (instanceConfigs.length < numClusters)
+      (instanceConfigs.length until numClusters).foreach { _ => instanceConfigs += null }
+    if (instanceConfigs(clusterIndex) == null)
+      instanceConfigs(clusterIndex) = generateConfigsByCluster(clusterIndex)
+    instanceConfigs(clusterIndex)
+  }
+
+  /**
+   * Implementations must override this method to return a set of KafkaConfigs matching the number of brokers per
+   * cluster. This method will be invoked for every test and should not reuse previous configurations unless they
+   * select their ports randomly when servers are started.
+   */
+  def generateConfigsByCluster(clusterIndex: Int): Seq[KafkaConfig]
+
+  /**
+   * Override this in case ACLs or security credentials must be set before `servers` are started.
+   *
+   * This is required in some cases because of the topic creation in the setup of `IntegrationTestHarness`. If
+   * the ACLs are only set later, tests may fail. The failure could manifest itself as a cluster action
+   * authorization exception when processing an update metadata request (controller -> broker) or in more obscure
+   * ways (e.g. `__consumer_offsets` topic replication fails because the metadata cache has no brokers as a previous
+   * update metadata request failed due to an authorization exception).
+   *
+   * The default implementation of this method is a no-op.
+   */
+  def configureSecurityBeforeServersStart(clusterIndex: Int): Unit = {}
+
+  /**
+   * Override this in case Tokens or security credentials needs to be created after `servers` are started.
+   * The default implementation of this method is a no-op.
+   */
+  def configureSecurityAfterServersStart(clusterIndex: Int): Unit = {}
+
+  def boundPort(server: KafkaServer): Int = server.boundPort(listenerName)
+
+  protected def securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT
+  protected def listenerName: ListenerName = ListenerName.forSecurityProtocol(securityProtocol)
+  protected def trustStoreFile: Option[File] = None
+  protected def serverSaslProperties: Option[Properties] = None
+  protected def clientSaslProperties: Option[Properties] = None
+  protected def brokerTime(brokerId: Int): Time = Time.SYSTEM
+
+  @BeforeEach
+  override def setUp(): Unit = {
+    super.setUp()
+
+    (0 until numClusters).foreach { clusterIndex =>
+      // apparently intended semantic is that each config in the Seq[KafkaConfig] corresponds to a single broker?
+      if (configsByCluster(clusterIndex).isEmpty)
+        throw new KafkaException(s"Must supply at least one server config for cluster #${clusterIndex}")
+
+      instanceServers += new ArrayBuffer(configsByCluster(clusterIndex).length)
+
+      // default implementation is a no-op, it is overridden by subclasses if required
+      configureSecurityBeforeServersStart(clusterIndex)
+
+      // Add each broker to `instanceServers` buffer as soon as it is created to ensure that brokers
+      // are shut down cleanly in tearDown even if a subsequent broker fails to start
+      for (config <- configsByCluster(clusterIndex))
+        instanceServers(clusterIndex) += TestUtils.createServer(config, time = brokerTime(config.brokerId))
+      brokerLists += TestUtils.bootstrapServers(instanceServers(clusterIndex), listenerName)
+
+      // default implementation is a no-op, it is overridden by subclasses if required
+      configureSecurityAfterServersStart(clusterIndex)
+    }
+  }
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    (0 until numClusters).foreach { clusterIndex =>
+      if (serversByCluster(clusterIndex) != null) {
+        TestUtils.shutdownServers(serversByCluster(clusterIndex))
+      }
+    }
+    super.tearDown()
+  }
+
+  /**
+   * Create a topic in ZooKeeper.
+   * Wait until the leader is elected and the metadata is propagated to all brokers.
+   * Return the leader for each partition.
+   */
+  def createTopic(topic: String, numPartitions: Int = 1, replicationFactor: Int = 1,
+                  topicConfig: Properties = new Properties, clusterIndex: Int = 0):
+                  scala.collection.immutable.Map[Int, Int] =
+    TestUtils.createTopic(zkClient(clusterIndex), topic, numPartitions, replicationFactor,
+      serversByCluster(clusterIndex), topicConfig)
+
+  /**
+   * Create a topic in ZooKeeper using a customized replica assignment.
+   * Wait until the leader is elected and the metadata is propagated to all brokers.
+   * Return the leader for each partition.
+   */
+  def createTopic(topic: String, partitionReplicaAssignment: collection.Map[Int, Seq[Int]], clusterIndex: Int):
+                  scala.collection.immutable.Map[Int, Int] =
+    TestUtils.createTopic(zkClient(clusterIndex), topic, partitionReplicaAssignment, serversByCluster(clusterIndex))
+
+}

--- a/core/src/test/scala/unit/kafka/server/MultiClusterBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MultiClusterBaseRequestTest.scala
@@ -1,0 +1,155 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import java.io.{DataInputStream, DataOutputStream}
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.util.{EnumSet, Properties}
+
+import kafka.api.MultiClusterIntegrationTestHarness
+import kafka.network.SocketServer
+import kafka.utils.NotNothing
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, RequestHeader, ResponseHeader}
+import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.metadata.BrokerState
+
+import scala.collection.Seq
+import scala.reflect.ClassTag
+
+abstract class MultiClusterBaseRequestTest extends MultiClusterIntegrationTestHarness {
+  private var correlationId = 0
+
+  // If required, override properties by mutating the passed Properties object
+  protected def brokerPropertyOverrides(properties: Properties): Unit = {}
+
+  override def modifyConfigs(props: Seq[Properties], clusterIndex: Int): Unit = {
+    super.modifyConfigs(props, clusterIndex)
+    props.foreach { p =>
+      p.put(KafkaConfig.ControlledShutdownEnableProp, "false")
+      brokerPropertyOverrides(p)
+    }
+  }
+
+  def anySocketServer(clusterId: Int): SocketServer = {
+    serversByCluster(clusterId)
+      .find {server => !EnumSet.of(BrokerState.NOT_RUNNING, BrokerState.SHUTTING_DOWN).contains(server.brokerState)}
+      .map(_.socketServer).getOrElse(throw new IllegalStateException(s"No live broker is available in cluster ${clusterId}"))
+  }
+
+  def controllerSocketServer(clusterId: Int): SocketServer = {
+    serversByCluster(clusterId).find { server =>
+      server.kafkaController.isActive
+    }.map(_.socketServer).getOrElse(throw new IllegalStateException(s"No controller broker is available in cluster ${clusterId}"))
+  }
+
+  def notControllerSocketServer(clusterId: Int): SocketServer = {
+    serversByCluster(clusterId).find { server =>
+      !server.kafkaController.isActive
+    }.map(_.socketServer).getOrElse(throw new IllegalStateException(s"No non-controller broker is available in cluster ${clusterId}"))
+  }
+
+  def brokerSocketServer(clusterId: Int, brokerId: Int): SocketServer = {
+    serversByCluster(clusterId).find { server =>
+      server.config.brokerId == brokerId
+    }.map(_.socketServer).getOrElse(throw new IllegalStateException(s"Could not find broker with id $brokerId in cluster ${clusterId}"))
+  }
+
+  def connectAndReceive[T <: AbstractResponse](request: AbstractRequest,
+                                               clusterId: Int,
+                                               socketServerOpt: Option[SocketServer] = None,
+                                               listenerName: ListenerName = listenerName)
+                                              (implicit classTag: ClassTag[T], nn: NotNothing[T]): T = {
+    val socket = connect(clusterId, socketServerOpt, listenerName)
+    try sendAndReceive[T](request, socket)
+    finally socket.close()
+  }
+
+  def connect(clusterId: Int,
+              socketServerOpt: Option[SocketServer] = None,
+              listenerName: ListenerName = listenerName): Socket = {
+    val socketServer = socketServerOpt.getOrElse {
+      anySocketServer(clusterId)
+    }
+    new Socket("localhost", socketServer.boundPort(listenerName))
+  }
+
+  def sendAndReceive[T <: AbstractResponse](request: AbstractRequest,
+                                            socket: Socket,
+                                            clientId: String = "client-id",
+                                            correlationId: Option[Int] = None)
+                                           (implicit classTag: ClassTag[T], nn: NotNothing[T]): T = {
+    send(request, socket, clientId, correlationId)
+    receive[T](socket, request.apiKey, request.version)
+  }
+
+  /**
+    * Serializes and sends the request to the given api.
+    */
+  def send(request: AbstractRequest,
+           socket: Socket,
+           clientId: String = "client-id",
+           correlationId: Option[Int] = None): Unit = {
+    val header = nextRequestHeader(request.apiKey, request.version, clientId, correlationId)
+    sendWithHeader(request, header, socket)
+  }
+
+  def nextRequestHeader[T <: AbstractResponse](apiKey: ApiKeys,
+                                               apiVersion: Short,
+                                               clientId: String = "client-id",
+                                               correlationIdOpt: Option[Int] = None): RequestHeader = {
+    val correlationId = correlationIdOpt.getOrElse {
+      this.correlationId += 1
+      this.correlationId
+    }
+    new RequestHeader(apiKey, apiVersion, clientId, correlationId)
+  }
+
+  def sendWithHeader(request: AbstractRequest, header: RequestHeader, socket: Socket): Unit = {
+    val serializedBytes = Utils.toArray(request.serializeWithHeader(header))
+    sendRequest(socket, serializedBytes)
+  }
+
+  private def sendRequest(socket: Socket, request: Array[Byte]): Unit = {
+    val outgoing = new DataOutputStream(socket.getOutputStream)
+    outgoing.writeInt(request.length)
+    outgoing.write(request)
+    outgoing.flush()
+  }
+
+  def receive[T <: AbstractResponse](socket: Socket, apiKey: ApiKeys, version: Short)
+                                    (implicit classTag: ClassTag[T], nn: NotNothing[T]): T = {
+    val incoming = new DataInputStream(socket.getInputStream)
+    val len = incoming.readInt()
+
+    val responseBytes = new Array[Byte](len)
+    incoming.readFully(responseBytes)
+
+    val responseBuffer = ByteBuffer.wrap(responseBytes)
+    ResponseHeader.parse(responseBuffer, apiKey.responseHeaderVersion(version))
+
+    AbstractResponse.parseResponse(apiKey, responseBuffer, version) match {
+      case response: T => response
+      case response =>
+        throw new ClassCastException(s"Expected response with type ${classTag.runtimeClass}, but found ${response.getClass}")
+    }
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/zk/MultiClusterZooKeeperTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/MultiClusterZooKeeperTestHarness.scala
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.zk
+
+import javax.security.auth.login.Configuration
+import kafka.controller.ControllerEventManager
+import kafka.utils.{CoreUtils, Logging, TestUtils}
+import org.apache.kafka.clients.admin.AdminClientUnitTestEnv
+import org.apache.kafka.clients.consumer.internals.AbstractCoordinator
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.common.security.JaasUtils
+import org.apache.kafka.common.utils.Time
+import org.apache.zookeeper.client.ZKClientConfig
+import org.apache.zookeeper.{WatchedEvent, Watcher, ZooKeeper}
+import org.junit.jupiter.api.Assertions.{assertNull, assertTrue}
+import org.junit.jupiter.api.{AfterAll, AfterEach, BeforeAll, BeforeEach, Tag}
+
+import scala.collection.JavaConverters._
+import scala.collection.Set
+import scala.collection.mutable.{ArrayBuffer, Buffer}
+
+@Tag("integration")
+abstract class MultiClusterZooKeeperTestHarness extends Logging {
+  protected def numClusters: Int = 1 // a.k.a. numZookeepers since each Kafka cluster requires its own ZK (or ZK-chroot)
+
+  val zkConnectionTimeout = 10000
+  val zkSessionTimeout = 15000 // Allows us to avoid ZK session expiration due to GC up to 2/3 * 15000ms = 10 secs
+  val zkMaxInFlightRequests = Int.MaxValue
+
+  protected def zkAclsEnabled: Option[Boolean] = None
+
+  private val zkClients: Buffer[KafkaZkClient] = new ArrayBuffer(numClusters)
+  private val adminZkClients: Buffer[AdminZkClient] = new ArrayBuffer(numClusters)
+  private val zookeepers: Buffer[EmbeddedZookeeper] = new ArrayBuffer(numClusters)
+
+  def zkClient(i: Int): KafkaZkClient = {
+    zkClients(i)
+  }
+
+  def adminZkClient(i: Int): AdminZkClient = {
+    adminZkClients(i)
+  }
+
+  def zookeeper(i: Int): EmbeddedZookeeper = {
+    zookeepers(i)
+  }
+
+  def zkConnect(i: Int): String = {
+    s"127.0.0.1:${zookeeper(i).port}"
+  }
+
+  @BeforeEach
+  def setUp(): Unit = {
+    (0 until numClusters).map { i =>
+      debug(s"creating zookeeper/zkClient/adminZkClient " + (i+1) + " of " + numClusters)
+      zookeepers += new EmbeddedZookeeper()
+      zkClients += KafkaZkClient(zkConnect(i), zkAclsEnabled.getOrElse(JaasUtils.isZkSaslEnabled), zkSessionTimeout,
+        zkConnectionTimeout, zkMaxInFlightRequests, Time.SYSTEM, name = MultiClusterZooKeeperTestHarness.getClass.getName, new ZKClientConfig)
+      adminZkClients += new AdminZkClient(zkClients(i))
+    }
+  }
+
+  @AfterEach
+  def tearDown(): Unit = {
+    for (zkc <- zkClients)
+      zkc.close()
+    for (zk <- zookeepers)
+      CoreUtils.swallow(zk.shutdown(), this)
+    Configuration.setConfiguration(null)
+  }
+
+  // Trigger session expiry by reusing the session id in another client
+  def createZooKeeperClientToTriggerSessionExpiry(zooKeeper: ZooKeeper, i: Int): ZooKeeper = {
+    val dummyWatcher = new Watcher {
+      override def process(event: WatchedEvent): Unit = {}
+    }
+    val anotherZkClient = new ZooKeeper(zkConnect(i), 1000, dummyWatcher,
+      zooKeeper.getSessionId,
+      zooKeeper.getSessionPasswd)
+    assertNull(anotherZkClient.exists("/nonexistent", false)) // Make sure new client works
+    anotherZkClient
+  }
+}
+
+object MultiClusterZooKeeperTestHarness {
+  val ZkClientEventThreadSuffix = "-EventThread"
+
+  // Threads which may cause transient failures in subsequent tests if not shutdown.
+  // These include threads which make connections to brokers and may cause issues
+  // when broker ports are reused (e.g. auto-create topics) as well as threads
+  // which reset static JAAS configuration.
+  val unexpectedThreadNames = Set(ControllerEventManager.ControllerEventThreadName,
+                                  KafkaProducer.NETWORK_THREAD_PREFIX,
+                                  AdminClientUnitTestEnv.kafkaAdminClientNetworkThreadPrefix(),
+                                  AbstractCoordinator.HEARTBEAT_THREAD_PREFIX,
+                                  ZkClientEventThreadSuffix)
+
+  /**
+   * Verify that a previous test that doesn't use MultiClusterZooKeeperTestHarness hasn't left behind an unexpected
+   * thread. This assumes that brokers, ZooKeeper clients, producers and consumers are not created in another
+   * {code @BeforeAll}, which is true for core tests where this harness is used.
+   */
+  @BeforeAll
+  def setUpClass(): Unit = {
+    verifyNoUnexpectedThreads("@BeforeClass")
+  }
+
+  /**
+   * Verify that tests from the current test class using MultiClusterZooKeeperTestHarness haven't left behind an
+   * unexpected thread.
+   */
+  @AfterAll
+  def tearDownClass(): Unit = {
+    verifyNoUnexpectedThreads("@AfterClass")
+  }
+
+  /**
+   * Verifies that threads which are known to cause transient failures in subsequent tests
+   * have been shutdown.
+   */
+  def verifyNoUnexpectedThreads(context: String): Unit = {
+    def allThreads = Thread.getAllStackTraces.keySet.asScala.map(thread => thread.getName)
+    val (threads, noUnexpected) = TestUtils.computeUntilTrue(allThreads) { threads =>
+      threads.forall(t => unexpectedThreadNames.forall(s => !t.contains(s)))
+    }
+    assertTrue(
+      noUnexpected,
+      s"Found unexpected threads during $context, allThreads=$threads, " +
+        s"unexpected=${threads.filterNot(t => unexpectedThreadNames.forall(s => !t.contains(s)))}"
+    )
+  }
+}


### PR DESCRIPTION
The original commit in 2.4-li branch is
- [LI-HOTFIX] Basic server-side support for multi-cluster integration tests (#217)

TICKET = LIKAFKA-41598
LI_DESCRIPTION = This extends the existing integration-test framework by adding a "sister tree" of test-harness classes modified for multi-cluster use. (For now, the client side still supports only cluster 0.)
EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
