### PR TITLE
[LI-HOTFIX] Downgrade the CI build to Java 8

### DIFF
--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -49,10 +49,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Set up release version env variable
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -37,9 +37,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Run rat code analysis steps
         run: ./gradlew rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest --no-daemon -PxmlSpotBugsReport=true -PtestLoggingEvents=started,passed,skipped,failed

--- a/.github/workflows/int-test.yml
+++ b/.github/workflows/int-test.yml
@@ -43,10 +43,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Run tests
         env:
           SCALA_VERSION: ${{ matrix.scalaVersion }}
@@ -78,10 +78,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Run tests
         env:
           SCALA_VERSION: ${{ matrix.scalaVersion }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -46,10 +46,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Run tests
         env:
           SCALA_VERSION: ${{ matrix.scalaVersion }}


### PR DESCRIPTION
TICKET = LIKAFKA-43889
LI_DESCRIPTION =
1. scala compiler run with java8 produces java8 compatible code before 2.4.1.42 (2.4.1.47 also worked since I built it via CLI on my localhost which also used java8).
2. scala compiler run with java11 produces java8 incompatible code. Even though java11 is given the
--release 8 option, the scala compiler is not aware of it. When I tried to add the -release 8 option
to the scala compiler, it throws out this error
```
/home/lucas/workspace/likafka-testing-java11/core/src/main/scala/kafka/Kafka.scala:80: Class sun.reflect.CallerSensitive not found - continuing with a stub.
 Runtime.getRuntime().addShutdownHook(new Thread("kafka-shutdown-hook") {
 ^
```


It seems we have the following options

1. Upgrade samza-li to java 11
2. Downgrade the kafka CI environment to java 8.

At this moment, the Samza team says option 1 is not acceptable.
Thus we are left with option 2.

As a side note, for kafka 3.x, we've decided to drop the support for scala 2.11.
Thus I think it's logical to also drop the support for Java 8. For that reason,
I'm not porting this PR to the 3.0 branch.

EXIT_CRITERIA =
In the future, when samza-li is upgraded to java 11 or when it no longer depends on
the kafka scala code, we can do the upgrade to java 11 again.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
