### PR TITLE
Add a new metric RequestsPerSecAcrossVersions for each request type

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -244,6 +244,7 @@ object RequestChannel extends Logging {
       metricNames.foreach { metricName =>
         val m = metrics(metricName)
         m.requestRate(header.apiVersion).mark()
+        m.requestRateAcrossVersionsInternal.mark()
         m.requestQueueTimeHist.update(Math.round(requestQueueTimeMs))
         m.localTimeHist.update(Math.round(apiLocalTimeMs))
         m.remoteTimeHist.update(Math.round(apiRemoteTimeMs))
@@ -517,6 +518,7 @@ object RequestMetrics {
   val MetadataAllTopics = ApiKeys.METADATA.name + "AllTopics"
 
   val RequestsPerSec = "RequestsPerSec"
+  val RequestsPerSecAcrossVersions = "RequestsPerSecAcrossVersions"
   val RequestQueueTimeMs = "RequestQueueTimeMs"
   val LocalTimeMs = "LocalTimeMs"
   val RemoteTimeMs = "RemoteTimeMs"
@@ -537,6 +539,8 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
 
   val tags = Map("request" -> name)
   val requestRateInternal = new Pool[Short, Meter]()
+  // Compared with the requestRateInterval, the aggregateRequestRateInterval is the request rate across all versions
+  val requestRateAcrossVersionsInternal = newMeter(RequestsPerSecAcrossVersions, "requests", TimeUnit.SECONDS, tags)
   // time a request spent in a request queue
   val requestQueueTimeHist = newHistogram(RequestQueueTimeMs, biased = true, tags)
   // time a request takes to be processed at the local broker
@@ -609,6 +613,7 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
 
   def removeMetrics(): Unit = {
     for (version <- requestRateInternal.keys) removeMetric(RequestsPerSec, tags + ("version" -> version.toString))
+    removeMetric(RequestsPerSecAcrossVersions, tags)
     removeMetric(RequestQueueTimeMs, tags)
     removeMetric(LocalTimeMs, tags)
     removeMetric(RemoteTimeMs, tags)

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -539,7 +539,7 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
 
   val tags = Map("request" -> name)
   val requestRateInternal = new Pool[Short, Meter]()
-  // Compared with the requestRateInterval, the aggregateRequestRateInterval is the request rate across all versions
+  // Compared with the requestRateInterval, the requestRateAcrossVersionsInternal is the request rate across all versions
   val requestRateAcrossVersionsInternal = newMeter(RequestsPerSecAcrossVersions, "requests", TimeUnit.SECONDS, tags)
   // time a request spent in a request queue
   val requestQueueTimeHist = newHistogram(RequestQueueTimeMs, biased = true, tags)

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -115,6 +115,23 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     assertEquals(1, responseBytesHist.count(), "The MetadataAllTopics ResponseBytes metric is not recorded")
   }
 
+  @Test
+  def testRequestsPerSecWithoutVersionMetric(): Unit = {
+    val topic = "topicWithOldMessageFormat"
+    val props = new Properties
+    createTopic(topic, numPartitions = 1, replicationFactor = 1, props)
+    val tp = new TopicPartition(topic, 0)
+
+    // Produce and consume some records
+    val numRecords = 10
+    val recordSize = 100000
+    val producer = createProducer()
+    sendRecords(producer, numRecords, recordSize, tp)
+
+    val requestRateWithoutVersionMeter = yammerMeterWithPrefix("kafka.network:type=RequestMetrics,name=RequestsPerSecAcrossVersions,request=Produce")
+    assertTrue(requestRateWithoutVersionMeter.count() > 0, "The Produce RequestsPerSecAcrossVersions metric is not recorded")
+  }
+
   private def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int,
       recordSize: Int, tp: TopicPartition) = {
     val bytes = new Array[Byte](recordSize)

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -116,8 +116,8 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
   }
 
   @Test
-  def testRequestsPerSecWithoutVersionMetric(): Unit = {
-    val topic = "topicWithOldMessageFormat"
+  def testRequestsPerSecAcrossVersionsMetric(): Unit = {
+    val topic = "topic"
     val props = new Properties
     createTopic(topic, numPartitions = 1, replicationFactor = 1, props)
     val tp = new TopicPartition(topic, 0)


### PR DESCRIPTION
TICKET = LIKAFKA-43267                                                                                                                                                               
LI_DESCRIPTION =                                                                                                                                                                     
Currently, we have a request rate for each <request type, version>.                                                                                                                    
As requested by our SRE team, it's desirable to have a request rate (QPS)                                                                                                              
across all request versions.                                                                                                                                                         
EXIT_CRITERIA = When this change is merged upstream and pulled to this repo.