### PR TITLE
[LI-HOTFIX] add config LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -164,6 +164,10 @@ public class CommonClientConfigs {
         + "which will try to refresh metadata by choosing from existing resolved node set, this config will force resolving "
         + "the bootstrap url again to get new node set and use the new node set to send update metadata request";
 
+    /** <code> li.update.metadata.last.refresh.time.upon.node.disconnect </code> */
+    public static final String LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG = "li.update.metadata.last.refresh.time.upon.node.disconnect";
+    public static final String LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_DOC = "whether the lastRefreshMs in NetworkClient should be updated when a node disconnection happens";
+
     /**
      * Postprocess the configuration so that exponential backoff is disabled when reconnect backoff
      * is explicitly configured but the maximum reconnect backoff is not explicitly configured.

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1494,7 +1494,7 @@ public class NetworkClient implements KafkaClient {
             // In case 1, the param maybeFatalException will be empty and in case 2, it will be an unsupportedVersionException,
             // so we'll use the existence of exception to keep the other behavior unchanged, only do not set lastRefreshMd
             // upon node disconnection.
-            handleFailedRequest(now, maybeFatalException, maybeFatalException.isPresent());
+            handleFailedRequest(now, maybeFatalException, updateMetadataLastRefreshTimeOnDisconnection || maybeFatalException.isPresent());
         }
 
         private void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException, boolean updateLastRefreshTime) {

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1488,7 +1488,7 @@ public class NetworkClient implements KafkaClient {
 
         @Override
         public void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException) {
-            handleFailedRequest(now, maybeFatalException, updateMetadataLastRefreshTimeOnDisconnection);
+            handleFailedRequest(now, maybeFatalException, true);
         }
 
         private void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException, boolean updateLastRefreshTime) {

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1488,7 +1488,13 @@ public class NetworkClient implements KafkaClient {
 
         @Override
         public void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException) {
-            handleFailedRequest(now, maybeFatalException, true);
+            // this handleFailedRequest can be called in two scenarios:
+            // 1. cancelInFlightRequests due to node disconnected
+            // 2. doSend when api version mismatch.
+            // In case 1, the param maybeFatalException will be empty and in case 2, it will be an unsupportedVersionException,
+            // so we'll use the existence of exception to keep the other behavior unchanged, only do not set lastRefreshMd
+            // upon node disconnection.
+            handleFailedRequest(now, maybeFatalException, maybeFatalException.isPresent());
         }
 
         private void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException, boolean updateLastRefreshTime) {

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -130,6 +130,9 @@ public class NetworkClient implements KafkaClient {
      */
     private final boolean discoverBrokerVersions;
 
+    /* whether metadata lastRefreshMs should be updated on node disconnection to honor backoff */
+    private final boolean updateMetadataLastRefreshTimeOnDisconnection;
+
     private final ApiVersions apiVersions;
 
     private final Map<String, ApiVersionsRequest.Builder> nodesNeedingApiVersionsFetch = new HashMap<>();
@@ -307,7 +310,8 @@ public class NetworkClient implements KafkaClient {
             LogContext logContext,
             String clientSoftwareNameAndCommit,
             LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm,
-            List<String> bootstrapServerUrls) {
+            List<String> bootstrapServerUrls,
+            boolean updateMetadataLastRefreshTimeOnDisconnection) {
         this(null,
              metadata,
              selector,
@@ -326,7 +330,8 @@ public class NetworkClient implements KafkaClient {
              logContext,
              clientSoftwareNameAndCommit,
              leastLoadedNodeAlgorithm,
-             bootstrapServerUrls);
+             bootstrapServerUrls,
+             updateMetadataLastRefreshTimeOnDisconnection);
     }
 
     public NetworkClient(Selectable selector,
@@ -402,6 +407,31 @@ public class NetworkClient implements KafkaClient {
     }
 
     private NetworkClient(MetadataUpdater metadataUpdater,
+        Metadata metadata,
+        Selectable selector,
+        String clientId,
+        int maxInFlightRequestsPerConnection,
+        long reconnectBackoffMs,
+        long reconnectBackoffMax,
+        int socketSendBuffer,
+        int socketReceiveBuffer,
+        int defaultRequestTimeoutMs,
+        ClientDnsLookup clientDnsLookup,
+        Time time,
+        boolean discoverBrokerVersions,
+        ApiVersions apiVersions,
+        Sensor throttleTimeSensor,
+        LogContext logContext,
+        String clientSoftwareNameAndCommit,
+        LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm,
+        List<String> bootstrapServersConfig) {
+        this(metadataUpdater, metadata, selector, clientId, maxInFlightRequestsPerConnection, reconnectBackoffMs,
+            reconnectBackoffMax, socketSendBuffer, socketReceiveBuffer, defaultRequestTimeoutMs, clientDnsLookup, time,
+            discoverBrokerVersions, apiVersions, throttleTimeSensor, logContext, clientSoftwareNameAndCommit,
+            leastLoadedNodeAlgorithm, bootstrapServersConfig, true);
+    }
+
+    private NetworkClient(MetadataUpdater metadataUpdater,
                           Metadata metadata,
                           Selectable selector,
                           String clientId,
@@ -419,7 +449,8 @@ public class NetworkClient implements KafkaClient {
                           LogContext logContext,
                           String clientSoftwareNameAndCommit,
                           LeastLoadedNodeAlgorithm leastLoadedNodeAlgorithm,
-                          List<String> bootstrapServersConfig) {
+                          List<String> bootstrapServersConfig,
+                          boolean updateMetadataLastRefreshTimeOnDisconnection) {
         /* It would be better if we could pass `DefaultMetadataUpdater` from the public constructor, but it's not
          * possible because `DefaultMetadataUpdater` is an inner class and it can only be instantiated after the
          * super constructor is invoked.
@@ -455,6 +486,7 @@ public class NetworkClient implements KafkaClient {
         }
         this.leastLoadedNodeAlgorithm = leastLoadedNodeAlgorithm;
         this.bootstrapServers.addAll(bootstrapServersConfig);
+        this.updateMetadataLastRefreshTimeOnDisconnection = updateMetadataLastRefreshTimeOnDisconnection;
     }
 
     public void setEnableClientResponseWithFinalize(boolean enableClientResponseWithFinalize) {
@@ -1446,7 +1478,7 @@ public class NetworkClient implements KafkaClient {
             // If we have a disconnect while an update is due, we treat it as a failed update
             // so that we can backoff properly
             if (isUpdateDue(now))
-                handleFailedRequest(now, Optional.empty());
+                handleFailedRequest(now, Optional.empty(), updateMetadataLastRefreshTimeOnDisconnection);
 
             maybeFatalException.ifPresent(metadata::fatalError);
 
@@ -1456,8 +1488,14 @@ public class NetworkClient implements KafkaClient {
 
         @Override
         public void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException) {
+            handleFailedRequest(now, maybeFatalException, updateMetadataLastRefreshTimeOnDisconnection);
+        }
+
+        private void handleFailedRequest(long now, Optional<KafkaException> maybeFatalException, boolean updateLastRefreshTime) {
             maybeFatalException.ifPresent(metadata::fatalError);
-            metadata.failedUpdate(now);
+            if (updateLastRefreshTime) {
+                metadata.failedUpdate(now);
+            }
             inProgressRequestVersion = null;
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -317,6 +317,8 @@ public class ConsumerConfig extends AbstractConfig {
 
     public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG = CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG;
 
+    public static final String LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG = CommonClientConfigs.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                                         Type.LIST,
@@ -366,6 +368,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.LOW,
                                         CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_DOC)
+                                .define(LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG,
+                                        Type.BOOLEAN,
+                                        true,
+                                        Importance.LOW,
+                                        CommonClientConfigs.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_DOC)
                                 .define(ENABLE_AUTO_COMMIT_CONFIG,
                                         Type.BOOLEAN,
                                         true,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -778,7 +778,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     logContext,
                     config.getString(ConsumerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG),
                     leastLoadedNodeAlgorithm,
-                    config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+                    config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
+                    config.getBoolean(ConsumerConfig.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG));
             netClient.setEnableClientResponseWithFinalize(config.getBoolean(ConsumerConfig.ENABLE_CLIENT_RESPONSE_LEAK_CHECK));
 
             this.client = new ConsumerNetworkClient(

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -490,7 +490,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 logContext,
                 producerConfig.getString(ProducerConfig.LI_CLIENT_SOFTWARE_NAME_AND_COMMIT_CONFIG),
                 leastLoadedNodeAlgorithm,
-                producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+                producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),
+                producerConfig.getBoolean(ProducerConfig.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG));
         int retries = configureRetries(producerConfig, transactionManager != null, log);
         short acks = configureAcks(producerConfig, transactionManager != null, log);
         return new Sender(logContext,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -275,6 +275,8 @@ public class ProducerConfig extends AbstractConfig {
 
     public static final String LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG = CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_CONFIG;
 
+    public static final String LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG = CommonClientConfigs.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Collections.emptyList(), new ConfigDef.NonNullValidator(), Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
                                 .define(CLIENT_DNS_LOOKUP_CONFIG,
@@ -329,6 +331,11 @@ public class ProducerConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.LOW,
                                         CommonClientConfigs.LI_CLIENT_CLUSTER_METADATA_EXPIRE_TIME_MS_DOC)
+                                .define(LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG,
+                                        Type.BOOLEAN,
+                                        true,
+                                         Importance.LOW,
+                                         CommonClientConfigs.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG)
                                 .define(METRICS_SAMPLE_WINDOW_MS_CONFIG,
                                         Type.LONG,
                                         30000,


### PR DESCRIPTION
Problem:
Currently whenever a disconnection happens, the NetworkClient will update the lastRefreshMs even though it's not updated, in order to backoff properly https://github.com/linkedin/kafka/blob/2.4-li/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java#L1460.

This causes problem in the following sequence:
1. a send triggers md update, user thread waiting on md update, and sender woken up, this is at time T1, and last successful md refresh is > T1 - retryBackoffMs, so NetworkClient.poll() is supposed to update md immediately.
2. a node disconnection happens immediately after 1, say T2, setting lastRefreshMs of metadata to T2, so metadata.timeToNextUpdate() will return T2 + retryBackoffMs
3. when NetworkClient.poll() calls metadataUpdater.maybeUpdate(), the latter will return retryBackoffMs since it thinks it just refreshed md at T2, so next time to update should honor retryBackoffMs.
4. user thread at 1 will need to wait for retryBackoffMs before NetworkClient can actually send md request to broker and update the md correctly.

And in some use cases, the disconnection happens frequently and the user thread can be blocked for min(N * retryBackoffMs, defaultRequestTimeoutMs) time, which violates some users' SLA.

Fix:
Add a config to not update md's lastRefreshMs in node disconnection, so that it will make decision based on the actual lastRefreshMs and not blocking the user thread for retryBackoffMs.

Test:
Added integration test.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
