### PR TITLE
[LI-HOTFIX] Update jackson-databind from vulnerable version 2.12.3.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,7 +68,7 @@ versions += [
   guava: "30.1.1-jre",
   httpclient: "4.5.13",
   easymock: "4.3",
-  jackson: "2.12.3",
+  jackson: "2.13.2",
   jacoco: "0.8.7",
   javassist: "3.27.0-GA",
   jetty: "9.4.43.v20210629",


### PR DESCRIPTION
`com.fasterxml.jackson.core:jackson-databind:2.12.3` is vulnerable to denial of service. A malicious user is able to cause a `StackOverflow` exception using a large depth of nested objects resulting in a denial of service conditions.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
