### PR TITLE
[LI-HOTFIX] Setting the delete flag correctly during controll request merging

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlResponse.java
@@ -40,6 +40,10 @@ public class LiCombinedControlResponse extends AbstractResponse {
         return data.leaderAndIsrPartitionErrors();
     }
 
+    public LiCombinedControlResponseData.LeaderAndIsrTopicErrorCollection leaderAndIsrTopicErrors() {
+        return data.leaderAndIsrTopics();
+    }
+
     public List<LiCombinedControlResponseData.StopReplicaPartitionError> stopReplicaPartitionErrors() {
         return data.stopReplicaPartitionErrors();
     }

--- a/clients/src/main/java/org/apache/kafka/common/utils/LiCombinedControlTransformer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/LiCombinedControlTransformer.java
@@ -155,6 +155,16 @@ public class LiCombinedControlTransformer {
                         .setErrorCode(error.errorCode())).collect(Collectors.toList());
     }
 
+    public static LeaderAndIsrResponseData.LeaderAndIsrTopicErrorCollection restoreLeaderAndIsrTopicErrors(
+            LiCombinedControlResponseData.LeaderAndIsrTopicErrorCollection errors) {
+        LeaderAndIsrResponseData.LeaderAndIsrTopicErrorCollection topicErrors = new LeaderAndIsrResponseData.LeaderAndIsrTopicErrorCollection();
+        for (LiCombinedControlResponseData.LeaderAndIsrTopicError error : errors) {
+            topicErrors.add(new LeaderAndIsrResponseData.LeaderAndIsrTopicError().setTopicId(error.topicId())
+                    .setPartitionErrors(restoreLeaderAndIsrPartitionErrors(error.partitionErrors())));
+        }
+        return topicErrors;
+    }
+
     public static List<LiCombinedControlResponseData.StopReplicaPartitionError> transformStopReplicaPartitionErrors(
             List<StopReplicaResponseData.StopReplicaPartitionError> errors) {
         return errors.stream().map(error ->

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -177,11 +177,10 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
 
         val queuedStates = stopReplicaPartitionStates.getOrElseUpdate(partition,
           new util.LinkedList[StopReplicaPartitionState]())
-        val deletePartitions = request.deletePartitions()
         val transformedPartitionState = new StopReplicaPartitionState()
           .setTopicName(partition.topicPartition().topic())
           .setPartitionIndex(partition.topicPartition().partition())
-          .setDeletePartitions(deletePartitions)
+          .setDeletePartitions(partitionState.deletePartition())
           .setBrokerEpoch(request.brokerEpoch())
 
           if (liCombinedControlRequestVersion >= 1) {
@@ -288,7 +287,9 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
       LiDecomposedControlResponseUtils.decomposeResponse(response.asInstanceOf[LiCombinedControlResponse])
     }
     if (leaderAndIsrCallback != null
-      && (!leaderAndIsrResponse.data.partitionErrors.isEmpty || leaderAndIsrResponse.error() != Errors.NONE)) {
+      && (!leaderAndIsrResponse.data.partitionErrors.isEmpty ||
+      !leaderAndIsrResponse.data().topics().isEmpty ||
+      leaderAndIsrResponse.error() != Errors.NONE)) {
       // fire callback only if leaderAndIsrResponse is non-empty or contains errors
       leaderAndIsrCallback(leaderAndIsrResponse)
     }

--- a/core/src/main/scala/kafka/utils/LiDecomposedControlRequestUtils.scala
+++ b/core/src/main/scala/kafka/utils/LiDecomposedControlRequestUtils.scala
@@ -69,7 +69,8 @@ object LiDecomposedControlRequestUtils {
       }
 
       val leaderAndIsrRequestVersion: Short =
-        if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 5
+        if (config.interBrokerProtocolVersion >= KAFKA_3_0_IV1) 6
+        else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 5
         else throw new IllegalStateException("The inter.broker.protocol.version config should not be smaller than 2.4-IV1")
 
       // the LiCombinedControl request will only include incremental LeaderAndIsr requests
@@ -101,7 +102,8 @@ object LiDecomposedControlRequestUtils {
       None
     } else {
       val updateMetadataRequestVersion: Short =
-        if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 7
+        if (config.interBrokerProtocolVersion >= KAFKA_3_0_IV1) 8
+        else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 7
         else throw new IllegalStateException("The inter.broker.protocol.version config should not be smaller than 2.4-IV1")
 
       val topicIds: util.Map[String, Uuid] = if (request.version() >= 1) {

--- a/core/src/main/scala/kafka/utils/LiDecomposedControlResponseUtils.scala
+++ b/core/src/main/scala/kafka/utils/LiDecomposedControlResponseUtils.scala
@@ -24,8 +24,9 @@ import org.apache.kafka.common.utils.LiCombinedControlTransformer
 object LiDecomposedControlResponseUtils {
   def decomposeResponse(response: LiCombinedControlResponse): LiDecomposedControlResponse = {
     val leaderAndIsrResponse = new LeaderAndIsrResponse(new LeaderAndIsrResponseData()
-    .setErrorCode(response.leaderAndIsrErrorCode())
-    .setPartitionErrors(LiCombinedControlTransformer.restoreLeaderAndIsrPartitionErrors(response.leaderAndIsrPartitionErrors())),
+      .setErrorCode(response.leaderAndIsrErrorCode())
+      .setPartitionErrors(LiCombinedControlTransformer.restoreLeaderAndIsrPartitionErrors(response.leaderAndIsrPartitionErrors()))
+      .setTopics(LiCombinedControlTransformer.restoreLeaderAndIsrTopicErrors(response.leaderAndIsrTopicErrors())),
       leaderAndIsrResponseVersion(response))
 
     val updateMetadataResponse = new UpdateMetadataResponse(new UpdateMetadataResponseData()

--- a/core/src/test/scala/integration/kafka/api/LiCombinedControlRequestTest.scala
+++ b/core/src/test/scala/integration/kafka/api/LiCombinedControlRequestTest.scala
@@ -57,9 +57,6 @@ class LiCombinedControlRequestTest extends KafkaServerTestHarness  with Logging 
 
   @Test
   def testChangingLiCombinedControlRequestFlag(): Unit = {
-    // check that no LiCombinedControlRequest can be sent with the default config
-    assertTrue(createTopicAndGetCombinedRequestCount(Set(0, 1).map("topic" + _)) == 0)
-
     // turn on the feature by setting the /li_combined_control_request_flag to true
     val props = new Properties
     props.put(KafkaConfig.LiCombinedControlRequestEnableProp, "true")

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -521,7 +521,6 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
 
   @Test
   def testLiCombinedControlRequestEnable(): Unit = {
-    verifyLiCombinedControlRequestEnable(false)
     val props = new Properties
     props.put(KafkaConfig.LiCombinedControlRequestEnableProp, "true")
     reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LiCombinedControlRequestEnableProp, "true"))

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -111,6 +111,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     val topicPartition = new TopicPartition(topic, 0)
     val brokerConfigs = TestUtils.createBrokerConfigs(4, zkConnect, false)
     brokerConfigs.foreach(p => p.setProperty("delete.topic.enable", "true"))
+    brokerConfigs.foreach(p => p.setProperty(KafkaConfig.LiCombinedControlRequestEnableProp, "true"))
     // create brokers
     val allServers = brokerConfigs.map(b => TestUtils.createServer(KafkaConfig.fromProps(b)))
     this.servers = allServers
@@ -194,6 +195,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     val topicPartition = new TopicPartition(topic, 0)
     val brokerConfigs = TestUtils.createBrokerConfigs(4, zkConnect, false)
     brokerConfigs.foreach(p => p.setProperty("delete.topic.enable", "true"))
+    brokerConfigs.foreach(p => p.setProperty(KafkaConfig.LiCombinedControlRequestEnableProp, "true"))
     // create brokers
     val allServers = brokerConfigs.map(b => TestUtils.createServer(KafkaConfig.fromProps(b)))
     this.servers = allServers
@@ -336,6 +338,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     brokerConfigs.head.setProperty("log.cleanup.policy","compact")
     brokerConfigs.head.setProperty("log.segment.bytes","100")
     brokerConfigs.head.setProperty("log.cleaner.dedupe.buffer.size","1048577")
+    brokerConfigs.head.setProperty(KafkaConfig.LiCombinedControlRequestEnableProp, "true")
 
     servers = createTestTopicAndCluster(topic, brokerConfigs, expectedReplicaAssignment)
 
@@ -370,6 +373,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
   private def createTestTopicAndCluster(topic: String, deleteTopicEnabled: Boolean = true, replicaAssignment: Map[Int, List[Int]] = expectedReplicaAssignment): Seq[KafkaServer] = {
     val brokerConfigs = TestUtils.createBrokerConfigs(3, zkConnect, enableControlledShutdown = false)
     brokerConfigs.foreach(_.setProperty("delete.topic.enable", deleteTopicEnabled.toString))
+    brokerConfigs.foreach(_.setProperty(KafkaConfig.LiCombinedControlRequestEnableProp, "true"))
     createTestTopicAndCluster(topic, brokerConfigs, replicaAssignment)
   }
 

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1766,6 +1766,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
       config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp, autoLeaderRebalanceEnable.toString)
       config.setProperty(KafkaConfig.UncleanLeaderElectionEnableProp, uncleanLeaderElectionEnable.toString)
       config.setProperty(KafkaConfig.LeaderImbalanceCheckIntervalSecondsProp, "1")
+      config.setProperty(KafkaConfig.LiCombinedControlRequestEnableProp, "true")
       listeners.foreach(listener => config.setProperty(KafkaConfig.ListenersProp, listener))
       listenerSecurityProtocolMap.foreach(listenerMap => config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, listenerMap))
       controlPlaneListenerName.foreach(controlPlaneListener => config.setProperty(KafkaConfig.ControlPlaneListenerNameProp, controlPlaneListener))

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -334,7 +334,7 @@ object TestUtils extends Logging {
 
     props.put(KafkaConfig.NumPartitionsProp, numPartitions.toString)
     props.put(KafkaConfig.DefaultReplicationFactorProp, defaultReplicationFactor.toString)
-
+    props.put(KafkaConfig.LiCombinedControlRequestEnableProp, "true")
     props
   }
 


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
1. When IBP >= KAFKA_2_6_IV0 and stopReplicaRequestVersion >= 4, the StopReplicaRequest.Builder's
deletePartitions flag will always be set to a placeholder value of false, and the source of truth
delete flag lies in each StopReplicaPartitionState.
This PR fixes the bug by using the source of truth flag from each StopReplicaPartitionState.

2. I'm also changing the default server config in integration tests by enabling the
LiCombinedControlRequestEnableProp, given that the "true" value is the setting used by our clusters.

3. Fixing version issues when converting between the LiCombinedControl request and the original
control request types. Make sure that the error codes from a LeaderAndIsrResponse can be properly
carried back.

EXIT_CRITERIA = If/when the LiCombinedControlRequest feature is merged in upstream.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
