### PR TITLE
[LI-HOTFIX] Return data to MemoryPool ByteBuffer when close()/poll() call happens

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -864,6 +864,9 @@ public class NetworkClient implements KafkaClient {
                 receive.close();
             }
         }
+
+        // Clear the completed receives once they have been added to ClientResponse returned via poll()
+        this.selector.completedReceives().clear();
     }
 
     private void handleApiVersionsResponse(List<ClientResponse> responses,

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -759,6 +759,9 @@ public class Selector implements Selectable, AutoCloseable {
             key.attach(null);
         }
         this.sensors.connectionClosed.record();
+        if (this.stagedReceives.containsKey(channel)) {
+            this.stagedReceives.get(channel).forEach(NetworkReceive::close);
+        }
         this.stagedReceives.remove(channel);
         this.explicitlyMutedChannels.remove(channel);
         if (notifyDisconnect)


### PR DESCRIPTION
Fixing small bugs with reference counting logic in KafkaConsumer ByteBuffers:
- Broker response might contain error for a specific topic partition and the parseCompletedFetch might return null
- Fetcher could still be buffering data for paused topic partitions when KafkaConsumer.close() is called (Same for Selector)
- KafkaConsumer.close() might cause the same ByteBuffer to be returned to MemoryPool twice if close() call happens after completed receives are returned via fetcher

Discovered these problems while trying to test the pause()/resume() API with MemoryPool configuration and discovered as MemoryLeak/Unhandled exceptions. Running with this patch seems to fix them.