### PR TITLE
 [LI-HOTFIX] Add metrics for each decomposed LiCombinedControlRequest

### DIFF
--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Utils
 import org.slf4j.event.Level
 
+import java.util.concurrent.TimeUnit
 import scala.annotation.nowarn
 
 /**
@@ -322,6 +323,19 @@ object CoreUtils {
     // required for Scala 2.12 compatibility, unused in Scala 2.13 and hence we need to suppress the unused warning
     import scala.collection.compat._
     elements.groupMapReduce(key)(f)(reduce)
+  }
+
+
+  /**
+   * Method copied from the RequestMetrics code path
+   *
+   * Converts nanos to millis with micros precision as additional decimal places in the request log have low
+   * signal to noise ratio. When it comes to metrics, there is little difference either way as we round the value
+   * to the nearest long.
+   */
+  def nanosToMs(nanos: Long): Double = {
+    val positiveNanos = math.max(nanos, 0)
+    TimeUnit.NANOSECONDS.toMicros(positiveNanos).toDouble / TimeUnit.MILLISECONDS.toMicros(1)
   }
 
 }


### PR DESCRIPTION
TICKET =
LI_DESCRIPTION =
The request time metrics, such as LocalTime and TotalTime, are marked at the socket channel level upon request completion.
When we introduce `LiCombinedControlRequest`, because now brokers don't receive those request individually
(except for on IBP=2.4 or when a new Broker joins it expect a native full update),
the processing time metrics of the composed control requests (`LeaderAndIsr`, `StopReplica`, `UpdateMetadata`) are effectively gone,
and we only see the combined process time from `LiCombinedControlRequest`.

This patch marks LocalTime and TotalTime for each decomposed sub-control requests when they're completed.
The other time related metrics (e.g. ThrottleTime) are yet to be determined how to define,
as in the context of "decompose", they doesn't seem valid.

EXIT_CRITERIA = When LiCombinedControlRequest feature is ejected or replaced by upstream implementation


*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
