### PR TITLE
[LI-HOTFIX] Change throttle request log to debug level from info level

### DIFF
--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -317,7 +317,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     } catch {
       case e: QuotaViolationException =>
         val throttleTimeMs = throttleTime(e, timeMs).toInt
-        info(s"Quota violated for sensor (${clientSensors.quotaSensor.name}). Delay time: ($throttleTimeMs)")
+        debug(s"Quota violated for sensor (${clientSensors.quotaSensor.name}). Delay time: ($throttleTimeMs)")
         throttleTimeMs
     }
   }


### PR DESCRIPTION

    TICKET = N/A
    LI_DESCRIPTION =
    This PR is to change throttle log to debug level from info level to prevent the possibility of generating huge log files and risking disk space. Currently, each throttled request is logged. Considering that the request rate could be as high as 1M/s, it could lead to huge log files if we log each throttle instance. As an example, in one of our hosts, it happened recently that there were ~6M requests throttled in about 5min, which lead to a log file of size ~1.2 GB (unzipped, after zip is ~10 MB). It is possible that the throttle events happen for even longer period and at a higher rate, which would lead to larger log files. This also has performance impact for writing such big log file to disk. On the other hand, the throttle instance could be alternatively checked in the throttle-count metric. Therefore, this PR changes the log level to debug for throttle log.

    
    EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
