### PR TITLE
[LI-FIXUP] Call the correct workflow id int-test during release

### DIFF
--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -39,8 +39,7 @@ jobs:
     needs:
       - code-analysis
       - unit-test
-      - int-test-clients
-      - int-test-core
+      - int-test
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
PR #323 introduced reusable workflows. This PR fixes an issue in
the original PR by calling the correct workflow id.
EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
