### PR TITLE
[LI-FIXUP] Fix listener of LiControlledShutdownSkipSafetyCheckRequest

### DIFF
--- a/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
+++ b/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
@@ -16,7 +16,10 @@
 {
   "apiKey": 1000,
   "type": "request",
-  "listeners": ["controller"],
+  // The current implementation of this feature involves recording the shutting down broker's epoch on zk,
+  // so probably doesn't make sense for the listener type "broker" for now.
+  // In the future, if/when we adopt KIP-500 changes, this request can be augmented to include the "broker" listener.
+  "listeners": ["zkBroker"],
   "name": "LiControlledShutdownSkipSafetyCheckRequest",
   "validVersions": "0-1",
   "flexibleVersions": "0+",


### PR DESCRIPTION
This commit is a fix-up to commit
* 1916a2d5 [LI-HOTFIX] Add safety check to controlled shutdown (#241)

LiControlledShutdownSkipSafetyCheckRequest is a request intended to be
received on the dedicated broker to be shutdown, which is suppose to be
a non-controller node.

If the listener is set to controller, the request will always result in UnsupportedApiVersionException.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
