### PR TITLE
[provisional] LIKAFKA-44768: Enhance timing-related logging for Kafka controller startup/failover

### DIFF
--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -26,6 +26,7 @@ import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.TopicPartitionStateZNode
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ControllerMovedException
+import org.apache.kafka.common.utils.Time
 import org.apache.zookeeper.KeeperException.Code
 import scala.collection.{Seq, mutable}
 
@@ -33,15 +34,15 @@ abstract class ReplicaStateMachine(controllerContext: ControllerContext) extends
   /**
    * Invoked on successful controller election.
    */
-  def startup(): Unit = {
-    info("Initializing replica state")
+  def startup(controllerStartMs: Long = Time.SYSTEM.milliseconds): Unit = {
+    info(s"Initializing replica state ${KafkaController.timing(-1, controllerStartMs)}")
     initializeReplicaState()
-    info("Triggering online replica state changes")
     val (onlineReplicas, offlineReplicas) = controllerContext.onlineAndOfflineReplicas
+    info(s"Triggering online replica state changes for ${onlineReplicas.size} replicas ${KafkaController.timing(-1, controllerStartMs)}")
     handleStateChanges(onlineReplicas.toSeq, OnlineReplica)
-    info("Triggering offline replica state changes")
+    info(s"Triggering offline replica state changes for ${offlineReplicas.size} replicas ${KafkaController.timing(-1, controllerStartMs)}")
     handleStateChanges(offlineReplicas.toSeq, OfflineReplica)
-    debug(s"Started replica state machine with initial state -> ${controllerContext.replicaStates}")
+    debug(s"Started replica state machine with initial state -> ${controllerContext.replicaStates} ${KafkaController.timing(-1, controllerStartMs)}")
   }
 
   /**
@@ -108,11 +109,39 @@ class ZkReplicaStateMachine(config: KafkaConfig,
   override def handleStateChanges(replicas: Seq[PartitionAndReplica], targetState: ReplicaState): Unit = {
     if (replicas.nonEmpty) {
       try {
+        var taskStartMs: Long = Time.SYSTEM.milliseconds
+        val doExtraTiming: Boolean = (targetState == OnlineReplica && replicas.size > 250000)
+        val timings = AggregatedTimings()
+        val timingsOpt = if (doExtraTiming) Some(timings) else None
+        var startMs: Long = 0L
+        var numBatches: Int = 0  // GRR TEMP
+
+        startMs = if (doExtraTiming) Time.SYSTEM.milliseconds else 0L
         controllerBrokerRequestBatch.newBatch()
-        replicas.groupBy(_.replica).forKeyValue { (replicaId, replicas) =>
-          doHandleStateChanges(replicaId, replicas, targetState)
+        if (doExtraTiming) {
+          timings.newBatchSumMs += (Time.SYSTEM.milliseconds - startMs)
         }
+
+        replicas.groupBy(_.replica).forKeyValue { (replicaId, replicas) =>
+          numBatches += 1
+          doHandleStateChanges(replicaId, replicas, targetState, timingsOpt)
+        }
+
+        startMs = if (doExtraTiming) Time.SYSTEM.milliseconds else 0L
         controllerBrokerRequestBatch.sendRequestsToBrokers(controllerContext.epoch)
+        if (doExtraTiming) {
+          timings.sendRequestsToBrokersSumMs += (Time.SYSTEM.milliseconds - startMs)
+
+          info(s"Done changing state of ${replicas.size} replicas in ${numBatches} batches to OnlineReplica ${KafkaController.timing(taskStartMs, -1)}:")
+          info(s" - single newBatch() took ${timings.newBatchSumMs} ms")
+          info(s" - aggregate variables-init took ${timings.varInitSumMs} ms")
+          info(s" - aggregate NewReplica partitionFullReplicaAssignment() took ${timings.partitionFullReplicaAssignmentSumMs} ms")
+          info(s" - aggregate NewReplica unassigned-replica handling took ${timings.unassignedReplicaHandlingSumMs} ms")
+          // in test env, this item is the bulk of the time:
+          info(s" - aggregate non-NewReplica addLeaderAndIsrRequestForBrokers() took ${timings.addLeaderAndIsrRequestForBrokersSumMs} ms")
+          info(s" - aggregate putReplicaState() took ${timings.putReplicaStateSumMs} ms")
+          info(s" - single sendRequestsToBrokers() took ${timings.sendRequestsToBrokersSumMs} ms")
+        }
       } catch {
         case e: ControllerMovedException =>
           error(s"Controller moved to another broker when moving some replicas to $targetState state", e)
@@ -122,6 +151,16 @@ class ZkReplicaStateMachine(config: KafkaConfig,
       }
     }
   }
+
+//GRR
+  case class AggregatedTimings(
+    var newBatchSumMs: Long = 0L,
+    var varInitSumMs: Long = 0L,
+    var partitionFullReplicaAssignmentSumMs: Long = 0L,
+    var unassignedReplicaHandlingSumMs: Long = 0L,
+    var addLeaderAndIsrRequestForBrokersSumMs: Long = 0L,
+    var putReplicaStateSumMs: Long = 0L,
+    var sendRequestsToBrokersSumMs: Long = 0L)
 
   /**
    * This API exercises the replica's state machine. It ensures that every state transition happens from a legal
@@ -158,7 +197,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
    * @param replicas The partitions on this replica for which the state transition is invoked
    * @param targetState The end state that the replica should be moved to
    */
-  private def doHandleStateChanges(replicaId: Int, replicas: Seq[PartitionAndReplica], targetState: ReplicaState): Unit = {
+  private def doHandleStateChanges(replicaId: Int, replicas: Seq[PartitionAndReplica], targetState: ReplicaState, timingsOpt: Option[AggregatedTimings]): Unit = {
     val stateLogger = stateChangeLogger.withControllerEpoch(controllerContext.epoch)
     val traceEnabled = stateLogger.isTraceEnabled
     replicas.foreach(replica => controllerContext.putReplicaStateIfNotExists(replica, NonExistentReplica))
@@ -193,17 +232,37 @@ class ZkReplicaStateMachine(config: KafkaConfig,
           }
         }
       case OnlineReplica =>
+        var timings: AggregatedTimings = if (timingsOpt.isDefined) timingsOpt.get else AggregatedTimings()
+        var startMs: Long = 0L
+        var endMs: Long = 0L
+
         validReplicas.foreach { replica =>
+          startMs = if (timingsOpt.isDefined) Time.SYSTEM.milliseconds else 0L
           val partition = replica.topicPartition
           val currentState = controllerContext.replicaState(replica)
+          if (timingsOpt.isDefined) {
+            endMs = Time.SYSTEM.milliseconds
+            timings.varInitSumMs += (endMs - startMs)
+            startMs = endMs
+          }
 
           currentState match {
             case NewReplica =>
               val assignment = controllerContext.partitionFullReplicaAssignment(partition)
+              if (timingsOpt.isDefined) {
+                endMs = Time.SYSTEM.milliseconds
+                timings.partitionFullReplicaAssignmentSumMs += (endMs - startMs)
+                startMs = endMs
+              }
               if (!assignment.replicas.contains(replicaId)) {
                 error(s"Adding replica ($replicaId) that is not part of the assignment $assignment")
                 val newAssignment = assignment.copy(replicas = assignment.replicas :+ replicaId)
                 controllerContext.updatePartitionFullReplicaAssignment(partition, newAssignment)
+              }
+              if (timingsOpt.isDefined) {
+                endMs = Time.SYSTEM.milliseconds
+                timings.unassignedReplicaHandlingSumMs += (endMs - startMs)
+                startMs = endMs
               }
             case _ =>
               controllerContext.partitionLeadershipInfo(partition) match {
@@ -214,10 +273,20 @@ class ZkReplicaStateMachine(config: KafkaConfig,
                     controllerContext.partitionFullReplicaAssignment(partition), isNew = false)
                 case None =>
               }
+              if (timingsOpt.isDefined) {
+                endMs = Time.SYSTEM.milliseconds
+                timings.addLeaderAndIsrRequestForBrokersSumMs += (endMs - startMs)
+                startMs = endMs
+              }
           }
           if (traceEnabled)
             logSuccessfulTransition(stateLogger, replicaId, partition, currentState, OnlineReplica)
           controllerContext.putReplicaState(replica, OnlineReplica)
+          if (timingsOpt.isDefined) {
+            endMs = Time.SYSTEM.milliseconds
+            timings.putReplicaStateSumMs += (endMs - startMs)
+            startMs = endMs
+          }
         }
       case OfflineReplica =>
         validReplicas.foreach { replica =>

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -42,7 +42,7 @@ abstract class ReplicaStateMachine(controllerContext: ControllerContext) extends
     handleStateChanges(onlineReplicas.toSeq, OnlineReplica)
     info(s"Triggering offline replica state changes for ${offlineReplicas.size} replicas ${KafkaController.timing(-1, controllerStartMs)}")
     handleStateChanges(offlineReplicas.toSeq, OfflineReplica)
-    debug(s"Started replica state machine with initial state -> ${controllerContext.replicaStates} ${KafkaController.timing(-1, controllerStartMs)}")
+    debug(s"Started replica state machine ${KafkaController.timing(-1, controllerStartMs)} with initial state -> ${controllerContext.replicaStates}")
   }
 
   /**
@@ -111,29 +111,19 @@ class ZkReplicaStateMachine(config: KafkaConfig,
       try {
         var taskStartMs: Long = Time.SYSTEM.milliseconds
         val doExtraTiming: Boolean = (targetState == OnlineReplica && replicas.size > 250000)
-        val timings = AggregatedTimings()
-        val timingsOpt = if (doExtraTiming) Some(timings) else None
-        var startMs: Long = 0L
-        var numBatches: Int = 0  // GRR TEMP
+        val timingsOpt = if (doExtraTiming) Some(AggregatedTimings()) else None
 
-        startMs = if (doExtraTiming) Time.SYSTEM.milliseconds else 0L
         controllerBrokerRequestBatch.newBatch()
-        if (doExtraTiming) {
-          timings.newBatchSumMs += (Time.SYSTEM.milliseconds - startMs)
-        }
-
         replicas.groupBy(_.replica).forKeyValue { (replicaId, replicas) =>
-          numBatches += 1
           doHandleStateChanges(replicaId, replicas, targetState, timingsOpt)
         }
 
-        startMs = if (doExtraTiming) Time.SYSTEM.milliseconds else 0L
+        var startMs: Long = if (doExtraTiming) Time.SYSTEM.milliseconds else 0L
         controllerBrokerRequestBatch.sendRequestsToBrokers(controllerContext.epoch)
-        if (doExtraTiming) {
+        timingsOpt.foreach { timings =>
           timings.sendRequestsToBrokersSumMs += (Time.SYSTEM.milliseconds - startMs)
 
-          info(s"Done changing state of ${replicas.size} replicas in ${numBatches} batches to OnlineReplica ${KafkaController.timing(taskStartMs, -1)}:")
-          info(s" - single newBatch() took ${timings.newBatchSumMs} ms")
+          info(s"Done changing state of ${replicas.size} replicas to OnlineReplica ${KafkaController.timing(taskStartMs, -1)}:")
           info(s" - aggregate variables-init took ${timings.varInitSumMs} ms")
           info(s" - aggregate NewReplica partitionFullReplicaAssignment() took ${timings.partitionFullReplicaAssignmentSumMs} ms")
           info(s" - aggregate NewReplica unassigned-replica handling took ${timings.unassignedReplicaHandlingSumMs} ms")
@@ -152,9 +142,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
     }
   }
 
-//GRR
   case class AggregatedTimings(
-    var newBatchSumMs: Long = 0L,
     var varInitSumMs: Long = 0L,
     var partitionFullReplicaAssignmentSumMs: Long = 0L,
     var unassignedReplicaHandlingSumMs: Long = 0L,
@@ -232,15 +220,14 @@ class ZkReplicaStateMachine(config: KafkaConfig,
           }
         }
       case OnlineReplica =>
-        var timings: AggregatedTimings = if (timingsOpt.isDefined) timingsOpt.get else AggregatedTimings()
         var startMs: Long = 0L
         var endMs: Long = 0L
 
         validReplicas.foreach { replica =>
-          startMs = if (timingsOpt.isDefined) Time.SYSTEM.milliseconds else 0L
+          if (timingsOpt.isDefined) startMs = Time.SYSTEM.milliseconds
           val partition = replica.topicPartition
           val currentState = controllerContext.replicaState(replica)
-          if (timingsOpt.isDefined) {
+          timingsOpt.foreach { timings =>
             endMs = Time.SYSTEM.milliseconds
             timings.varInitSumMs += (endMs - startMs)
             startMs = endMs
@@ -249,7 +236,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
           currentState match {
             case NewReplica =>
               val assignment = controllerContext.partitionFullReplicaAssignment(partition)
-              if (timingsOpt.isDefined) {
+              timingsOpt.foreach { timings =>
                 endMs = Time.SYSTEM.milliseconds
                 timings.partitionFullReplicaAssignmentSumMs += (endMs - startMs)
                 startMs = endMs
@@ -259,7 +246,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
                 val newAssignment = assignment.copy(replicas = assignment.replicas :+ replicaId)
                 controllerContext.updatePartitionFullReplicaAssignment(partition, newAssignment)
               }
-              if (timingsOpt.isDefined) {
+              timingsOpt.foreach { timings =>
                 endMs = Time.SYSTEM.milliseconds
                 timings.unassignedReplicaHandlingSumMs += (endMs - startMs)
                 startMs = endMs
@@ -273,7 +260,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
                     controllerContext.partitionFullReplicaAssignment(partition), isNew = false)
                 case None =>
               }
-              if (timingsOpt.isDefined) {
+              timingsOpt.foreach { timings =>
                 endMs = Time.SYSTEM.milliseconds
                 timings.addLeaderAndIsrRequestForBrokersSumMs += (endMs - startMs)
                 startMs = endMs
@@ -282,7 +269,7 @@ class ZkReplicaStateMachine(config: KafkaConfig,
           if (traceEnabled)
             logSuccessfulTransition(stateLogger, replicaId, partition, currentState, OnlineReplica)
           controllerContext.putReplicaState(replica, OnlineReplica)
-          if (timingsOpt.isDefined) {
+          timingsOpt.foreach { timings =>
             endMs = Time.SYSTEM.milliseconds
             timings.putReplicaStateSumMs += (endMs - startMs)
             startMs = endMs


### PR DESCRIPTION
THIS IS A PROVISIONAL PR.  I believe it would be useful for detecting hot spots in controller init across different clusters, but it's probably not as elegant as it could be. I did do my best to minimize its performance impact as much as possible.

This is mostly tested in cert-candidate by means of home-dir specials.  I've posted an excerpt of its actual output elsewhere; here's a summary of what it's turned up so far on a 275k-partition cluster:

     12.6s =  19% - initializing controller context; includes:
                     - topic-level (ZK) init (3%)
                     - partition-level (ZK) init (14%) - sequential version
     
      51.0s =  79% - starting replica state machine; includes:
                     - aggregate non-NewReplica addLeaderAndIsrRequestForBrokers() (58%)
                     - aggregate putReplicaState() (6%)
                     - single sendRequestsToBrokers() (8%)
        
       1.2s =   2% - starting partition state machine

      64.8s = 100% - TOTAL


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
