### PR TITLE
[LI-HOTFIX] Add debugger to print resolved IPs, and assign clientId to ProducerConfig

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -111,6 +111,10 @@ public final class ClientUtils {
 
     static List<InetAddress> resolve(String host, ClientDnsLookup clientDnsLookup) throws UnknownHostException {
         InetAddress[] addresses = InetAddress.getAllByName(host);
+        log.debug("Resolved {} and got addresses: ", host);
+        for (InetAddress address: addresses) {
+            log.debug(address.getHostAddress() + ";");
+        }
         if (ClientDnsLookup.USE_ALL_DNS_IPS == clientDnsLookup) {
             return filterPreferredAddresses(addresses);
         } else {

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -873,6 +873,7 @@ public class NetworkClient implements KafkaClient {
             int nodeId = -1;
             for (InetSocketAddress address : addresses) {
                 newNodes.add(new Node(nodeId--, address.getHostString(), address.getPort()));
+                log.debug("created Node with IP address: {}", address.getAddress().getHostAddress());
             }
 
             int offset = this.randOffset.nextInt(newNodes.size());

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -331,13 +331,20 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 valueSerializer));
         try {
             Map<String, Object> userProvidedConfigs = config.originals();
-            this.producerConfig = config;
             this.time = time;
 
             String transactionalId = userProvidedConfigs.containsKey(ProducerConfig.TRANSACTIONAL_ID_CONFIG) ?
                     (String) userProvidedConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG) : null;
 
-            this.clientId = buildClientId(config.getString(ProducerConfig.CLIENT_ID_CONFIG), transactionalId);
+            String configuredClientId = config.getString(ProducerConfig.CLIENT_ID_CONFIG);
+
+            this.clientId = buildClientId(configuredClientId, transactionalId);
+
+            if (configuredClientId.isEmpty()) {
+                config.originals().put(ProducerConfig.CLIENT_ID_CONFIG, this.clientId);
+            }
+
+            this.producerConfig = config;
 
             LogContext logContext;
             if (transactionalId == null)


### PR DESCRIPTION
Added debugger to print resolved IPs; assigned the self generated producer clientId to ProducerConfig when users haven't provided one.

EXIT_CRITERIA = When gets to the root of how the client’s DNS resolver gets it’s IPs in a kafka clients test in EI cluster

More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.

Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.

Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)