### PR TITLE
[LI-HOTFIX] When a controller is elected, do not consider replicas on shutting down brokers as offline

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -285,7 +285,7 @@ class ControllerContext {
       val partition = new TopicPartition(topic, partitionId)
       for (replica <- assignment.replicas) {
         val partitionAndReplica = PartitionAndReplica(partition, replica)
-        if (snapshot.isReplicaOnline(replica, partition))
+        if (snapshot.isReplicaOnline(replica, partition, includeShuttingDownBrokers = true))
           onlineReplicas.add(partitionAndReplica)
         else
           offlineReplicas.add(partitionAndReplica)

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -535,6 +535,63 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
   }
 
   @Test
+  def testControllerChangeDoesNotPutReplicasOffline(): Unit = {
+    val expectedReplicaAssignment = Map(0  -> List(0, 1))
+    val topic = "test"
+    val partition = 0
+
+    // create brokers
+    val serverConfigs = TestUtils.createBrokerConfigs(3, zkConnect, false).map(KafkaConfig.fromProps)
+    servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    // create the topic
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers)
+    assertTrue(servers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.leader == 0))
+
+    var controllerId = zkClient.getControllerId.get
+    var controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+
+    val resultQueue = new LinkedBlockingQueue[Try[collection.Set[TopicPartition]]]()
+    val controlledShutdownCallback = (controlledShutdownResult: Try[collection.Set[TopicPartition]]) => resultQueue.put(controlledShutdownResult)
+    controller.controlledShutdown(1, servers.find(_.config.brokerId == 1).get.kafkaController.brokerEpoch, controlledShutdownCallback)
+
+    var partitionsRemaining = resultQueue.take().get
+    var activeServers = servers.filter(s => s.config.brokerId != 1)
+    // wait for the update metadata request to trickle to the brokers
+    TestUtils.waitUntilTrue(() =>
+      activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size != 3),
+      "Topic test not created after timeout")
+    assertEquals(0, partitionsRemaining.size)
+
+    servers.find(_.config.brokerId == 1).get.shutdown()
+
+    controllerId = zkClient.getControllerId.get
+    controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+    controller.controlledShutdown(0, servers.find(_.config.brokerId == 0).get.kafkaController.brokerEpoch, controlledShutdownCallback)
+
+    partitionsRemaining = resultQueue.take().get
+    assertEquals(1, partitionsRemaining.size)
+    // leader doesn't change since all the other replicas are shut down
+    assertTrue(servers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.leader == 0))
+
+    TestUtils.waitUntilTrue(() => {
+      // Now ensure that after the controller moves, shutdown is still rejected.
+      zkClient.deleteController(controller.controllerContext.epochZkVersion)
+      TestUtils.waitUntilTrue(() => !controller.isActive, "Controller fails to resign")
+      TestUtils.waitUntilTrue(() => zkClient.getControllerId.isDefined, "New controller failed to start")
+      zkClient.getControllerId.get != controllerId
+    }, "Controller did not get changed")
+
+    val newControllerId = zkClient.getControllerId.get
+    val newController = servers.find(p => p.config.brokerId == newControllerId).get.kafkaController
+
+    newController.controlledShutdown(0, servers.find(_.config.brokerId == 0).get.kafkaController.brokerEpoch, controlledShutdownCallback)
+    partitionsRemaining = resultQueue.take().get
+    assertEquals(1, partitionsRemaining.size)
+    // leader should still not change
+    assertTrue(servers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.leader == 0))
+  }
+
+  @Test
   def testControlledShutdown(): Unit = {
     val expectedReplicaAssignment = Map(0  -> List(0, 1, 2))
     val topic = "test"

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -541,7 +541,12 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     val partition = 0
 
     // create brokers
-    val serverConfigs = TestUtils.createBrokerConfigs(3, zkConnect, false).map(KafkaConfig.fromProps)
+    val serverConfigs = TestUtils.createBrokerConfigs(3, zkConnect, enableControlledShutdown = false)
+      .map { props => {
+        props.setProperty(KafkaConfig.ControlledShutdownMaxRetriesProp, "2147483640")
+        KafkaConfig.fromProps(props)
+      }
+      }
     servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
     // create the topic
     TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers)
@@ -550,36 +555,32 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     var controllerId = zkClient.getControllerId.get
     var controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
 
-    val resultQueue = new LinkedBlockingQueue[Try[collection.Set[TopicPartition]]]()
-    val controlledShutdownCallback = (controlledShutdownResult: Try[collection.Set[TopicPartition]]) => resultQueue.put(controlledShutdownResult)
-    controller.controlledShutdown(1, servers.find(_.config.brokerId == 1).get.kafkaController.brokerEpoch, controlledShutdownCallback)
+    val broker1 = servers.find(_.config.brokerId == 1).get
+    broker1.shutdown()
 
-    var partitionsRemaining = resultQueue.take().get
-    var activeServers = servers.filter(s => s.config.brokerId != 1)
+    var activeServers = servers.filter(s => s != broker1)
     // wait for the update metadata request to trickle to the brokers
     TestUtils.waitUntilTrue(() =>
-      activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size != 3),
-      "Topic test not created after timeout")
-    assertEquals(0, partitionsRemaining.size)
-
-    servers.find(_.config.brokerId == 1).get.shutdown()
+      activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size == 1),
+      "ISR did not get reduced after controlled shutdown of broker 1")
 
     controllerId = zkClient.getControllerId.get
     controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+
+    val resultQueue = new LinkedBlockingQueue[Try[collection.Set[TopicPartition]]]()
+    val controlledShutdownCallback = (controlledShutdownResult: Try[collection.Set[TopicPartition]]) => resultQueue.put(controlledShutdownResult)
+
     controller.controlledShutdown(0, servers.find(_.config.brokerId == 0).get.kafkaController.brokerEpoch, controlledShutdownCallback)
 
-    partitionsRemaining = resultQueue.take().get
+    var partitionsRemaining = resultQueue.take().get
     assertEquals(1, partitionsRemaining.size)
     // leader doesn't change since all the other replicas are shut down
     assertTrue(servers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.leader == 0))
 
-    TestUtils.waitUntilTrue(() => {
-      // Now ensure that after the controller moves, shutdown is still rejected.
-      zkClient.deleteController(controller.controllerContext.epochZkVersion)
-      TestUtils.waitUntilTrue(() => !controller.isActive, "Controller fails to resign")
-      TestUtils.waitUntilTrue(() => zkClient.getControllerId.isDefined, "New controller failed to start")
-      zkClient.getControllerId.get != controllerId
-    }, "Controller did not get changed")
+  // Now ensure that after the controller moves, shutdown is still rejected.
+    zkClient.deleteController(controller.controllerContext.epochZkVersion)
+    TestUtils.waitUntilTrue(() => !controller.isActive, "Controller fails to resign")
+    TestUtils.waitUntilTrue(() => zkClient.getControllerId.isDefined, "New controller failed to start")
 
     val newControllerId = zkClient.getControllerId.get
     val newController = servers.find(p => p.config.brokerId == newControllerId).get.kafkaController


### PR DESCRIPTION
TICKET = LIKAFKA-43624
LI_DESCRIPTION =

When a controller re-election happens, the ReplicaStateMachine initializes the replicas with appropriate state -

1. If they are in the shutting down brokers list, or if the disk that the replica is on is marked as offline, then the replica is marked as OfflineReplica
1. Otherwise, they are initialized as OnlineReplica
 

Because shutting down brokers are persisted across different controllers (through ZK) in Linkedin's version of Kafka, hence replicas are being marked as offline even though they don't have any other nodes in the ISR. This is cause data to be unavailable for that partition.

 

This was observed in [GCN-36415](https://jira01.corp.linkedin.com:8443/browse/GCN-36415) and detailed in the document [https://docs.google.com/document/d/1rSeJkTuVrBF1VAb0whAO0xTK1_qpcmJNhNeK5ePFvpQ/edit. ](https://docs.google.com/document/d/1rSeJkTuVrBF1VAb0whAO0xTK1_qpcmJNhNeK5ePFvpQ/edit)The corresponding RCA ticket is [LIKAFKA-42499](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-42499).

 

We want to change the behavior so that replicas on shutting down brokers are not initialized to OfflineReplica, but rather to OnlineReplica.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
