### PR TITLE
[LI-HOTFIX] Keep LiCombinedControl request enabled when IBP<2.8

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -286,7 +286,9 @@ class RequestSendThread(val controllerId: Int,
       (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1 &&
         config.liCombinedControlRequestEnable &&
         firstUpdateMetadataWithPartitionsSent &&
-        firstFullLeaderAndIsrSent)) {
+        // The LeaderAndIsrRequest starts having the full/incremental flag since IBP KAFKA_2_8_IV1.
+        // Thus, we require the firstFullLeaderAndIsrSent to be set only when IBP >= KAFKA_2_8_IV1
+        (config.interBrokerProtocolVersion < KAFKA_2_8_IV1 || firstFullLeaderAndIsrSent))) {
       // Only start the merging logic after the first UpdateMetadata request with partitions,
       // since the first UpdateMetadata request with partitions may contain hundreds of thousands of partitions,
       // and thus needs to be cached and shared by all brokers in order to prevent OOM


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =

The upgrade from Kafka 2.4 to 3.0 is a 2-step process:
Code 2.4/IBP=2.4
---1st upgrade-->
Code 3.0/IBP=2.4
---2nd upgrade-->
Code 3.0/IBP=3.0

Considering the Code 3.0/IBP=2.4 state in the middle, the current implementation requires
that the first full LeaderAndIsr request be sent before the LiCombinedControl request
feature can be enabled. However, the full LeaderAndIsr is only enabled when the IBP>=2.8.
It means the LiCombinedControl request feature is disabled in the interim state, which
may cause delays in metadata propagation and further cause GCNs.

This patch ensures that the LiCombinedControl feature is not disabled during the upgrade.

EXIT_CRITERIA = The same with the LiCombinedControl feature

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
