### PR TITLE
[LI-HOTFIX] Add logging to understand follower's ISR state

### DIFF
--- a/core/src/test/scala/unit/kafka/integration/LoggingTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/LoggingTest.scala
@@ -1,0 +1,56 @@
+package unit.kafka.integration
+
+import kafka.api.IntegrationTestHarness
+import kafka.server.HostedPartition.Online
+import kafka.utils.TestUtils
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.TopicConfig
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.{BeforeEach, Test}
+
+import java.util.Properties
+
+class PartitionLoggingTest extends IntegrationTestHarness{
+  override protected def brokerCount: Int = 4
+  val topic = "test"
+  @BeforeEach
+  override def setUp(): Unit = {
+    super.setUp()
+
+    // create the test topic with all the brokers as replicas
+    val topicConfig = new Properties()
+    topicConfig.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3")
+    createTopic(topic, 1, brokerCount, topicConfig)
+  }
+
+  @Test
+  def loggingTest(): Unit = {
+    // shutdown 2 brokers to make sure the partition go under MinISR
+    val brokersToShutdown = servers.filter{s => s.config.brokerId == 2 || s.config.brokerId == 3}
+
+    val tp = new TopicPartition(topic, 0)
+
+    // wait for the partition to enter the UnderMinISR state
+    brokersToShutdown.foreach(_.shutdown())
+    waitForPartitionUnderMinISRState(tp, true)
+
+    // wait for the partition to exit the UnderMinISR state
+    brokersToShutdown.foreach(_.startup())
+    waitForPartitionUnderMinISRState(tp, false)
+  }
+
+
+  private def waitForPartitionUnderMinISRState(tp: TopicPartition, shouldBeUnderMinISR: Boolean): Unit = {
+    TestUtils.waitUntilTrue(() => {
+      val leaderIdOpt = zkClient.getLeaderForPartition(tp)
+      assertTrue(leaderIdOpt.isDefined, "Leader should exist for partition [test,0]")
+      val leader = servers.filter(s => s.config.brokerId == leaderIdOpt.get).last
+      leader.replicaManager.getPartition(tp) match {
+        case Online(partition) => {
+          partition.isUnderMinIsr == shouldBeUnderMinISR
+        }
+        case _ => false
+      }
+    }, "the partition's UnderMinISR state should be " + shouldBeUnderMinISR)
+  }
+}

--- a/core/src/test/scala/unit/kafka/integration/PartitionLoggingTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/PartitionLoggingTest.scala
@@ -1,4 +1,21 @@
-package unit.kafka.integration
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.integration
 
 import kafka.api.IntegrationTestHarness
 import kafka.server.HostedPartition.Online


### PR DESCRIPTION
TICKET = LIKAFKA-46520
LI_DESCRIPTION =
We are seeing several cases where even after the follower added a
partition to its fetcher thread, the follower still couldn't join the
ISR quickly enough. This PR adds more logging to show the follower's
state when a partition goes under MinISR.

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
