### PR TITLE
[LI-HOTFIX] Add deletePartition flag in StopReplica response

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/LiCombinedControlTransformer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/LiCombinedControlTransformer.java
@@ -170,30 +170,29 @@ public class LiCombinedControlTransformer {
     }
 
     public static List<LiCombinedControlResponseData.StopReplicaPartitionError> transformStopReplicaPartitionErrors(
-            Map<TopicPartition, StopReplicaRequestData.StopReplicaPartitionState> partitionStates,
-            List<StopReplicaResponseData.StopReplicaPartitionError> errors,
-            int liCombinedControlRequestVersion) {
+        Map<TopicPartition, StopReplicaRequestData.StopReplicaPartitionState> partitionStates,
+        List<StopReplicaResponseData.StopReplicaPartitionError> errors, int liCombinedControlRequestVersion) {
         return errors.stream().map(error -> {
-                    LiCombinedControlResponseData.StopReplicaPartitionError stopReplicaPartitionError = new LiCombinedControlResponseData.StopReplicaPartitionError().setTopicName(error.topicName())
-                            .setPartitionIndex(error.partitionIndex())
-                            .setErrorCode(error.errorCode());
-                    if (liCombinedControlRequestVersion >= 1) {
-                        StopReplicaRequestData.StopReplicaPartitionState partitionState =
-                                partitionStates.get(new TopicPartition(error.topicName(), error.partitionIndex()));
-                        boolean deletePartition = false;
-                        if (partitionState != null) {
-                            // Considering the partitions in the StopReplica response should always match that in
-                            // the StopReplica request, we expect the partition to be always present in the
-                            // partitionStates map and the partitionState variable to be always non-null.
-                            // The check against null is to guard against unexpected mis-behaviors.
-                            deletePartition = partitionState.deletePartition();
-                        }
-
-                        stopReplicaPartitionError.setDeletePartition(deletePartition);
-                    }
-                    return stopReplicaPartitionError;
+            LiCombinedControlResponseData.StopReplicaPartitionError stopReplicaPartitionError =
+                new LiCombinedControlResponseData.StopReplicaPartitionError().setTopicName(error.topicName())
+                    .setPartitionIndex(error.partitionIndex())
+                    .setErrorCode(error.errorCode());
+            if (liCombinedControlRequestVersion >= 1) {
+                StopReplicaRequestData.StopReplicaPartitionState partitionState =
+                    partitionStates.get(new TopicPartition(error.topicName(), error.partitionIndex()));
+                boolean deletePartition = false;
+                if (partitionState != null) {
+                    // Considering the partitions in the StopReplica response should always match that in
+                    // the StopReplica request, we expect the partition to be always present in the
+                    // partitionStates map and the partitionState variable to be always non-null.
+                    // The check against null is to guard against unexpected mis-behaviors.
+                    deletePartition = partitionState.deletePartition();
                 }
-        ).collect(Collectors.toList());
+
+                stopReplicaPartitionError.setDeletePartition(deletePartition);
+            }
+            return stopReplicaPartitionError;
+        }).collect(Collectors.toList());
     }
 
     public static List<StopReplicaResponseData.StopReplicaPartitionError> restoreStopReplicaPartitionErrors(

--- a/clients/src/main/java/org/apache/kafka/common/utils/LiCombinedControlTransformer.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/LiCombinedControlTransformer.java
@@ -18,14 +18,18 @@
 package org.apache.kafka.common.utils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.LeaderAndIsrRequestData;
 import org.apache.kafka.common.message.LeaderAndIsrResponseData;
 import org.apache.kafka.common.message.LiCombinedControlRequestData;
 import org.apache.kafka.common.message.LiCombinedControlResponseData;
+import org.apache.kafka.common.message.StopReplicaRequestData;
 import org.apache.kafka.common.message.StopReplicaResponseData;
 import org.apache.kafka.common.message.UpdateMetadataRequestData;
+
 
 
 public class LiCombinedControlTransformer {
@@ -166,11 +170,30 @@ public class LiCombinedControlTransformer {
     }
 
     public static List<LiCombinedControlResponseData.StopReplicaPartitionError> transformStopReplicaPartitionErrors(
-            List<StopReplicaResponseData.StopReplicaPartitionError> errors) {
-        return errors.stream().map(error ->
-                new LiCombinedControlResponseData.StopReplicaPartitionError().setTopicName(error.topicName())
-                        .setPartitionIndex(error.partitionIndex())
-                        .setErrorCode(error.errorCode())).collect(Collectors.toList());
+            Map<TopicPartition, StopReplicaRequestData.StopReplicaPartitionState> partitionStates,
+            List<StopReplicaResponseData.StopReplicaPartitionError> errors,
+            int liCombinedControlRequestVersion) {
+        return errors.stream().map(error -> {
+                    LiCombinedControlResponseData.StopReplicaPartitionError stopReplicaPartitionError = new LiCombinedControlResponseData.StopReplicaPartitionError().setTopicName(error.topicName())
+                            .setPartitionIndex(error.partitionIndex())
+                            .setErrorCode(error.errorCode());
+                    if (liCombinedControlRequestVersion >= 1) {
+                        StopReplicaRequestData.StopReplicaPartitionState partitionState =
+                                partitionStates.get(new TopicPartition(error.topicName(), error.partitionIndex()));
+                        boolean deletePartition = false;
+                        if (partitionState != null) {
+                            // Considering the partitions in the StopReplica response should always match that in
+                            // the StopReplica request, we expect the partition to be always present in the
+                            // partitionStates map and the partitionState variable to be always non-null.
+                            // The check against null is to guard against unexpected mis-behaviors.
+                            deletePartition = partitionState.deletePartition();
+                        }
+
+                        stopReplicaPartitionError.setDeletePartition(deletePartition);
+                    }
+                    return stopReplicaPartitionError;
+                }
+        ).collect(Collectors.toList());
     }
 
     public static List<StopReplicaResponseData.StopReplicaPartitionError> restoreStopReplicaPartitionErrors(
@@ -178,6 +201,7 @@ public class LiCombinedControlTransformer {
         return errors.stream().map(error ->
                 new StopReplicaResponseData.StopReplicaPartitionError().setTopicName(error.topicName())
                         .setPartitionIndex(error.partitionIndex())
+                        .setDeletePartition(error.deletePartition())
                         .setErrorCode(error.errorCode())).collect(Collectors.toList());
     }
 }

--- a/clients/src/main/resources/common/message/LiCombinedControlResponse.json
+++ b/clients/src/main/resources/common/message/LiCombinedControlResponse.json
@@ -49,6 +49,8 @@
         "about": "The topic name." },
       { "name": "PartitionIndex", "type": "int32", "versions": "0+",
         "about": "The partition index." },
+      { "name": "DeletePartition", "type": "bool", "versions": "1+",
+        "tag": 0, "taggedVersions": "1+","about": "Whether this partition should be deleted." },
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The partition error code, or 0 if there was no partition error." }
     ]}

--- a/clients/src/main/resources/common/message/StopReplicaResponse.json
+++ b/clients/src/main/resources/common/message/StopReplicaResponse.json
@@ -35,6 +35,8 @@
         "about": "The topic name." },
       { "name": "PartitionIndex", "type": "int32", "versions": "0+",
         "about": "The partition index." },
+      { "name": "DeletePartition", "type": "bool", "versions": "4+",
+        "tag": 0, "taggedVersions": "4+","about": "Whether this partition should be deleted." },
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The partition error code, or 0 if there was no partition error." }
     ]}

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -731,6 +731,13 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
       else if (config.interBrokerProtocolVersion >= KAFKA_2_2_IV0) 1
       else 0
 
+    /**
+     * For StopReplica request version below 4, we rely on the isPartitionDeleted function to check a partition's delete flag,
+     * this may not be always correct considering a later request's callback may overwrite an earlier
+     * request's callback inside the {@link ControllerRequestMerger#addStopReplicaRequest) method.
+     * For StopReplica request version 4 and above, we rely on the delete field inside the StopReplica response to
+     * check a partition's delete flag, which should be always correct.
+     */
     def responseCallback(brokerId: Int, isPartitionDeleted: TopicPartition => Boolean)
                         (response: AbstractResponse): Unit = {
       val stopReplicaResponse = response.asInstanceOf[StopReplicaResponse]
@@ -738,7 +745,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
       stopReplicaResponse.partitionErrors.forEach { pe =>
         val tp = new TopicPartition(pe.topicName, pe.partitionIndex)
         if (controllerContext.isTopicDeletionInProgress(pe.topicName) &&
-            isPartitionDeleted(tp)) {
+          (isPartitionDeleted(tp) || pe.deletePartition())) {
           partitionErrorsForDeletingTopics += tp -> Errors.forCode(pe.errorCode)
         }
       }

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -732,7 +732,7 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
       else 0
 
     /**
-     * For StopReplica request version below 4, we rely on the isPartitionDeleted function to check a partition's delete flag,
+     * For StopReplica request version < 4, we rely on the isPartitionDeleted function to check a partition's delete flag,
      * this may not be always correct considering a later request's callback may overwrite an earlier
      * request's callback inside the {@link ControllerRequestMerger#addStopReplicaRequest) method.
      * For StopReplica request version 4 and above, we rely on the delete field inside the StopReplica response to

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -194,6 +194,9 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
       }
     }}
 
+    // Here a later request's callback may be overwriting a previous request's callback.
+    // To preserve correctness, we require that the later callback and the earlier callback
+    // must have the same sideeffects when they are provided with the same StopReplica response.
     stopReplicaCallback = callback
   }
   private def clearStopReplicaPartitionState(topicIdPartition: TopicIdPartition): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3583,7 +3583,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     stopReplicaRequests.foreach{ stopReplicaRequest => {
       val stopReplicaResponse = doHandleStopReplicaRequest(request, stopReplicaRequest)
       responseData.setStopReplicaErrorCode(stopReplicaResponse.errorCode())
-      stopReplicaPartitionErrors.addAll(LiCombinedControlTransformer.transformStopReplicaPartitionErrors(stopReplicaResponse.partitionErrors()))
+      stopReplicaPartitionErrors.addAll(LiCombinedControlTransformer.transformStopReplicaPartitionErrors(
+        stopReplicaRequest.partitionStates(),
+        stopReplicaResponse.partitionErrors(), liCombinedControlRequest.version()))
     }}
     responseData.setStopReplicaPartitionErrors(stopReplicaPartitionErrors)
 

--- a/core/src/main/scala/kafka/utils/LiDecomposedControlRequestUtils.scala
+++ b/core/src/main/scala/kafka/utils/LiDecomposedControlRequestUtils.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrParti
 import org.apache.kafka.common.message.LiCombinedControlRequestData
 import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartitionState, StopReplicaTopicState}
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataPartitionState}
-import org.apache.kafka.common.requests.{LeaderAndIsrRequest, LeaderAndIsrRequestType, LiCombinedControlRequest, StopReplicaRequest, UpdateMetadataRequest}
+import org.apache.kafka.common.requests.{LeaderAndIsrRequest, LiCombinedControlRequest, StopReplicaRequest, UpdateMetadataRequest}
 import org.apache.kafka.common.utils.LiCombinedControlTransformer
 
 import scala.collection.JavaConverters._


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
Kafka 3.0 introduced states to the callback used for StopReplica responses.
In the LiCombinedControl feature, we allow a later StopReplica's callback to
overwrite an earlier request's callback. Thus the following bug is possible
1. sendStopReplicaRequest is called for partition p0 with a callback that captures
   the mapping of p0 to false (deletePartition flag).
2. sendStopReplicaRequest is called again for partition p0 with a callback that captures
   the mapping of p0 to true. This later callback will overwrite the earlier callback.
3. the response to the 1st request is received and the callback of the 2nd request is triggered,
   which will move the corresponding replica's state to ReplicaDeletionSuccessful state.
4. the response to the 2nd request is received and the callback of the 2nd request is triggered
   again, which tries to move the replica's state from ReplicaDeletionSuccessful to the same state
   ReplicaDeletionSuccessful. The state change will fail.

This PR resolves this problem by deprecating the state captured by the callback and making the
callback stateless.
To achieve the same functionality, a deletePartition field is added to the StopReplica response.

EXIT_CRITERIA =

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
