### PR TITLE
[LI-FIXUP] Fix dynamic delete.topic.enable flag not handled in broker request code path

### DIFF
--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -106,7 +106,7 @@ class TopicDeletionManager(config: KafkaConfig,
                            partitionStateMachine: PartitionStateMachine,
                            client: DeletionClient) extends Logging {
   this.logIdent = s"[Topic Deletion Manager ${config.brokerId}] "
-  var isDeleteTopicEnabled: Boolean = config.deleteTopicEnable
+  @volatile var isDeleteTopicEnabled: Boolean = config.deleteTopicEnable
 
   // Try to create the znode for delete topic flag
   try {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2079,7 +2079,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setErrorCode(Errors.NOT_CONTROLLER.code))
       }
       sendResponseCallback(results)
-    } else if (!config.deleteTopicEnable) {
+    } else if (!zkSupport.controller.topicDeletionManager.isDeleteTopicEnabled) {
       val error = if (request.context.apiVersion < 3) Errors.INVALID_REQUEST else Errors.TOPIC_DELETION_DISABLED
       deleteTopicRequest.topics().forEach { topic =>
         results.add(new DeletableTopicResult()

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -474,6 +474,7 @@ object DeleteTopicsTopicZNode {
   def path(topic: String) = s"${DeleteTopicsZNode.path}/$topic"
 }
 
+// LI feature of dynamic deletion flag requires Zk, so actually KIP-500 would fail the feature"
 object DeleteTopicFlagZNode {
   def path = "/topic_deletion_flag"
   def encode(topicDeletionFlag: String): Array[Byte] = topicDeletionFlag.getBytes(UTF_8)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -24,7 +24,7 @@ import java.nio.file.{Files, StandardOpenOption}
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.concurrent.{Callable, ExecutionException, Executors, TimeUnit}
+import java.util.concurrent.{Callable, ExecutionException, Executors, ScheduledExecutorService, TimeUnit}
 import java.util.{Arrays, Collections, Optional, Properties}
 import com.yammer.metrics.core.{Gauge, Histogram, Meter}
 
@@ -964,6 +964,49 @@ object TestUtils extends Logging {
       new TopicPartition(topic, i) -> servers.head.metadataCache.getPartitionInfo(topic, i).getOrElse(
           throw new IllegalStateException(s"Cannot get topic: $topic, partition: $i in server metadata cache"))
     }.toMap
+  }
+
+  def waitUntilTopicPresent(client: Admin, topic: String, maxAttempts: Int = 3): Unit = {
+    if (maxAttempts <= 0) {
+      throw new IllegalArgumentException("0 or negative maxAttempts")
+    }
+
+    var remaining = maxAttempts
+    while (remaining > 0) {
+      remaining -= 1
+      try {
+        client.describeTopics(List(topic).asJava).values().get(topic).get(JTestUtils.DEFAULT_MAX_WAIT_MS, TimeUnit.MILLISECONDS)
+      } catch {
+        case e: Throwable =>
+          if (remaining == 0) {
+            e.getCause match {
+              // On unknown topic, it's wrapped inside an ExecutionException's cause
+              case _: UnknownTopicOrPartitionException => fail(s"Specified topic not present after ($maxAttempts) attempts ")
+              case _ => fail(e)
+            }
+          }
+      }
+    }
+  }
+
+  def waitUntilTopicNotPresent(client: Admin, topic: String, maxAttempts: Int = 3): Unit = {
+    if (maxAttempts <= 0) {
+      throw new IllegalArgumentException("0 or negative maxAttempts")
+    }
+    assertThrows(
+      classOf[UnknownTopicOrPartitionException],
+      () => {
+        try {
+          (0 until maxAttempts).foreach {_ =>
+            client.describeTopics(List(topic).asJava).values().get(topic).get(JTestUtils.DEFAULT_MAX_WAIT_MS, TimeUnit.MILLISECONDS)
+          }
+        } catch {
+          case e: ExecutionException => throw e.getCause  // UnknownTopicOrPartitionException is wrapped inside
+          case e => throw e
+        }
+      },
+      () => s"Exceeded ${maxAttempts} attempts awaiting topic `${topic}` to not present"
+    )
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -966,46 +966,34 @@ object TestUtils extends Logging {
     }.toMap
   }
 
-  def waitUntilTopicPresent(client: Admin, topic: String, maxAttempts: Int = 3): Unit = {
-    if (maxAttempts <= 0) {
-      throw new IllegalArgumentException("0 or negative maxAttempts")
-    }
-
-    var remaining = maxAttempts
-    while (remaining > 0) {
-      remaining -= 1
-      try {
-        client.describeTopics(List(topic).asJava).values().get(topic).get(JTestUtils.DEFAULT_MAX_WAIT_MS, TimeUnit.MILLISECONDS)
-      } catch {
-        case e: Throwable =>
-          if (remaining == 0) {
-            e.getCause match {
-              // On unknown topic, it's wrapped inside an ExecutionException's cause
-              case _: UnknownTopicOrPartitionException => fail(s"Specified topic not present after ($maxAttempts) attempts ")
-              case _ => fail(e)
-            }
-          }
-      }
-    }
-  }
-
-  def waitUntilTopicNotPresent(client: Admin, topic: String, maxAttempts: Int = 3): Unit = {
-    if (maxAttempts <= 0) {
-      throw new IllegalArgumentException("0 or negative maxAttempts")
-    }
-    assertThrows(
-      classOf[UnknownTopicOrPartitionException],
+  def waitUntilTopicPresent(client: Admin, topic: String): Unit = {
+    waitUntilTrue(
       () => {
         try {
-          (0 until maxAttempts).foreach {_ =>
-            client.describeTopics(List(topic).asJava).values().get(topic).get(JTestUtils.DEFAULT_MAX_WAIT_MS, TimeUnit.MILLISECONDS)
-          }
+          client.describeTopics(List(topic).asJava).values().get(topic).get(JTestUtils.DEFAULT_MAX_WAIT_MS, TimeUnit.MILLISECONDS)
+          true
         } catch {
-          case e: ExecutionException => throw e.getCause  // UnknownTopicOrPartitionException is wrapped inside
-          case e => throw e
+          case _: Throwable => false
         }
       },
-      () => s"Exceeded ${maxAttempts} attempts awaiting topic `${topic}` to not present"
+      s"Timeout awaiting topic ${topic} to present."
+    )
+  }
+
+  def waitUntilTopicNotPresent(client: Admin, topic: String): Unit = {
+    def describeTopicFailWithUnknownTopicOrPartitionException(): Boolean = {
+      try {
+        client.describeTopics(List(topic).asJava).values().get(topic).get(JTestUtils.DEFAULT_MAX_WAIT_MS, TimeUnit.MILLISECONDS)
+        false
+      } catch {
+        // On unknown topic, it's wrapped inside an ExecutionException's cause
+        case e: ExecutionException => e.getCause.getClass == classOf[UnknownTopicOrPartitionException]
+        case _ => false
+      }
+    }
+    waitUntilTrue(
+      describeTopicFailWithUnknownTopicOrPartitionException,
+      s"Timeout attempts awaiting topic `${topic}` to not present"
     )
   }
 


### PR DESCRIPTION
This should be a direct fix-up to the commit:
- b5fa0af [LI-HOTFIX] Add topic deletion hook in zookeeper to trigger in-memory topic deletion flag changes

LI_DESCRIPTION =
When the ZK hook was introduced, it didn't change the KafkaApi handler to make it honor the internal state.
Therefore, the deletion would still be blocked unless it's directly writing to the `/admin/delete_topics` ZNode.
This patch fixes the code in API handling by change the reference to `config.deleteTopicEnabled` to `TopicDeletionManager`'s  internal state.

EXIT_CRITERIA = "When the original dynamic flag commit is ejected"

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
