### PR TITLE
[LI-HOTFIX] Resume topic deletion on broker failure

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -374,12 +374,16 @@ class ControllerContext {
     topicsToBeDeleted
   }
 
+  def replicasInState(topic: String, expectedStates: Set[ReplicaState]): Set[PartitionAndReplica] = {
+    replicasForTopic(topic).filter(replica => expectedStates.contains(replicaStates(replica))).toSet
+  }
+
   def replicasInState(topic: String, state: ReplicaState): Set[PartitionAndReplica] = {
     replicasForTopic(topic).filter(replica => replicaStates(replica) == state).toSet
   }
 
-  def areAllReplicasInState(topic: String, state: ReplicaState): Boolean = {
-    replicasForTopic(topic).forall(replica => replicaStates(replica) == state)
+  def areAllReplicasInStates(topic: String, expectedStates: Set[ReplicaState]): Boolean = {
+    replicasForTopic(topic).forall(replica => expectedStates.contains(replicaStates(replica)))
   }
 
   def isAnyReplicaInState(topic: String, state: ReplicaState): Boolean = {

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -374,7 +374,7 @@ class ControllerContext {
     topicsToBeDeleted
   }
 
-  def replicasInState(topic: String, expectedStates: Set[ReplicaState]): Set[PartitionAndReplica] = {
+  def replicasInStates(topic: String, expectedStates: Set[ReplicaState]): Set[PartitionAndReplica] = {
     replicasForTopic(topic).filter(replica => expectedStates.contains(replicaStates(replica))).toSet
   }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -693,7 +693,7 @@ class KafkaController(val config: KafkaConfig,
     // trigger OnlinePartition state changes for offline or new partitions
     partitionStateMachine.triggerOnlinePartitionStateChange()
     // trigger OfflineReplica state change for those newly offline replicas
-    replicaStateMachine.handleStateChanges(newOfflineReplicasNotForDeletion.toSeq, OfflineReplica)
+    replicaStateMachine.handleStateChanges(newOfflineReplicas.toSeq, OfflineReplica)
 
     if (newOfflineReplicasForDeletion.nonEmpty) {
       info(s"Some replicas ${newOfflineReplicasForDeletion.mkString(",")} for topics scheduled for deletion " +

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -695,12 +695,11 @@ class KafkaController(val config: KafkaConfig,
     // trigger OfflineReplica state change for those newly offline replicas
     replicaStateMachine.handleStateChanges(newOfflineReplicasNotForDeletion.toSeq, OfflineReplica)
 
-    // fail deletion of topics that are affected by the offline replicas
     if (newOfflineReplicasForDeletion.nonEmpty) {
-      // it is required to mark the respective replicas in TopicDeletionFailed state since the replica cannot be
-      // deleted when its log directory is offline. This will prevent the replica from being in TopicDeletionStarted state indefinitely
-      // since topic deletion cannot be retried until at least one replica is in TopicDeletionStarted state
-      topicDeletionManager.failReplicaDeletion(newOfflineReplicasForDeletion)
+      info(s"Some replicas ${newOfflineReplicasForDeletion.mkString(",")} for topics scheduled for deletion " +
+        s"${controllerContext.topicsToBeDeleted.mkString(",")} have become offline. " +
+        "Signaling restart of topic deletion for these topics")
+      topicDeletionManager.resumeDeletionForTopics(newOfflineReplicasForDeletion.map(_.topic))
     }
 
     // If replica failure did not require leader re-election, inform brokers of the offline brokers

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -482,7 +482,7 @@ case object ReplicaDeletionStarted extends ReplicaState {
 
 case object ReplicaDeletionSuccessful extends ReplicaState {
   val state: Byte = 5
-  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionStarted, OfflineReplica)
+  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionStarted)
 }
 
 case object ReplicaDeletionIneligible extends ReplicaState {

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -472,7 +472,7 @@ case object OnlineReplica extends ReplicaState {
 
 case object OfflineReplica extends ReplicaState {
   val state: Byte = 3
-  val validPreviousStates: Set[ReplicaState] = Set(NewReplica, OnlineReplica, OfflineReplica, ReplicaDeletionIneligible)
+  val validPreviousStates: Set[ReplicaState] = Set(NewReplica, OnlineReplica, OfflineReplica, ReplicaDeletionStarted, ReplicaDeletionIneligible)
 }
 
 case object ReplicaDeletionStarted extends ReplicaState {
@@ -492,5 +492,5 @@ case object ReplicaDeletionIneligible extends ReplicaState {
 
 case object NonExistentReplica extends ReplicaState {
   val state: Byte = 7
-  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionSuccessful)
+  val validPreviousStates: Set[ReplicaState] = Set(ReplicaDeletionSuccessful, OfflineReplica)
 }

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -180,7 +180,7 @@ class TopicDeletionManager(config: KafkaConfig,
       val replicasThatFailedToDelete = replicas.filter(r => isTopicQueuedUpForDeletion(r.topic))
       if (replicasThatFailedToDelete.nonEmpty) {
         val topics = replicasThatFailedToDelete.map(_.topic)
-        debug(s"Deletion failed for replicas ${replicasThatFailedToDelete.mkString(",")}. Halting deletion for topics $topics")
+        info(s"Deletion failed for replicas ${replicasThatFailedToDelete.mkString(",")}. Halting deletion for topics $topics")
         replicaStateMachine.handleStateChanges(replicasThatFailedToDelete.toSeq, ReplicaDeletionIneligible)
         markTopicIneligibleForDeletion(topics, reason = "replica deletion failure")
         resumeDeletions()
@@ -269,7 +269,7 @@ class TopicDeletionManager(config: KafkaConfig,
     // deregister partition change listener on the deleted topic. This is to prevent the partition change listener
     // firing before the new topic listener when a deleted topic gets auto created
     client.mutePartitionModifications(topic)
-    val replicasForDeletedTopic = controllerContext.replicasInState(topic, ReplicaDeletionSuccessful)
+    val replicasForDeletedTopic = controllerContext.replicasInState(topic, Set(ReplicaDeletionSuccessful, OfflineReplica))
     // controller will remove this replica from the state machine as well as its partition assignment cache
     replicaStateMachine.handleStateChanges(replicasForDeletedTopic.toSeq, NonExistentReplica)
     client.deleteTopic(topic, controllerContext.epochZkVersion)
@@ -340,8 +340,6 @@ class TopicDeletionManager(config: KafkaConfig,
       }
     }
 
-    // move dead replicas directly to deletion successful state
-    replicaStateMachine.handleStateChanges(allDeadReplicas, ReplicaDeletionSuccessful)
     // send stop replica to all followers that are not in the OfflineReplica state so they stop sending fetch requests to the leader
     replicaStateMachine.handleStateChanges(allReplicasForDeletionRetry, OfflineReplica)
     replicaStateMachine.handleStateChanges(allReplicasForDeletionRetry, ReplicaDeletionStarted)
@@ -357,7 +355,7 @@ class TopicDeletionManager(config: KafkaConfig,
 
     topicsQueuedForDeletion.foreach { topic =>
       // if all replicas are marked as deleted successfully, then topic deletion is done
-      if (controllerContext.areAllReplicasInState(topic, ReplicaDeletionSuccessful)) {
+      if (controllerContext.areAllReplicasInStates(topic, Set(ReplicaDeletionSuccessful, OfflineReplica))) {
         // clear up all state for this topic from controller cache and zookeeper
         completeDeleteTopic(topic)
         info(s"Deletion of topic $topic successfully completed")

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -269,7 +269,7 @@ class TopicDeletionManager(config: KafkaConfig,
     // deregister partition change listener on the deleted topic. This is to prevent the partition change listener
     // firing before the new topic listener when a deleted topic gets auto created
     client.mutePartitionModifications(topic)
-    val replicasForDeletedTopic = controllerContext.replicasInState(topic, Set(ReplicaDeletionSuccessful, OfflineReplica))
+    val replicasForDeletedTopic = controllerContext.replicasInStates(topic, Set(ReplicaDeletionSuccessful, OfflineReplica))
     // controller will remove this replica from the state machine as well as its partition assignment cache
     replicaStateMachine.handleStateChanges(replicasForDeletedTopic.toSeq, NonExistentReplica)
     client.deleteTopic(topic, controllerContext.epochZkVersion)

--- a/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
@@ -290,6 +290,11 @@ class ReplicaStateMachineTest {
   }
 
   @Test
+  def testInvalidOfflineReplicaToReplicaDeletionSuccessfulTransition(): Unit = {
+    testInvalidTransition(OfflineReplica, ReplicaDeletionSuccessful)
+  }
+
+  @Test
   def testInvalidReplicaDeletionStartedToNonexistentReplicaTransition(): Unit = {
     testInvalidTransition(ReplicaDeletionStarted, NonExistentReplica)
   }

--- a/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
@@ -250,11 +250,6 @@ class ReplicaStateMachineTest {
   }
 
   @Test
-  def testInvalidOfflineReplicaToNonexistentReplicaTransition(): Unit = {
-    testInvalidTransition(OfflineReplica, NonExistentReplica)
-  }
-
-  @Test
   def testInvalidOfflineReplicaToNewReplicaTransition(): Unit = {
     testInvalidTransition(OfflineReplica, NewReplica)
   }
@@ -307,11 +302,6 @@ class ReplicaStateMachineTest {
   @Test
   def testInvalidReplicaDeletionStartedToOnlineReplicaTransition(): Unit = {
     testInvalidTransition(ReplicaDeletionStarted, OnlineReplica)
-  }
-
-  @Test
-  def testInvalidReplicaDeletionStartedToOfflineReplicaTransition(): Unit = {
-    testInvalidTransition(ReplicaDeletionStarted, OfflineReplica)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -111,7 +111,7 @@ class TopicDeletionManagerTest {
 
     assertEquals(1, replicaStateMachine.stateChangesCalls(OfflineReplica))
     assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionStarted))
-    assertEquals(2, replicaStateMachine.stateChangesCalls(ReplicaDeletionSuccessful))
+    assertEquals(1, replicaStateMachine.stateChangesCalls(ReplicaDeletionSuccessful))
   }
 
   @Test
@@ -163,6 +163,7 @@ class TopicDeletionManagerTest {
     assertEquals(Set(), controllerContext.topicsToBeDeleted)
     assertEquals(Set(), controllerContext.topicsWithDeletionStarted)
     assertEquals(Set(), controllerContext.topicsIneligibleForDeletion)
+    assertFalse(controllerContext.allTopics.contains("foo"))
   }
 
   @Test
@@ -193,38 +194,18 @@ class TopicDeletionManagerTest {
 
     // Broker 2 fails
     val failedBrokerId = 2
-    val offlineBroker = controllerContext.liveOrShuttingDownBroker(failedBrokerId).get
-    val lastEpoch = controllerContext.liveBrokerIdAndEpochs(failedBrokerId)
     controllerContext.removeLiveBrokers(Set(failedBrokerId))
     assertEquals(Set(1, 3), controllerContext.liveBrokerIds)
     val (offlineReplicas, onlineReplicas) = fooReplicas.partition(_.replica == failedBrokerId)
+    // signal that the replicas on broker 2 have failed
+    replicaStateMachine.handleStateChanges(offlineReplicas.toSeq, OfflineReplica)
 
-    // Fail replica deletion
-    deletionManager.failReplicaDeletion(offlineReplicas)
-    assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
-    assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)
-    assertEquals(Set("foo"), controllerContext.topicsIneligibleForDeletion)
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionIneligible))
-    assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-
-    // Broker 2 is restarted. The offline replicas remain ineligable
-    // (TODO: this is probably not desired)
-    controllerContext.addLiveBrokers(Map(offlineBroker -> (lastEpoch + 1L)))
-    deletionManager.resumeDeletionForTopics(Set("foo"))
-    assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
-    assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)
-    assertEquals(Set(), controllerContext.topicsIneligibleForDeletion)
-    assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionIneligible))
-
-    // When deletion completes for the replicas which started, then deletion begins for the remaining ones
+    // Verify that when the deletion of online replicas are completed, the deletion of the topic can be completed
     deletionManager.completeReplicaDeletion(onlineReplicas)
-    assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
-    assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)
+    assertEquals(Set(), controllerContext.topicsToBeDeleted)
+    assertEquals(Set(), controllerContext.topicsWithDeletionStarted)
     assertEquals(Set(), controllerContext.topicsIneligibleForDeletion)
-    assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-
+    assertFalse(controllerContext.allTopics.contains("foo"))
   }
 
   def initContext(brokers: Seq[Int],

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -149,7 +149,7 @@ class TopicDeletionManagerTest {
     assertEquals(fooPartitions, controllerContext.partitionsInState("foo", NonExistentPartition))
     verify(deletionClient).sendMetadataUpdate(fooPartitions)
     assertEquals(onlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionStarted))
-    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", ReplicaDeletionSuccessful))
+    assertEquals(offlineReplicas, controllerContext.replicasInState("foo", OfflineReplica))
 
     assertEquals(Set("foo"), controllerContext.topicsToBeDeleted)
     assertEquals(Set("foo"), controllerContext.topicsWithDeletionStarted)


### PR DESCRIPTION
TICKET = KAFKA-10548
LI_DESCRIPTION =
In the current implementation, a topic goes through the following phases during deletion
1. the topic is added to the ControllerContext.topicsToBeDeleted
2. replicas of the topic are moved to ReplicaDeletionStarted if the broker is online, or
   to ReplicaDeletionSuccessful if the broker is offline
3. upon receiving a response of the StopReplica request from the broker, a replica's state is
   updated to ReplicaDeletionSuccessful, or to ReplicaDeletionIneligible if there is
   an error in the response

However, it does not cover the case where a broker immediately fails after a topic goes through
the above steps for deletion. Under such conditions, the replicas for the to-be-deleted topic
would stay in ReplicaDeletionStarted, and the deletion would still be stuck.

This PR fixes the issue by resuming the deletion of a topic upon broker failure.
It makes the following changes
1. The deletion success criteria has been changed from "all replicas in ReplicaDeletionSuccessful"
   to "all replicas in ReplicaDeletionSuccessful or OfflineReplica".
2. During deletion, an offline broker's replicas will stay in the state OfflineReplica,
   and will no longer be moved to ReplicaDeletionSuccessful. This change is for easier
   understanding.
3. Upon broker failure, the topics of the new offline replicas is checked for deletion,
   and will have their deletion resumed if eligible.

EXIT_CRITERIA = When changes in KAFKA-10548 merged in upstream and the changes are pulled in

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
