### PR TITLE
[LI-HOTFIX] Do not resolve bootstrap server during client bootstrap/startup

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -136,13 +136,13 @@ public class Metadata implements Closeable {
     /**
      * Whether the client should update the cluster metadata by resolving the bootstrap server again
      * @param nowMs
-     * @return true if client hasn't refreshed cluster metadata for maxClusterMetadataExpireTimeMs and
+     * @return true if client is not in bootstrap mode and hasn't refreshed cluster metadata for maxClusterMetadataExpireTimeMs and
      * has tried connecting to at least one node in current node set; or forceClusterMetadataUpdateFromBootstrap
      * has been set by receiving stale metadata from a different cluster
      */
     public synchronized boolean shouldUpdateClusterMetadataFromBootstrap(long nowMs) {
         return (this.nodesTriedSinceLastSuccessfulRefresh >= 1 &&
-            this.lastSuccessfulRefreshMs + this.maxClusterMetadataExpireTimeMs <= nowMs) ||
+            (this.lastRefreshMs != 0 && this.lastSuccessfulRefreshMs + this.maxClusterMetadataExpireTimeMs <= nowMs)) ||
             this.forceClusterMetadataUpdateFromBootstrap;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -99,6 +99,8 @@ public class MetadataTest {
         //bootstrap the metadata cache with some valid nodes
         clusterMetadata.bootstrap(addresses);
 
+        clusterMetadata.requestClusterMetadataUpdateFromBootstrap();
+
         //first time call leastLoadedNode on the created NetworkClient should pass since nodesTriedSinceLastSuccessfulRefresh is 0
         clusterClient.leastLoadedNode(time.milliseconds());
 


### PR DESCRIPTION
Problem: previously to avoid idle consumer keep sending md request to stale brokers, we added logic to re-resolve bootstrap server if clients hasn't refreshed md for a long time. This works fine after clients has been started/connected successfully.

But during espresso testing where they intentionally killed all other brokers except one and try to start the producer, it takes a long time(> 1 min) for the producer to connect to the only one good broker, since during producer startup, lastSuccessfulRefreshMs is always 0, plus 1 hr timeout, it will still always be less than the unix timestamp of current time, so making it re-resolve the bootstrap servers and randomly pick one, which makes the producer jumping between the bad brokers until eventually picks the good one and send md request to it. We also see in other user reporting that during client startup it keeps re-resolving the bootstrap server and logs got piled up quickly.

Fix: consider the following two scenarios:
1. during bootstrap: we should NOT re-resolve the bootstrap server and random pick the nodes, but fall to the original logic of least loaded node which will favor the connected brokers
2. during stable consumption/producing but cluster swap/broker removal happens: we should still re-resolve the bootstrap server and random pick one to ensure clients not stuck on stale brokers.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
