### PR TITLE
[LI-HOTFIX] Improve the efficiency of replica deletion

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -741,7 +741,7 @@ class Log(@volatile private var _dir: File,
    *
    * @throws KafkaStorageException if rename fails
    */
-  def renameDir(name: String): Unit = {
+  def renameDir(name: String, reinitialize: Boolean): Unit = {
     lock synchronized {
       maybeHandleIOException(s"Error while renaming dir for $topicPartition in log dir ${dir.getParent}") {
         // Flush partitionMetadata file before initializing again
@@ -755,8 +755,10 @@ class Log(@volatile private var _dir: File,
           producerStateManager.updateParentDir(dir)
           // re-initialize leader epoch cache so that LeaderEpochCheckpointFile.checkpoint can correctly reference
           // the checkpoint file in renamed log directory
-          initializeLeaderEpochCache()
-          initializePartitionMetadata()
+          if (reinitialize) {
+            initializeLeaderEpochCache()
+            initializePartitionMetadata()
+          }
         }
       }
     }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -741,7 +741,7 @@ class Log(@volatile private var _dir: File,
    *
    * @throws KafkaStorageException if rename fails
    */
-  def renameDir(name: String, reinitialize: Boolean): Unit = {
+  def renameDir(name: String, shouldReinitialize: Boolean): Unit = {
     lock synchronized {
       maybeHandleIOException(s"Error while renaming dir for $topicPartition in log dir ${dir.getParent}") {
         // Flush partitionMetadata file before initializing again
@@ -755,7 +755,7 @@ class Log(@volatile private var _dir: File,
           producerStateManager.updateParentDir(dir)
           // re-initialize leader epoch cache so that LeaderEpochCheckpointFile.checkpoint can correctly reference
           // the checkpoint file in renamed log directory
-          if (reinitialize) {
+          if (shouldReinitialize) {
             initializeLeaderEpochCache()
             initializePartitionMetadata()
           }

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -981,7 +981,7 @@ class LogManager(logDirs: Seq[File],
       if (destLog == null)
         throw new KafkaStorageException(s"The future replica for $topicPartition is offline")
 
-      destLog.renameDir(Log.logDirName(topicPartition))
+      destLog.renameDir(Log.logDirName(topicPartition), true)
       destLog.updateHighWatermark(sourceLog.highWatermark)
 
       // Now that future replica has been successfully renamed to be the current replica
@@ -994,7 +994,7 @@ class LogManager(logDirs: Seq[File],
       }
 
       try {
-        sourceLog.renameDir(Log.logDeleteDirName(topicPartition))
+        sourceLog.renameDir(Log.logDeleteDirName(topicPartition), true)
         // Now that replica in source log directory has been successfully renamed for deletion.
         // Close the log, update checkpoint files, and enqueue this log to be deleted.
         sourceLog.close()
@@ -1041,7 +1041,7 @@ class LogManager(logDirs: Seq[File],
             cleaner.updateCheckpoints(removedLog.parentDirFile, partitionToRemove = Option(topicPartition))
           }
         }
-        removedLog.renameDir(Log.logDeleteDirName(topicPartition))
+        removedLog.renameDir(Log.logDeleteDirName(topicPartition), false)
         if (checkpoint) {
           val logDir = removedLog.parentDirFile
           val logsToCheckpoint = logsInDir(logDir)

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -2613,7 +2613,7 @@ class LogTest {
 
     // Ensure that after a directory rename, the epoch cache is written to the right location
     val tp = Log.parseTopicPartitionName(log.dir)
-    log.renameDir(Log.logDeleteDirName(tp))
+    log.renameDir(Log.logDeleteDirName(tp), true)
     log.appendAsLeader(TestUtils.records(List(new SimpleRecord("foo".getBytes()))), leaderEpoch = 10)
     assertEquals(Some(10), log.latestEpoch)
     assertTrue(LeaderEpochCheckpointFile.newFile(log.dir).exists())
@@ -2634,7 +2634,7 @@ class LogTest {
 
     // Ensure that after a directory rename, the partition metadata file is written to the right location.
     val tp = Log.parseTopicPartitionName(log.dir)
-    log.renameDir(Log.logDeleteDirName(tp))
+    log.renameDir(Log.logDeleteDirName(tp), true)
     log.appendAsLeader(TestUtils.records(List(new SimpleRecord("foo".getBytes()))), leaderEpoch = 10)
     assertEquals(Some(10), log.latestEpoch)
     assertTrue(PartitionMetadataFile.newFile(log.dir).exists())
@@ -2657,7 +2657,7 @@ class LogTest {
 
     // Ensure that after a directory rename, the partition metadata file is written to the right location.
     val tp = Log.parseTopicPartitionName(log.dir)
-    log.renameDir(Log.logDeleteDirName(tp))
+    log.renameDir(Log.logDeleteDirName(tp), true)
     assertTrue(PartitionMetadataFile.newFile(log.dir).exists())
     assertFalse(PartitionMetadataFile.newFile(this.logDir).exists())
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -2287,7 +2287,7 @@ class ReplicaManagerTest {
 
   @Test
   def testStopReplicaWithDeletePartitionAndExistingPartitionAndNewerLeaderEpochAndIOException(): Unit = {
-    testStopReplicaWithExistingPartition(2, true, true, Errors.KAFKA_STORAGE_ERROR)
+    testStopReplicaWithExistingPartition(2, true, true, Errors.NONE)
   }
 
   @Test


### PR DESCRIPTION
TICKET = KAFKA-13815
LI_DESCRIPTION =
KAFKA-10002 identified that deletion of replicas can be slow when a StopReplica request is being
processed, and has implemented a change to improve the efficiency.
We found that the efficiency can be further improved by avoiding the reinitialization of the
leader epoch cache and partition metadata for a replica that needs to be deleted.

EXIT_CRITERIA = When KAFKA-13815 is resolved and the change is pulled in

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
