### PR TITLE
[LI-HOTFIX] Down pin non-databind jackson dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2038,6 +2038,7 @@ project(':streams:upgrade-system-tests-0100') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-0100"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_0100
     testRuntimeOnly libs.junitJupiter
   }
@@ -2051,6 +2052,7 @@ project(':streams:upgrade-system-tests-0101') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-0101"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_0101
     testRuntimeOnly libs.junitJupiter
   }
@@ -2064,6 +2066,7 @@ project(':streams:upgrade-system-tests-0102') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-0102"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_0102
     testRuntimeOnly libs.junitJupiter
   }
@@ -2077,6 +2080,7 @@ project(':streams:upgrade-system-tests-0110') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-0110"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_0110
     testRuntimeOnly libs.junitJupiter
   }
@@ -2090,6 +2094,7 @@ project(':streams:upgrade-system-tests-10') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-10"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_10
     testRuntimeOnly libs.junitJupiter
   }
@@ -2103,6 +2108,7 @@ project(':streams:upgrade-system-tests-11') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-11"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_11
     testRuntimeOnly libs.junitJupiter
   }
@@ -2116,6 +2122,7 @@ project(':streams:upgrade-system-tests-20') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-20"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_20
     testRuntimeOnly libs.junitJupiter
   }
@@ -2129,6 +2136,7 @@ project(':streams:upgrade-system-tests-21') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-21"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_21
     testRuntimeOnly libs.junitJupiter
   }
@@ -2142,6 +2150,7 @@ project(':streams:upgrade-system-tests-22') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-22"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_22
     testRuntimeOnly libs.junitJupiter
   }
@@ -2155,6 +2164,7 @@ project(':streams:upgrade-system-tests-23') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-23"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_23
     testRuntimeOnly libs.junitJupiter
   }
@@ -2168,6 +2178,7 @@ project(':streams:upgrade-system-tests-24') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-24"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_24
     testRuntimeOnly libs.junitJupiter
   }
@@ -2181,6 +2192,7 @@ project(':streams:upgrade-system-tests-25') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-25"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_25
     testRuntimeOnly libs.junitJupiter
   }
@@ -2194,6 +2206,7 @@ project(':streams:upgrade-system-tests-26') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-26"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_26
     testRuntimeOnly libs.junitJupiter
   }
@@ -2207,6 +2220,7 @@ project(':streams:upgrade-system-tests-27') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-27"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_27
     testRuntimeOnly libs.junitJupiter
   }
@@ -2220,6 +2234,7 @@ project(':streams:upgrade-system-tests-28') {
   archivesBaseName = "kafka-streams-upgrade-system-tests-28"
 
   dependencies {
+    testImplementation libs.jacksonDatabind // Pin for CVE-2020-36518
     testImplementation libs.kafkaStreams_28
     testRuntimeOnly libs.junitJupiter
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,7 +68,7 @@ versions += [
   guava: "30.1.1-jre",
   httpclient: "4.5.13",
   easymock: "4.3",
-  jackson: "2.12.6",
+  jackson: "2.12.5",
   jacksonDatabind: "2.12.6.1",
   jacoco: "0.8.7",
   javassist: "3.27.0-GA",


### PR DESCRIPTION
LI_DESCRIPTION =
Linkedin internal system blocks jar import on dependencies that declares a dependency transitively.
For example, with a dependency chain

```
A > B > C
```

when C is found vulnerable, both A & B will be blocked, which is normal.

However, if A pins a fixed C' and the dependency becomes

```
A > B > C
  > C'

// Which should resolve to A, B, C'
```
A is still blocked even if the whole dependency resolution does not
include vulnerable C, because the system still blocks B, and it thinks
"A is not usable without B", thus rejecting importing A.

In order to get over this, we have to down pin B to a lib that already
exists internally (in this specific use case, all non-`databind` `jackson`
dependencies) while maintaining the directly vulnerable library C (in
this case, `jackson-databind`) pinned to a fixed, non-vulnerable
version.

TICKET = CVE-2020-36518, KAFKA-13775
EXIT_CRITERIA = "When upstream bumps all `jackson` series to >= `2.13.3`"

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
