### PR TITLE
[LI-TIERING] Pass security.protocol property along to RLMM Kafka clients.

### DIFF
--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG;
 import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.Type.INT;
@@ -121,6 +122,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     private final long metadataTopicRetentionMs;
     private final short metadataTopicReplicationFactor;
     private final long secondaryConsumerSubscriptionIntervalMs;
+    private final String securityProtocol;
 
     private Map<String, Object> consumerProps;
     private Map<String, Object> producerProps;
@@ -137,6 +139,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
         }
 
         logDir = getLogDirectory(props);
+        securityProtocol = (String) props.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG);
 
         consumeWaitMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP);
         secondaryConsumerSubscriptionIntervalMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_SECONDARY_CONSUMER_SUBSCRIPTION_INTERVAL_MS_PROP);
@@ -155,6 +158,9 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     private void initializeProducerConsumerProperties(Map<String, ?> configs) {
         Map<String, Object> commonClientConfigs = new HashMap<>();
         commonClientConfigs.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        if (securityProtocol != null && !securityProtocol.isEmpty()) {
+            commonClientConfigs.put(SECURITY_PROTOCOL_CONFIG, securityProtocol);
+        }
 
         Map<String, Object> producerOnlyConfigs = new HashMap<>();
         Map<String, Object> consumerOnlyConfigs = new HashMap<>();

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManagerTest.java
@@ -66,6 +66,7 @@ class ConsumerManagerTest {
     private Map<String, Object> getRLMMConfigProps(int numMetadataTopicPartitions) {
         final Map<String, Object> props = new HashMap<>();
         props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
         props.put(TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_SECONDARY_CONSUMER_SUBSCRIPTION_INTERVAL_MS_PROP, "10");
         props.put(TopicBasedRemoteLogMetadataManagerConfig.LOG_DIR, TestUtils.tempDirectory().getName());
         props.put(TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, numMetadataTopicPartitions);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerHarness.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerHarness.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,6 +98,7 @@ public class TopicBasedRemoteLogMetadataManagerHarness extends IntegrationTestHa
         // Initialize TopicBasedRemoteLogMetadataManager.
         Map<String, Object> configs = new HashMap<>();
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerList());
+        configs.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name);
         configs.put(BROKER_ID, 0);
         configs.put(LOG_DIR, logDir);
         configs.put(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, METADATA_TOPIC_PARTITIONS_COUNT);


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION = The RLM currently gets the bootstrap string and security protocol for the configured endpoint on which the broker is listening, but and passes this info on to the Topic-Based RLMM. See https://github.com/linkedin/kafka/blob/3.0-li-rc1/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala#L188

But the `TopicBasedRLMM` currently only reads the `bootstrap.servers` property and not the `security.protocol`. Thus, `TopicBasedRLMM` has no idea which security protocol to use for the Kafka client to connect to the endpoint, and does not configure it while creating the AdminClient. This change makes the `TopicBasedRLMM` read the `security.protocol` sent to it from `RLM` and use it in the client configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
