### PR TITLE
[LI-FIXUP] Bypass cluster metadata auto refresh code path by default

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -93,7 +93,7 @@ public class Metadata implements Closeable {
                     long metadataExpireMs,
                     LogContext logContext,
                     ClusterResourceListeners clusterResourceListeners) {
-        this(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, Long.MAX_VALUE);
+        this(refreshBackoffMs, metadataExpireMs, logContext, clusterResourceListeners, -1);
     }
 
     public Metadata(long refreshBackoffMs,
@@ -142,7 +142,8 @@ public class Metadata implements Closeable {
      * has been set by receiving stale metadata from a different cluster
      */
     public synchronized boolean shouldUpdateClusterMetadataFromBootstrap(long nowMs) {
-        return (this.nodesTriedSinceLastSuccessfulRefresh >= 1 &&
+        return this.maxClusterMetadataExpireTimeMs > 0 &&
+            (this.nodesTriedSinceLastSuccessfulRefresh >= 1 &&
             (this.lastRefreshMs != 0 && this.lastSuccessfulRefreshMs + this.maxClusterMetadataExpireTimeMs <= nowMs)) ||
             this.forceClusterMetadataUpdateFromBootstrap;
     }


### PR DESCRIPTION
This should be a fix-up to linkedin#316, and the same patch is also made to the 2.4 branch in linkedin#329.

The PR linkedin#228 attempted to resolve provided bootstrap servers when
the metadata is exceeding a staleness threshold.  The config is covered
both on producer and consumer, and default behavior without configured
value is setting the timeout to `Long.MAX_VALUE`.

However, `cruise-control` is affected by the behavior as it implements a
similar mechanism on its own and directly uses `NetworkClient`. The code
would fail if an empty bootstrap server list is passed to `NetworkClient`, which
is the case for internal use of CC.

To resolve this, this patch aims to make the default value -1, and omit
the code path referencing bootstrap server when we see -1.

EXIT_CRITERIA = When linkedin#316 is ejected

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
