### PR TITLE
[LI-HOTFIX] Adding metrics to show the bytes and number of messages truncated

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2027,8 +2027,11 @@ class Log(@volatile private var _dir: File,
               endOffset = targetOffset
             )
           }
+          val messagesTruncated = originalLogEndOffset - targetOffset
           warn(s"Truncated to offset $targetOffset from the log end offset $originalLogEndOffset " +
-            s"with ${originalLogEndOffset - targetOffset} messages and $bytesTruncated bytes truncated")
+            s"with $messagesTruncated messages and $bytesTruncated bytes truncated")
+          LogTruncationStats.logTruncatedBytesRate.mark(bytesTruncated)
+          LogTruncationStats.logTruncatedMessagesRate.mark(messagesTruncated)
           true
         }
       }
@@ -2969,4 +2972,9 @@ case object LogDeletion extends SegmentDeletionReason {
   override def logReason(log: Log, toDelete: List[LogSegment]): Unit = {
     log.info(s"Deleting segments as the log has been deleted: ${toDelete.mkString(",")}")
   }
+}
+
+object LogTruncationStats extends KafkaMetricsGroup {
+  val logTruncatedBytesRate = newMeter("LogTruncatedBytesPerSec", "log-truncation", TimeUnit.SECONDS)
+  val logTruncatedMessagesRate = newMeter("LogTruncatedMessagesPerSec", "log-truncation", TimeUnit.SECONDS)
 }


### PR DESCRIPTION
TICKET = KAFKA-10751 LIKAFKA-43267
LI_DESCRIPTION =
Adding two metrics to show
1. the number of bytes truncated
2. the number of messages truncated
EXIT_CRITERIA = When the two metrics are added to upstream as tracked in KAFKA-10751

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
