### PR TITLE
[LI-HOTFIX] Fix core integration tests (minor)

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -205,18 +205,15 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
   def testDescribeLogDirs(): Unit = {
     client = Admin.create(createConfig)
     val topic = "topic"
-    val leaderByPartition = createTopic(topic, numPartitions = 10)
+    val numPartitions = 10
+    val leaderByPartition = createTopic(topic, numPartitions)
+    TestUtils.verifyTopicLogDirsCreation(topic, numPartitions, servers)
+
     val partitionsByBroker = leaderByPartition.groupBy { case (_, leaderId) => leaderId }.map { case (k, v) =>
       k -> v.keys.toSeq
     }
     val brokers = (0 until brokerCount).map(Integer.valueOf)
     val logDirInfosByBroker = client.describeLogDirs(brokers.asJava).allDescriptions.get
-    debug(s"done describing log dirs for all ${brokerCount} brokers")
-
-    // BUG: there's a race condition here; this test case assumes createTopic() is fully synchronous and
-    // completes before describeLogDirs(), but that's clearly false in many runs, based on the logging:
-    // some logDirs for "topic" partitions are still being created AFTER the admin client gets its response,
-    // leading to failure of the first assertion below
 
     (0 until brokerCount).foreach { brokerId =>
       val server = servers.find(_.config.brokerId == brokerId).get
@@ -226,10 +223,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
         logDirInfo.replicaInfos.asScala
       }.filter { case (k, _) => k.topic == topic }
 
-      debug(s"about to test first assertion (broker ${brokerId + 1} of ${brokerCount})")
       assertEquals(expectedPartitions.toSet, replicaInfos.keys.map(_.partition).toSet,
         s"partitions from logdir replicas do not match those for broker id=${brokerId} (${brokerId + 1} of ${brokerCount})")
-        
       logDirInfos.forEach { (logDir, logDirInfo) =>
         logDirInfo.replicaInfos.asScala.keys.foreach(tp =>
           assertEquals(server.logManager.getLog(tp).get.dir.getParent, logDir)

--- a/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
@@ -44,6 +44,7 @@ abstract class BaseRequestTest extends IntegrationTestHarness {
   protected def brokerPropertyOverrides(properties: Properties): Unit = {}
 
   override def modifyConfigs(props: Seq[Properties]): Unit = {
+    super.modifyConfigs(props)
     props.foreach { p =>
       p.put(KafkaConfig.ControlledShutdownEnableProp, "false")
       brokerPropertyOverrides(p)


### PR DESCRIPTION
1. Add missing super.modifyConfigs() to BaseRequestTest (else test-case modfications of serverConfig are ignored). This fix doesn't appear to affect any existing tests, but it did break a test I was writing recently (later bypassed by inheriting from a superclass of BaseRequestTest rather than from a subclass). Future-proofing.
2. Fix a race condition in PlaintextAdminIntegrationTest (premature call to describeLogDirs() before all logDirs are created). This test case (testDescribeLogDirs()) fails 100% of the time on my Azure Linux VM.

First fix was verified via the subsequently modified test mentioned above (and by visual inspection), and second fixes the 100% failure rate on my VM.

EXIT_CRITERIA = If and when this change is accepted upstream and pulled into this repo.