### PR TITLE
[LI-HOTFIX] Reduce lock contention between control-plane-kafka-request-handler and kafka-log-cleaner-thread

### DIFF
--- a/core/src/main/scala/kafka/log/CleanerConfig.scala
+++ b/core/src/main/scala/kafka/log/CleanerConfig.scala
@@ -28,6 +28,7 @@ package kafka.log
  * @param backOffMs The amount of time to wait before rechecking if no logs are eligible for cleaning
  * @param enableCleaner Allows completely disabling the log cleaner
  * @param hashAlgorithm The hash algorithm to use in key comparison.
+ * @param fineGrainedLockEnable Whether the fine grained lock for calculating filthiest log is enabled
  */
 case class CleanerConfig(numThreads: Int = 1,
                          dedupeBufferSize: Long = 4*1024*1024L,
@@ -37,5 +38,6 @@ case class CleanerConfig(numThreads: Int = 1,
                          maxIoBytesPerSecond: Double = Double.MaxValue,
                          backOffMs: Long = 15 * 1000,
                          enableCleaner: Boolean = true,
-                         hashAlgorithm: String = "MD5") {
+                         hashAlgorithm: String = "MD5",
+                         fineGrainedLockEnable: Boolean = true) {
 }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -101,7 +101,7 @@ class LogCleaner(initialConfig: CleanerConfig,
   @volatile private var config = initialConfig
 
   /* for managing the state of partitions being cleaned. package-private to allow access in tests */
-  private[log] val cleanerManager = new LogCleanerManager(logDirs, logs, logDirFailureChannel, retentionCheckMs)
+  private[log] val cleanerManager = new LogCleanerManager(logDirs, logs, logDirFailureChannel, retentionCheckMs, config.fineGrainedLockEnable)
 
   /* a throttle used to limit the I/O of all the cleaner threads to a user-specified maximum rate */
   private val throttler = new Throttler(desiredRatePerSec = config.maxIoBytesPerSecond,
@@ -450,7 +450,8 @@ object LogCleaner {
       maxMessageSize = config.messageMaxBytes,
       maxIoBytesPerSecond = config.logCleanerIoMaxBytesPerSecond,
       backOffMs = config.logCleanerBackoffMs,
-      enableCleaner = config.logCleanerEnable)
+      enableCleaner = config.logCleanerEnable,
+      fineGrainedLockEnable = config.liLogCleanerFineGrainedLockEnable)
 
   }
 

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -204,18 +204,27 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
 
       this.dirtiestLogCleanableRatio = if (dirtyLogs.nonEmpty) dirtyLogs.max.cleanableRatio else 0
       // and must meet the minimum threshold for dirty byte ratio or have some bytes required to be compacted
-      val cleanableLogs = dirtyLogs.filter { ltc =>
+      var cleanableLogs = dirtyLogs.filter { ltc =>
         (ltc.needCompactionNow && ltc.cleanableBytes > 0) || ltc.cleanableRatio > ltc.log.config.minCleanableRatio
+      }
+      inLock(lock) {
+      // the logs inside cleanableLogs may have changed when we are not holding the lock, possibilities are
+      // 1. becoming aborted
+      // 2. becoming in progress in other cleaner threads
+      // 3. becoming uncleanable due to LogCleaningExceptions
+      // We shouldn't proceed in any of these cases
+      cleanableLogs = cleanableLogs.filterNot {
+        logToClean =>
+          inProgress.contains(logToClean.topicPartition) || isUncleanablePartition(logToClean.log, logToClean.topicPartition)
       }
       if(cleanableLogs.isEmpty) {
         None
       } else {
         preCleanStats.recordCleanablePartitions(cleanableLogs.size)
         val filthiest = cleanableLogs.max
-        inLock(lock) {
-          inProgress.put(filthiest.topicPartition, LogCleaningInProgress)
-        }
+        inProgress.put(filthiest.topicPartition, LogCleaningInProgress)
         Some(filthiest)
+      }
       }
    //}
   }

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -61,7 +61,8 @@ private[log] class LogCleaningException(val log: Log,
 private[log] class LogCleanerManager(val logDirs: Seq[File],
                                      val logs: Pool[TopicPartition, Log],
                                      val logDirFailureChannel: LogDirFailureChannel,
-                                     val retentionCheckMs: Long) extends Logging with KafkaMetricsGroup {
+                                     val retentionCheckMs: Long,
+                                     val fineGrainedLockEnable: Boolean) extends Logging with KafkaMetricsGroup {
   import LogCleanerManager._
 
 
@@ -163,12 +164,71 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     }
   }
 
-   /**
+  def grabFilthiestCompactedLog(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
+    if (fineGrainedLockEnable) {
+      grabFilthiestCompactedLogWithFineGrainedLock(time, preCleanStats)
+    } else {
+      grabFilthiestCompactedLogWithLongLastingLock(time, preCleanStats)
+    }
+  }
+
+  /**
+   * Choose the log to clean next and add it to the in-progress set. We recompute this
+   * each time from the full set of logs to allow logs to be dynamically added to the pool of logs
+   * the log manager maintains.
+   */
+  def grabFilthiestCompactedLogWithLongLastingLock(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
+    inLock(lock) {
+      val now = time.milliseconds
+      this.timeOfLastRun = now
+      val lastClean = allCleanerCheckpoints
+      val dirtyLogs = logs.filter {
+        case (_, log) => log.config.compact  // match logs that are marked as compacted
+      }.filterNot {
+        case (topicPartition, log) =>
+          // skip any logs already in-progress and uncleanable partitions
+          inProgress.contains(topicPartition) || isUncleanablePartition(log, topicPartition)
+      }.map {
+        case (topicPartition, log) => // create a LogToClean instance for each
+          try {
+            val lastCleanOffset = lastClean.get(topicPartition)
+            val offsetsToClean = cleanableOffsets(log, lastCleanOffset, now)
+            // update checkpoint for logs with invalid checkpointed offsets
+            if (offsetsToClean.forceUpdateCheckpoint)
+              updateCheckpoints(log.parentDirFile, partitionToUpdateOrAdd = Option(topicPartition, offsetsToClean.firstDirtyOffset))
+            val compactionDelayMs = maxCompactionDelay(log, offsetsToClean.firstDirtyOffset, now)
+            preCleanStats.updateMaxCompactionDelay(compactionDelayMs)
+
+            LogToClean(topicPartition, log, offsetsToClean.firstDirtyOffset, offsetsToClean.firstUncleanableDirtyOffset, compactionDelayMs > 0)
+          } catch {
+            case e: Throwable => throw new LogCleaningException(log,
+              s"Failed to calculate log cleaning stats for partition $topicPartition", e)
+          }
+      }.filter(ltc => ltc.totalBytes > 0) // skip any empty logs
+
+      this.dirtiestLogCleanableRatio = if (dirtyLogs.nonEmpty) dirtyLogs.max.cleanableRatio else 0
+      // and must meet the minimum threshold for dirty byte ratio or have some bytes required to be compacted
+      val cleanableLogs = dirtyLogs.filter { ltc =>
+        (ltc.needCompactionNow && ltc.cleanableBytes > 0) || ltc.cleanableRatio > ltc.log.config.minCleanableRatio
+      }
+      if(cleanableLogs.isEmpty) {
+        None
+      } else {
+        preCleanStats.recordCleanablePartitions(cleanableLogs.size)
+        val filthiest = cleanableLogs.max
+        inProgress.put(filthiest.topicPartition, LogCleaningInProgress)
+        Some(filthiest)
+      }
+    }
+  }
+
+
+  /**
     * Choose the log to clean next and add it to the in-progress set. We recompute this
     * each time from the full set of logs to allow logs to be dynamically added to the pool of logs
     * the log manager maintains.
     */
-  def grabFilthiestCompactedLog(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
+  def grabFilthiestCompactedLogWithFineGrainedLock(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
     // This method's indentation is not fixed, since we'd like to minimize the code changes with upstream Kafka.
     // The indentation should be fixed after the code is merged in upstream.
       val now = time.milliseconds

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -169,7 +169,8 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     * the log manager maintains.
     */
   def grabFilthiestCompactedLog(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
-    // inLock(lock) {
+    // This method's indentation is not fixed, since we'd like to minimize the code changes with upstream Kafka.
+    // The indentation should be fixed after the code is merged in upstream.
       val now = time.milliseconds
       this.timeOfLastRun = now
       val lastClean = allCleanerCheckpoints
@@ -208,12 +209,16 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
         (ltc.needCompactionNow && ltc.cleanableBytes > 0) || ltc.cleanableRatio > ltc.log.config.minCleanableRatio
       }
       inLock(lock) {
-      // the logs inside cleanableLogs may have changed when we are not holding the lock, possibilities are
-      // 1. becoming aborted
-      // 2. becoming in progress in other cleaner threads
-      // 3. becoming uncleanable due to LogCleaningExceptions
-      // We shouldn't proceed in any of these cases
-      cleanableLogs = cleanableLogs.filterNot {
+      // the logs inside cleanableLogs may have changed when we are not holding the lock, e.g. they could have become
+      // 1. removed from the logs due to topic deletion
+      // 2. aborted (with the log's value in the inProgress map being LogCleaningAborted)
+      // 3. in progress in other cleaner threads
+      // 4. uncleanable due to LogCleaningExceptions
+      // We shouldn't proceed with logs in any of these condition
+      //
+      cleanableLogs = cleanableLogs.filter {
+        logToClean => logs.contains(logToClean.topicPartition)
+      }.filterNot {
         logToClean =>
           inProgress.contains(logToClean.topicPartition) || isUncleanablePartition(logToClean.log, logToClean.topicPartition)
       }
@@ -226,7 +231,6 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
         Some(filthiest)
       }
       }
-   //}
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -168,6 +168,9 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     if (fineGrainedLockEnable) {
       grabFilthiestCompactedLogWithFineGrainedLock(time, preCleanStats)
     } else {
+      // TODO: once we know the grabFilthiestCompactedLogWithFineGrainedLock is stable,
+      // the fineGrainedLockEnable should always be set to true, and we should discard the following
+      // grabFilthiestCompactedLogWithLongLastingLock method
       grabFilthiestCompactedLogWithLongLastingLock(time, preCleanStats)
     }
   }
@@ -175,9 +178,10 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   /**
    * Choose the log to clean next and add it to the in-progress set. We recompute this
    * each time from the full set of logs to allow logs to be dynamically added to the pool of logs
-   * the log manager maintains.
+   * the log manager maintains. Compared with {@link grabFilthiestCompactedLogWithFineGrainedLock() grabFilthiestCompactedLogWithFineGrainedLock},
+   * this method holds the lock while iterating through the logs to check which one is the filthiest.
    */
-  def grabFilthiestCompactedLogWithLongLastingLock(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
+  private def grabFilthiestCompactedLogWithLongLastingLock(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
     inLock(lock) {
       val now = time.milliseconds
       this.timeOfLastRun = now
@@ -226,11 +230,11 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   /**
     * Choose the log to clean next and add it to the in-progress set. We recompute this
     * each time from the full set of logs to allow logs to be dynamically added to the pool of logs
-    * the log manager maintains.
+    * the log manager maintains. Compared with {@link grabFilthiestCompactedLogWithLongLastingLock() grabFilthiestCompactedLogWithLongLastingLock},
+   * this method does NOT hold the lock while iterating through the logs to check which one is the filthiest.
     */
-  def grabFilthiestCompactedLogWithFineGrainedLock(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
-    // This method's indentation is not fixed, since we'd like to minimize the code changes with upstream Kafka.
-    // The indentation should be fixed after the code is merged in upstream.
+  private def grabFilthiestCompactedLogWithFineGrainedLock(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
+      info(s"Grabbing filthiest compacted log with fine grained lock")
       val now = time.milliseconds
       this.timeOfLastRun = now
       val lastClean = allCleanerCheckpoints

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -169,17 +169,22 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     * the log manager maintains.
     */
   def grabFilthiestCompactedLog(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
-    inLock(lock) {
+    // inLock(lock) {
       val now = time.milliseconds
       this.timeOfLastRun = now
       val lastClean = allCleanerCheckpoints
-      val dirtyLogs = logs.filter {
-        case (_, log) => log.config.compact  // match logs that are marked as compacted
-      }.filterNot {
-        case (topicPartition, log) =>
-          // skip any logs already in-progress and uncleanable partitions
-          inProgress.contains(topicPartition) || isUncleanablePartition(log, topicPartition)
-      }.map {
+
+      val candidateLogs = inLock(lock) {
+        logs.filter {
+          case (_, log) => log.config.compact // match logs that are marked as compacted
+        }.filterNot {
+          case (topicPartition, log) =>
+            // skip any logs already in-progress and uncleanable partitions
+            inProgress.contains(topicPartition) || isUncleanablePartition(log, topicPartition)
+        }
+      }
+
+      val dirtyLogs = candidateLogs.map {
         case (topicPartition, log) => // create a LogToClean instance for each
           try {
             val lastCleanOffset = lastClean.get(topicPartition)
@@ -207,10 +212,12 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
       } else {
         preCleanStats.recordCleanablePartitions(cleanableLogs.size)
         val filthiest = cleanableLogs.max
-        inProgress.put(filthiest.topicPartition, LogCleaningInProgress)
+        inLock(lock) {
+          inProgress.put(filthiest.topicPartition, LogCleaningInProgress)
+        }
         Some(filthiest)
       }
-    }
+   //}
   }
 
   /**

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -325,6 +325,7 @@ object Defaults {
   val LiAlterIsrEnabled = false
   val LiAsyncFetcherEnabled = false
   val LiNumControllerInitThreads = 1
+  val LiLogCleanerFineGrainedLockEnabled = true
 }
 
 object KafkaConfig {
@@ -439,6 +440,7 @@ object KafkaConfig {
   val LiCombinedControlRequestEnableProp = "li.combined.control.request.enable"
   val LiAlterIsrEnableProp = "li.alter.isr.enable"
   val LiNumControllerInitThreadsProp = "li.num.controller.init.threads"
+  val LiLogCleanerFineGrainedLockEnableProp = "li.log.cleaner.fine.grained.lock.enable"
   val AllowPreferredControllerFallbackProp = "allow.preferred.controller.fallback"
   val UnofficialClientLoggingEnableProp = "unofficial.client.logging.enable"
   val UnofficialClientCacheTtlProp = "unofficial.client.cache.ttl"
@@ -775,6 +777,7 @@ object KafkaConfig {
   val LiCombinedControlRequestEnableDoc = "Specifies whether the controller should use the LiCombinedControlRequest."
   val LiAlterIsrEnabledDoc = "Specifies whether the brokers should use the AlterISR request to propagate ISR changes to the controller. If set to false, brokers will propagate the updates via Zookeeper."
   val LiNumControllerInitThreadsDoc = "Number of threads (and Zookeeper clients + connections) to be used while recursing the topic-partitions tree in Zookeeper during controller startup/failover."
+  val LiLogCleanerFineGrainedLockEnableDoc = "Specifies whether the log cleaner should use fine grained locks when calculating the filthiest log to clean"
   // Although AllowPreferredControllerFallback is expected to be configured dynamically at per cluster level, providing a static configuration entry
   // here allows its value to be obtained without holding the dynamic broker configuration lock.
   val AllowPreferredControllerFallbackDoc = "Specifies whether a non-preferred controller node (broker) is allowed to become the controller." +
@@ -1214,6 +1217,7 @@ object KafkaConfig {
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
       .define(LiAlterIsrEnableProp, BOOLEAN, Defaults.LiAlterIsrEnabled, HIGH, LiAlterIsrEnabledDoc)
       .define(LiNumControllerInitThreadsProp, INT, Defaults.LiNumControllerInitThreads, atLeast(1), LOW, LiNumControllerInitThreadsDoc)
+      .define(LiLogCleanerFineGrainedLockEnableProp, BOOLEAN, Defaults.LiLogCleanerFineGrainedLockEnabled, LOW, LiLogCleanerFineGrainedLockEnableDoc)
       .define(AllowPreferredControllerFallbackProp, BOOLEAN, Defaults.AllowPreferredControllerFallback, HIGH, AllowPreferredControllerFallbackDoc)
       .define(UnofficialClientLoggingEnableProp, BOOLEAN, Defaults.UnofficialClientLoggingEnable, LOW, UnofficialClientLoggingEnableDoc)
       .define(UnofficialClientCacheTtlProp, LONG, Defaults.UnofficialClientCacheTtl, LOW, UnofficialClientCacheTtlDoc)
@@ -1723,6 +1727,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   def liCombinedControlRequestEnable = getBoolean(KafkaConfig.LiCombinedControlRequestEnableProp)
   def liAlterIsrEnable = getBoolean(KafkaConfig.LiAlterIsrEnableProp)
   def liNumControllerInitThreads = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
+  def liLogCleanerFineGrainedLockEnable = getBoolean(KafkaConfig.LiLogCleanerFineGrainedLockEnableProp)
 
   def unofficialClientLoggingEnable = getBoolean(KafkaConfig.UnofficialClientLoggingEnableProp)
   def unofficialClientCacheTtl = getLong(KafkaConfig.UnofficialClientCacheTtlProp)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -54,7 +54,7 @@ class LogCleanerManagerTest extends Logging {
 
   class LogCleanerManagerMock(logDirs: Seq[File],
                               logs: Pool[TopicPartition, Log],
-                              logDirFailureChannel: LogDirFailureChannel) extends LogCleanerManager(logDirs, logs, logDirFailureChannel, 0L) {
+                              logDirFailureChannel: LogDirFailureChannel) extends LogCleanerManager(logDirs, logs, logDirFailureChannel, 0L, true) {
     override def allCleanerCheckpoints: Map[TopicPartition, Long] = {
       cleanerCheckpoints.toMap
     }
@@ -755,7 +755,7 @@ class LogCleanerManagerTest extends Logging {
   private def createCleanerManager(log: Log): LogCleanerManager = {
     val logs = new Pool[TopicPartition, Log]()
     logs.put(topicPartition, log)
-    new LogCleanerManager(Seq(logDir, logDir2), logs, null, 0L)
+    new LogCleanerManager(Seq(logDir, logDir2), logs, null, 0L, true)
   }
 
   private def createCleanerManagerMock(pool: Pool[TopicPartition, Log]): LogCleanerManagerMock = {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -128,7 +128,7 @@ public class ReplicaFetcherThreadBenchmark {
                 JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
                 new MockConfigRepository(),
                 logConfig,
-                new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
+                new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5", true),
                 1,
                 1000L,
                 10000L,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -107,7 +107,7 @@ public class PartitionMakeFollowerBenchmark {
             JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
             new MockConfigRepository(),
             logConfig,
-            new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
+            new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5", true),
             1,
             1000L,
             10000L,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -92,7 +92,7 @@ public class UpdateFollowerFetchStateBenchmark {
                 JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
                 new MockConfigRepository(),
                 logConfig,
-                new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
+                new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5", true),
                 1,
                 1000L,
                 10000L,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -109,7 +109,7 @@ public class CheckpointBench {
         this.logManager = TestUtils.createLogManager(JavaConverters.asScalaBuffer(files),
                 LogConfig.apply(), new MockConfigRepository(), CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
                         1024 * 1024, 32 * 1024 * 1024,
-                        Double.MAX_VALUE, 15 * 1000, true, "MD5"), time,
+                        Double.MAX_VALUE, 15 * 1000, true, "MD5", true), time,
                     ApiVersion.latestVersion(), new RemoteLogManagerConfig(new Properties()));
         scheduler.startup();
         final BrokerTopicStats brokerTopicStats = new BrokerTopicStats();

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -120,7 +120,7 @@ public class PartitionCreationBench {
         CleanerConfig cleanerConfig = CleanerConfig.apply(1,
                 4 * 1024 * 1024L, 0.9d,
                 1024 * 1024, 32 * 1024 * 1024,
-                Double.MAX_VALUE, 15 * 1000, true, "MD5");
+                Double.MAX_VALUE, 15 * 1000, true, "MD5", true);
 
         ConfigRepository configRepository = new MockConfigRepository();
         this.logManager = new LogManager(JavaConverters.asScalaIteratorConverter(files.iterator()).asScala().toSeq(),


### PR DESCRIPTION
TICKET = https://issues.apache.org/jira/browse/KAFKA-14213
LI_DESCRIPTION =
Please refer to the ticket for the motivation behind this change.
This PR tries to reduce the lock contention by moving the most time-consuming part of the `grabFilthiestCompactedLog` method out of the lock.
EXIT_CRITERIA = When the ticket is resolved and the fix is pulled from upstream kafka.