### PR TITLE
[LI-HOTFIX] Adding the SumOfTopicNameLength metric to track scalability

### DIFF
--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -558,7 +558,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     val broker1 = servers.find(_.config.brokerId == 1).get
     broker1.shutdown()
 
-    var activeServers = servers.filter(s => s != broker1)
+    val activeServers = servers.filter(s => s != broker1)
     // wait for the update metadata request to trickle to the brokers
     TestUtils.waitUntilTrue(() =>
       activeServers.forall(_.dataPlaneRequestProcessor.metadataCache.getPartitionInfo(topic,partition).get.isr.size == 1),


### PR DESCRIPTION
TICKET = LIKAFKA-44962
LI_DESCRIPTION =
1. Adding the SumOfTopicNameLength metric to track the scalability risk of kafka clusters.
   When the metric hits the 1M limit, a vanilla zk client won't be able to read all of the topic
   names that are placed under the same /brokers/topics znode. We are currently working on using the zk pagination
   feature to get past the 1M limit. Nonetheless, it's useful to monitor this value.

2. Minor fixes of the code base to avoid compiler warnings
EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
