### PR TITLE
[LI-HOTFIX] Restore metrics expiration, and record a throttle time of 0 even without quota violations

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -269,6 +269,7 @@ public class JmxReporter implements MetricsReporter {
         }
 
         KafkaMetric removeAttribute(String name) {
+            log.info("removing attribute " + name + " from " + this.objectName);
             return this.metrics.remove(name);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -269,7 +269,6 @@ public class JmxReporter implements MetricsReporter {
         }
 
         KafkaMetric removeAttribute(String name) {
-            log.info("removing attribute " + name + " from " + this.objectName);
             return this.metrics.remove(name);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -76,6 +76,8 @@ public class Metrics implements Closeable {
     private final Time time;
     private final ScheduledThreadPoolExecutor metricsScheduler;
     private static final Logger log = LoggerFactory.getLogger(Metrics.class);
+    public static long METRICS_SCHEDULER_INITIAL_DELAY = 30;
+    public static long METRICS_SCHEDULER_PERIOD = 30;
 
     private volatile boolean replaceOnDuplicate = false;
 
@@ -174,7 +176,7 @@ public class Metrics implements Closeable {
             this.metricsScheduler = new ScheduledThreadPoolExecutor(1);
             // Creating a daemon thread to not block shutdown
             this.metricsScheduler.setThreadFactory(runnable -> KafkaThread.daemon("SensorExpiryThread", runnable));
-            this.metricsScheduler.scheduleAtFixedRate(new ExpireSensorTask(), 30, 30, TimeUnit.SECONDS);
+            this.metricsScheduler.scheduleAtFixedRate(new ExpireSensorTask(), METRICS_SCHEDULER_INITIAL_DELAY, METRICS_SCHEDULER_PERIOD, TimeUnit.SECONDS);
         } else {
             this.metricsScheduler = null;
         }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -78,8 +78,8 @@ public class Metrics implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(Metrics.class);
     // Allowing the initial delay and period of the metrics scheduler to be changed
     // so that metrics can be expired faster in tests
-    private static long metricsSchedulerInitialDelay = 30;
-    private static long metricsSchedulerPeriod = 30;
+    private static long metricsSchedulerInitialDelaySeconds = 30;
+    private static long metricsSchedulerPeriodSeconds = 30;
 
     private volatile boolean replaceOnDuplicate = false;
 
@@ -178,8 +178,8 @@ public class Metrics implements Closeable {
             this.metricsScheduler = new ScheduledThreadPoolExecutor(1);
             // Creating a daemon thread to not block shutdown
             this.metricsScheduler.setThreadFactory(runnable -> KafkaThread.daemon("SensorExpiryThread", runnable));
-            this.metricsScheduler.scheduleAtFixedRate(new ExpireSensorTask(), metricsSchedulerInitialDelay,
-                metricsSchedulerPeriod, TimeUnit.SECONDS);
+            this.metricsScheduler.scheduleAtFixedRate(new ExpireSensorTask(), metricsSchedulerInitialDelaySeconds,
+                metricsSchedulerPeriodSeconds, TimeUnit.SECONDS);
         } else {
             this.metricsScheduler = null;
         }
@@ -188,12 +188,12 @@ public class Metrics implements Closeable {
             (config, now) -> metrics.size());
     }
 
-    public static void setMetricsSchedulerInitialDelay(long metricsSchedulerInitialDelay) {
-        Metrics.metricsSchedulerInitialDelay = metricsSchedulerInitialDelay;
+    public static void setMetricsSchedulerInitialDelaySeconds(long metricsSchedulerInitialDelaySeconds) {
+        Metrics.metricsSchedulerInitialDelaySeconds = metricsSchedulerInitialDelaySeconds;
     }
 
-    public static void setMetricsSchedulerPeriod(long metricsSchedulerPeriod) {
-        Metrics.metricsSchedulerPeriod = metricsSchedulerPeriod;
+    public static void setMetricsSchedulerPeriodSeconds(long metricsSchedulerPeriodSeconds) {
+        Metrics.metricsSchedulerPeriodSeconds = metricsSchedulerPeriodSeconds;
     }
 
   /**

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -76,8 +76,10 @@ public class Metrics implements Closeable {
     private final Time time;
     private final ScheduledThreadPoolExecutor metricsScheduler;
     private static final Logger log = LoggerFactory.getLogger(Metrics.class);
-    public static long METRICS_SCHEDULER_INITIAL_DELAY = 30;
-    public static long METRICS_SCHEDULER_PERIOD = 30;
+    // Allowing the initial delay and period of the metrics scheduler to be changed
+    // so that metrics can be expired faster in tests
+    private static long metricsSchedulerInitialDelay = 30;
+    private static long metricsSchedulerPeriod = 30;
 
     private volatile boolean replaceOnDuplicate = false;
 
@@ -176,7 +178,8 @@ public class Metrics implements Closeable {
             this.metricsScheduler = new ScheduledThreadPoolExecutor(1);
             // Creating a daemon thread to not block shutdown
             this.metricsScheduler.setThreadFactory(runnable -> KafkaThread.daemon("SensorExpiryThread", runnable));
-            this.metricsScheduler.scheduleAtFixedRate(new ExpireSensorTask(), METRICS_SCHEDULER_INITIAL_DELAY, METRICS_SCHEDULER_PERIOD, TimeUnit.SECONDS);
+            this.metricsScheduler.scheduleAtFixedRate(new ExpireSensorTask(), metricsSchedulerInitialDelay,
+                metricsSchedulerPeriod, TimeUnit.SECONDS);
         } else {
             this.metricsScheduler = null;
         }
@@ -185,7 +188,15 @@ public class Metrics implements Closeable {
             (config, now) -> metrics.size());
     }
 
-    /**
+    public static void setMetricsSchedulerInitialDelay(long metricsSchedulerInitialDelay) {
+        Metrics.metricsSchedulerInitialDelay = metricsSchedulerInitialDelay;
+    }
+
+    public static void setMetricsSchedulerPeriod(long metricsSchedulerPeriod) {
+        Metrics.metricsSchedulerPeriod = metricsSchedulerPeriod;
+    }
+
+  /**
      * Create a MetricName with the given name, group, description and tags, plus default tags specified in the metric
      * configuration. Tag in tags takes precedence if the same tag key is specified in the default metric configuration.
      *

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -55,13 +55,17 @@ case class ClientQuotaManagerConfig(quotaDefault: Long =
                                     numQuotaSamples: Int =
                                         ClientQuotaManagerConfig.DefaultNumQuotaSamples,
                                     quotaWindowSizeSeconds: Int =
-                                        ClientQuotaManagerConfig.DefaultQuotaWindowSizeSeconds)
+                                        ClientQuotaManagerConfig.DefaultQuotaWindowSizeSeconds,
+                                    inactiveSensorExpirationTimeSeconds: Long =
+                                        ClientQuotaManagerConfig.DefaultInactiveSensorExpirationTimeSeconds)
 
 object ClientQuotaManagerConfig {
   val QuotaDefault = Long.MaxValue
   // Always have 10 whole windows + 1 current window
   val DefaultNumQuotaSamples = 11
   val DefaultQuotaWindowSizeSeconds = 1
+
+  val DefaultInactiveSensorExpirationTimeSeconds = 3600
 }
 
 object QuotaTypes {
@@ -73,9 +77,6 @@ object QuotaTypes {
 }
 
 object ClientQuotaManager {
-  // Do not expire quota sensors
-  val InactiveSensorExpirationTimeSeconds = 120
-
   val DefaultClientIdQuotaEntity = KafkaQuotaEntity(None, Some(DefaultClientIdEntity))
   val DefaultUserQuotaEntity = KafkaQuotaEntity(Some(DefaultUserEntity), None)
   val DefaultUserClientIdQuotaEntity = KafkaQuotaEntity(Some(DefaultUserEntity), Some(DefaultClientIdEntity))
@@ -437,12 +438,12 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
       metricTags,
       sensorAccessor.getOrCreate(
         getQuotaSensorName(metricTags),
-        ClientQuotaManager.InactiveSensorExpirationTimeSeconds,
+        config.inactiveSensorExpirationTimeSeconds,
         registerQuotaMetrics(metricTags)
       ),
       sensorAccessor.getOrCreate(
         getThrottleTimeSensorName(metricTags),
-        ClientQuotaManager.InactiveSensorExpirationTimeSeconds,
+        config.inactiveSensorExpirationTimeSeconds,
         sensor => sensor.add(throttleMetricName(metricTags), new Avg)
       )
     )
@@ -482,7 +483,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   protected def getOrCreateSensor(sensorName: String, metricName: MetricName): Sensor = {
     sensorAccessor.getOrCreate(
       sensorName,
-      ClientQuotaManager.InactiveSensorExpirationTimeSeconds,
+      config.inactiveSensorExpirationTimeSeconds,
       sensor => sensor.add(metricName, new Rate)
     )
   }

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -379,7 +379,6 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     // the throttle-time sensor does not expire before the byte-rate sensor
     val clientSensors = getOrCreateQuotaSensors(request.session, request.headerForLoggingOrThrottling().clientId)
     clientSensors.throttleTimeSensor.record(throttleTimeMs)
-    info("Channel throttled for sensor (%s). Delay time: (%d)".format(clientSensors.throttleTimeSensor.name(), throttleTimeMs))
     if (throttleTimeMs > 0) {
       val throttledChannel = new ThrottledChannel(time, throttleTimeMs, throttleCallback)
       delayQueue.add(throttledChannel)

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -74,7 +74,7 @@ object QuotaTypes {
 
 object ClientQuotaManager {
   // Do not expire quota sensors
-  val InactiveSensorExpirationTimeSeconds = Int.MaxValue
+  val InactiveSensorExpirationTimeSeconds = 120
 
   val DefaultClientIdQuotaEntity = KafkaQuotaEntity(None, Some(DefaultClientIdEntity))
   val DefaultUserQuotaEntity = KafkaQuotaEntity(Some(DefaultUserEntity), None)
@@ -374,9 +374,12 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     throttleCallback: ThrottleCallback,
     throttleTimeMs: Int
   ): Unit = {
+    // LIKAFKA-45345, even if the throttleTimeMs is 0, we still record it so that
+    // the throttle-time sensor does not expire before the byte-rate sensor
+    val clientSensors = getOrCreateQuotaSensors(request.session, request.headerForLoggingOrThrottling().clientId)
+    clientSensors.throttleTimeSensor.record(throttleTimeMs)
+    info("Channel throttled for sensor (%s). Delay time: (%d)".format(clientSensors.throttleTimeSensor.name(), throttleTimeMs))
     if (throttleTimeMs > 0) {
-      val clientSensors = getOrCreateQuotaSensors(request.session, request.headerForLoggingOrThrottling().clientId)
-      clientSensors.throttleTimeSensor.record(throttleTimeMs)
       val throttledChannel = new ThrottledChannel(time, throttleTimeMs, throttleCallback)
       delayQueue.add(throttledChannel)
       delayQueueSensor.record()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -644,17 +644,20 @@ class KafkaApis(val requestChannel: RequestChannel,
         else quotas.request.maybeRecordAndGetThrottleTimeMs(request, timeMs)
       val maxThrottleTimeMs = Math.max(bandwidthThrottleTimeMs, requestThrottleTimeMs)
       // LIKAFKA-45345, even if the throttleTimeMs is 0, we still record it so that
-      // the throttle-time sensor does not expire before the byte-rate sensor
-      if (true) {
+      // the throttle-time sensor does not expire before the byte-rate sensor.
+      // We are putting the value true as the condition below to minimize merging conflicts with upstream.
+      val (effectiveBandWidthThrottleTime, effectiveRequestThrottleTime) = if (maxThrottleTimeMs > 0) {
         request.apiThrottleTimeMs = maxThrottleTimeMs
         if (bandwidthThrottleTimeMs > requestThrottleTimeMs) {
-          requestHelper.throttle(quotas.produce, request, bandwidthThrottleTimeMs)
-          requestHelper.throttle(quotas.request, request, 0)
+          (bandwidthThrottleTimeMs, 0)
         } else {
-          requestHelper.throttle(quotas.request, request, requestThrottleTimeMs)
-          requestHelper.throttle(quotas.produce, request, 0)
+          (0, requestThrottleTimeMs)
         }
+      } else {
+        (0, 0)
       }
+      requestHelper.throttle(quotas.produce, request, effectiveBandWidthThrottleTime)
+      requestHelper.throttle(quotas.request, request, effectiveRequestThrottleTime)
 
       // Send the response immediately. In case of throttling, the channel has already been muted.
       if (produceRequest.acks == 0) {
@@ -940,23 +943,29 @@ class KafkaApis(val requestChannel: RequestChannel,
         val bandwidthThrottleTimeMs = quotas.fetch.maybeRecordAndGetThrottleTimeMs(request, responseSize, timeMs)
 
         val maxThrottleTimeMs = math.max(bandwidthThrottleTimeMs, requestThrottleTimeMs)
-        if (maxThrottleTimeMs > 0) {
+        // LIKAFKA-45345, even if the throttleTimeMs is 0, we still record it so that
+        // the throttle-time sensor does not expire before the byte-rate sensor.
+        // We are putting the value true as the condition below to minimize merging conflicts with upstream.
+        val (effectiveBandwidthThrottleTime, effectiveRequestThrottleTime) = if (maxThrottleTimeMs > 0) {
           request.apiThrottleTimeMs = maxThrottleTimeMs
           // Even if we need to throttle for request quota violation, we should "unrecord" the already recorded value
           // from the fetch quota because we are going to return an empty response.
           quotas.fetch.unrecordQuotaSensor(request, responseSize, timeMs)
-          if (bandwidthThrottleTimeMs > requestThrottleTimeMs) {
-            requestHelper.throttle(quotas.fetch, request, bandwidthThrottleTimeMs)
-          } else {
-            requestHelper.throttle(quotas.request, request, requestThrottleTimeMs)
-          }
           // If throttling is required, return an empty response.
           unconvertedFetchResponse = fetchContext.getThrottledResponse(maxThrottleTimeMs)
+          if (bandwidthThrottleTimeMs > requestThrottleTimeMs) {
+            (bandwidthThrottleTimeMs, 0)
+          } else {
+            (0, requestThrottleTimeMs)
+          }
         } else {
           // Get the actual response. This will update the fetch context.
           unconvertedFetchResponse = fetchContext.updateAndGenerateResponseData(partitions)
           trace(s"Sending Fetch response with partitions.size=$responseSize, metadata=${unconvertedFetchResponse.sessionId}")
+          (0, 0)
         }
+        requestHelper.throttle(quotas.fetch, request, effectiveBandwidthThrottleTime)
+        requestHelper.throttle(quotas.request, request, effectiveRequestThrottleTime)
 
         // Send the response immediately.
         requestChannel.sendResponse(request, createResponse(maxThrottleTimeMs), Some(updateConversionStats))

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -643,12 +643,16 @@ class KafkaApis(val requestChannel: RequestChannel,
         if (produceRequest.acks == 0) 0
         else quotas.request.maybeRecordAndGetThrottleTimeMs(request, timeMs)
       val maxThrottleTimeMs = Math.max(bandwidthThrottleTimeMs, requestThrottleTimeMs)
-      if (maxThrottleTimeMs > 0) {
+      // LIKAFKA-45345, even if the throttleTimeMs is 0, we still record it so that
+      // the throttle-time sensor does not expire before the byte-rate sensor
+      if (true) {
         request.apiThrottleTimeMs = maxThrottleTimeMs
         if (bandwidthThrottleTimeMs > requestThrottleTimeMs) {
           requestHelper.throttle(quotas.produce, request, bandwidthThrottleTimeMs)
+          requestHelper.throttle(quotas.request, request, 0)
         } else {
           requestHelper.throttle(quotas.request, request, requestThrottleTimeMs)
+          requestHelper.throttle(quotas.produce, request, 0)
         }
       }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -643,9 +643,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         if (produceRequest.acks == 0) 0
         else quotas.request.maybeRecordAndGetThrottleTimeMs(request, timeMs)
       val maxThrottleTimeMs = Math.max(bandwidthThrottleTimeMs, requestThrottleTimeMs)
-      // LIKAFKA-45345, even if the throttleTimeMs is 0, we still record it so that
-      // the throttle-time sensor does not expire before the byte-rate sensor.
-      // We are putting the value true as the condition below to minimize merging conflicts with upstream.
+      // [LIKAFKA-45345] even if the throttleTimeMs is 0, we still record it so that
+      // the throttle-time sensor does not expire before the byte-rate sensor in quotas.produce or
+      // the request-time sensor in quotas.request.
       val (effectiveBandWidthThrottleTime, effectiveRequestThrottleTime) = if (maxThrottleTimeMs > 0) {
         request.apiThrottleTimeMs = maxThrottleTimeMs
         if (bandwidthThrottleTimeMs > requestThrottleTimeMs) {
@@ -943,9 +943,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         val bandwidthThrottleTimeMs = quotas.fetch.maybeRecordAndGetThrottleTimeMs(request, responseSize, timeMs)
 
         val maxThrottleTimeMs = math.max(bandwidthThrottleTimeMs, requestThrottleTimeMs)
-        // LIKAFKA-45345, even if the throttleTimeMs is 0, we still record it so that
-        // the throttle-time sensor does not expire before the byte-rate sensor.
-        // We are putting the value true as the condition below to minimize merging conflicts with upstream.
+        // [LIKAFKA-45345] even if the throttleTimeMs is 0, we still record it so that
+        // the throttle-time sensor does not expire before the byte-rate sensor in quotas.fetch
+        // or the request-time sensor in quotas.request.
         val (effectiveBandwidthThrottleTime, effectiveRequestThrottleTime) = if (maxThrottleTimeMs > 0) {
           request.apiThrottleTimeMs = maxThrottleTimeMs
           // Even if we need to throttle for request quota violation, we should "unrecord" the already recorded value

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1379,7 +1379,7 @@ object KafkaConfig {
       .define(AlterLogDirsReplicationQuotaWindowSizeSecondsProp, INT, Defaults.AlterLogDirsReplicationQuotaWindowSizeSeconds, atLeast(1), LOW, AlterLogDirsReplicationQuotaWindowSizeSecondsDoc)
       .define(ControllerQuotaWindowSizeSecondsProp, INT, Defaults.ControllerQuotaWindowSizeSeconds, atLeast(1), LOW, ControllerQuotaWindowSizeSecondsDoc)
       .define(ClientQuotaCallbackClassProp, CLASS, null, LOW, ClientQuotaCallbackClassDoc)
-      .define(InactiveSensorExpirationTimeSecondsProp, LONG, Defaults.InactiveSensorExpirationTimeSeconds, LOW, InactiveSensorExpirationTimeSecondsDoc)
+      .define(InactiveSensorExpirationTimeSecondsProp, LONG, Defaults.InactiveSensorExpirationTimeSeconds, atLeast(1), LOW, InactiveSensorExpirationTimeSecondsDoc)
 
       /** ********* General Security Configuration ****************/
       .define(ConnectionsMaxReauthMsProp, LONG, Defaults.ConnectionsMaxReauthMsDefault, MEDIUM, ConnectionsMaxReauthMsDoc)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -250,7 +250,7 @@ object Defaults {
   val AlterLogDirsReplicationQuotaWindowSizeSeconds: Int = ReplicationQuotaManagerConfig.DefaultQuotaWindowSizeSeconds
   val NumControllerQuotaSamples: Int = ClientQuotaManagerConfig.DefaultNumQuotaSamples
   val ControllerQuotaWindowSizeSeconds: Int = ClientQuotaManagerConfig.DefaultQuotaWindowSizeSeconds
-
+  val InactiveSensorExpirationTimeSeconds = ClientQuotaManagerConfig.DefaultInactiveSensorExpirationTimeSeconds
   /** ********* Transaction Configuration ***********/
   val TransactionalIdExpirationMsDefault = 604800000
 
@@ -596,7 +596,7 @@ object KafkaConfig {
   val AlterLogDirsReplicationQuotaWindowSizeSecondsProp = "alter.log.dirs.replication.quota.window.size.seconds"
   val ControllerQuotaWindowSizeSecondsProp = "controller.quota.window.size.seconds"
   val ClientQuotaCallbackClassProp = "client.quota.callback.class"
-
+  val InactiveSensorExpirationTimeSecondsProp = "inactive.sensor.expiration.time.seconds"
   val DeleteTopicEnableProp = "delete.topic.enable"
   val CompressionTypeProp = "compression.type"
 
@@ -1032,6 +1032,7 @@ object KafkaConfig {
     "which is used to determine quota limits applied to client requests. By default, <user, client-id>, <user> or <client-id> " +
     "quotas stored in ZooKeeper are applied. For any given request, the most specific quota that matches the user principal " +
     "of the session and the client-id of the request is applied."
+  val InactiveSensorExpirationTimeSecondsDoc = "The time it takes an inactive sensor to expire and be removed from JMX"
 
   val DeleteTopicEnableDoc = "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off"
   val CompressionTypeDoc = "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs " +
@@ -1378,6 +1379,7 @@ object KafkaConfig {
       .define(AlterLogDirsReplicationQuotaWindowSizeSecondsProp, INT, Defaults.AlterLogDirsReplicationQuotaWindowSizeSeconds, atLeast(1), LOW, AlterLogDirsReplicationQuotaWindowSizeSecondsDoc)
       .define(ControllerQuotaWindowSizeSecondsProp, INT, Defaults.ControllerQuotaWindowSizeSeconds, atLeast(1), LOW, ControllerQuotaWindowSizeSecondsDoc)
       .define(ClientQuotaCallbackClassProp, CLASS, null, LOW, ClientQuotaCallbackClassDoc)
+      .define(InactiveSensorExpirationTimeSecondsProp, LONG, Defaults.InactiveSensorExpirationTimeSeconds, LOW, InactiveSensorExpirationTimeSecondsDoc)
 
       /** ********* General Security Configuration ****************/
       .define(ConnectionsMaxReauthMsProp, LONG, Defaults.ConnectionsMaxReauthMsDefault, MEDIUM, ConnectionsMaxReauthMsDoc)
@@ -1924,6 +1926,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val alterLogDirsReplicationQuotaWindowSizeSeconds = getInt(KafkaConfig.AlterLogDirsReplicationQuotaWindowSizeSecondsProp)
   val numControllerQuotaSamples = getInt(KafkaConfig.NumControllerQuotaSamplesProp)
   val controllerQuotaWindowSizeSeconds = getInt(KafkaConfig.ControllerQuotaWindowSizeSecondsProp)
+  val inactiveSensorExpirationTimeSeconds = getLong(KafkaConfig.InactiveSensorExpirationTimeSecondsProp)
 
   /** ********* Fetch Configuration **************/
   val maxIncrementalFetchSessionCacheSlots = getInt(KafkaConfig.MaxIncrementalFetchSessionCacheSlots)

--- a/core/src/main/scala/kafka/server/QuotaFactory.scala
+++ b/core/src/main/scala/kafka/server/QuotaFactory.scala
@@ -98,7 +98,8 @@ object QuotaFactory extends Logging {
     ClientQuotaManagerConfig(
       quotaDefault = cfg.producerQuotaBytesPerSecondDefault,
       numQuotaSamples = cfg.numQuotaSamples,
-      quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds
+      quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds,
+      inactiveSensorExpirationTimeSeconds = cfg.inactiveSensorExpirationTimeSeconds
     )
   }
 
@@ -108,21 +109,24 @@ object QuotaFactory extends Logging {
     ClientQuotaManagerConfig(
       quotaDefault = cfg.consumerQuotaBytesPerSecondDefault,
       numQuotaSamples = cfg.numQuotaSamples,
-      quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds
+      quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds,
+      inactiveSensorExpirationTimeSeconds = cfg.inactiveSensorExpirationTimeSeconds
     )
   }
 
   def clientRequestConfig(cfg: KafkaConfig): ClientQuotaManagerConfig = {
     ClientQuotaManagerConfig(
       numQuotaSamples = cfg.numQuotaSamples,
-      quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds
+      quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds,
+      inactiveSensorExpirationTimeSeconds = cfg.inactiveSensorExpirationTimeSeconds
     )
   }
 
   def clientControllerMutationConfig(cfg: KafkaConfig): ClientQuotaManagerConfig = {
     ClientQuotaManagerConfig(
       numQuotaSamples = cfg.numControllerQuotaSamples,
-      quotaWindowSizeSeconds = cfg.controllerQuotaWindowSizeSeconds
+      quotaWindowSizeSeconds = cfg.controllerQuotaWindowSizeSeconds,
+      inactiveSensorExpirationTimeSeconds = cfg.inactiveSensorExpirationTimeSeconds
     )
   }
 

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -277,7 +277,7 @@ abstract class QuotaTestClients(topic: String,
     if (expectThrottle) {
       assertTrue(throttleMetricValue > 0, s"Client with id=$clientId should have been throttled")
     } else {
-      assertTrue(throttleMetricValue.isNaN, s"Client with id=$clientId should not have been throttled")
+      assertTrue(throttleMetricValue == 0, s"Client with id=$clientId should not have been throttled")
     }
   }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.serialization._
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.test.{MockConsumerInterceptor, MockProducerInterceptor}
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.{Disabled, Test}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.Buffer
@@ -1525,6 +1525,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   }
 
   @Test
+  @Disabled
   def testQuotaMetricsNotCreatedIfNoQuotasConfigured(): Unit = {
     val numRecords = 1000
     val producer = createProducer()

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -631,7 +631,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(0L, consumer.position(tp), "position() on a partition that we are subscribed to should reset the offset")
     consumer.commitSync()
     assertEquals(0L, consumer.committed(Set(tp).asJava).get(tp).offset)
-    
+
     consumeAndVerifyRecords(consumer = consumer, numRecords = 5, startingOffset = 0, startingTimestamp = startingTimestamp)
     assertEquals(5L, consumer.position(tp), "After consuming 5 records, position should be 5")
     consumer.commitSync()
@@ -1524,6 +1524,8 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertEquals(numMessages - records.count, lag.metricValue.asInstanceOf[Double], epsilon, s"The lag should be ${numMessages - records.count}")
   }
 
+  // Due to LIKAFKA-45569, we make the change to always record a throttle-time of 0 as long as there is traffic,
+  // even when the traffic is not causing quota violations. Thus, this test is no longer applicable.
   @Test
   @Disabled
   def testQuotaMetricsNotCreatedIfNoQuotasConfigured(): Unit = {

--- a/core/src/test/scala/integration/kafka/api/QuotaMetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/QuotaMetricsTest.scala
@@ -1,0 +1,133 @@
+package integration.kafka.api
+
+import kafka.api.IntegrationTestHarness
+import kafka.server.{ConfigEntityName, KafkaConfig}
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.internals.QuotaConfigs
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{BeforeEach, Test}
+
+import java.util
+import java.util.Collections.singleton
+import java.util.Properties
+import java.util.concurrent.{Future, TimeUnit}
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+class QuotaMetricsTest extends IntegrationTestHarness {
+  val producerClientId = "producer-100"
+  val consumerClientId = "consumer-100"
+  val inactiveSensorExpirationTimeSeconds = 2
+  override protected def brokerCount: Int = 1
+  this.serverConfig.setProperty(KafkaConfig.ConsumerQuotaBytesPerSecondDefaultProp, "1000000")
+  this.serverConfig.setProperty(KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp, "1000000")
+  this.serverConfig.setProperty(KafkaConfig.InactiveSensorExpirationTimeSecondsProp, inactiveSensorExpirationTimeSeconds.toString)
+
+
+  @BeforeEach
+  override def setUp(): Unit = {
+    Metrics.METRICS_SCHEDULER_INITIAL_DELAY = 0
+    Metrics.METRICS_SCHEDULER_PERIOD = 1
+    super.setUp()
+
+    // apply the dynamic request_percentage quota override
+    val adminClient = createAdminClient()
+    val alterEntityMap = new util.HashMap[String, String]()
+    alterEntityMap.put(ClientQuotaEntity.CLIENT_ID, ConfigEntityName.Default)
+    val entity = new ClientQuotaEntity(alterEntityMap)
+    val entries: util.List[ClientQuotaAlteration] = new util.ArrayList[ClientQuotaAlteration](1)
+    entries.add(new ClientQuotaAlteration(entity, singleton(new ClientQuotaAlteration.Op(QuotaConfigs.REQUEST_PERCENTAGE_OVERRIDE_CONFIG, 100.0))))
+    adminClient.alterClientQuotas(entries).all().get(60, TimeUnit.SECONDS)
+  }
+
+  // Verify that the throttle time metric shows up with a value of 0 when there is no quota violations
+  @Test
+  def testThrottleTime(): Unit = {
+    val topic = "test"
+    val props = new Properties
+    createTopic(topic, numPartitions = 1, replicationFactor = 1, props)
+    val tp = new TopicPartition(topic, 0)
+
+    // Produce and consume some records
+    val numRecords = 10
+    val recordSize = 100000
+
+    val producerProps = new Properties()
+    producerProps.put(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)
+    val producer = createProducer(configOverrides = producerProps)
+    sendRecords(producer, numRecords, recordSize, tp)
+
+    verifyQuotaMetrics("throttle-time", "Produce", producerClientId, true, value => value == 0)
+    verifyQuotaMetrics("byte-rate", "Produce", producerClientId, true, value => value > 0)
+    verifyQuotaMetrics("throttle-time", "Request", producerClientId, true, value => value == 0)
+    verifyQuotaMetrics("request-time", "Request", producerClientId, true, value => value > 0)
+
+    val consumerProps = new Properties()
+    consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, consumerClientId)
+    val consumer = createConsumer(configOverrides = consumerProps)
+    consumer.assign(List(tp).asJava)
+    consumer.seek(tp, 0)
+    TestUtils.consumeRecords(consumer, numRecords)
+    verifyQuotaMetrics("throttle-time", "Fetch", consumerClientId, true, value => value == 0)
+    verifyQuotaMetrics("byte-rate", "Fetch", consumerClientId, true, value => value > 0)
+    verifyQuotaMetrics("throttle-time", "Request", consumerClientId, true, value => value == 0)
+    verifyQuotaMetrics("request-time", "Request", consumerClientId, true, value => value > 0)
+
+    // Wait until the Produce and Fetch metrics are removed
+    TestUtils.waitUntilTrue(() => {
+      val produceMetrics = filterMetric("throttle-time", "Produce", producerClientId)
+      val consumeMetrics = filterMetric("throttle-time", "Fetch", consumerClientId)
+      produceMetrics.isEmpty && consumeMetrics.isEmpty
+    }, "The Produce and Fetch throttle-time metrics should expire")
+    // Verify that the Produce metrics are gone
+    verifyQuotaMetrics("throttle-time", "Produce", producerClientId, false)
+    verifyQuotaMetrics("byte-rate", "Produce", producerClientId, false)
+    verifyQuotaMetrics("throttle-time", "Request", producerClientId, false)
+    verifyQuotaMetrics("request-time", "Request", producerClientId, false)
+
+    // Verify that the Fetch metrics are gone
+    verifyQuotaMetrics("throttle-time", "Fetch", consumerClientId, false)
+    verifyQuotaMetrics("byte-rate", "Fetch", consumerClientId, false)
+    verifyQuotaMetrics("throttle-time", "Request", consumerClientId, false)
+    verifyQuotaMetrics("request-time", "Request", consumerClientId, false)
+  }
+
+  private def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int,
+    recordSize: Int, tp: TopicPartition) = {
+    val bytes = new Array[Byte](recordSize)
+    val sendFutures = mutable.Buffer[Future[RecordMetadata]]()
+    (0 until numRecords).map { i =>
+      sendFutures += producer.send(new ProducerRecord(tp.topic, tp.partition, i.toLong, s"key $i".getBytes, bytes))
+    }
+    sendFutures.foreach{_.get()}
+  }
+
+  private def filterMetric(metricNameFilter: String, metricGroupFilter: String,
+    clientIdFilter: String) = {
+    val allMetrics = servers(0).metrics.metrics().asScala
+
+    allMetrics.filterKeys{name =>
+      name.name().equals(metricNameFilter) && name.group().equals(metricGroupFilter) &&
+        name.tags().containsKey("client-id") &&
+        name.tags.get("client-id").equals(clientIdFilter)}
+  }
+
+  private def verifyQuotaMetrics(metricNameFilter: String, metricGroupFilter: String,
+    clientIdFilter: String,
+    shouldExist: Boolean,
+    valuePredicate: Double => Boolean = v => true): Unit = {
+
+    val metricsToCheck = filterMetric(metricNameFilter, metricGroupFilter, clientIdFilter)
+    if (shouldExist) {
+      assertEquals(1, metricsToCheck.size)
+      assertTrue(metricsToCheck.forall{metric => valuePredicate(metric._2.metricValue.asInstanceOf[Double]) })
+    } else {
+      assertEquals(0, metricsToCheck.size)
+    }
+  }
+}

--- a/core/src/test/scala/integration/kafka/api/QuotaMetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/QuotaMetricsTest.scala
@@ -48,8 +48,8 @@ class QuotaMetricsTest extends IntegrationTestHarness {
   @BeforeEach
   override def setUp(): Unit = {
     // change the frequency of the Metrics Scheduler so that expired metrics can be removed faster
-    Metrics.setMetricsSchedulerInitialDelay(0);
-    Metrics.setMetricsSchedulerPeriod(1);
+    Metrics.setMetricsSchedulerInitialDelaySeconds(0);
+    Metrics.setMetricsSchedulerPeriodSeconds(1);
     super.setUp()
 
     // [KIP-124] apply the dynamic request_percentage quota override on the client id level for all client ids

--- a/core/src/test/scala/integration/kafka/api/QuotaMetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/QuotaMetricsTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package integration.kafka.api
 
 import kafka.api.IntegrationTestHarness
@@ -31,11 +47,12 @@ class QuotaMetricsTest extends IntegrationTestHarness {
 
   @BeforeEach
   override def setUp(): Unit = {
-    Metrics.METRICS_SCHEDULER_INITIAL_DELAY = 0
-    Metrics.METRICS_SCHEDULER_PERIOD = 1
+    // change the frequency of the Metrics Scheduler so that expired metrics can be removed faster
+    Metrics.setMetricsSchedulerInitialDelay(0);
+    Metrics.setMetricsSchedulerPeriod(1);
     super.setUp()
 
-    // apply the dynamic request_percentage quota override
+    // [KIP-124] apply the dynamic request_percentage quota override on the client id level for all client ids
     val adminClient = createAdminClient()
     val alterEntityMap = new util.HashMap[String, String]()
     alterEntityMap.put(ClientQuotaEntity.CLIENT_ID, ConfigEntityName.Default)
@@ -45,7 +62,6 @@ class QuotaMetricsTest extends IntegrationTestHarness {
     adminClient.alterClientQuotas(entries).all().get(60, TimeUnit.SECONDS)
   }
 
-  // Verify that the throttle time metric shows up with a value of 0 when there is no quota violations
   @Test
   def testThrottleTime(): Unit = {
     val topic = "test"
@@ -53,7 +69,7 @@ class QuotaMetricsTest extends IntegrationTestHarness {
     createTopic(topic, numPartitions = 1, replicationFactor = 1, props)
     val tp = new TopicPartition(topic, 0)
 
-    // Produce and consume some records
+    // Produce some records
     val numRecords = 10
     val recordSize = 100000
 
@@ -62,17 +78,21 @@ class QuotaMetricsTest extends IntegrationTestHarness {
     val producer = createProducer(configOverrides = producerProps)
     sendRecords(producer, numRecords, recordSize, tp)
 
+    // Verify that the client id level throttle-time metrics show up even without producing quota violations
     verifyQuotaMetrics("throttle-time", "Produce", producerClientId, true, value => value == 0)
     verifyQuotaMetrics("byte-rate", "Produce", producerClientId, true, value => value > 0)
     verifyQuotaMetrics("throttle-time", "Request", producerClientId, true, value => value == 0)
     verifyQuotaMetrics("request-time", "Request", producerClientId, true, value => value > 0)
 
+    // Consume some records
     val consumerProps = new Properties()
     consumerProps.put(ConsumerConfig.CLIENT_ID_CONFIG, consumerClientId)
     val consumer = createConsumer(configOverrides = consumerProps)
     consumer.assign(List(tp).asJava)
     consumer.seek(tp, 0)
     TestUtils.consumeRecords(consumer, numRecords)
+
+    // Verify that the client id level throttle-time metrics show up even without fetching quota violations
     verifyQuotaMetrics("throttle-time", "Fetch", consumerClientId, true, value => value == 0)
     verifyQuotaMetrics("byte-rate", "Fetch", consumerClientId, true, value => value > 0)
     verifyQuotaMetrics("throttle-time", "Request", consumerClientId, true, value => value == 0)

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -735,6 +735,7 @@ class KafkaConfigTest {
         case KafkaConfig.ConsumerQuotaBytesPerSecondDefaultProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
         case KafkaConfig.NumQuotaSamplesProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
         case KafkaConfig.QuotaWindowSizeSecondsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
+        case KafkaConfig.InactiveSensorExpirationTimeSecondsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "0")
         case KafkaConfig.DeleteTopicEnableProp => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")
 
         case KafkaConfig.MetricNumSamplesProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -734,7 +734,7 @@ class RequestQuotaTest extends BaseRequestTest {
     assertTrue(throttled, s"Response not throttled: $smallQuotaProducerClient")
     assertTrue(throttleTimeMetricValueForQuotaType(smallQuotaProducerClientId, QuotaType.Produce) > 0,
       s"Throttle time metrics for produce quota not updated: $smallQuotaProducerClient")
-    assertTrue(throttleTimeMetricValueForQuotaType(smallQuotaProducerClientId, QuotaType.Request).isNaN,
+    assertTrue(throttleTimeMetricValueForQuotaType(smallQuotaProducerClientId, QuotaType.Request) == 0,
       s"Throttle time metrics for request quota updated: $smallQuotaProducerClient")
   }
 
@@ -747,7 +747,7 @@ class RequestQuotaTest extends BaseRequestTest {
     assertTrue(throttled, s"Response not throttled: $smallQuotaConsumerClientId")
     assertTrue(throttleTimeMetricValueForQuotaType(smallQuotaConsumerClientId, QuotaType.Fetch) > 0,
       s"Throttle time metrics for consumer quota not updated: $smallQuotaConsumerClient")
-    assertTrue(throttleTimeMetricValueForQuotaType(smallQuotaConsumerClientId, QuotaType.Request).isNaN,
+    assertTrue(throttleTimeMetricValueForQuotaType(smallQuotaConsumerClientId, QuotaType.Request) == 0,
       s"Throttle time metrics for request quota updated: $smallQuotaConsumerClient")
   }
 
@@ -757,7 +757,7 @@ class RequestQuotaTest extends BaseRequestTest {
     val unthrottledClient = Client(unthrottledClientId, apiKey)
     unthrottledClient.runUntil(_.throttleTimeMs <= 0.0)
     assertEquals(1, unthrottledClient.correlationId)
-    assertTrue(throttleTimeMetricValue(unthrottledClientId).isNaN, s"Client should not have been throttled: $unthrottledClient")
+    assertTrue(throttleTimeMetricValue(unthrottledClientId) == 0, s"Client should not have been throttled: $unthrottledClient")
   }
 
   private def checkExemptRequestMetric(apiKey: ApiKeys): Unit = {


### PR DESCRIPTION
TICKET = LIKAFKA-45345
LI_DESCRIPTION =
A detailed analysis of this issue is at
https://docs.google.com/document/d/1JqqjjT4u6zyYefLcwokCdKH_q-EDTxP2K3AHkLpfJdc/edit#
In summary, the changes in this PR include
1. allowing metrics to expire instead of staying in memory indefinitely
2. record a throttle time of 0 even when a Produce or Fetch request is not causing quota violations

EXIT_CRITERIA = When the change is accepted in upstream Kafka and merged into this repo