### PR TITLE
[LI-HOTFIX] Add API to support electing recommended leaders for partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1002,6 +1002,15 @@ public interface Admin extends AutoCloseable {
         ElectLeadersOptions options);
 
 
+    default ElectLeadersResult electRecommendedLeaders(
+        Map<TopicPartition, Integer> partitionsWithRecommendedLeaders) {
+        return electRecommendedLeaders(partitionsWithRecommendedLeaders, new ElectLeadersOptions());
+    }
+
+    ElectLeadersResult electRecommendedLeaders(
+        Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
+        ElectLeadersOptions options);
+
     /**
      * Change the reassignments for one or more partitions.
      * Providing an empty Optional (e.g via {@link Optional#empty()}) will <bold>revert</bold> the reassignment for the associated partition.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1007,6 +1007,37 @@ public interface Admin extends AutoCloseable {
         return electRecommendedLeaders(partitionsWithRecommendedLeaders, new ElectLeadersOptions());
     }
 
+    /**
+     * Switch the leadership of the given {@code partitions} to the corresponding recommending replicas.
+     * <p>
+     * This operation is not transactional, so it may succeed for some partitions while fail for others.
+     * <p>
+     * It may take several seconds after this method returns success for all the brokers in the cluster
+     * to become aware that the partitions have new leaders. During this time,
+     * {@link #describeTopics(Collection)} may not return information about the partitions'
+     * new leaders.
+     * <p>
+     * The following exceptions can be anticipated when calling {@code get()} on the future obtained
+     * from the returned {@link ElectLeadersResult}:
+     * <ul>
+     * <li>{@link org.apache.kafka.common.errors.ClusterAuthorizationException}
+     * if the authenticated user didn't have alter access to the cluster.</li>
+     * <li>{@link org.apache.kafka.common.errors.UnknownTopicOrPartitionException}
+     * if the topic or partition did not exist within the cluster.</li>
+     * <li>{@link org.apache.kafka.common.errors.InvalidTopicException}
+     * if the topic was already queued for deletion.</li>
+     * <li>{@link org.apache.kafka.common.errors.NotControllerException}
+     * if the request was sent to a broker that was not the controller for the cluster.</li>
+     * <li>{@link org.apache.kafka.common.errors.TimeoutException}
+     * if the request timed out before the election was complete.</li>
+     * <li>{@link org.apache.kafka.common.errors.LeaderNotAvailableException}
+     * if the preferred leader was not alive or not in the ISR.</li>
+     * </ul>
+     *
+     * @param partitionsWithRecommendedLeaders      The map from partitions to their corresponding recommended new leaders
+     * @param options                               The options to use when electing the leaders.
+     * @return The ElectLeadersResult.
+     */
     ElectLeadersResult electRecommendedLeaders(
         Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
         ElectLeadersOptions options);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3468,7 +3468,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             public ElectLeadersRequest.Builder createRequest(int timeoutMs) {
-                return new ElectLeadersRequest.Builder(electionType, topicPartitions, timeoutMs);
+                return new ElectLeadersRequest.Builder(electionType, topicPartitions, recommendedLeaders, timeoutMs);
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3439,9 +3439,27 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
+    public ElectLeadersResult electRecommendedLeaders(
+        Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
+        ElectLeadersOptions options) {
+        return electLeaders(ElectionType.RECOMMENDED, partitionsWithRecommendedLeaders.keySet(),
+            partitionsWithRecommendedLeaders, options);
+    }
+
+
+    @Override
     public ElectLeadersResult electLeaders(
             final ElectionType electionType,
             final Set<TopicPartition> topicPartitions,
+            ElectLeadersOptions options) {
+        return electLeaders(electionType, topicPartitions, Collections.<TopicPartition, Integer>emptyMap(), options);
+    }
+
+
+    private ElectLeadersResult electLeaders(
+            final ElectionType electionType,
+            final Set<TopicPartition> topicPartitions,
+            final Map<TopicPartition, Integer> recommendedLeaders,
             ElectLeadersOptions options) {
         final KafkaFutureImpl<Map<TopicPartition, Optional<Throwable>>> electionFuture = new KafkaFutureImpl<>();
         final long now = time.milliseconds();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
@@ -183,6 +183,13 @@ public class NoOpAdminClient extends AdminClient {
     }
 
     @Override
+    public ElectLeadersResult electRecommendedLeaders(
+        Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
+        ElectLeadersOptions options) {
+        return null;
+    }
+
+    @Override
     public AlterPartitionReassignmentsResult alterPartitionReassignments(
         Map<TopicPartition, Optional<NewPartitionReassignment>> reassignments,
         AlterPartitionReassignmentsOptions options) {

--- a/clients/src/main/java/org/apache/kafka/common/ElectionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/ElectionType.java
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 @InterfaceStability.Evolving
 public enum ElectionType {
-    PREFERRED((byte) 0), UNCLEAN((byte) 1);
+    PREFERRED((byte) 0), UNCLEAN((byte) 1), RECOMMENDED((byte) 2);
 
     public final byte value;
 
@@ -42,6 +42,8 @@ public enum ElectionType {
             return PREFERRED;
         } else if (value == UNCLEAN.value) {
             return UNCLEAN;
+        } else if (value == RECOMMENDED.value) {
+            return RECOMMENDED;
         } else {
             throw new IllegalArgumentException(
                     String.format("Value %s must be one of %s", value, Arrays.asList(ElectionType.values())));

--- a/clients/src/main/resources/common/message/ElectLeadersRequest.json
+++ b/clients/src/main/resources/common/message/ElectLeadersRequest.json
@@ -33,8 +33,15 @@
           "about": "The name of a topic." },
         { "name": "Partitions", "type": "[]int32", "versions": "0+",
           "about": "The partitions of this topic whose leader should be elected." },
-        { "name":  "RecommendedLeader", "type":  "int32", "versions":  "2+", "tag": 0, "taggedVersions": "2+",
-          "about":  "The recommended new leader for the partition"}
+        { "name":  "RecommendedPartitionLeaders", "type":  "[]RecommendedPartitionLeaderState", "versions":  "2+", "tag": 0, "taggedVersions": "2+",
+          "about":  "The recommended new leaders for partitions",
+          "fields": [
+            { "name": "PartitionIndex", "type": "int32", "versions": "2+",
+              "about": "The partition index." },
+            { "name": "RecommendedLeader", "type": "int32", "versions": "2+",
+              "about": "The recommended leader." }
+          ]
+        }
       ]
     },
     { "name": "TimeoutMs", "type": "int32", "versions": "0+", "default": "60000",

--- a/clients/src/main/resources/common/message/ElectLeadersRequest.json
+++ b/clients/src/main/resources/common/message/ElectLeadersRequest.json
@@ -32,7 +32,9 @@
         { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName", "mapKey": true,
           "about": "The name of a topic." },
         { "name": "Partitions", "type": "[]int32", "versions": "0+",
-          "about": "The partitions of this topic whose leader should be elected." }
+          "about": "The partitions of this topic whose leader should be elected." },
+        { "name":  "RecommendedLeader", "type":  "int32", "versions":  "2+", "tag": 0, "taggedVersions": "2+",
+          "about":  "The recommended new leader for the partition"}
       ]
     },
     { "name": "TimeoutMs", "type": "int32", "versions": "0+", "default": "60000",

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -535,6 +535,14 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    synchronized public ElectLeadersResult electRecommendedLeaders(
+        Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
+        ElectLeadersOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+
+    @Override
     synchronized public RemoveMembersFromConsumerGroupResult removeMembersFromConsumerGroup(String groupId, RemoveMembersFromConsumerGroupOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/core/src/main/scala/kafka/api/package.scala
+++ b/core/src/main/scala/kafka/api/package.scala
@@ -35,6 +35,19 @@ package object api {
       }
     }
 
+    def partitionRecommendedLeaders: Map[TopicPartition, Int] = {
+      if (self.data.topicPartitions == null) {
+        Map.empty
+      } else {
+        self.data.topicPartitions.asScala.iterator.flatMap { topicPartition =>
+          topicPartition.recommendedPartitionLeaders().asScala.map { recommendedPartitionLeaderState =>
+            new TopicPartition(topicPartition.topic, recommendedPartitionLeaderState.partitionIndex()) ->
+              recommendedPartitionLeaderState.recommendedLeader()
+          }
+        }.toMap
+      }
+    }
+
     def electionType: ElectionType = {
       if (self.version == 0) {
         ElectionType.PREFERRED

--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -103,6 +103,36 @@ object Election extends Logging {
     }
   }
 
+  private def leaderForRecommendation(partition: TopicPartition,
+    leaderAndIsr: LeaderAndIsr,
+    recommendedLeader: Option[Int],
+    controllerContext: ControllerContext): ElectionResult = {
+    val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
+    val assignment = controllerContext.partitionReplicaAssignment(partition)
+    val liveReplicas = assignment.filter(replica => controllerContextSnapshot.isReplicaOnline(replica, partition))
+    val isr = leaderAndIsr.isr
+    val leaderOpt = PartitionLeaderElectionAlgorithms.recommendedPartitionLeaderElection(recommendedLeader, isr, liveReplicas.toSet)
+    val newLeaderAndIsrOpt = leaderOpt.map(leader => leaderAndIsr.newLeader(leader))
+    ElectionResult(partition, newLeaderAndIsrOpt, liveReplicas)
+  }
+
+  /**
+   * Elect leaders for partitions that have a recommended leader.
+   *
+   * @param controllerContext Context with the current state of the cluster
+   * @param leaderAndIsrs A sequence of tuples representing the partitions that need election
+   *                                     and their respective leader/ISR states
+   * @param recommendedLeaders A map from each partition to its recommended leader
+   * @return The election results
+   */
+  def leaderForRecommendation(controllerContext: ControllerContext,
+    leaderAndIsrs: Seq[(TopicPartition, LeaderAndIsr)],
+    recommendedLeaders: Map[TopicPartition, Int]): Seq[ElectionResult] = {
+    leaderAndIsrs.map { case (partition, leaderAndIsr) =>
+      leaderForRecommendation(partition, leaderAndIsr, recommendedLeaders.get(partition), controllerContext)
+    }
+  }
+
   private def leaderForPreferredReplica(partition: TopicPartition,
                                         leaderAndIsr: LeaderAndIsr,
                                         controllerContext: ControllerContext): ElectionResult = {

--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -19,8 +19,7 @@ package kafka.controller
 import kafka.api.LeaderAndIsr
 import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
-
-import scala.collection.Seq
+import scala.collection.{Map, Seq}
 
 case class ElectionResult(topicPartition: TopicPartition, leaderAndIsr: Option[LeaderAndIsr], liveReplicas: Seq[Int])
 

--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -105,8 +105,8 @@ object Election extends Logging {
   private def leaderForRecommendation(partition: TopicPartition,
     leaderAndIsr: LeaderAndIsr,
     recommendedLeader: Option[Int],
-    controllerContext: ControllerContext): ElectionResult = {
-    val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
+    controllerContext: ControllerContext,
+    controllerContextSnapshot: ControllerContextSnapshot): ElectionResult = {
     val assignment = controllerContext.partitionReplicaAssignment(partition)
     val liveReplicas = assignment.filter(replica => controllerContextSnapshot.isReplicaOnline(replica, partition))
     val isr = leaderAndIsr.isr
@@ -127,8 +127,9 @@ object Election extends Logging {
   def leaderForRecommendation(controllerContext: ControllerContext,
     leaderAndIsrs: Seq[(TopicPartition, LeaderAndIsr)],
     recommendedLeaders: Map[TopicPartition, Int]): Seq[ElectionResult] = {
+    val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
     leaderAndIsrs.map { case (partition, leaderAndIsr) =>
-      leaderForRecommendation(partition, leaderAndIsr, recommendedLeaders.get(partition), controllerContext)
+      leaderForRecommendation(partition, leaderAndIsr, recommendedLeaders.get(partition), controllerContext, controllerContextSnapshot)
     }
   }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -367,7 +367,7 @@ class KafkaController(val config: KafkaConfig,
     initializePartitionReassignments()
     topicDeletionManager.tryTopicDeletion()
     val pendingPreferredReplicaElections = fetchPendingPreferredReplicaElections()
-    onReplicaElection(pendingPreferredReplicaElections, ElectionType.PREFERRED, ZkTriggered)
+    onReplicaElection(pendingPreferredReplicaElections, Map.empty, ElectionType.PREFERRED, ZkTriggered)
     info(s"Starting the controller scheduler ${KafkaController.timing(-1, failoverStartMs, time)}")
     kafkaScheduler.startup()
     if (config.autoLeaderRebalanceEnable) {
@@ -962,6 +962,7 @@ class KafkaController(val config: KafkaConfig,
     */
   private[this] def onReplicaElection(
     partitions: Set[TopicPartition],
+    partitionRecommendedLeaders: Map[TopicPartition, Int],
     electionType: ElectionType,
     electionTrigger: ElectionTrigger
   ): Map[TopicPartition, Either[Throwable, LeaderAndIsr]] = {
@@ -974,6 +975,10 @@ class KafkaController(val config: KafkaConfig,
            * triggered by the admin client
            */
           OfflinePartitionLeaderElectionStrategy(allowUnclean = electionTrigger == AdminClientTriggered)
+        case ElectionType.RECOMMENDED =>
+          val effectivePartitionsWithRecommendedLeaders = partitionRecommendedLeaders.filter{ case (tp, _) =>
+            partitions.contains(tp)}
+          RecommendedLeaderElectionStrategy(effectivePartitionsWithRecommendedLeaders)
       }
 
       val results = partitionStateMachine.handleStateChanges(
@@ -1434,7 +1439,7 @@ class KafkaController(val config: KafkaConfig,
     if (!isTriggeredByAutoRebalance) {
       zkClient.deletePreferredReplicaElection(controllerContext.epochZkVersion)
       // Ensure we detect future preferred replica leader elections
-      eventManager.put(ReplicaLeaderElection(None, ElectionType.PREFERRED, ZkTriggered))
+      eventManager.put(ReplicaLeaderElection(None, None, ElectionType.PREFERRED, ZkTriggered))
     }
   }
 
@@ -1534,7 +1539,7 @@ class KafkaController(val config: KafkaConfig,
           controllerContext.allTopics.contains(tp.topic) &&
           canPreferredReplicaBeLeader(tp, controllerContextSnapshot)
        )
-        onReplicaElection(candidatePartitions.toSet, ElectionType.PREFERRED, AutoTriggered)
+        onReplicaElection(candidatePartitions.toSet, Map.empty, ElectionType.PREFERRED, AutoTriggered)
       }
     }
   }
@@ -2579,10 +2584,11 @@ class KafkaController(val config: KafkaConfig,
 
   def electLeaders(
     partitions: Set[TopicPartition],
+    partitionRecommendedLeaders: Map[TopicPartition, Int],
     electionType: ElectionType,
     callback: ElectLeadersCallback
   ): Unit = {
-    eventManager.put(ReplicaLeaderElection(Some(partitions), electionType, AdminClientTriggered, callback))
+    eventManager.put(ReplicaLeaderElection(Some(partitions), Some(partitionRecommendedLeaders), electionType, AdminClientTriggered, callback))
   }
 
   def listPartitionReassignments(partitions: Option[Set[TopicPartition]],
@@ -2602,6 +2608,7 @@ class KafkaController(val config: KafkaConfig,
 
   private def processReplicaLeaderElection(
     partitionsFromAdminClientOpt: Option[Set[TopicPartition]],
+    partitionRecommendedLeadersFromAdminClientOpt: Option[Map[TopicPartition, Int]],
     electionType: ElectionType,
     electionTrigger: ElectionTrigger,
     callback: ElectLeadersCallback
@@ -2625,7 +2632,23 @@ class KafkaController(val config: KafkaConfig,
           info(s"Skipping replica leader election ($electionType) for partition $p by $electionTrigger since it doesn't exist.")
         }
 
-        val (partitionsBeingDeleted, livePartitions) = knownPartitions.partition(partition =>
+        val knownPartitionsWithValidRequest = if (electionType == ElectionType.RECOMMENDED) {
+          val (validPartitions, invalidPartitions) = partitionRecommendedLeadersFromAdminClientOpt match {
+            case Some(partitionRecommendedLeaders) => {
+              knownPartitions.partition(partitionRecommendedLeaders.contains(_))
+            }
+            case None => (Set.empty[TopicPartition], knownPartitions) // all known partitions are invalid
+          }
+          if (invalidPartitions.nonEmpty) {
+            warn(s"Skipping replica leader election ($electionType) for partitions $invalidPartitions " +
+              s"by $electionTrigger since there is no recommended leader")
+          }
+          validPartitions
+        } else {
+          knownPartitions
+        }
+
+        val (partitionsBeingDeleted, livePartitions) = knownPartitionsWithValidRequest.partition(partition =>
             topicDeletionManager.isTopicQueuedUpForDeletion(partition.topic))
         if (partitionsBeingDeleted.nonEmpty) {
           warn(s"Skipping replica leader election ($electionType) for partitions $partitionsBeingDeleted " +
@@ -2644,10 +2667,17 @@ class KafkaController(val config: KafkaConfig,
             case ElectionType.UNCLEAN =>
               val currentLeader = controllerContext.partitionLeadershipInfo(partition).get.leaderAndIsr.leader
               currentLeader == LeaderAndIsr.NoLeader || !controllerContext.liveBrokerIds.contains(currentLeader)
+            case ElectionType.RECOMMENDED =>
+              val currentLeader = controllerContext.partitionLeadershipInfo(partition).get.leaderAndIsr.leader
+              // Due to the checks for knownPartitionsWithValidRequest, we know for sure that there is a
+              // recommended leader for the partition in the partitionRecommendedLeadersFromAdminClientOpt argument
+              val recommendedLeader = partitionRecommendedLeadersFromAdminClientOpt.get.get(partition).get
+              currentLeader != recommendedLeader
           }
         }
 
-        val results = onReplicaElection(electablePartitions, electionType, electionTrigger).map {
+        val results = onReplicaElection(electablePartitions, partitionRecommendedLeadersFromAdminClientOpt.getOrElse(Map.empty),
+          electionType, electionTrigger).map {
           case (k, Left(ex)) =>
             if (ex.isInstanceOf[StateChangeFailedException]) {
               val error = if (electionType == ElectionType.PREFERRED) {
@@ -2960,8 +2990,8 @@ class KafkaController(val config: KafkaConfig,
           error("Received a ShutdownEventThread event. This type of event is supposed to be handle by ControllerEventThread")
         case AutoPreferredReplicaLeaderElection =>
           processAutoPreferredReplicaLeaderElection()
-        case ReplicaLeaderElection(partitions, electionType, electionTrigger, callback) =>
-          processReplicaLeaderElection(partitions, electionType, electionTrigger, callback)
+        case ReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback) =>
+          processReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback)
         case UncleanLeaderElectionEnable =>
           processUncleanLeaderElectionEnable()
         case TopicUncleanLeaderElectionEnable(topic) =>
@@ -3130,7 +3160,7 @@ object IsrChangeNotificationHandler {
 class PreferredReplicaElectionHandler(eventManager: ControllerEventManager) extends ZNodeChangeHandler {
   override val path: String = PreferredReplicaElectionZNode.path
 
-  override def handleCreation(): Unit = eventManager.put(ReplicaLeaderElection(None, ElectionType.PREFERRED, ZkTriggered))
+  override def handleCreation(): Unit = eventManager.put(ReplicaLeaderElection(None, None, ElectionType.PREFERRED, ZkTriggered))
 }
 
 class ControllerChangeHandler(eventManager: ControllerEventManager) extends ZNodeChangeHandler {
@@ -3328,6 +3358,7 @@ case class TopicDeletionFlagChange(reset: Boolean = false) extends ControllerEve
 
 case class ReplicaLeaderElection(
   partitionsFromAdminClientOpt: Option[Set[TopicPartition]],
+  partitionRecommendedLeadersFromAdminClientOpt: Option[Map[TopicPartition, Int]],
   electionType: ElectionType,
   electionTrigger: ElectionTrigger,
   callback: ElectLeadersCallback = _ => {}

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2632,20 +2632,18 @@ class KafkaController(val config: KafkaConfig,
           info(s"Skipping replica leader election ($electionType) for partition $p by $electionTrigger since it doesn't exist.")
         }
 
-        val knownPartitionsWithValidRequest = if (electionType == ElectionType.RECOMMENDED) {
-          val (validPartitions, invalidPartitions) = partitionRecommendedLeadersFromAdminClientOpt match {
-            case Some(partitionRecommendedLeaders) => {
-              knownPartitions.partition(partitionRecommendedLeaders.contains(_))
-            }
+        val (knownPartitionsWithValidRequest, knownPartitionsWithInvalidRequest) = if (electionType == ElectionType.RECOMMENDED) {
+          partitionRecommendedLeadersFromAdminClientOpt match {
+            case Some(partitionRecommendedLeaders) => knownPartitions.partition(partitionRecommendedLeaders.contains(_))
             case None => (Set.empty[TopicPartition], knownPartitions) // all known partitions are invalid
           }
-          if (invalidPartitions.nonEmpty) {
-            warn(s"Skipping replica leader election ($electionType) for partitions $invalidPartitions " +
-              s"by $electionTrigger since there is no recommended leader")
-          }
-          validPartitions
         } else {
-          knownPartitions
+          (knownPartitions, Set.empty)
+        }
+
+        if (knownPartitionsWithInvalidRequest.nonEmpty) {
+          warn(s"Skipping replica leader election ($electionType) for partitions $knownPartitionsWithInvalidRequest " +
+            s"by $electionTrigger since there is no recommended leader")
         }
 
         val (partitionsBeingDeleted, livePartitions) = knownPartitionsWithValidRequest.partition(partition =>
@@ -2694,6 +2692,9 @@ class KafkaController(val config: KafkaConfig,
         alreadyValidLeader.map(_ -> Left(new ApiError(Errors.ELECTION_NOT_NEEDED))) ++
         partitionsBeingDeleted.map(
           _ -> Left(new ApiError(Errors.INVALID_TOPIC_EXCEPTION, "The topic is being deleted"))
+        ) ++
+        knownPartitionsWithInvalidRequest.map(
+          _ -> Left(new ApiError(Errors.INVALID_REQUEST, "No recommended leader provided for the partition"))
         ) ++
         unknownPartitions.map(
           _ -> Left(new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, "The partition does not exist."))

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -419,6 +419,8 @@ class ZkPartitionStateMachine(config: KafkaConfig,
         leaderForPreferredReplica(controllerContext, validLeaderAndIsrs).partition(_.leaderAndIsr.isEmpty)
       case ControlledShutdownPartitionLeaderElectionStrategy =>
         leaderForControlledShutdown(controllerContext, validLeaderAndIsrs).partition(_.leaderAndIsr.isEmpty)
+      case RecommendedLeaderElectionStrategy(recommendedLeaders) =>
+        leaderForRecommendation(controllerContext, validLeaderAndIsrs, recommendedLeaders).partition(_.leaderAndIsr.isEmpty)
     }
     partitionsWithoutLeaders.foreach { electionResult =>
       val partition = electionResult.topicPartition

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -540,6 +540,10 @@ object PartitionLeaderElectionAlgorithms {
     reassignment.find(id => liveReplicas.contains(id) && isr.contains(id))
   }
 
+  def recommendedPartitionLeaderElection(recommendedLeader: Option[Int], isr: Seq[Int], liveReplicas: Set[Int]): Option[Int] = {
+    recommendedLeader.find(id => liveReplicas.contains(id) && isr.contains(id))
+  }
+
   def preferredReplicaPartitionLeaderElection(assignment: Seq[Int], isr: Seq[Int], liveReplicas: Set[Int]): Option[Int] = {
     assignment.headOption.filter(id => liveReplicas.contains(id) && isr.contains(id))
   }
@@ -554,6 +558,7 @@ final case class OfflinePartitionLeaderElectionStrategy(allowUnclean: Boolean) e
 final case object ReassignPartitionLeaderElectionStrategy extends PartitionLeaderElectionStrategy
 final case object PreferredReplicaPartitionLeaderElectionStrategy extends PartitionLeaderElectionStrategy
 final case object ControlledShutdownPartitionLeaderElectionStrategy extends PartitionLeaderElectionStrategy
+final case class RecommendedLeaderElectionStrategy(recommendedLeaders: Map[TopicPartition, Int]) extends PartitionLeaderElectionStrategy
 
 sealed trait PartitionState {
   def state: Byte

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3098,6 +3098,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       replicaManager.electLeaders(
         zkSupport.controller,
         partitions,
+        electionRequest.partitionRecommendedLeaders,
         electionRequest.electionType,
         sendResponseCallback(ApiError.NONE),
         electionRequest.data.timeoutMs

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2220,6 +2220,7 @@ class ReplicaManager(val config: KafkaConfig,
   def electLeaders(
     controller: KafkaController,
     partitions: Set[TopicPartition],
+    partitionRecommendedLeaders: Map[TopicPartition, Int],
     electionType: ElectionType,
     responseCallback: Map[TopicPartition, ApiError] => Unit,
     requestTimeout: Int
@@ -2255,7 +2256,7 @@ class ReplicaManager(val config: KafkaConfig,
       }
     }
 
-    controller.electLeaders(partitions, electionType, electionCallback)
+    controller.electLeaders(partitions, partitionRecommendedLeaders, electionType, electionCallback)
   }
 
   def activeProducerState(requestPartition: TopicPartition): DescribeProducersResponseData.PartitionResponse = {

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1051,7 +1051,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     val tp0 = new TopicPartition("t", 0)
     val tp1 = new TopicPartition("t", 1)
     val partitions = Set(tp0, tp1)
-    val event1 = ReplicaLeaderElection(Some(partitions), ElectionType.PREFERRED, ZkTriggered, partitionsMap => {
+    val event1 = ReplicaLeaderElection(Some(partitions), Some(Map.empty), ElectionType.PREFERRED, ZkTriggered, partitionsMap => {
       for (partition <- partitionsMap) {
         partition._2 match {
           case Left(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())

--- a/core/src/test/scala/unit/kafka/controller/MockPartitionStateMachine.scala
+++ b/core/src/test/scala/unit/kafka/controller/MockPartitionStateMachine.scala
@@ -108,6 +108,8 @@ class MockPartitionStateMachine(controllerContext: ControllerContext,
         leaderForPreferredReplica(controllerContext, validLeaderAndIsrs)
       case ControlledShutdownPartitionLeaderElectionStrategy =>
         leaderForControlledShutdown(controllerContext, validLeaderAndIsrs)
+      case RecommendedLeaderElectionStrategy(recommendedLeaders) =>
+        leaderForRecommendation(controllerContext, validLeaderAndIsrs, recommendedLeaders)
     }
 
     val results: Map[TopicPartition, Either[Exception, LeaderAndIsr]] = electionResults.map { electionResult =>

--- a/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
@@ -37,7 +37,6 @@ class RecommendedLeaderElectionTest extends KafkaServerTestHarness {
     val tp = new TopicPartition(topic, 0)
     createTopic(topic, 1, 2)
 
-    // val allBrokerIds = Set(0, 1)
     val currentLeader = zkClient.getTopicPartitionState(tp).get.leaderAndIsr.leader
     val currentFollower = if (currentLeader == 0) {
       1
@@ -46,7 +45,7 @@ class RecommendedLeaderElectionTest extends KafkaServerTestHarness {
     }
     val newLeader = currentFollower
 
-    // create admin client
+    // elect the recommended leader for the partition
     val adminClient = createAdminClient()
     val partitionWithRecommendedLeaders = new util.HashMap[TopicPartition, Integer]()
     partitionWithRecommendedLeaders.put(tp, newLeader)

--- a/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
@@ -32,7 +32,7 @@ class RecommendedLeaderElectionTest extends KafkaServerTestHarness {
   override def generateConfigs: Seq[KafkaConfig] = TestUtils.createBrokerConfigs(numNodes, zkConnect).map(KafkaConfig.fromProps(_, overridingProps))
 
   @Test
-  def testRecommendedLeaderElection: Unit = {
+  def testRecommendedLeaderElection(): Unit = {
     val topic = "test"
     val tp = new TopicPartition(topic, 0)
     createTopic(topic, 1, 2 )

--- a/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
@@ -35,7 +35,7 @@ class RecommendedLeaderElectionTest extends KafkaServerTestHarness {
   def testRecommendedLeaderElection(): Unit = {
     val topic = "test"
     val tp = new TopicPartition(topic, 0)
-    createTopic(topic, 1, 2 )
+    createTopic(topic, 1, 2)
 
     // val allBrokerIds = Set(0, 1)
     val currentLeader = zkClient.getTopicPartitionState(tp).get.leaderAndIsr.leader
@@ -61,7 +61,14 @@ class RecommendedLeaderElectionTest extends KafkaServerTestHarness {
 
   @Test
   def testRecommendedLeaderElectionWithoutLeaderInRequest(): Unit = {
+    val topic = "test"
+    createTopic(topic, 1, 2)
 
+    val adminClient = createAdminClient()
+    val partitionWithRecommendedLeaders = new util.HashMap[TopicPartition, Integer]()
+    // elect with empty map should result in no exceptions
+    adminClient.electRecommendedLeaders(partitionWithRecommendedLeaders).all().get()
+    adminClient.close()
   }
 
   def createAdminClient(props: Properties = new Properties): Admin = {

--- a/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
@@ -44,14 +44,24 @@ class RecommendedLeaderElectionTest extends KafkaServerTestHarness {
     } else {
       0
     }
-
     val newLeader = currentFollower
 
     // create admin client
     val adminClient = createAdminClient()
     val partitionWithRecommendedLeaders = new util.HashMap[TopicPartition, Integer]()
     partitionWithRecommendedLeaders.put(tp, newLeader)
-    adminClient.electRecommendedLeaders(partitionWithRecommendedLeaders).all().get();
+    adminClient.electRecommendedLeaders(partitionWithRecommendedLeaders).all().get()
+    adminClient.close()
+
+    // wait until the leader has changed to the recommended one
+    TestUtils.waitUntilTrue(() => {
+      zkClient.getTopicPartitionState(tp).get.leaderAndIsr.leader == newLeader
+    }, s"The leader cannot be changed to the recommended one $newLeader")
+  }
+
+  @Test
+  def testRecommendedLeaderElectionWithoutLeaderInRequest(): Unit = {
+
   }
 
   def createAdminClient(props: Properties = new Properties): Admin = {

--- a/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RecommendedLeaderElectionTest.scala
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.integration.KafkaServerTestHarness
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.Test
+
+import java.util
+import java.util.Properties
+
+class RecommendedLeaderElectionTest extends KafkaServerTestHarness {
+  val numNodes = 2
+  val overridingProps = new Properties
+  override def generateConfigs: Seq[KafkaConfig] = TestUtils.createBrokerConfigs(numNodes, zkConnect).map(KafkaConfig.fromProps(_, overridingProps))
+
+  @Test
+  def testRecommendedLeaderElection: Unit = {
+    val topic = "test"
+    val tp = new TopicPartition(topic, 0)
+    createTopic(topic, 1, 2 )
+
+    // val allBrokerIds = Set(0, 1)
+    val currentLeader = zkClient.getTopicPartitionState(tp).get.leaderAndIsr.leader
+    val currentFollower = if (currentLeader == 0) {
+      1
+    } else {
+      0
+    }
+
+    val newLeader = currentFollower
+
+    // create admin client
+    val adminClient = createAdminClient()
+    val partitionWithRecommendedLeaders = new util.HashMap[TopicPartition, Integer]()
+    partitionWithRecommendedLeaders.put(tp, newLeader)
+    adminClient.electRecommendedLeaders(partitionWithRecommendedLeaders).all().get();
+  }
+
+  def createAdminClient(props: Properties = new Properties): Admin = {
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    Admin.create(props)
+  }
+}


### PR DESCRIPTION
TICKET = LIKAFKA-45529
LI_DESCRIPTION =
Sometimes, a leader host can become too busy to serve Fetch requests from followers within the default request timeout of 10s. The impact is that all followers experience the timeout and fall out of the ISR, resulting in UnderMinISR partitions.

A proposed solution to this problem is to let the leader host request a leadership switch for the affected partitions.
The leader host already knows what followers have been in the ISR, and thus can recommend a new leader to the controller.
This PR is the 1st step toward that goal by adding a new API to support electing recommended leaders for partitions. 
Specifically, the PR includes the following changes
- adding support in the controller for electing the recommended leaders. The recommended leader must be alive and already in the ISR;
- changing the ElectLeadersRequest.json to add a new optional field that indicates the recommended leaders;
- exposing a new API in the KafkaAdminClient. 

EXIT_CRITERIA = We will likely propose this change as a KIP in upstream Kafka. Thus this hotfix can exit when the change is merged upstream and pulled in as part of a major release.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
