### PR TITLE
[LI-HOTFIX] Cache LogTruncationException in Fetcher

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -877,7 +877,7 @@ public class NetworkClient implements KafkaClient {
 
             int offset = this.randOffset.nextInt(newNodes.size());
             Node node = newNodes.get(offset);
-            log.info("Resolved bootstrap server again, randomly picked node {} as least loaded node from the resolved node set", node);
+            log.trace("Resolved bootstrap server again, randomly picked node {} as least loaded node from the resolved node set", node);
 
             return node;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -839,7 +839,11 @@ public class Fetcher<K, V> implements Closeable {
                     });
 
                     if (!truncationWithoutResetPolicy.isEmpty()) {
-                        throw new LogTruncationException(truncationWithoutResetPolicy);
+                        LogTruncationException e = new LogTruncationException(truncationWithoutResetPolicy);
+                        // cache the LogTruncationException to ensure it can be thrown and caught
+                        if (!cachedOffsetForLeaderException.compareAndSet(null, e)) {
+                            log.error("Discarding error in OffsetsForLeaderEpoch because another error is pending", e);
+                        }
                     }
                 }
 


### PR DESCRIPTION
[LI-HOTFIX] When LogTruncationException occured, cache it instead of throwing it out from asynchronous request listener
TICKET=DS-3552,GCN-36443
