### PR TITLE
[LI-HOTFIX] Return data to MemoryPool ByteBuffer when close()/poll() call happens

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1288,6 +1288,9 @@ public class NetworkClient implements KafkaClient {
                 receive.close();
             }
         }
+
+        // Clear the completed receives once they have been added to ClientResponse returned via poll()
+        this.selector.completedReceives().clear();
     }
 
     private void handleApiVersionsResponse(List<ClientResponse> responses,

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -883,6 +883,9 @@ public class Selector implements Selectable, AutoCloseable {
             key.attach(null);
         }
         this.sensors.connectionClosed.record();
+        if (this.stagedReceives.containsKey(channel)) {
+            this.stagedReceives.get(channel).forEach(NetworkReceive::close);
+        }
         this.stagedReceives.remove(channel);
         this.explicitlyMutedChannels.remove(channel);
         if (notifyDisconnect)

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -408,9 +408,6 @@ public class NetworkClientTest {
         // ApiVersionsRequest is in flight but not sent yet
         assertTrue(client.hasInFlightRequests(node.idString()));
 
-        // ApiVersionsResponse has been received
-        assertEquals(1, selector.completedReceives().size());
-
         // clean up the buffers
         selector.completedSends().clear();
         selector.completedSendBuffers().clear();
@@ -436,7 +433,6 @@ public class NetworkClientTest {
 
         // the ApiVersionsRequest is gone
         assertFalse(client.hasInFlightRequests(node.idString()));
-        assertEquals(1, selector.completedReceives().size());
 
         // the client is ready
         assertTrue(client.isReady(node, time.milliseconds()));
@@ -475,9 +471,6 @@ public class NetworkClientTest {
         // ApiVersionsRequest is in flight but not sent yet
         assertTrue(client.hasInFlightRequests(node.idString()));
 
-        // ApiVersionsResponse has been received
-        assertEquals(1, selector.completedReceives().size());
-
         // clean up the buffers
         selector.completedSends().clear();
         selector.completedSendBuffers().clear();
@@ -503,7 +496,6 @@ public class NetworkClientTest {
 
         // the ApiVersionsRequest is gone
         assertFalse(client.hasInFlightRequests(node.idString()));
-        assertEquals(1, selector.completedReceives().size());
 
         // the client is ready
         assertTrue(client.isReady(node, time.milliseconds()));


### PR DESCRIPTION
Fixing small bugs with reference counting logic in KafkaConsumer ByteBuffers:

- Fetcher could still be buffering data for paused topic partitions when KafkaConsumer.close() is called (Same for Selector)
- KafkaConsumer.close() might cause the same ByteBuffer to be returned to MemoryPool twice if close() call happens after completed receives are returned via fetcher

Discovered these problems while trying to test the pause()/resume() API with MemoryPool configuration and discovered as MemoryLeak/Unhandled exceptions. Running with this patch seems to fix them.
