### PR TITLE
[LI-HOTFIX] Enable LiCombinedControl for non-data brokers

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -288,7 +288,8 @@ class RequestSendThread(val controllerId: Int,
         firstUpdateMetadataWithPartitionsSent &&
         // The LeaderAndIsrRequest starts having the full/incremental flag since IBP KAFKA_2_8_IV1.
         // Thus, we require the firstFullLeaderAndIsrSent to be set only when IBP >= KAFKA_2_8_IV1
-        (config.interBrokerProtocolVersion < KAFKA_2_8_IV1 || firstFullLeaderAndIsrSent))) {
+        (config.interBrokerProtocolVersion < KAFKA_2_8_IV1 || firstFullLeaderAndIsrSent ||
+          controllerContext.partitionUnassignableBrokerIds(config.getMaintenanceBrokerList).toSet.contains(config.brokerId)))) {
       // Only start the merging logic after the first UpdateMetadata request with partitions,
       // since the first UpdateMetadata request with partitions may contain hundreds of thousands of partitions,
       // and thus needs to be cached and shared by all brokers in order to prevent OOM

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -289,6 +289,9 @@ class RequestSendThread(val controllerId: Int,
         // The LeaderAndIsrRequest starts having the full/incremental flag since IBP KAFKA_2_8_IV1.
         // Thus, we require the firstFullLeaderAndIsrSent to be set only when IBP >= KAFKA_2_8_IV1
         (config.interBrokerProtocolVersion < KAFKA_2_8_IV1 || firstFullLeaderAndIsrSent ||
+          // The preferred controllers and maintenance brokers don't hast any partitions,
+          // and therefore will never receive a LeaderAndIsr request. We treat them specially here
+          // so that they can have the LiCombinedControl requests enabled.
           controllerContext.partitionUnassignableBrokerIds(config.getMaintenanceBrokerList).toSet.contains(config.brokerId)))) {
       // Only start the merging logic after the first UpdateMetadata request with partitions,
       // since the first UpdateMetadata request with partitions may contain hundreds of thousands of partitions,

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -244,6 +244,11 @@ class ControllerContext {
 
   def getLivePreferredControllerIds : Set[Int] = livePreferredControllerIds
 
+  /**
+   * @return brokers that don't accept new replicas, including maintenance brokers and preferred controller brokers
+   */
+  def partitionUnassignableBrokerIds(maintenanceBrokers: Seq[Int]): Seq[Int] = maintenanceBrokers ++ getLivePreferredControllerIds
+
   def partitionsOnBroker(brokerId: Int): Set[TopicPartition] = {
     partitionAssignments.flatMap {
       case (topic, topicReplicaAssignment) => topicReplicaAssignment.filter {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1226,7 +1226,7 @@ class KafkaController(val config: KafkaConfig,
   // maintenance brokers that do not take new partitions
   private def rearrangePartitionReplicaAssignmentForNewTopics(topics: Set[String]) {
     try {
-      val noNewPartitionBrokerIds = partitionUnassignableBrokerIds
+      val noNewPartitionBrokerIds = controllerContext.partitionUnassignableBrokerIds(config.getMaintenanceBrokerList)
       if (noNewPartitionBrokerIds.nonEmpty) {
         val newTopics = zkClient.getPartitionNodeNonExistsTopics(topics.toSet)
         val newTopicsToBeArranged = zkClient.getPartitionAssignmentForTopics(newTopics).filter {
@@ -2898,7 +2898,7 @@ class KafkaController(val config: KafkaConfig,
 
     val replicationFactor = config.defaultReplicationFactor
     val brokers = controllerContext.liveOrShuttingDownBrokers.map { sb => kafka.admin.BrokerMetadata(sb.id, sb.rack) }.toSeq
-    val noNewPartitionBrokerIds = partitionUnassignableBrokerIds.toSet
+    val noNewPartitionBrokerIds = controllerContext.partitionUnassignableBrokerIds(config.getMaintenanceBrokerList).toSet
 
     topicIdReplicaAssignments.foreach{ topicsIdReplicaAssignment =>
       val topic = topicsIdReplicaAssignment.topic


### PR DESCRIPTION
TICKET = LIKAFKA-46387

LI_DESCRIPTION = In the current implementation, the LiCombinedControl requests are enabled only
after a full LeaderAndIsr request is sent. For the preferred controllers and maintenance brokers,
they'll never receive a LeaderAndIsr request, and thus have the LiCombinedControl requests
permanently disabled.

This PR fixes the problem by enabling the LiCombinedControl requests for the preferred
controllers and maintenance brokers.

EXIT_CRITERIA = The same criteria as the LiCombinedControl feature.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
