### PR TITLE
[LI-HOTFIX]  Improve poison pill logging and expose the time-since-last-dequeue metric

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
@@ -24,10 +24,8 @@ import java.nio.file.StandardCopyOption;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.management.MBeanServer;
-import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Value;
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
@@ -86,7 +86,7 @@ public class PoisonPill {
             return;
         }
 
-        System.err.println("dumping heap to " + heapDumpFolder.getCanonicalPath());
+        System.err.println("PoisonPill dumping heap to " + heapDumpFolder.getCanonicalPath());
         System.err.flush();
 
         //we dump into dump.inprogress and atomically rename it to be dump.complete

--- a/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
@@ -34,6 +34,9 @@ class PoisonPillStats {
     private final Metrics metrics;
     private final Sensor timeSinceLastDequeueSensor;
     public PoisonPillStats(Metrics metrics) {
+        if (metrics == null) {
+            throw new IllegalArgumentException("The metrics for PoisonPillStats should not be null");
+        }
         this.metrics = metrics;
 
         String metricGroupName = "PoisonPill-metrics";
@@ -49,11 +52,20 @@ class PoisonPillStats {
             new Max());
     }
 
-    public void recordTimeSinceLastDequeInMs(final long timeSinceLastDequeue) {
-        this.timeSinceLastDequeueSensor.record(timeSinceLastDequeue);
+    public void recordTimeSinceLastDequeue(final long timeSinceLastDequeueMs) {
+        this.timeSinceLastDequeueSensor.record(timeSinceLastDequeueMs, Time.SYSTEM.milliseconds(), false);
     }
 }
 
+/**
+ * The PoisonPill class provides the die method to
+ * 1) generate a heap-dump file under the provided directory;
+ * 2) exit the JVM process.
+ *
+ * A maxWait time can be specified for generating the heap-dump. If the heap-dump cannot be finished within the maxWait,
+ * the JVM process will be terminated.
+ * Logs from this class are sent to standard error output (which means they are sent to the kafka.out file within LinkedIn).
+ */
 public class PoisonPill {
     private final PoisonPillStats poisonPillStats;
 
@@ -83,8 +95,8 @@ public class PoisonPill {
         }
     }
 
-    public void recordTimeSinceLastDequeInMs(final long timeSinceLastDequeue) {
-        this.poisonPillStats.recordTimeSinceLastDequeInMs(timeSinceLastDequeue);
+    public void recordTimeSinceLastDequeue(final long timeSinceLastDequeueMs) {
+        this.poisonPillStats.recordTimeSinceLastDequeue(timeSinceLastDequeueMs);
     }
 
     private void grabHeapDump(File heapDumpFolder, final long maxWait, final int haltStatusCode) throws Exception {
@@ -97,6 +109,7 @@ public class PoisonPill {
             public void run() {
                 try {
                     latch.countDown();
+                    System.err.println("PoisonPill watch-dog will sleep for " + maxWait + "ms, waiting for heap-dump to be completed");
                     Thread.sleep(maxWait);
                     //at this point ~maxWait has passed since the call to die().
                     //if the heap dump process completed successfully die() would

--- a/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
@@ -24,19 +24,54 @@ import java.nio.file.StandardCopyOption;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.management.MBeanServer;
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Value;
 
+
+class PoisonPillStats {
+    private final Metrics metrics;
+    private final Sensor timeSinceLastDequeueSensor;
+    public PoisonPillStats(Metrics metrics) {
+        this.metrics = metrics;
+
+        String metricGroupName = "PoisonPill-metrics";
+        this.timeSinceLastDequeueSensor = metrics.sensor("time-since-last-dequeue");
+
+        this.timeSinceLastDequeueSensor.add(metrics.metricName("time-since-last-dequeue",
+            metricGroupName,
+            "The latest time-since-last-dequeue in milliseconds"),
+            new Value());
+        this.timeSinceLastDequeueSensor.add(metrics.metricName("time-since-last-dequeue-max",
+            metricGroupName,
+            "The maximum value of time-since-last-dequeue in milliseconds"),
+            new Max());
+    }
+
+    public void recordTimeSinceLastDequeInMs(final long timeSinceLastDequeue) {
+        this.timeSinceLastDequeueSensor.record(timeSinceLastDequeue);
+    }
+}
 
 public class PoisonPill {
+    private final PoisonPillStats poisonPillStats;
 
-    public static void die() {
+    public PoisonPill(Metrics metrics) {
+        poisonPillStats = new PoisonPillStats(metrics);
+    }
+
+    public void die() {
         die(null, -1, 1);
     }
 
-    public static void die(File heapDumpFolder, final long maxWaitForDump) {
+    public void die(File heapDumpFolder, final long maxWaitForDump) {
         die(heapDumpFolder, maxWaitForDump, 1);
     }
 
-    public static void die(File heapDumpFolder, final long maxWaitForDump, int haltStatusCode) {
+    public void die(File heapDumpFolder, final long maxWaitForDump, int haltStatusCode) {
         try {
             if (maxWaitForDump > 0 && heapDumpFolder != null) {
                 grabHeapDump(heapDumpFolder, maxWaitForDump, haltStatusCode);
@@ -50,7 +85,11 @@ public class PoisonPill {
         }
     }
 
-    private static void grabHeapDump(File heapDumpFolder, final long maxWait, final int haltStatusCode) throws Exception {
+    public void recordTimeSinceLastDequeInMs(final long timeSinceLastDequeue) {
+        this.poisonPillStats.recordTimeSinceLastDequeInMs(timeSinceLastDequeue);
+    }
+
+    private void grabHeapDump(File heapDumpFolder, final long maxWait, final int haltStatusCode) throws Exception {
 
         //set up a watchdog background thread that will halt in ~maxWait regardless of whether or not
         //we succeed in taking a heap dump (since we dont know when it'll ever complete)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -189,7 +189,7 @@ class KafkaServer(
     // This relies on io-thread to receive request from RequestChannel with 300 ms timeout, so that lastDequeueTimeMs
     // will keep increasing even if there is no incoming request
     val timeSinceLastDequeueInMs = time.milliseconds - socketServer.dataPlaneRequestChannel.lastDequeueTimeMs;
-    poisonPill.recordTimeSinceLastDequeInMs(timeSinceLastDequeueInMs)
+    poisonPill.recordTimeSinceLastDequeue(timeSinceLastDequeueInMs)
     if (timeSinceLastDequeueInMs > config.requestMaxLocalTimeMs) {
       fatal(s"It has been more than ${config.requestMaxLocalTimeMs} ms since the last time any io-thread reads from RequestChannel. Shutdown broker now.")
       poisonPill.die(config.heapDumpFolder, config.heapDumpTimeout)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -183,12 +183,16 @@ class KafkaServer(
 
   private val kafkaActions: KafkaActions = actions
 
+  @volatile private var poisonPill: PoisonPill = null
+
   private def haltIfNotHealthy(): Unit = {
     // This relies on io-thread to receive request from RequestChannel with 300 ms timeout, so that lastDequeueTimeMs
     // will keep increasing even if there is no incoming request
-    if (time.milliseconds - socketServer.dataPlaneRequestChannel.lastDequeueTimeMs > config.requestMaxLocalTimeMs) {
+    val timeSinceLastDequeueInMs = time.milliseconds - socketServer.dataPlaneRequestChannel.lastDequeueTimeMs;
+    poisonPill.recordTimeSinceLastDequeInMs(timeSinceLastDequeueInMs)
+    if (timeSinceLastDequeueInMs > config.requestMaxLocalTimeMs) {
       fatal(s"It has been more than ${config.requestMaxLocalTimeMs} ms since the last time any io-thread reads from RequestChannel. Shutdown broker now.")
-      PoisonPill.die(config.heapDumpFolder, config.heapDumpTimeout)
+      poisonPill.die(config.heapDumpFolder, config.heapDumpTimeout)
     }
   }
 
@@ -358,6 +362,7 @@ class KafkaServer(
         }
         val brokerEpoch = zkClient.registerBroker(brokerInfo)
 
+        poisonPill = new PoisonPill(metrics)
         healthCheckScheduler = new KafkaScheduler(threads = 1, threadNamePrefix = "kafka-healthcheck-scheduler-")
         healthCheckScheduler.startup()
         healthCheckScheduler.schedule(name = "halt-broker-if-not-healthy",


### PR DESCRIPTION
TICKET = LIKAFKA-46871
LI_DESCRIPTION =
This PR includes 2 changes
1. We are improving the logging of PoisonPill to make it more obvious that the heap dump is triggered by the PoisonPill logic.
2. We are exposing the metric time-since-last-dequeue so that it can be alerted on.
EXIT_CRITERIA = Probably never.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
