### PR TITLE
[LI-HOTFIX] Mark FetchSession cache misses

### DIFF
--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -45,6 +45,8 @@ object FetchSession {
   val NUM_INCREMENTAL_FETCH_PARTITIONS_CACHED = "NumIncrementalFetchPartitionsCached"
   val INCREMENTAL_FETCH_SESSIONS_EVICTIONS_PER_SEC = "IncrementalFetchSessionEvictionsPerSec"
   val EVICTIONS = "evictions"
+  val INCREMENTAL_FETCH_SESSION_CACHE_MISSES_PER_SEC = "IncrementalFetchSessionCacheMissesPerSec"
+  val CACHE_MISSES = "cacheMisses"
 
   def partitionsToLogString(partitions: util.Collection[TopicPartition], traceEnabled: Boolean): String = {
     if (traceEnabled) {
@@ -576,6 +578,10 @@ class FetchSessionCache(private val maxEntries: Int,
   val evictionsMeter = newMeter(FetchSession.INCREMENTAL_FETCH_SESSIONS_EVICTIONS_PER_SEC,
     FetchSession.EVICTIONS, TimeUnit.SECONDS, Map.empty)
 
+  removeMetric(FetchSession.INCREMENTAL_FETCH_SESSION_CACHE_MISSES_PER_SEC)
+  val cacheMissesMeter = newMeter(FetchSession.INCREMENTAL_FETCH_SESSION_CACHE_MISSES_PER_SEC,
+    FetchSession.CACHE_MISSES, TimeUnit.SECONDS, Map.empty)
+
   /**
     * Get a session by session ID.
     *
@@ -584,6 +590,13 @@ class FetchSessionCache(private val maxEntries: Int,
     */
   def get(sessionId: Int): Option[FetchSession] = synchronized {
     sessions.get(sessionId)
+  }
+
+  /**
+    * Records the event that the cache did not have a session it might have been expected to have (ie. a cache miss).
+    */
+  def markCacheMiss() = synchronized {
+    cacheMissesMeter.mark();
   }
 
   /**
@@ -779,6 +792,7 @@ class FetchManager(private val time: Time,
         cache.get(reqMetadata.sessionId) match {
           case None => {
             debug(s"Session error for ${reqMetadata.sessionId}: no such session ID found.")
+            cache.markCacheMiss();
             new SessionErrorContext(Errors.FETCH_SESSION_ID_NOT_FOUND, reqMetadata)
           }
           case Some(session) => session.synchronized {


### PR DESCRIPTION
TICKET = LIKAFKA-44865
LI_DESCRIPTION =
This change adds a meter to keep track of fetch session cache misses. When used in conjunction with the cache evictions meter, this can help diagnose configuration issues like the fetch sessions cache being too small.

EXIT_CRITERIA = N/A

TESTING =
This change does not affect behavior or control flow, only metrics. No additional testing needed.