### PR TITLE
[LI-HOTFIX] Implement topic deletion logic with the LeaderAndIsr in KIP-516

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
@@ -47,14 +47,23 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
         private final List<LeaderAndIsrPartitionState> partitionStates;
         private final Map<String, Uuid> topicIds;
         private final Collection<Node> liveLeaders;
+        private final LeaderAndIsrRequestType type;
 
         public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch, long maxBrokerEpoch,
                        List<LeaderAndIsrPartitionState> partitionStates, Map<String, Uuid> topicIds,
                        Collection<Node> liveLeaders) {
+            this(version, controllerId, controllerEpoch, brokerEpoch, maxBrokerEpoch, partitionStates, topicIds,
+                    liveLeaders, false);
+        }
+
+        public Builder(short version, int controllerId, int controllerEpoch, long brokerEpoch, long maxBrokerEpoch,
+                       List<LeaderAndIsrPartitionState> partitionStates, Map<String, Uuid> topicIds,
+                       Collection<Node> liveLeaders, boolean isFull) {
             super(ApiKeys.LEADER_AND_ISR, version, controllerId, controllerEpoch, brokerEpoch, maxBrokerEpoch);
             this.partitionStates = partitionStates;
             this.topicIds = topicIds;
             this.liveLeaders = liveLeaders;
+            this.type = isFull ? LeaderAndIsrRequestType.FULL : LeaderAndIsrRequestType.INCREMENTAL;
         }
 
         @Override
@@ -72,6 +81,10 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
                 .setMaxBrokerEpoch(maxBrokerEpoch)
                 .setLiveLeaders(leaders);
 
+            if (version >= 5) {
+                data.setType(type.code());
+            }
+
             if (version >= 2) {
                 Map<String, LeaderAndIsrTopicState> topicStatesMap = groupByTopic(partitionStates, topicIds);
                 data.setTopicStates(new ArrayList<>(topicStatesMap.values()));
@@ -88,6 +101,10 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
 
         public Map<String, Uuid> topicIds() {
             return topicIds;
+        }
+
+        public LeaderAndIsrRequestType type() {
+            return type;
         }
 
         public Collection<Node> liveLeaders() {
@@ -206,6 +223,10 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
             return () -> new FlattenedIterator<>(data.topicStates().iterator(),
                 topicState -> topicState.partitionStates().iterator());
         return data.ungroupedPartitionStates();
+    }
+
+    public LeaderAndIsrRequestType type() {
+        return LeaderAndIsrRequestType.forCode(data.type());
     }
 
     public Map<String, Uuid> topicIds() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
@@ -81,7 +81,7 @@ public class LeaderAndIsrRequest extends AbstractControlRequest {
                 .setMaxBrokerEpoch(maxBrokerEpoch)
                 .setLiveLeaders(leaders);
 
-            if (version >= 5) {
+            if (version >= 6) {
                 data.setType(type.code());
             }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequestType.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequestType.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum LeaderAndIsrRequestType {
+    UNKNOWN_TYPE((byte) -1, "Unknown type"),
+    INCREMENTAL((byte) 0, "A LeaderAndIsrRequest that is not guaranteed to contain all topic partitions assigned to a broker."),
+    FULL((byte) 1, "A full LeaderAndIsrRequest containing all partitions the broker is a replica for.");
+
+    private static final Map<Byte, LeaderAndIsrRequestType> CODE_TO_TYPE = new HashMap<>();
+
+    static {
+        for (LeaderAndIsrRequestType type : LeaderAndIsrRequestType.values()) {
+            if (CODE_TO_TYPE.put(type.code(), type) != null) {
+                throw new ExceptionInInitializerError("Code " + type.code() + " for LeaderAndIsrRequestType " +
+                    "has already been used");
+            }
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(LeaderAndIsrRequestType.class);
+
+    private final byte code;
+    private final String description;
+
+    LeaderAndIsrRequestType(byte code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public byte code() {
+        return this.code;
+    }
+
+    public String description() {
+        return this.description;
+    }
+
+    public static LeaderAndIsrRequestType forCode(byte code) {
+        LeaderAndIsrRequestType type = CODE_TO_TYPE.get(code);
+        if (type != null) {
+            return type;
+        } else {
+            log.warn("Unexpected code for LeaderAndIsrRequestType: {}", code);
+            return UNKNOWN_TYPE;
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
@@ -272,6 +272,10 @@ public class LiCombinedControlRequest extends AbstractControlRequest {
         return -1;
     }
 
+    public byte leaderAndIsrType() {
+        return data.leaderAndIsrType();
+    }
+
     public Iterable<LiCombinedControlRequestData.LeaderAndIsrPartitionState> leaderAndIsrPartitionStates() {
         return () -> new FlattenedIterator<>(data.leaderAndIsrTopicStates().iterator(),
             topicState -> topicState.partitionStates().iterator());

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -253,6 +253,8 @@ class RequestSendThread(val controllerId: Int,
 
   private var firstUpdateMetadataWithPartitionsSent = false
 
+  private var fullLeaderAndIsrSent = false
+
   @volatile private var latestRequestStatus = LatestRequestStatus(isInFlight = false, isInQueue = false, 0)
 
   // This metric reports the queued time of the latest request from the queue
@@ -283,7 +285,8 @@ class RequestSendThread(val controllerId: Int,
     if (controllerRequestMerger.hasPendingRequests() ||
       (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1 &&
         config.liCombinedControlRequestEnable &&
-        firstUpdateMetadataWithPartitionsSent)) {
+        firstUpdateMetadataWithPartitionsSent &&
+        fullLeaderAndIsrSent)) {
       // Only start the merging logic after the first UpdateMetadata request with partitions,
       // since the first UpdateMetadata request with partitions may contain hundreds of thousands of partitions,
       // and thus needs to be cached and shared by all brokers in order to prevent OOM
@@ -373,6 +376,10 @@ class RequestSendThread(val controllerId: Int,
 
         if (api == ApiKeys.UPDATE_METADATA && !requestBuilder.asInstanceOf[UpdateMetadataRequest.Builder].partitionStates().isEmpty) {
           firstUpdateMetadataWithPartitionsSent = true
+        }
+        if (api == ApiKeys.LEADER_AND_ISR &&
+          requestBuilder.asInstanceOf[LeaderAndIsrRequest.Builder].`type`() == LeaderAndIsrRequestType.FULL) {
+          fullLeaderAndIsrSent = true
         }
 
         val response = clientResponse.responseBody
@@ -618,12 +625,22 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
           .toSet[String]
           .map(topic => (topic, controllerContext.topicIds.getOrElse(topic, Uuid.ZERO_UUID)))
           .toMap
-        val leaderAndIsrRequestBuilder = new LeaderAndIsrRequest.Builder(leaderAndIsrRequestVersion, controllerId,
-          controllerEpoch, brokerEpoch, maxBrokerEpoch, leaderAndIsrPartitionStates.values.toBuffer.asJava, topicIds.asJava, leaders.asJava)
+        val leaderAndIsrRequestBuilder = if (leaderAndIsrRequestVersion >= 6) {
+          // LeaderAndIsr.Type is supported since version 6
+          new LeaderAndIsrRequest.Builder(leaderAndIsrRequestVersion, controllerId,
+          controllerEpoch, brokerEpoch, maxBrokerEpoch, leaderAndIsrPartitionStates.values.toBuffer.asJava, topicIds.asJava, leaders.asJava,
+          controllerContext.shouldSendFullLeaderAndIsr(broker))
+        } else {
+          new LeaderAndIsrRequest.Builder(leaderAndIsrRequestVersion, controllerId,
+            controllerEpoch, brokerEpoch, maxBrokerEpoch, leaderAndIsrPartitionStates.values.toBuffer.asJava, topicIds.asJava, leaders.asJava)
+        }
+
+
         sendRequest(broker, leaderAndIsrRequestBuilder, (r: AbstractResponse) => {
           val leaderAndIsrResponse = r.asInstanceOf[LeaderAndIsrResponse]
           sendEvent(LeaderAndIsrResponseReceived(leaderAndIsrResponse, broker))
         })
+        controllerContext.markLeaderAndIsrSent(broker)
       }
     }
     leaderAndIsrRequestMap.clear()

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -253,7 +253,7 @@ class RequestSendThread(val controllerId: Int,
 
   private var firstUpdateMetadataWithPartitionsSent = false
 
-  private var fullLeaderAndIsrSent = false
+  private var firstFullLeaderAndIsrSent = false
 
   @volatile private var latestRequestStatus = LatestRequestStatus(isInFlight = false, isInQueue = false, 0)
 
@@ -286,7 +286,7 @@ class RequestSendThread(val controllerId: Int,
       (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1 &&
         config.liCombinedControlRequestEnable &&
         firstUpdateMetadataWithPartitionsSent &&
-        fullLeaderAndIsrSent)) {
+        firstFullLeaderAndIsrSent)) {
       // Only start the merging logic after the first UpdateMetadata request with partitions,
       // since the first UpdateMetadata request with partitions may contain hundreds of thousands of partitions,
       // and thus needs to be cached and shared by all brokers in order to prevent OOM
@@ -379,7 +379,7 @@ class RequestSendThread(val controllerId: Int,
         }
         if (api == ApiKeys.LEADER_AND_ISR &&
           requestBuilder.asInstanceOf[LeaderAndIsrRequest.Builder].`type`() == LeaderAndIsrRequestType.FULL) {
-          fullLeaderAndIsrSent = true
+          firstFullLeaderAndIsrSent = true
         }
 
         val response = clientResponse.responseBody

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -80,6 +80,7 @@ class ControllerContext {
   val skipShutdownSafetyCheck = mutable.Map.empty[Int, Long]
   private val liveBrokers = mutable.Set.empty[Broker]
   private val liveBrokerEpochs = mutable.Map.empty[Int, Long]
+  private val leaderAndIsrRequestSent = mutable.Map.empty[Int, Boolean]
   var epoch: Int = KafkaController.InitialControllerEpoch
   var epochZkVersion: Int = KafkaController.InitialControllerEpochZkVersion
 
@@ -215,6 +216,7 @@ class ControllerContext {
   def removeLiveBrokers(brokerIds: Set[Int]): Unit = {
     liveBrokers --= liveBrokers.filter(broker => brokerIds.contains(broker.id))
     liveBrokerEpochs --= brokerIds
+    leaderAndIsrRequestSent --= brokerIds
   }
 
   def updateBrokerMetadata(oldMetadata: Broker, newMetadata: Broker): Unit = {
@@ -226,6 +228,10 @@ class ControllerContext {
     livePreferredControllerIds = preferredControllerIds
   }
 
+  def markLeaderAndIsrSent(brokerId: Int): Unit = {
+    leaderAndIsrRequestSent.put(brokerId, true)
+  }
+
   // getter
   def liveBrokerIds: Set[Int] = liveBrokerEpochs.filter(b => b._2 > shuttingDownBrokerIds.getOrElse(b._1, -1L)).keySet
   def liveOrShuttingDownBrokerIds: Set[Int] = liveBrokerEpochs.keySet
@@ -233,6 +239,7 @@ class ControllerContext {
   def liveBrokerIdAndEpochs: Map[Int, Long] = liveBrokerEpochs
   def maxBrokerEpoch: Long = liveBrokerEpochs.values.max
   def liveOrShuttingDownBroker(brokerId: Int): Option[Broker] = liveOrShuttingDownBrokers.find(_.id == brokerId)
+  def shouldSendFullLeaderAndIsr(brokerId: Int): Boolean = !leaderAndIsrRequestSent.get(brokerId).exists(_ == true)
 
   def getLivePreferredControllerIds : Set[Int] = livePreferredControllerIds
 

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -239,6 +239,7 @@ class ControllerContext {
   def liveBrokerIdAndEpochs: Map[Int, Long] = liveBrokerEpochs
   def maxBrokerEpoch: Long = liveBrokerEpochs.values.max
   def liveOrShuttingDownBroker(brokerId: Int): Option[Broker] = liveOrShuttingDownBrokers.find(_.id == brokerId)
+  // send full LeaderAndIsr request when it's the first LeaderAndIsr request
   def shouldSendFullLeaderAndIsr(brokerId: Int): Boolean = !leaderAndIsrRequestSent.get(brokerId).exists(_ == true)
 
   def getLivePreferredControllerIds : Set[Int] = livePreferredControllerIds

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1057,12 +1057,8 @@ class KafkaController(val config: KafkaConfig,
   private def fetchTopicDeletionsInProgress(): (Set[String], Set[String]) = {
     val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
     val topicsToBeDeleted = zkClient.getTopicDeletions.toSet
-    val topicsWithOfflineReplicas = controllerContext.allTopics.filter { topic => {
-      val replicasForTopic = controllerContext.replicasForTopic(topic)
-      replicasForTopic.exists(r => !controllerContextSnapshot.isReplicaOnline(r.replica, r.topicPartition))
-    }}
     val topicsForWhichPartitionReassignmentIsInProgress = controllerContext.partitionsBeingReassigned.map(_.topic)
-    val topicsIneligibleForDeletion = topicsWithOfflineReplicas | topicsForWhichPartitionReassignmentIsInProgress
+    val topicsIneligibleForDeletion = topicsForWhichPartitionReassignmentIsInProgress
     info(s"List of topics to be deleted: ${topicsToBeDeleted.mkString(",")}")
     info(s"List of topics ineligible for deletion: ${topicsIneligibleForDeletion.mkString(",")}")
     (topicsToBeDeleted, topicsIneligibleForDeletion)

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -482,7 +482,7 @@ case object ReplicaDeletionStarted extends ReplicaState {
 
 case object ReplicaDeletionSuccessful extends ReplicaState {
   val state: Byte = 5
-  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionStarted)
+  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionStarted, OfflineReplica)
 }
 
 case object ReplicaDeletionIneligible extends ReplicaState {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1530,7 +1530,6 @@ class ReplicaManager(val config: KafkaConfig,
                   // recreate the partition
                   maybeRecreatedPartition = Partition(topicPartition, time, this)
                   allPartitions.put(topicPartition, HostedPartition.Online(maybeRecreatedPartition))
-                  // responseMap.put(topicPartition, Errors.INCONSISTENT_TOPIC_ID)
                 }
 
                 // If the leader epoch is valid record the epoch of the controller that made the leadership decision.

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1489,10 +1489,12 @@ class ReplicaManager(val config: KafkaConfig,
           controllerEpoch = leaderAndIsrRequest.controllerEpoch
 
           val partitionStates = new mutable.HashMap[Partition, LeaderAndIsrPartitionState]()
-
+          val allRequestPartitions = new mutable.HashSet[TopicPartition]()
           // First create the partition if it doesn't exist already
           requestPartitionStates.foreach { partitionState =>
             val topicPartition = new TopicPartition(partitionState.topicName, partitionState.partitionIndex)
+            allRequestPartitions.add(topicPartition)
+
             val partitionOpt = getPartition(topicPartition) match {
               case HostedPartition.Offline =>
                 stateChangeLogger.warn(s"Ignoring LeaderAndIsr request from " +
@@ -1519,11 +1521,13 @@ class ReplicaManager(val config: KafkaConfig,
               val logTopicId = partition.topicId
 
               if (!hasConsistentTopicId(requestTopicId, logTopicId)) {
-                stateChangeLogger.error(s"Topic ID in memory: ${logTopicId.get} does not" +
+                stateChangeLogger.warn(s"Topic ID in memory: ${logTopicId.get} does not" +
                   s" match the topic ID for partition $topicPartition received: " +
-                  s"${requestTopicId.get}.")
-                responseMap.put(topicPartition, Errors.INCONSISTENT_TOPIC_ID)
-              } else if (requestLeaderEpoch > currentLeaderEpoch) {
+                  s"${requestTopicId.get}. Deleting the current replica.")
+                deleteStrayReplicas(List(topicPartition))
+              }
+
+              if (requestLeaderEpoch > currentLeaderEpoch) {
                 // If the leader epoch is valid record the epoch of the controller that made the leadership decision.
                 // This is useful while updating the isr to maintain the decision maker controller's epoch in the zookeeper path
                 if (partitionState.replicas.contains(localBrokerId))
@@ -1562,6 +1566,11 @@ class ReplicaManager(val config: KafkaConfig,
                 responseMap.put(topicPartition, error)
               }
             }
+          }
+
+          if (leaderAndIsrRequest.`type`() == LeaderAndIsrRequestType.FULL) {
+            val partitionsToDelete = findStrayPartitions(allRequestPartitions, logManager.allLogs)
+            deleteStrayReplicas(partitionsToDelete)
           }
 
           val partitionsToBeLeader = partitionStates.filter { case (_, partitionState) =>
@@ -2409,6 +2418,21 @@ class ReplicaManager(val config: KafkaConfig,
     partitionsToMakeFollower.keySet.foreach(completeDelayedFetchOrProduceRequests)
 
     updateLeaderAndFollowerMetrics(newFollowerTopicSet)
+  }
+
+  // Return all the partitions that are not included in the full LeaderAndIsr request.
+  // The result will NOT include partitions with inconsistent topic IDs since that logic
+  // is handled inside {@link becomeLeaderOrFollower(Int, LeaderAndIsrRequest, (Iterable[Partition], Iterable[Partition]) => Unit)}
+  def findStrayPartitions(requestPartitions: Set[TopicPartition],
+                          logs: Iterable[Log]): Iterable[TopicPartition] = {
+    logs.flatMap{ log => {
+      val topicPartition = log.topicPartition
+      if (!requestPartitions.contains(topicPartition)) {
+        Some(topicPartition)
+      } else {
+        None
+      }
+    }}
   }
 
   def deleteStrayReplicas(topicPartitions: Iterable[TopicPartition]): Unit = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1520,19 +1520,24 @@ class ReplicaManager(val config: KafkaConfig,
               val requestTopicId = topicIdFromRequest(topicPartition.topic)
               val logTopicId = partition.topicId
 
-              if (!hasConsistentTopicId(requestTopicId, logTopicId)) {
-                stateChangeLogger.warn(s"Topic ID in memory: ${logTopicId.get} does not" +
-                  s" match the topic ID for partition $topicPartition received: " +
-                  s"${requestTopicId.get}. Deleting the current replica.")
-                deleteStrayReplicas(List(topicPartition))
-              }
-
               if (requestLeaderEpoch > currentLeaderEpoch) {
+                var maybeRecreatedPartition = partition
+                if (!hasConsistentTopicId(requestTopicId, logTopicId)) {
+                  stateChangeLogger.warn(s"Topic ID in memory: ${logTopicId.get} does not" +
+                    s" match the topic ID for partition $topicPartition received: " +
+                    s"${requestTopicId.get}. Deleting the current replica.")
+                  deleteStrayReplicas(List(topicPartition))
+                  // recreate the partition
+                  maybeRecreatedPartition = Partition(topicPartition, time, this)
+                  allPartitions.put(topicPartition, HostedPartition.Online(maybeRecreatedPartition))
+                  // responseMap.put(topicPartition, Errors.INCONSISTENT_TOPIC_ID)
+                }
+
                 // If the leader epoch is valid record the epoch of the controller that made the leadership decision.
                 // This is useful while updating the isr to maintain the decision maker controller's epoch in the zookeeper path
-                if (partitionState.replicas.contains(localBrokerId))
-                  partitionStates.put(partition, partitionState)
-                else {
+                if (partitionState.replicas.contains(localBrokerId)) {
+                  partitionStates.put(maybeRecreatedPartition, partitionState)
+                } else {
                   stateChangeLogger.warn(s"Ignoring LeaderAndIsr request from controller $controllerId with " +
                     s"correlation id $correlationId epoch $controllerEpoch for partition $topicPartition as itself is not " +
                     s"in assigned replica list ${partitionState.replicas.asScala.mkString(",")}")

--- a/core/src/main/scala/kafka/utils/LiDecomposedControlRequestUtils.scala
+++ b/core/src/main/scala/kafka/utils/LiDecomposedControlRequestUtils.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrParti
 import org.apache.kafka.common.message.LiCombinedControlRequestData
 import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartitionState, StopReplicaTopicState}
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataPartitionState}
-import org.apache.kafka.common.requests.{LeaderAndIsrRequest, LiCombinedControlRequest, StopReplicaRequest, UpdateMetadataRequest}
+import org.apache.kafka.common.requests.{LeaderAndIsrRequest, LeaderAndIsrRequestType, LiCombinedControlRequest, StopReplicaRequest, UpdateMetadataRequest}
 import org.apache.kafka.common.utils.LiCombinedControlTransformer
 
 import scala.collection.JavaConverters._
@@ -72,8 +72,10 @@ object LiDecomposedControlRequestUtils {
         if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 5
         else throw new IllegalStateException("The inter.broker.protocol.version config should not be smaller than 2.4-IV1")
 
+      // the LiCombinedControl request will only include incremental LeaderAndIsr requests
       Some(new LeaderAndIsrRequest.Builder(leaderAndIsrRequestVersion, request.controllerId(), request.controllerEpoch(), request.brokerEpoch(),
-        request.maxBrokerEpoch(), effectivePartitionStates, util.Collections.emptyMap(), leaderNodes).build())
+        request.maxBrokerEpoch(), effectivePartitionStates, util.Collections.emptyMap(), leaderNodes
+      ).build())
     }
   }
 

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -19,7 +19,6 @@ package kafka.admin
 import java.util
 import java.util.concurrent.ExecutionException
 import java.util.{Collections, Optional, Properties}
-
 import scala.collection.Seq
 import kafka.log.Log
 import kafka.zk.{DeleteTopicFlagZNode, TopicPartitionZNode, TopicZNode, ZooKeeperTestHarness}
@@ -28,10 +27,11 @@ import kafka.server.{KafkaConfig, KafkaServer}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
 import kafka.common.TopicAlreadyMarkedForDeletionException
-import kafka.controller.{OfflineReplica, PartitionAndReplica, ReplicaAssignment, ReplicaDeletionSuccessful}
+import kafka.controller.ReplicaAssignment
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, NewPartitionReassignment, NewPartitions}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import org.apache.kafka.common.errors.{InvalidReplicaAssignmentException, UnknownTopicOrPartitionException}
+
 import scala.jdk.CollectionConverters._
 
 class DeleteTopicTest extends ZooKeeperTestHarness {
@@ -74,11 +74,10 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilTrue(() =>
       servers.filter(s => s.config.brokerId != follower.config.brokerId)
         .forall(_.getLogManager.getLog(topicPartition).isEmpty), "Replicas 0,1 have not deleted log.")
-    // ensure topic deletion is halted
-    TestUtils.waitUntilTrue(() => zkClient.isTopicMarkedForDeletion(topic),
-      "Admin path /admin/delete_topics/test path deleted even when a follower replica is down")
     // restart follower replica
     follower.startup()
+    // create another topic to ensure the restarted brokers can receive at least one LeaderAndIsr request
+    TestUtils.createTopic(zkClient, "topic2", expectedReplicaAssignment, servers)
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
   }
 
@@ -98,13 +97,11 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // shut down the controller to trigger controller failover during delete topic
     controller.shutdown()
 
-    // ensure topic deletion is halted
-    TestUtils.waitUntilTrue(() => zkClient.isTopicMarkedForDeletion(topic),
-      "Admin path /admin/delete_topics/test path deleted even when a replica is down")
-
     controller.startup()
     follower.startup()
 
+    // create another topic to ensure the restarted brokers can receive at least one LeaderAndIsr request
+    TestUtils.createTopic(zkClient, "topic2", expectedReplicaAssignment, servers)
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
   }
 
@@ -141,6 +138,8 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
       adminClient.close()
     }
     follower.startup()
+    // create another topic to ensure the restarted brokers can receive at least one LeaderAndIsr request
+    TestUtils.createTopic(zkClient, "topic2", expectedReplicaAssignment, servers)
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
   }
 
@@ -161,7 +160,15 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
                                                 reassignment: NewPartitionReassignment): Unit = {
     val e = assertThrows(classOf[ExecutionException], () => adminClient.alterPartitionReassignments(Collections.singletonMap(partition,
       Optional.of(reassignment))).all().get())
-    assertEquals(classOf[UnknownTopicOrPartitionException], e.getCause.getClass)
+    // If the controller has already purged the current assignment for the partition,
+    // the adding replicas would include all of the replicas in the reassignment, i.e. replicas 1, 2, 3
+    // which will result in a InvalidReplicaAssignmentException since they are offline brokers.
+    // Otherwise, if the controller still has the current assignment, the adding replicas would only contain 3.
+    // Thus there won't be an InvalidReplicaAssignmentException. Instead, an UnknownTopicOrPartitionException
+    // will be returned.
+    val exceptionCause = e.getCause.getClass
+    assertTrue(exceptionCause.equals(classOf[InvalidReplicaAssignmentException]) ||
+      exceptionCause.equals(classOf[UnknownTopicOrPartitionException]))
   }
 
   private def getController() : (KafkaServer, Int) = {
@@ -179,12 +186,6 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
         case _: Throwable  => false
       }
     }, "Controller should eventually exist")
-  }
-
-  private def getAllReplicasFromAssignment(topic : String, assignment : Map[Int, Seq[Int]]) : Set[PartitionAndReplica] = {
-    assignment.flatMap { case (partition, replicas) =>
-      replicas.map {r => new PartitionAndReplica(new TopicPartition(topic, partition), r)}
-    }.toSet
   }
 
   @Test
@@ -213,12 +214,6 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // make sure deletion of all of the topic's replicas have been tried
     ensureControllerExists()
     val (controller, controllerId) = getController()
-    val allReplicasForTopic = getAllReplicasFromAssignment(topic, expectedReplicaAssignment)
-    TestUtils.waitUntilTrue(() => {
-      val replicasInDeletionSuccessful = controller.kafkaController.controllerContext.replicasInState(topic, ReplicaDeletionSuccessful)
-      val offlineReplicas = controller.kafkaController.controllerContext.replicasInState(topic, OfflineReplica)
-      allReplicasForTopic == (replicasInDeletionSuccessful union offlineReplicas)
-    }, s"Not all replicas for topic $topic are in states of either ReplicaDeletionSuccessful or OfflineReplica")
 
     // increase the partition count for topic
     val props = new Properties()
@@ -244,6 +239,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     // bring back the failed brokers
     follower.startup()
     controller.startup()
+    TestUtils.createTopic(zkClient, "topic2", expectedReplicaAssignment, servers)
     TestUtils.verifyTopicDeletion(zkClient, topic, 2, servers)
     adminClient.close()
   }
@@ -501,6 +497,8 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
       */
     servers.foreach(_.startup())
     TestUtils.waitUntilTrue(() => servers.exists(_.kafkaController.isActive), "No controller is elected")
+    // create another topic to ensure the restarted brokers can receive at least one LeaderAndIsr request
+    TestUtils.createTopic(zkClient, "topic2", expectedReplicaAssignment, servers)
     TestUtils.verifyTopicDeletion(zkClient, topic, 2, servers)
   }
 }

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1446,6 +1446,83 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
   }
 
   @Test
+  def testTopicDeletionWithOfflineBrokers(): Unit = {
+    val tp = new TopicPartition("t", 0)
+    val adminZkClient = new AdminZkClient(zkClient)
+
+    servers = makeServers(2)
+    TestUtils.createTopic(zkClient, tp.topic, 1, 2, servers)
+    val topicId1 = zkClient.getTopicIdsForTopics(Set(tp.topic())).get(tp.topic())
+
+    // shutdown one broker and then delete the topic
+    val broker0 = servers.find(_.config.brokerId == 0).get
+    broker0.shutdown()
+    broker0.awaitShutdown()
+    adminZkClient.deleteTopic(tp.topic())
+    val broker1 = servers.find(_.config.brokerId == 1).get
+    TestUtils.waitUntilTrue(() => {
+      !broker1.replicaManager.getLog(tp).isDefined
+    }, "The replica on broker1 cannot be deleted")
+    TestUtils.waitUntilTrue(() => {
+      !zkClient.pathExists(TopicZNode.path(tp.topic()))
+    }, s"The topic ${tp.topic} is not removed from zookeeper")
+
+    // recreate the topic and wait until broker1 get the log recreated
+    val assignment = Map(tp.partition -> Seq(0, 1))
+    adminZkClient.createTopicWithAssignment(tp.topic, config = new Properties(), assignment)
+    TestUtils.waitUntilTrue(() => {
+      broker1.replicaManager.getLog(tp).isDefined
+    }, "The replica on broker1 cannot be deleted")
+    val topicId2 = zkClient.getTopicIdsForTopics(Set(tp.topic())).get(tp.topic())
+    assertNotEquals(topicId2, topicId1, "Topic IDs across generations should not be the same")
+
+    // restart the offline broker0, and wait until convergence of topic ID on all brokers
+    broker0.startup()
+    TestUtils.waitUntilTrue(() => {
+      servers.forall{s => {
+        val logOpt = s.replicaManager.getLog(tp)
+        if (logOpt.isDefined) {
+          logOpt.get.topicId == topicId2
+        } else {
+          false
+        }
+      }}
+    }, s"Not every online broker has the correct topic ID for topic ${tp.topic()}")
+  }
+
+  @Test
+  def testDeletionOfStrayPartitions(): Unit = {
+    val tp = new TopicPartition("t1", 0)
+    val adminZkClient = new AdminZkClient(zkClient)
+
+    servers = makeServers(2)
+    TestUtils.createTopic(zkClient, tp.topic, 1, 2, servers)
+    TestUtils.waitUntilTrue(() => {
+      servers.forall{server => server.replicaManager.getLog(tp).isDefined}
+    }, "The replica on broker1 cannot be deleted")
+
+    // shutdown one broker and then delete the topic
+    val broker0 = servers.find(_.config.brokerId == 0).get
+    broker0.shutdown()
+    broker0.awaitShutdown()
+    adminZkClient.deleteTopic(tp.topic())
+    TestUtils.waitUntilTrue(() => {
+      !zkClient.pathExists(TopicZNode.path(tp.topic()))
+    }, "The replica on broker1 cannot be deleted")
+
+
+    // restart the offline broker and make sure the stray partitions will be deleted
+    broker0.startup()
+    val topic2 = "t2"
+    // create another topic to ensure at least one LeaderAndIsr request is being sent to the restarted broker
+    TestUtils.createTopic(zkClient, topic2, 1, 2, servers)
+
+    TestUtils.waitUntilTrue(() => {
+      !broker0.replicaManager.getLog(tp).isDefined
+    }, "The replica on broker0 cannot be deleted", waitTimeMs = 20000)
+  }
+
+  @Test
   def testTopicIdUpgradeAfterReassigningPartitions(): Unit = {
     val tp = new TopicPartition("t", 0)
     val reassignment = Map(tp -> Some(Seq(0)))

--- a/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
@@ -295,11 +295,6 @@ class ReplicaStateMachineTest {
   }
 
   @Test
-  def testInvalidOfflineReplicaToReplicaDeletionSuccessfulTransition(): Unit = {
-    testInvalidTransition(OfflineReplica, ReplicaDeletionSuccessful)
-  }
-
-  @Test
   def testInvalidReplicaDeletionStartedToNonexistentReplicaTransition(): Unit = {
     testInvalidTransition(ReplicaDeletionStarted, NonExistentReplica)
   }

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -109,10 +109,9 @@ class TopicDeletionManagerTest {
     assertEquals(1, partitionStateMachine.stateChangesCalls(OfflinePartition))
     assertEquals(1, partitionStateMachine.stateChangesCalls(NonExistentPartition))
 
-    assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionIneligible))
     assertEquals(1, replicaStateMachine.stateChangesCalls(OfflineReplica))
     assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionStarted))
-    assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionSuccessful))
+    assertEquals(2, replicaStateMachine.stateChangesCalls(ReplicaDeletionSuccessful))
   }
 
   @Test
@@ -139,8 +138,6 @@ class TopicDeletionManagerTest {
 
     // Broker 2 is taken offline
     val failedBrokerId = 2
-    val offlineBroker = controllerContext.liveOrShuttingDownBroker(failedBrokerId).get
-    val lastEpoch = controllerContext.liveBrokerIdAndEpochs(failedBrokerId)
     controllerContext.removeLiveBrokers(Set(failedBrokerId))
     assertEquals(Set(1, 3), controllerContext.liveBrokerIds)
 
@@ -152,30 +149,15 @@ class TopicDeletionManagerTest {
     assertEquals(fooPartitions, controllerContext.partitionsInState("foo", NonExistentPartition))
     verify(deletionClient).sendMetadataUpdate(fooPartitions)
     assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionIneligible))
+    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
 
     assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
     assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)
-    assertEquals(Set("foo"), controllerContext.topicsIneligibleForDeletion)
+    assertEquals(Set(), controllerContext.topicsIneligibleForDeletion)
 
     // Deletion succeeds for online replicas
     deletionManager.completeReplicaDeletion(onlineReplicas)
 
-    assertEquals(fooPartitions, controllerContext.partitionsInState("foo", NonExistentPartition))
-    assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
-    assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)
-    assertEquals(Set("foo"), controllerContext.topicsIneligibleForDeletion)
-    assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", OfflineReplica))
-
-    // Broker 2 comes back online and deletion is resumed
-    controllerContext.addLiveBrokers(Map(offlineBroker -> (lastEpoch + 1L)))
-    deletionManager.resumeDeletionForTopics(Set("foo"))
-
-    assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-
-    deletionManager.completeReplicaDeletion(offlineReplicas)
     assertEquals(Set.empty, controllerContext.partitionsForTopic("foo"))
     assertEquals(Set.empty[PartitionAndReplica], controllerContext.replicaStates.keySet.filter(_.topic == "foo"))
     assertEquals(Set(), controllerContext.topicsToBeDeleted)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -29,6 +29,7 @@ import kafka.api._
 import kafka.cluster.{BrokerEndPoint, Partition}
 import kafka.log._
 import kafka.log.remote.RemoteLogManager
+import kafka.server.HostedPartition.Online
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
 import kafka.server.checkpoints.{LazyOffsetCheckpoints, OffsetCheckpointFile}
 import kafka.server.epoch.util.ReplicaFetcherMockBlockingSend
@@ -2559,7 +2560,7 @@ class ReplicaManagerTest {
   }
 
   @Test
-  def testInconsistentIdReturnsError(): Unit = {
+  def testInconsistentIdRecreatesPartition(): Unit = {
     val replicaManager = setupReplicaManagerWithMockedPurgatories(new MockTimer(time))
     try {
       val brokerList = Seq[Integer](0, 1).asJava
@@ -2567,8 +2568,8 @@ class ReplicaManagerTest {
       val topicIds = Collections.singletonMap(topic, Uuid.randomUuid())
       val topicNames = topicIds.asScala.map(_.swap).asJava
 
-      val invalidTopicIds = Collections.singletonMap(topic, Uuid.randomUuid())
-      val invalidTopicNames = invalidTopicIds.asScala.map(_.swap).asJava
+      val newTopicIds = Collections.singletonMap(topic, Uuid.randomUuid())
+      val invalidTopicNames = newTopicIds.asScala.map(_.swap).asJava
 
       def leaderAndIsrRequest(epoch: Int, topicIds: java.util.Map[String, Uuid]): LeaderAndIsrRequest =
         new LeaderAndIsrRequest.Builder(ApiKeys.LEADER_AND_ISR.latestVersion, 0, 0, brokerEpoch, brokerEpoch,
@@ -2585,18 +2586,28 @@ class ReplicaManagerTest {
         topicIds,
         Set(new Node(0, "host1", 0), new Node(1, "host2", 1)).asJava).build()
 
+      def verifyPartitionTopicId(expected: Uuid): Unit = {
+        replicaManager.getPartition(topicPartition) match {
+          case Online(partition) => assertEquals(expected, partition.topicId.get)
+          case _ => fail(s"$topicPartition is not online")
+        }
+      }
+
       val response = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest(0, topicIds), (_, _) => ())
       assertEquals(Errors.NONE, response.partitionErrors(topicNames).get(topicPartition))
 
       val response2 = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest(1, topicIds), (_, _) => ())
       assertEquals(Errors.NONE, response2.partitionErrors(topicNames).get(topicPartition))
+      verifyPartitionTopicId(topicIds.get(topic))
 
       // Send request with inconsistent ID.
-      val response3 = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest(1, invalidTopicIds), (_, _) => ())
-      assertEquals(Errors.INCONSISTENT_TOPIC_ID, response3.partitionErrors(invalidTopicNames).get(topicPartition))
+      val response3 = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest(1, newTopicIds), (_, _) => ())
+      // The request sent with the same leader epoch will be ignored
+      assertEquals(Errors.STALE_CONTROLLER_EPOCH, response3.partitionErrors(invalidTopicNames).get(topicPartition))
 
-      val response4 = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest(2, invalidTopicIds), (_, _) => ())
-      assertEquals(Errors.INCONSISTENT_TOPIC_ID, response4.partitionErrors(invalidTopicNames).get(topicPartition))
+      val response4 = replicaManager.becomeLeaderOrFollower(0, leaderAndIsrRequest(2, newTopicIds), (_, _) => ())
+      assertEquals(Errors.NONE, response4.partitionErrors(invalidTopicNames).get(topicPartition))
+      verifyPartitionTopicId(newTopicIds.get(topic))
     } finally replicaManager.shutdown(checkpointHW = false)
   }
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1229,8 +1229,8 @@ object TestUtils extends Logging {
     waitUntilTrue(() =>
       servers.forall(server => topicPartitions.forall(tp => server.replicaManager.onlinePartition(tp).isEmpty)),
       "Replica manager's should have deleted all of this topic's partitions")
-    // ensure that logs from all replicas are deleted if delete topic is marked successful in ZooKeeper
-    assertTrue(servers.forall(server => topicPartitions.forall(tp => server.getLogManager.getLog(tp).isEmpty)),
+
+    waitUntilTrue(() => servers.forall(server => topicPartitions.forall(tp => server.getLogManager.getLog(tp).isEmpty)),
       "Replica logs not deleted after delete topic is complete")
     // ensure that topic is removed from all cleaner offsets
     waitUntilTrue(() => servers.forall(server => topicPartitions.forall { tp =>


### PR DESCRIPTION
TICKET = KAFKA-10548
LI_DESCRIPTION =
This PR includes the following changes

Adding the type field to the LeaderAndIsr request as proposed in KIP-516
Letting the controller set the type of LeaderAndIsr requests to be either FULL or INCREMENTAL
Allowing topic deletion to complete even with offline brokers
Schedule the deletion of replicas with inconsistent topic IDs or not present in the full LeaderAndIsr request
Testing Strategy:
This PR added two tests

testTopicDeletionWithOfflineBrokers: to ensure that topic deletion can proceed even with offline brokers
testDeletionOfStrayPartitions: to ensure stray replicas whose topic has been deleted will be removed upon broker startup

EXIT_CRITERIA = When the upstream PR https://github.com/apache/kafka/pull/11285 is merged and pulled in

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
