### PR TITLE
[LI-HOTFIX] Add extra logging to check if the NetworkReceive is reading successfully

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -153,7 +153,7 @@ public class NetworkReceive implements Receive {
         }
 
         log.trace("readFromReadableChannel read {} bytes of data, is read complete {} with size.hasRemaining {}, "
-            + " buffer not empty {}, buffer hasRemaining {}", read, complete(), size.hasRemaining(), buffer != null,
+            + " buffer not empty {}, buffer remaining {}", read, complete(), size.hasRemaining(), buffer != null,
             buffer != null ? buffer.remaining() : 0);
         return read;
     }

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -118,6 +118,7 @@ public class NetworkReceive implements Receive {
     @Deprecated
     public long readFromReadableChannel(ReadableByteChannel channel) throws IOException {
         int read = 0;
+        log.trace("readFromReadableChannel with size.hasRemaining {}, limit {}", size.hasRemaining(), size.limit());
         if (size.hasRemaining()) {
             int bytesRead = channel.read(size);
             if (bytesRead < 0)
@@ -148,6 +149,8 @@ public class NetworkReceive implements Receive {
             read += bytesRead;
         }
 
+        log.trace("readFromReadableChannel read {} bytes of data, is read complete {} with size.hasRemaining {}, "
+            + " buffer empty {}, buffer hasRemaining {}", read, complete(), size.hasRemaining(), buffer != null, buffer.hasRemaining());
         return read;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -153,8 +153,7 @@ public class NetworkReceive implements Receive {
         }
 
         log.trace("readFromReadableChannel read {} bytes of data, is read complete {} with size.hasRemaining {}, "
-            + " buffer not empty {}, buffer remaining {}", read, complete(), size.hasRemaining(), buffer != null,
-            buffer != null ? buffer.remaining() : 0);
+            + " buffer not empty {}", read, complete(), size.hasRemaining(), buffer != null);
         return read;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -153,7 +153,8 @@ public class NetworkReceive implements Receive {
         }
 
         log.trace("readFromReadableChannel read {} bytes of data, is read complete {} with size.hasRemaining {}, "
-            + " buffer empty {}, buffer hasRemaining {}", read, complete(), size.hasRemaining(), buffer != null, buffer.hasRemaining());
+            + " buffer not empty {}, buffer hasRemaining {}", read, complete(), size.hasRemaining(), buffer != null,
+            buffer != null ? buffer.remaining() : 0);
         return read;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -124,9 +124,11 @@ public class NetworkReceive implements Receive {
             if (bytesRead < 0)
                 throw new EOFException();
             read += bytesRead;
+            log.trace("readFromReadableChannel bytes read into size buffer {}", bytesRead);
             if (!size.hasRemaining()) {
                 size.rewind();
                 int receiveSize = size.getInt();
+                log.trace("readFromReadableChannel size buffer full, receiveSize is {}", receiveSize);
                 if (receiveSize < 0)
                     throw new InvalidReceiveException("Invalid receive (size = " + receiveSize + ")");
                 if (maxSize != UNLIMITED && receiveSize > maxSize)
@@ -144,6 +146,7 @@ public class NetworkReceive implements Receive {
         }
         if (buffer != null) {
             int bytesRead = channel.read(buffer);
+            log.trace("readFromReadableChannel bytes read into buffer buffer {}", bytesRead);
             if (bytesRead < 0)
                 throw new EOFException();
             read += bytesRead;

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -466,8 +466,8 @@ public class Selector implements Selectable, AutoCloseable {
         long startSelect = time.nanoseconds();
         int numReadyKeys = select(timeout);
         long endSelect = time.nanoseconds();
-        log.trace("Completed select in " + (endSelect - startSelect) + "ns, with numReadyKeys " + numReadyKeys + ", "
-            + "connectedKeysEmpty " + immediatelyConnectedKeys.isEmpty() + ", dataInBuffers " + dataInBuffers);
+        log.trace("Completed select in {}ns, with numReadyKeys {}, connectedKeysEmpty {}, dataInBuffers {}",
+            (endSelect - startSelect), numReadyKeys, immediatelyConnectedKeys.isEmpty(), dataInBuffers);
         this.sensors.selectTime.record(endSelect - startSelect, time.milliseconds());
 
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -467,7 +467,7 @@ public class Selector implements Selectable, AutoCloseable {
         int numReadyKeys = select(timeout);
         long endSelect = time.nanoseconds();
         log.trace("Completed select in {}ns, with numReadyKeys {}, connectedKeysEmpty {}, dataInBuffers {}",
-            (endSelect - startSelect), numReadyKeys, immediatelyConnectedKeys.isEmpty(), dataInBuffers);
+            endSelect - startSelect, numReadyKeys, immediatelyConnectedKeys.isEmpty(), dataInBuffers);
         this.sensors.selectTime.record(endSelect - startSelect, time.milliseconds());
 
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -466,7 +466,8 @@ public class Selector implements Selectable, AutoCloseable {
         long startSelect = time.nanoseconds();
         int numReadyKeys = select(timeout);
         long endSelect = time.nanoseconds();
-        log.trace("Completed select in " + (endSelect - startSelect) + "ns");
+        log.trace("Completed select in " + (endSelect - startSelect) + "ns, with numReadyKeys " + numReadyKeys + ", "
+            + "connectedKeysEmpty " + immediatelyConnectedKeys.isEmpty() + ", dataInBuffers " + dataInBuffers);
         this.sensors.selectTime.record(endSelect - startSelect, time.milliseconds());
 
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -466,7 +466,7 @@ public class Selector implements Selectable, AutoCloseable {
         long startSelect = time.nanoseconds();
         int numReadyKeys = select(timeout);
         long endSelect = time.nanoseconds();
-        log.trace("Completed select in {}ns, with numReadyKeys {}, connectedKeysEmpty {}, dataInBuffers {}",
+        log.trace("Completed select in {}ns, with numReadyKeys {}, immediatelyConnectedKeys.isEmpty {}, dataInBuffers {}",
             endSelect - startSelect, numReadyKeys, immediatelyConnectedKeys.isEmpty(), dataInBuffers);
         this.sensors.selectTime.record(endSelect - startSelect, time.milliseconds());
 


### PR DESCRIPTION
TICKET = GCN-37194
 LI_DESCRIPTION =
 In the GCN, we are seeing that the client timed out while waiting for a MetadataResponse to come.
 However, Wireshark packet capture seems to suggest that the response did arrive for the client.
    
 This PR adds extra logging to check whether the NetworkReceive is able to read from channel successfully.
 EXIT_CRITERIA = N/A


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
