### PR TITLE
[LI-HOTFIX] Fix bug for brooklin-li-common test error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/NoOffsetForPartitionException.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/NoOffsetForPartitionException.java
@@ -50,9 +50,9 @@ public class NoOffsetForPartitionException extends InvalidOffsetException {
     }
 
     public NoOffsetForPartitionException(Map<TopicPartition, SubscriptionState.FetchState> partitionFetchStates) {
-        super("Undefined offset with no reset policy for partitionss with states: " + partitionFetchStates);
+        super("Undefined offset with no reset policy for partitions with states: " + partitionFetchStates);
         this.partitionFetchStates = Collections.unmodifiableMap(new HashMap<>(partitionFetchStates));
-        this.partitions = Collections.emptySet();
+        this.partitions = Collections.unmodifiableSet(partitionFetchStates.keySet());
     }
 
     /**


### PR DESCRIPTION
TICKET = DATAPIPES-23596
LI_DESCRIPTION =
Empty partitions set in NoOffsetForPartitionException causes brooklin test failure. Populate partitions set with partitionFetchStates

(ported from 2.4-li branch)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
