### PR TITLE
[LI-HOTFIX] Fix deadlock caused by lazy val exemptSensor by removing lazy initialization

### DIFF
--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -479,10 +479,10 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
       .quota(new Quota(quotaLimit, true))
   }
 
-  protected def getOrCreateSensor(sensorName: String, metricName: MetricName): Sensor = {
+  protected def getOrCreateSensor(sensorName: String, expirationTime: Long, metricName: MetricName): Sensor = {
     sensorAccessor.getOrCreate(
       sensorName,
-      config.inactiveSensorExpirationTimeSeconds,
+      expirationTime,
       sensor => sensor.add(metricName, new Rate)
     )
   }

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -30,6 +30,9 @@ import scala.jdk.CollectionConverters._
 object ClientRequestQuotaManager {
   val QuotaRequestPercentDefault = Int.MaxValue.toDouble
   val NanosToPercentagePerSecond = 100.0 / TimeUnit.SECONDS.toNanos(1)
+  // Since exemptSensor is for all clients and has a constant name, we do not expire exemptSensor and only
+  // create once.
+  val DefaultInactiveExemptSensorExpirationTimeSeconds = Long.MaxValue
 
   private val ExemptSensorName = "exempt-" + QuotaType.Request
 }
@@ -46,13 +49,11 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
   private val exemptMetricName = metrics.metricName("exempt-request-time",
     QuotaType.Request.toString, "Tracking exempt-request-time utilization percentage")
 
-  def recordExempt(value: Double): Unit = {
-    val exemptSensor = getOrCreateExemptSensor()
-    exemptSensor.record(value)
-  }
+  val exemptSensor: Sensor = getOrCreateSensor(ClientRequestQuotaManager.ExemptSensorName,
+    ClientRequestQuotaManager.DefaultInactiveExemptSensorExpirationTimeSeconds, exemptMetricName)
 
-  def getOrCreateExemptSensor(): Sensor = {
-    getOrCreateSensor(ClientRequestQuotaManager.ExemptSensorName, exemptMetricName)
+  def recordExempt(value: Double): Unit = {
+    exemptSensor.record(value)
   }
 
   /**

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -46,10 +46,13 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
   private val exemptMetricName = metrics.metricName("exempt-request-time",
     QuotaType.Request.toString, "Tracking exempt-request-time utilization percentage")
 
-  lazy val exemptSensor: Sensor = getOrCreateSensor(ClientRequestQuotaManager.ExemptSensorName, exemptMetricName)
-
   def recordExempt(value: Double): Unit = {
+    val exemptSensor = getOrCreateExemptSensor()
     exemptSensor.record(value)
+  }
+
+  def getOrCreateExemptSensor(): Sensor = {
+    getOrCreateSensor(ClientRequestQuotaManager.ExemptSensorName, exemptMetricName)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -202,7 +202,7 @@ class RequestQuotaTest extends BaseRequestTest {
 
   private def exemptRequestMetricValue: Double = {
     val metricName = leaderNode.metrics.metricName("exempt-request-time", QuotaType.Request.toString, "")
-    metricValue(leaderNode.metrics.metrics.get(metricName), leaderNode.quotaManagers.request.getOrCreateExemptSensor())
+    metricValue(leaderNode.metrics.metrics.get(metricName), leaderNode.quotaManagers.request.exemptSensor)
   }
 
   private def metricValue(metric: KafkaMetric, sensor: Sensor): Double = {

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -202,7 +202,7 @@ class RequestQuotaTest extends BaseRequestTest {
 
   private def exemptRequestMetricValue: Double = {
     val metricName = leaderNode.metrics.metricName("exempt-request-time", QuotaType.Request.toString, "")
-    metricValue(leaderNode.metrics.metrics.get(metricName), leaderNode.quotaManagers.request.exemptSensor)
+    metricValue(leaderNode.metrics.metrics.get(metricName), leaderNode.quotaManagers.request.getOrCreateExemptSensor())
   }
 
   private def metricValue(metric: KafkaMetric, sensor: Sensor): Double = {


### PR DESCRIPTION
TICKET = LIKAFKA-46434

LI_DESCRIPTION =
A detailed analysis of this issue is at
https://docs.google.com/document/d/1lnHrSVwiBvEiJN_s5Ub5JFjP0u94EO3h0fla9u81WWI/edit?usp=sharing

In summary, there is a chance to cause deadlock when multiple threads access `ClientRequestQuotaManager`. In the current used version of Scala 2.12, the lazy val initialization is under the object lock. The deadlock could happen in the following condition:
1. In thread a, when `ClientRequestQuotaManager.exemptSensor` is being initialized, it has acquired the object lock and enters the  the actual initialization block. The initialization of 'exemptSensor' requires another lock `private val lock = new ReentrantReadWriteLock()` and it is waiting for this lock.
2. In thread b, at the same time, `ClientQuotaManager.updateQuota()` is called and it has already acquired `ReentrantReadWriteLock lock` by calling `lock.writeLock().lock()`. And then it executes `info()`. If this is the first time accessing `Logging.logger`, which is also a lazy val, it need to wait for the object lock.

Since the lazy val initialization is under the object lock, we should avoid using lazy val if the initialization function holds another lock to prevent holding two locks at the same time which is prone for deadlock. Change to create exemptSensor during ClientRequestQuotaManager initialization with an expiration time of Long.MaxValue to prevent expiration if request quota is not enabled at that time. 

EXIT_CRITERIA = When the change is accepted in upstream Kafka and merged into this repo
