### PR TITLE
[LI-HOTFIX] Downgrade FETCH_SESSION_ID_NOT_FOUND logging from info to debug

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -382,11 +382,15 @@ public class FetchSessionHandler {
      */
     public boolean handleResponse(FetchResponse<?> response) {
         if (response.error() != Errors.NONE) {
-            log.info("Node {} was unable to process the fetch request with {}: {}.",
-                node, nextMetadata, response.error());
             if (response.error() == Errors.FETCH_SESSION_ID_NOT_FOUND) {
+                log.debug("Node {} was unable to process the fetch request with {} due to a cache miss. " +
+                    "This client will reset the fetch session. " +
+                    "This is not an error, bit may indicate a sub-optimal broker configuration.",
+                    node, nextMetadata);
                 nextMetadata = FetchMetadata.INITIAL;
             } else {
+                log.info("Node {} was unable to process the fetch request with {}: {}.",
+                    node, nextMetadata, response.error());
                 nextMetadata = nextMetadata.nextCloseExisting();
             }
             return false;

--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -385,7 +385,7 @@ public class FetchSessionHandler {
             if (response.error() == Errors.FETCH_SESSION_ID_NOT_FOUND) {
                 log.debug("Node {} was unable to process the fetch request with {} due to a cache miss. " +
                     "This client will reset the fetch session. " +
-                    "This is not an error, bit may indicate a sub-optimal broker configuration.",
+                    "This is not an error, but may indicate a sub-optimal broker configuration.",
                     node, nextMetadata);
                 nextMetadata = FetchMetadata.INITIAL;
             } else {


### PR DESCRIPTION
TICKET = LIKAFKA-44865
LI_DESCRIPTION =
Whenever the fetch session has a cache miss on the broker, the client logs FETCH_SESSION_ID_NOT_FOUND at the info level. This message isn't actionable to clients, and does not actually indicate an error. More accurately, it possibly indicates that the broker is sub-optimally configured. This change improves client-side logging by making this a debug log, and also improves the log message for this specific situation.

EXIT_CRITERIA = N/A

TESTING =
This change does not affect behavior or control flow, only logging. Therefore, no additional testing is needed.