### PR TITLE
[LI-HOTFIX] Add extra logging to check if the Selector is notified of incoming data

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -466,7 +466,7 @@ public class Selector implements Selectable, AutoCloseable {
         long startSelect = time.nanoseconds();
         int numReadyKeys = select(timeout);
         long endSelect = time.nanoseconds();
-        log.trace("Completed select in " + (endSelect - startSelect) + "ms");
+        log.trace("Completed select in " + (endSelect - startSelect) + "ns");
         this.sensors.selectTime.record(endSelect - startSelect, time.milliseconds());
 
 
@@ -647,8 +647,8 @@ public class Selector implements Selectable, AutoCloseable {
     private void attemptRead(SelectionKey key, KafkaChannel channel) throws IOException {
         //if channel is ready and has bytes to read from socket or buffer, and has no
         //previous receive(s) already staged or otherwise in progress then read from it
-        log.trace("attempt read from the channel (channel.ready:{}, key.isReadable:{}, " +
-            "channel.hasBytesBuffered:{}, hasStagedReceive: {}, explicitlyMutedChannels.contains(channel): {})",
+        log.trace("Attempt read from the channel (channel.ready:{}, key.isReadable:{}, " +
+            "channel.hasBytesBuffered:{}, hasStagedReceive:{}, explicitlyMutedChannels.contains(channel): {})",
             channel.ready(), key.isReadable(), channel.hasBytesBuffered(), hasStagedReceive(channel),
             explicitlyMutedChannels.contains(channel));
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -647,9 +647,9 @@ public class Selector implements Selectable, AutoCloseable {
     private void attemptRead(SelectionKey key, KafkaChannel channel) throws IOException {
         //if channel is ready and has bytes to read from socket or buffer, and has no
         //previous receive(s) already staged or otherwise in progress then read from it
-        log.trace("Attempt read from the channel (channel.ready:{}, key.isReadable:{}, " +
+        log.trace("Attempt read from the channel {} (channel.ready:{}, key.isReadable:{}, " +
             "channel.hasBytesBuffered:{}, hasStagedReceive:{}, explicitlyMutedChannels.contains(channel): {})",
-            channel.ready(), key.isReadable(), channel.hasBytesBuffered(), hasStagedReceive(channel),
+            channel.id(), channel.ready(), key.isReadable(), channel.hasBytesBuffered(), hasStagedReceive(channel),
             explicitlyMutedChannels.contains(channel));
 
         if (channel.ready() && (key.isReadable() || channel.hasBytesBuffered()) && !hasStagedReceive(channel)
@@ -1017,6 +1017,7 @@ public class Selector implements Selectable, AutoCloseable {
 
     private void addToCompletedReceives(KafkaChannel channel, Deque<NetworkReceive> stagedDeque) {
         NetworkReceive networkReceive = stagedDeque.poll();
+        log.trace("Adding NetworkReceive from the source {} to completed receives", networkReceive.source());
         this.completedReceives.add(networkReceive);
         this.sensors.recordBytesReceived(channel.id(), networkReceive.size());
     }

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -647,7 +647,7 @@ public class Selector implements Selectable, AutoCloseable {
     private void attemptRead(SelectionKey key, KafkaChannel channel) throws IOException {
         //if channel is ready and has bytes to read from socket or buffer, and has no
         //previous receive(s) already staged or otherwise in progress then read from it
-        log.trace("attempt read from the channel (channel.ready:{}, key.isReadable:{}, "+
+        log.trace("attempt read from the channel (channel.ready:{}, key.isReadable:{}, " +
             "channel.hasBytesBuffered:{}, hasStagedReceive: {}, explicitlyMutedChannels.contains(channel): {})",
             channel.ready(), key.isReadable(), channel.hasBytesBuffered(), hasStagedReceive(channel),
             explicitlyMutedChannels.contains(channel));

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -466,7 +466,9 @@ public class Selector implements Selectable, AutoCloseable {
         long startSelect = time.nanoseconds();
         int numReadyKeys = select(timeout);
         long endSelect = time.nanoseconds();
+        log.trace("Completed select in " + (endSelect - startSelect) + "ms");
         this.sensors.selectTime.record(endSelect - startSelect, time.milliseconds());
+
 
         if (numReadyKeys > 0 || !immediatelyConnectedKeys.isEmpty() || dataInBuffers) {
             Set<SelectionKey> readyKeys = this.nioSelector.selectedKeys();
@@ -645,6 +647,11 @@ public class Selector implements Selectable, AutoCloseable {
     private void attemptRead(SelectionKey key, KafkaChannel channel) throws IOException {
         //if channel is ready and has bytes to read from socket or buffer, and has no
         //previous receive(s) already staged or otherwise in progress then read from it
+        log.trace("attempt read from the channel (channel.ready:{}, key.isReadable:{}, "+
+            "channel.hasBytesBuffered:{}, hasStagedReceive: {}, explicitlyMutedChannels.contains(channel): {})",
+            channel.ready(), key.isReadable(), channel.hasBytesBuffered(), hasStagedReceive(channel),
+            explicitlyMutedChannels.contains(channel));
+
         if (channel.ready() && (key.isReadable() || channel.hasBytesBuffered()) && !hasStagedReceive(channel)
             && !explicitlyMutedChannels.contains(channel)) {
             NetworkReceive networkReceive;


### PR DESCRIPTION
TICKET = GCN-37194
LI_DESCRIPTION =
In the GCN, we are seeing that the client timed out while waiting for a MetadataResponse to come.
However, Wireshark packet capture seems to suggest that the response did arrive for the client.

This PR adds extra logging to check whether the Selector is notified of the incoming data
and is able to read from the socket.
EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
