### PR TITLE
[LI-HOTFIX] Add metric to track ProduceRequestsWithInvalidAcksPerSec

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -223,6 +223,7 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
     BrokerTopicStats.BytesOutPerSec -> MeterWrapper(BrokerTopicStats.BytesOutPerSec, "bytes"),
     BrokerTopicStats.BytesRejectedPerSec -> MeterWrapper(BrokerTopicStats.BytesRejectedPerSec, "bytes"),
     BrokerTopicStats.FailedProduceRequestsPerSec -> MeterWrapper(BrokerTopicStats.FailedProduceRequestsPerSec, "requests"),
+    BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec -> MeterWrapper(BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec, "requests"),
     BrokerTopicStats.FailedFetchRequestsPerSec -> MeterWrapper(BrokerTopicStats.FailedFetchRequestsPerSec, "requests"),
     BrokerTopicStats.TotalProduceRequestsPerSec -> MeterWrapper(BrokerTopicStats.TotalProduceRequestsPerSec, "requests"),
     BrokerTopicStats.TotalFetchRequestsPerSec -> MeterWrapper(BrokerTopicStats.TotalFetchRequestsPerSec, "requests"),
@@ -286,6 +287,8 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
 
   def failedProduceRequestRate: Meter = metricTypeMap.get(BrokerTopicStats.FailedProduceRequestsPerSec).meter()
 
+  def produceRequestsWithInvalidAcksRate: Meter = metricTypeMap.get(BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec).meter()
+
   def failedFetchRequestRate: Meter = metricTypeMap.get(BrokerTopicStats.FailedFetchRequestsPerSec).meter()
 
   def totalProduceRequestRate: Meter = metricTypeMap.get(BrokerTopicStats.TotalProduceRequestsPerSec).meter()
@@ -337,6 +340,7 @@ object BrokerTopicStats {
   val ReplicationBytesInPerSec = "ReplicationBytesInPerSec"
   val ReplicationBytesOutPerSec = "ReplicationBytesOutPerSec"
   val FailedProduceRequestsPerSec = "FailedProduceRequestsPerSec"
+  val ProduceRequestsWithInvalidAcksPerSec = "ProduceRequestsWithInvalidAcksPerSec"
   val FailedFetchRequestsPerSec = "FailedFetchRequestsPerSec"
   val TotalProduceRequestsPerSec = "TotalProduceRequestsPerSec"
   val TotalFetchRequestsPerSec = "TotalFetchRequestsPerSec"

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -978,6 +978,8 @@ class ReplicaManager(val config: KafkaConfig,
         try {
           val partition = getPartitionOrException(topicPartition)
           if (!partition.isAcksValid(requiredAcks)) {
+            // When this metric is recorded, enable the DEBUG level logging on kafka.request.logger to
+            // get the identify of producers
             brokerTopicStats.topicStats(topicPartition.topic).produceRequestsWithInvalidAcksRate.mark()
             brokerTopicStats.allTopicsStats.produceRequestsWithInvalidAcksRate.mark()
           }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -977,6 +977,11 @@ class ReplicaManager(val config: KafkaConfig,
       } else {
         try {
           val partition = getPartitionOrException(topicPartition)
+          if (!partition.isAcksValid(requiredAcks)) {
+            brokerTopicStats.topicStats(topicPartition.topic).produceRequestsWithInvalidAcksRate.mark()
+            brokerTopicStats.allTopicsStats.produceRequestsWithInvalidAcksRate.mark()
+          }
+
           val info = partition.appendRecordsToLeader(records, origin, requiredAcks, requestLocal)
           val numAppendedMessages = info.numMessages
 

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -18,6 +18,7 @@ import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import com.yammer.metrics.core.{Gauge, Histogram, Meter}
 import kafka.metrics.KafkaYammerMetrics
+import kafka.utils.TestUtils.{sendRecords, verifyYammerMetricRecorded, yammerMetricValue}
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
@@ -130,15 +131,6 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
 
     val requestRateWithoutVersionMeter = yammerMeterWithPrefix("kafka.network:type=RequestMetrics,name=RequestsPerSecAcrossVersions,request=Produce")
     assertTrue(requestRateWithoutVersionMeter.count() > 0, "The Produce RequestsPerSecAcrossVersions metric is not recorded")
-  }
-
-  def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int,
-      recordSize: Int, tp: TopicPartition) = {
-    val bytes = new Array[Byte](recordSize)
-    (0 until numRecords).map { i =>
-      producer.send(new ProducerRecord(tp.topic, tp.partition, i.toLong, s"key $i".getBytes, bytes))
-    }
-    producer.flush()
   }
 
   // Create a producer that fails authentication to verify authentication failure metrics
@@ -301,18 +293,6 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     assertTrue(value > 0.0, s"$entity metric not recorded correctly for $name value $value")
   }
 
-  private def yammerMetricValue(name: String): Any = {
-    val allMetrics = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
-    val (_, metric) = allMetrics.find { case (n, _) => n.getMBeanName.endsWith(name) }
-      .getOrElse(fail(s"Unable to find broker metric $name: allMetrics: ${allMetrics.keySet.map(_.getMBeanName)}"))
-    metric match {
-      case m: Meter => m.count.toDouble
-      case m: Histogram => m.max
-      case m: Gauge[_] => m.value
-      case m => fail(s"Unexpected broker metric of class ${m.getClass}")
-    }
-  }
-
   private def yammerHistogram(name: String): Histogram = {
     val allMetrics = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
     val (_, metric) = allMetrics.find { case (n, _) => n.getMBeanName.endsWith(name) }
@@ -331,12 +311,6 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
       case m: Meter => m
       case m => fail(s"Unexpected broker metric of class ${m.getClass}")
     }
-  }
-
-  def verifyYammerMetricRecorded(name: String, verify: Double => Boolean = d => d > 0): Double = {
-    val metricValue = yammerMetricValue(name).asInstanceOf[Double]
-    assertTrue(verify(metricValue), s"Broker metric not recorded correctly for $name value $metricValue")
-    metricValue
   }
 
   private def verifyNoRequestMetrics(errorMessage: String): Unit = {

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -303,7 +303,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     }
   }
 
-  def yammerMeterWithPrefix(prefix: String): Meter = {
+  private def yammerMeterWithPrefix(prefix: String): Meter = {
     val allMetrics = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
     val (_, metric) = allMetrics.find { case (n, _) => n.getMBeanName.startsWith(prefix) }
       .getOrElse(fail(s"Unable to find broker metric with prefix $prefix: allMetrics: ${allMetrics.keySet.map(_.getMBeanName)}"))

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -132,7 +132,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     assertTrue(requestRateWithoutVersionMeter.count() > 0, "The Produce RequestsPerSecAcrossVersions metric is not recorded")
   }
 
-  private def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int,
+  def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int,
       recordSize: Int, tp: TopicPartition) = {
     val bytes = new Array[Byte](recordSize)
     (0 until numRecords).map { i =>
@@ -323,7 +323,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     }
   }
 
-  private def yammerMeterWithPrefix(prefix: String): Meter = {
+  def yammerMeterWithPrefix(prefix: String): Meter = {
     val allMetrics = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
     val (_, metric) = allMetrics.find { case (n, _) => n.getMBeanName.startsWith(prefix) }
       .getOrElse(fail(s"Unable to find broker metric with prefix $prefix: allMetrics: ${allMetrics.keySet.map(_.getMBeanName)}"))
@@ -333,7 +333,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     }
   }
 
-  private def verifyYammerMetricRecorded(name: String, verify: Double => Boolean = d => d > 0): Double = {
+  def verifyYammerMetricRecorded(name: String, verify: Double => Boolean = d => d > 0): Double = {
     val metricValue = yammerMetricValue(name).asInstanceOf[Double]
     assertTrue(verify(metricValue), s"Broker metric not recorded correctly for $name value $metricValue")
     metricValue

--- a/core/src/test/scala/integration/kafka/api/MultiBrokerMetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MultiBrokerMetricsTest.scala
@@ -1,0 +1,33 @@
+package kafka.api
+
+import kafka.server.BrokerTopicStats
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.TopicConfig
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+import java.util.Properties
+
+class MultiBrokerMetricsTest extends MetricsTest {
+  override val brokerCount = 4
+
+  @Test
+  def testProduceRequestsWithInvalidAcks(): Unit = {
+    val topic = "Topic1"
+    val props = new Properties
+    props.setProperty(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+    createTopic(topic, numPartitions = 1, replicationFactor = 4, props)
+    val tp = new TopicPartition(topic, 0)
+
+    val numRecords = 10
+    val recordSize = 100000
+    val producerConfigs = new Properties
+    producerConfigs.put(ProducerConfig.ACKS_CONFIG, "1")
+    val producer = createProducer(configOverrides = producerConfigs)
+    sendRecords(producer, numRecords, recordSize, tp)
+
+    verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=${BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec},topic=$topic")
+    verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=${BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec}")
+  }
+}

--- a/core/src/test/scala/integration/kafka/api/MultiBrokerMetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MultiBrokerMetricsTest.scala
@@ -1,15 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package kafka.api
 
 import kafka.server.BrokerTopicStats
-import org.apache.kafka.clients.producer.ProducerConfig
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
+import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
 import java.util.Properties
 
-class MultiBrokerMetricsTest extends MetricsTest {
+class MultiBrokerMetricsTest extends IntegrationTestHarness {
   override val brokerCount = 4
 
   @Test
@@ -22,12 +37,14 @@ class MultiBrokerMetricsTest extends MetricsTest {
 
     val numRecords = 10
     val recordSize = 100000
-    val producerConfigs = new Properties
-    producerConfigs.put(ProducerConfig.ACKS_CONFIG, "1")
-    val producer = createProducer(configOverrides = producerConfigs)
-    sendRecords(producer, numRecords, recordSize, tp)
+    val producerConfig = new Properties
+    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    producerConfig.put(ProducerConfig.ACKS_CONFIG, "1")
+    val producer = new KafkaProducer(producerConfig, new ByteArraySerializer, new ByteArraySerializer)
+    TestUtils.sendRecords(producer, numRecords, recordSize, tp)
+    producer.close()
 
-    verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=${BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec},topic=$topic")
-    verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=${BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec}")
+    TestUtils.verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=${BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec},topic=$topic")
+    TestUtils.verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=${BrokerTopicStats.ProduceRequestsWithInvalidAcksPerSec}")
   }
 }


### PR DESCRIPTION
TICKET = LIKAFKA-45529
LI_DESCRIPTION =
Inside LI, if a topic has minISR=2, we'd expect all of the topic's corresponding producers
to have the durable acks setting, i.e. acks=-1.

Currently, there is no metric to track whether the producers' acks settings are correct.
This PR adds the metric so that we can discover the producers with invalid acks settings.

EXIT_CRITERIA = N/A since this policy is specific to LI.