### PR TITLE
Added KafkaServer constructor for backwards compat with LKC 10.

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -94,6 +94,17 @@ class KafkaServer(
   actions: KafkaActions = NoOpKafkaActions
 ) extends KafkaBroker with Server {
 
+  // Visible for testing from linkedin-kafka-clients for backwards compatibility.
+  @deprecated
+  def this(
+    config: KafkaConfig,
+    time: Time,
+    threadNamePrefix: Option[String],
+    kafkaMetricsReporters: Seq[KafkaMetricsReporter],
+    actions: KafkaActions) {
+    this(config, time, threadNamePrefix, enableForwarding = false, actions = actions)
+  }
+
   private val startupComplete = new AtomicBoolean(false)
   private val isShuttingDown = new AtomicBoolean(false)
   private val isStartingUp = new AtomicBoolean(false)


### PR DESCRIPTION
LI-HOTFIX]

TICKET =
LI_DESCRIPTION = Added back KafkaServer constructor that was removed in Kafka 3.0 for backwards compat with LKC 10.
EXIT_CRITERIA = None. When LKC migrates to using just Kafka 3.0, and doesn't need to build against Kafka 2.4 anymore, we can get rid of this hotfix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
