### PR TITLE
[LI-HOTFIX] Don't trigger tests when creating a release

### DIFF
--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -24,24 +24,11 @@ on:
       - '*'
 
 jobs:
-  code-analysis:
-    uses: ./.github/workflows/code-analysis.yml
-
-  unit-test:
-    uses: ./.github/workflows/unit-test.yml
-
-  int-test:
-    uses: ./.github/workflows/int-test.yml
-
   publish:
     # Name the Job
     name: Build tagged commit and upload the artifacts
     # Set the type of machine to run on
     runs-on: ubuntu-latest
-    needs:
-      - code-analysis
-      - unit-test
-      - int-test
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -20,7 +20,6 @@ name: Code analysis
 on:
   workflow_call:
   pull_request:
-  push:
     # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
     branches:
       - 3.0-li

--- a/.github/workflows/int-test.yml
+++ b/.github/workflows/int-test.yml
@@ -20,7 +20,6 @@ name: intTest
 on:
   workflow_call:
   pull_request:
-  push:
     # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
     branches:
       - 3.0-li

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,6 @@ name: unitTest
 on:
   workflow_call:
   pull_request:
-  push:
     # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
     branches:
       - 3.0-li


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
1. I added the following rules to project the main branch 3.0-li
- Require a pull request before merging. Also Require approvals.
- Require status checks to pass before merging.
Thus we no longer need to trigger all tests when creating a release.

2. There is no need to trigger tests upon a push. So this PR also removes the push trigger.

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
