### PR TITLE
[LI-HOTFIX]  Support dropping corrupted leader-epoch-checkpoint files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -294,7 +294,7 @@ subprojects {
   def shouldUseJUnit5 = !(["runtime", "streams"].contains(it.project.name))
 
   def testLoggingEvents = ["passed", "skipped", "failed"]
-  def testShowStandardStreams = false
+  def testShowStandardStreams = true
   def testExceptionFormat = 'full'
   // Gradle built-in logging only supports sending test output to stdout, which generates a lot
   // of noise, especially for passing tests. We really only want output for failed tests. This
@@ -386,6 +386,7 @@ subprojects {
   }
 
   test {
+    outputs.upToDateWhen { false }
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
     ignoreFailures = userIgnoreFailures
 

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -199,15 +199,15 @@ public class TestUtils {
         } catch (final IOException ex) {
             throw new RuntimeException("Failed to create a temp dir", ex);
         }
-        file.deleteOnExit();
+        // file.deleteOnExit();
 
-        Exit.addShutdownHook("delete-temp-file-shutdown-hook", () -> {
-            try {
-                Utils.delete(file);
-            } catch (IOException e) {
-                log.error("Error deleting {}", file.getAbsolutePath(), e);
-            }
-        });
+//        Exit.addShutdownHook("delete-temp-file-shutdown-hook", () -> {
+//            try {
+//                Utils.delete(file);
+//            } catch (IOException e) {
+//                log.error("Error deleting {}", file.getAbsolutePath(), e);
+//            }
+//        });
 
         return file;
     }

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -227,7 +227,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
         if (uninitializedPartitions.nonEmpty) {
           val successfulInitializations = initializeLeaderAndIsrForPartitions(uninitializedPartitions)
           successfulInitializations.foreach { partition =>
-            stateChangeLog.info(s"Changed partition $partition from ${partitionState(partition)} to $targetState with state " +
+            stateChangeLog.info(s"LLWW0 Changed partition $partition from ${partitionState(partition)} to $targetState with state " +
               s"${controllerContext.partitionLeadershipInfo(partition).get.leaderAndIsr}")
             controllerContext.putPartitionState(partition, OnlinePartition)
           }
@@ -256,7 +256,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
       case OfflinePartition | NonExistentPartition =>
         validPartitions.foreach { partition =>
           if (traceEnabled)
-            stateChangeLog.trace(s"Changed partition $partition state from ${partitionState(partition)} to $targetState")
+            stateChangeLog.trace(s"LLWW0 Changed partition $partition state from ${partitionState(partition)} to $targetState")
           controllerContext.putPartitionState(partition, targetState)
         }
         Map.empty

--- a/core/src/main/scala/kafka/server/GlobalConfig.scala
+++ b/core/src/main/scala/kafka/server/GlobalConfig.scala
@@ -1,0 +1,6 @@
+package kafka.server
+
+object GlobalConfig {
+  // a global flag to indicate whether the corrupted files should be dropped
+  var liDropCorruptedFilesEnable = false
+}

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -326,6 +326,7 @@ object Defaults {
   val LiAsyncFetcherEnabled = false
   val LiNumControllerInitThreads = 1
   val LiLogCleanerFineGrainedLockEnabled = true
+  val LiDropCorruptedFilesEnabled = false
 }
 
 object KafkaConfig {
@@ -441,6 +442,7 @@ object KafkaConfig {
   val LiAlterIsrEnableProp = "li.alter.isr.enable"
   val LiNumControllerInitThreadsProp = "li.num.controller.init.threads"
   val LiLogCleanerFineGrainedLockEnableProp = "li.log.cleaner.fine.grained.lock.enable"
+  val LiDropCorruptedFilesEnableProp = "li.drop.corrupted.files.enable"
   val AllowPreferredControllerFallbackProp = "allow.preferred.controller.fallback"
   val UnofficialClientLoggingEnableProp = "unofficial.client.logging.enable"
   val UnofficialClientCacheTtlProp = "unofficial.client.cache.ttl"
@@ -775,6 +777,7 @@ object KafkaConfig {
   val PreferredControllerDoc = "Specifies whether the broker is a dedicated controller node. If set to true, the broker is a preferred controller node."
   val LiAsyncFetcherEnableDoc = "Specifies whether the event-based async fetcher should be used."
   val LiCombinedControlRequestEnableDoc = "Specifies whether the controller should use the LiCombinedControlRequest."
+  val LiDropCorruptedFilesEnableDoc = "Specifies whether the broker should delete corrupted files during startup."
   val LiAlterIsrEnabledDoc = "Specifies whether the brokers should use the AlterISR request to propagate ISR changes to the controller. If set to false, brokers will propagate the updates via Zookeeper."
   val LiNumControllerInitThreadsDoc = "Number of threads (and Zookeeper clients + connections) to be used while recursing the topic-partitions tree in Zookeeper during controller startup/failover."
   val LiLogCleanerFineGrainedLockEnableDoc = "Specifies whether the log cleaner should use fine grained locks when calculating the filthiest log to clean"
@@ -1218,6 +1221,7 @@ object KafkaConfig {
       .define(LiAlterIsrEnableProp, BOOLEAN, Defaults.LiAlterIsrEnabled, HIGH, LiAlterIsrEnabledDoc)
       .define(LiNumControllerInitThreadsProp, INT, Defaults.LiNumControllerInitThreads, atLeast(1), LOW, LiNumControllerInitThreadsDoc)
       .define(LiLogCleanerFineGrainedLockEnableProp, BOOLEAN, Defaults.LiLogCleanerFineGrainedLockEnabled, LOW, LiLogCleanerFineGrainedLockEnableDoc)
+      .define(LiDropCorruptedFilesEnableProp, BOOLEAN, Defaults.LiDropCorruptedFilesEnabled, HIGH, LiDropCorruptedFilesEnableDoc)
       .define(AllowPreferredControllerFallbackProp, BOOLEAN, Defaults.AllowPreferredControllerFallback, HIGH, AllowPreferredControllerFallbackDoc)
       .define(UnofficialClientLoggingEnableProp, BOOLEAN, Defaults.UnofficialClientLoggingEnable, LOW, UnofficialClientLoggingEnableDoc)
       .define(UnofficialClientCacheTtlProp, LONG, Defaults.UnofficialClientCacheTtl, LOW, UnofficialClientCacheTtlDoc)
@@ -1728,6 +1732,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   def liAlterIsrEnable = getBoolean(KafkaConfig.LiAlterIsrEnableProp)
   def liNumControllerInitThreads = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
   def liLogCleanerFineGrainedLockEnable = getBoolean(KafkaConfig.LiLogCleanerFineGrainedLockEnableProp)
+  val liDropCorruptedFilesEnable = getBoolean(KafkaConfig.LiDropCorruptedFilesEnableProp)
 
   def unofficialClientLoggingEnable = getBoolean(KafkaConfig.UnofficialClientLoggingEnableProp)
   def unofficialClientCacheTtl = getLong(KafkaConfig.UnofficialClientCacheTtlProp)

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -50,6 +50,8 @@ class KafkaRaftServer(
 
   KafkaMetricsReporter.startReporters(VerifiableProperties(config.originals))
   KafkaYammerMetrics.INSTANCE.configure(config.originals)
+  // populate the global flag
+  GlobalConfig.liDropCorruptedFilesEnable = config.liDropCorruptedFilesEnable
 
   private val (metaProps, offlineDirs) = KafkaRaftServer.initializeLogDirs(config)
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -185,6 +185,9 @@ class KafkaServer(
 
   @volatile private var poisonPill: PoisonPill = null
 
+  // populate the global flag
+  GlobalConfig.liDropCorruptedFilesEnable = config.liDropCorruptedFilesEnable
+
   private def haltIfNotHealthy(): Unit = {
     // This relies on io-thread to receive request from RequestChannel with 300 ms timeout, so that lastDequeueTimeMs
     // will keep increasing even if there is no incoming request

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1480,7 +1480,7 @@ class ReplicaManager(val config: KafkaConfig,
         s"$controllerId for ${requestPartitionStates.size} partitions")
       if (stateChangeLogger.isTraceEnabled)
         requestPartitionStates.foreach { partitionState =>
-          stateChangeLogger.trace(s"Received LeaderAndIsr request $partitionState " +
+          stateChangeLogger.trace(s"LLWW0 Received LeaderAndIsr request $partitionState " +
             s"correlation id $correlationId from controller $controllerId " +
             s"epoch ${leaderAndIsrRequest.controllerEpoch}")
         }

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
@@ -18,12 +18,13 @@ package kafka.server.checkpoints
 
 import java.io._
 import java.nio.charset.StandardCharsets
-import java.nio.file.{FileAlreadyExistsException, Files, Paths}
+import java.nio.file.{FileAlreadyExistsException, Files, Paths, StandardOpenOption}
 import kafka.server.{GlobalConfig, LogDirFailureChannel}
-import kafka.utils.Logging
+import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.errors.KafkaStorageException
 import org.apache.kafka.common.utils.Utils
 
+import java.nio.channels.FileChannel
 import scala.collection.{Seq, mutable}
 
 trait CheckpointFileFormatter[T]{
@@ -75,8 +76,8 @@ class CheckpointReadBuffer[T](location: String,
 
   private def maybeThrowException(e: Exception): Seq[T] = {
     if (GlobalConfig.liDropCorruptedFilesEnable) {
-      // delete the file and return an empty sequence
-      Files.deleteIfExists(new File(location).toPath)
+      // clear contents of the file and return an empty sequence
+      CoreUtils.truncateToZero(location)
       Seq.empty[T]
     } else {
       throw e

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
@@ -18,13 +18,12 @@ package kafka.server.checkpoints
 
 import java.io._
 import java.nio.charset.StandardCharsets
-import java.nio.file.{FileAlreadyExistsException, Files, Paths, StandardOpenOption}
+import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import kafka.server.{GlobalConfig, LogDirFailureChannel}
 import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.errors.KafkaStorageException
 import org.apache.kafka.common.utils.Utils
 
-import java.nio.channels.FileChannel
 import scala.collection.{Seq, mutable}
 
 trait CheckpointFileFormatter[T]{

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
@@ -19,8 +19,7 @@ package kafka.server.checkpoints
 import java.io._
 import java.nio.charset.StandardCharsets
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
-
-import kafka.server.LogDirFailureChannel
+import kafka.server.{GlobalConfig, LogDirFailureChannel}
 import kafka.utils.Logging
 import org.apache.kafka.common.errors.KafkaStorageException
 import org.apache.kafka.common.utils.Utils
@@ -60,17 +59,27 @@ class CheckpointReadBuffer[T](location: String,
               case Some(e) =>
                 entries += e
                 line = reader.readLine()
-              case _ => throw malformedLineException(line)
+              case _ => return maybeThrowException(malformedLineException(line))
             }
           }
           if (entries.size != expectedSize)
-            throw new IOException(s"Expected $expectedSize entries in checkpoint file ($location), but found only ${entries.size}")
+            return maybeThrowException(new IOException(s"Expected $expectedSize entries in checkpoint file ($location), but found only ${entries.size}"))
           entries
         case _ =>
-          throw new IOException(s"Unrecognized version of the checkpoint file ($location): " + version)
+          maybeThrowException(new IOException(s"Unrecognized version of the checkpoint file ($location): " + line))
       }
     } catch {
-      case _: NumberFormatException => throw malformedLineException(line)
+      case _: NumberFormatException => maybeThrowException(malformedLineException(line))
+    }
+  }
+
+  private def maybeThrowException(e: Exception): Seq[T] = {
+    if (GlobalConfig.liDropCorruptedFilesEnable) {
+      // delete the file and return an empty sequence
+      Files.deleteIfExists(new File(location).toPath)
+      Seq.empty[T]
+    } else {
+      throw e
     }
   }
 }

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Utils
 import org.slf4j.event.Level
 
+import java.nio.file.{Files, Paths}
 import java.util.concurrent.TimeUnit
 import scala.annotation.nowarn
 
@@ -83,6 +84,12 @@ object CoreUtils {
    * @param files sequence of files to be deleted
    */
   def delete(files: Seq[String]): Unit = files.foreach(f => Utils.delete(new File(f)))
+
+  /**
+   * Clear the content of a file by truncating its size to 0
+   * @param file the file to be truncated
+   */
+  def truncateToZero(file: String): Unit = Files.deleteIfExists(Paths.get(file))
 
   /**
    * Invokes every function in `all` even if one or more functions throws an exception.

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -20,7 +20,9 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.kafka=WARN
 log4j.logger.org.apache.kafka=WARN
-
+log4j.logger.integration.kafka.api=WARN
 
 # zkclient can be verbose, during debugging it is common to adjust it separately
 log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.state.change.logger=TRACE
+log4j.logger.kafka.controller=INFO

--- a/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
@@ -1,0 +1,73 @@
+package integration.kafka.api
+
+import kafka.api.IntegrationTestHarness
+import kafka.utils.{Exit, TestUtils}
+import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.TopicConfig
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets
+import java.util.{Collections, Properties}
+
+class DropCorruptedFilesTest extends IntegrationTestHarness {
+  override protected def brokerCount: Int = 2
+
+  @Test
+  def testCorruptedLeaderEpochCheckpointOnLeader(): Unit = {
+    try {
+      val topic = "test"
+      val partition = 0
+      val tp = new TopicPartition(topic, partition)
+      val topicProps = new Properties()
+      topicProps.put(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+      createTopic(topic, 1, 2, topicProps)
+      val adminClient = createAdminClient()
+      val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
+      val leader = topicDescMap.get(topic).partitions().get(0).leader().id()
+      val follower = if (leader == 0) 1 else 0
+      // shutdown the follower
+      val leaderBroker = servers.find(_.config.brokerId == leader).get
+      val followerBroker = servers.find(_.config.brokerId == follower).get
+
+      val producerConfigs = new Properties()
+      producerConfigs.put(ProducerConfig.ACKS_CONFIG, "-1")
+
+      val producer = createProducer()
+      // send a normal record
+      val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
+        "value".getBytes(StandardCharsets.UTF_8))
+      producer.send(record).get
+      // wait until all servers get the message
+      TestUtils.waitUntilTrue(() => {
+        servers.forall{s => s.replicaManager.getLog(tp).get.logEndOffset == 1}
+      }, "some brokers cannot get the message")
+
+      // shutdown the follower
+      followerBroker.shutdown()
+      // produce the 2nd message
+      producer.send(record).get
+      
+
+      // shutdown the leader and startup the follower
+      leaderBroker.shutdown()
+      followerBroker.startup()
+      // produce the record in epoch 2
+      producer.send(record).get()
+
+    } catch {
+      case e: Exception => warn("got exception ", e)
+    } finally {
+      // for now avoid the shutting down phase to reduce noise
+      Exit.exit(0)
+    }
+
+
+    // shutdown the leader broker and corrupt its leader-epoch-checkpoint file
+
+
+
+  }
+
+
+}

--- a/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
@@ -1,46 +1,133 @@
 package integration.kafka.api
 
 import kafka.api.IntegrationTestHarness
+import kafka.server.{KafkaConfig, KafkaServer}
+import kafka.utils.Implicits.PropertiesOps
 import kafka.utils.{Exit, TestUtils}
-import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig}
+import org.apache.kafka.clients.producer.{KafkaProducer, Producer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
+import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.serialization.{ByteArraySerializer, Serializer}
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 import java.nio.charset.StandardCharsets
 import java.util.{Collections, Properties}
+import scala.collection.{Map, Seq}
 
-class DropCorruptedFilesTest extends IntegrationTestHarness {
-  override protected def brokerCount: Int = 2
-
+class DropCorruptedFilesTest extends ZooKeeperTestHarness {
   @Test
   def testCorruptedLeaderEpochCheckpointOnLeader(): Unit = {
     try {
+
+      // create brokers
+      val serverConfigs = TestUtils.createBrokerConfigs(3, zkConnect, false)
+        .map(KafkaConfig.fromProps)
+      // start servers in reverse order to ensure broker 2 becomes the controller
+      val servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+      val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+      assertTrue(controllerId == 2)
+
+      // create the topic with min ISR of 2, which should allow one broker to shut down but should block subsequent
+      // shutdowns.
       val topic = "test"
       val partition = 0
       val tp = new TopicPartition(topic, partition)
-      val topicProps = new Properties()
-      topicProps.put(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
-      createTopic(topic, 1, 2, topicProps)
-      val adminClient = createAdminClient()
+      val topicConfig = new Properties()
+      topicConfig.put(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+      val expectedReplicaAssignment = Map(0  -> List(0, 1))
+      TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+
+
+
+      val adminClient = createAdminClient(servers)
       val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
       val leader = topicDescMap.get(topic).partitions().get(0).leader().id()
-      val follower = if (leader == 0) 1 else 0
+      assertTrue(leader == 0)
+      val follower = 1
 
-      warn(s"LLWW0 leader: $leader")
-      warn(s"LLWW0 follower: $follower")
       val orderedBrokers = Seq(leader, follower).map {brokerId =>
         servers.find(_.config.brokerId == brokerId).get
       }
+      val leaderBroker = orderedBrokers(0)
+      val followerBroker = orderedBrokers(1)
 
-      val orderedLogs = orderedBrokers.map{broker => broker.logManager.getLog(tp).get}
-      val leaderLog = orderedLogs(0)
-      val followerLog = orderedLogs(1)
+      val producerConfigs = new Properties()
+      producerConfigs.put(ProducerConfig.ACKS_CONFIG, "-1")
+      val producer = createProducer(servers)
+      // send a normal record to epoch 0
+      val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
+        "value".getBytes(StandardCharsets.UTF_8))
+      val recordMetadata0 = producer.send(record).get
+      warn("LLWW0 0th message produced at offset "+ recordMetadata0.offset())
+      // wait until all servers get the message
+      // wait until truncation of the message in epoch 1 on the follower
+      TestUtils.waitUntilTrue(() => {
+        followerBroker.replicaManager.getLog(tp).get.logEndOffset == 1
+      }, "some brokers cannot get the message")
 
-      // shutdown the servers before appending messages
-      servers.foreach(_.shutdown())
+      // shutdown the follower
+      followerBroker.shutdown()
+      // check that the partition has become offline
+      // produce the 2nd message and make sure the leader gets it
+      val recordMetadata1 = producer.send(record).get
+      warn("LLWW0 1th message produced at offset "+ recordMetadata1.offset())
+
+      // shutdown the leader and startup the follower
+      leaderBroker.shutdown()
+      warn("LLWW0 leader shutdown complete")
+      followerBroker.startup()
+      warn("LLWW0 follower startup complete")
+
+
+      TestUtils.waitUntilTrue(() => {
+        val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
+        val currentLeader = topicDescMap.get(topic).partitions().get(0).leader()
+        currentLeader == follower
+      }, "LLWW0 the leadership cannot be transferred to the follower")
+      // produce the record in epoch 1
+      val recordMetadata2 = producer.send(record).get()
+      warn("LLWW0 2nd message produced at offset "+ recordMetadata2.offset())
+
+      adminClient.close()
+      producer.close()
+    } catch {
+      case e: Exception => warn("LLWW0 got exception ", e)
+    } finally {
+      // for now avoid the shutting down phase to reduce noise
+      Exit.exit(0)
+    }
+
+
+    // shutdown the leader broker and corrupt its leader-epoch-checkpoint file
+  }
+
+  private def createAdminClient(servers: Seq[KafkaServer]): Admin = {
+    val config = new Properties
+    val bootstrapServers = TestUtils.bootstrapServers(servers, new ListenerName("PLAINTEXT"))
+    config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    config.put(AdminClientConfig.METADATA_MAX_AGE_CONFIG, "10")
+    AdminClient.create(config)
+  }
+  def createProducer[K, V](servers: Seq[KafkaServer],
+    keySerializer: Serializer[K] = new ByteArraySerializer,
+    valueSerializer: Serializer[V] = new ByteArraySerializer,
+    configOverrides: Properties = new Properties): KafkaProducer[K, V] = {
+    val props = new Properties
+    val bootstrapServers = TestUtils.bootstrapServers(servers, new ListenerName("PLAINTEXT"))
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    props ++= configOverrides
+    val producer = new KafkaProducer[K, V](props, keySerializer, valueSerializer)
+    producer
+  }
+
+  def anotherFunc() : Unit = {
+    /*
+    servers.foreach(_.shutdown())
       warn("LLWW0 all servers have been shutdown")
 
       // the offset of the records gets changed, so we cannot reuse the same records object on mulitple appends
@@ -62,8 +149,7 @@ class DropCorruptedFilesTest extends IntegrationTestHarness {
       warn("LLWW0 all brokers have 2 messages now")
 
       // start the leader host first so that it's still the leader
-      val leaderBroker = orderedBrokers(0)
-      val followerBroker = orderedBrokers(1)
+
       leaderBroker.startup()
       warn("LLWW0 leader broker has been restarted")
       followerBroker.startup()
@@ -75,53 +161,7 @@ class DropCorruptedFilesTest extends IntegrationTestHarness {
       }, "some brokers cannot get the message")
       warn("LLWW0 message in epoch 1 on the followir has been truncated")
       adminClient.close()
-      /*
-      val producerConfigs = new Properties()
-      producerConfigs.put(ProducerConfig.ACKS_CONFIG, "-1")
-      val producer = createProducer()
-      // send a normal record to epoch 0
-      val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
-        "value".getBytes(StandardCharsets.UTF_8))
-      val recordMetadata0 = producer.send(record).get
-      warn("LLWW0 0th message produced at offset "+ recordMetadata0.offset())
-      // wait until all servers get the message
-
-
-      // shutdown the follower
-      followerBroker.shutdown()
-      // produce the 2nd message and make sure the leader gets it
-      val recordMetadata1 = producer.send(record).get
-      warn("LLWW0 1th message produced at offset "+ recordMetadata1.offset())
-
-      // shutdown the leader and startup the follower
-      leaderBroker.shutdown()
-      warn("LLWW0 leader shutdown complete")
-      followerBroker.startup()
-      warn("LLWW0 follower startup complete")
-      TestUtils.waitUntilTrue(() => {
-        val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
-        val currentLeader = topicDescMap.get(topic).partitions().get(0).leader()
-        currentLeader == follower
-      }, "LLWW0 the leadership cannot be transferred to the follower")
-      // produce the record in epoch 1
-      val recordMetadata2 = producer.send(record).get()
-      warn("LLWW0 2nd message produced at offset "+ recordMetadata2.offset())
-
-
-      producer.close()
-       */
-    } catch {
-      case e: Exception => warn("LLWW0 got exception ", e)
-    } finally {
-      // for now avoid the shutting down phase to reduce noise
-      Exit.exit(0)
-    }
-
-
-    // shutdown the leader broker and corrupt its leader-epoch-checkpoint file
-
-
-
+     */
   }
 
 

--- a/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
@@ -5,6 +5,8 @@ import kafka.utils.{Exit, TestUtils}
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
+import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 import java.nio.charset.StandardCharsets
@@ -26,37 +28,90 @@ class DropCorruptedFilesTest extends IntegrationTestHarness {
       val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
       val leader = topicDescMap.get(topic).partitions().get(0).leader().id()
       val follower = if (leader == 0) 1 else 0
-      // shutdown the follower
-      val leaderBroker = servers.find(_.config.brokerId == leader).get
-      val followerBroker = servers.find(_.config.brokerId == follower).get
 
+      warn(s"LLWW0 leader: $leader")
+      warn(s"LLWW0 follower: $follower")
+      val orderedBrokers = Seq(leader, follower).map {brokerId =>
+        servers.find(_.config.brokerId == brokerId).get
+      }
+
+      val orderedLogs = orderedBrokers.map{broker => broker.logManager.getLog(tp).get}
+      val leaderLog = orderedLogs(0)
+      val followerLog = orderedLogs(1)
+
+      // shutdown the servers before appending messages
+      servers.foreach(_.shutdown())
+      warn("LLWW0 all servers have been shutdown")
+
+      // the offset of the records gets changed, so we cannot reuse the same records object on mulitple appends
+      def getRecords(leaderEpoch: Int) = {
+        MemoryRecords.withRecords(CompressionType.NONE, leaderEpoch,
+          new SimpleRecord("hello".getBytes))
+      }
+
+      leaderLog.appendAsLeader(getRecords(0), leaderEpoch = 0)
+      leaderLog.appendAsLeader(getRecords(0), leaderEpoch = 0)
+
+      followerLog.appendAsFollower(getRecords(0))
+
+      followerLog.appendAsLeader(getRecords(1), leaderEpoch = 1)
+
+      assertTrue(orderedBrokers.forall{broker =>
+        broker.replicaManager.getLog(tp).get.logEndOffset == 2
+      })
+      warn("LLWW0 all brokers have 2 messages now")
+
+      // start the leader host first so that it's still the leader
+      val leaderBroker = orderedBrokers(0)
+      val followerBroker = orderedBrokers(1)
+      leaderBroker.startup()
+      warn("LLWW0 leader broker has been restarted")
+      followerBroker.startup()
+      warn("LLWW0 follower broker has been restarted")
+
+      // wait until truncation of the message in epoch 1 on the follower
+      TestUtils.waitUntilTrue(() => {
+        followerBroker.replicaManager.getLog(tp).get.logEndOffset == 1
+      }, "some brokers cannot get the message")
+      warn("LLWW0 message in epoch 1 on the followir has been truncated")
+      adminClient.close()
+      /*
       val producerConfigs = new Properties()
       producerConfigs.put(ProducerConfig.ACKS_CONFIG, "-1")
-
       val producer = createProducer()
-      // send a normal record
+      // send a normal record to epoch 0
       val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
         "value".getBytes(StandardCharsets.UTF_8))
-      producer.send(record).get
+      val recordMetadata0 = producer.send(record).get
+      warn("LLWW0 0th message produced at offset "+ recordMetadata0.offset())
       // wait until all servers get the message
-      TestUtils.waitUntilTrue(() => {
-        servers.forall{s => s.replicaManager.getLog(tp).get.logEndOffset == 1}
-      }, "some brokers cannot get the message")
+
 
       // shutdown the follower
       followerBroker.shutdown()
-      // produce the 2nd message
-      producer.send(record).get
-      
+      // produce the 2nd message and make sure the leader gets it
+      val recordMetadata1 = producer.send(record).get
+      warn("LLWW0 1th message produced at offset "+ recordMetadata1.offset())
 
       // shutdown the leader and startup the follower
       leaderBroker.shutdown()
+      warn("LLWW0 leader shutdown complete")
       followerBroker.startup()
-      // produce the record in epoch 2
-      producer.send(record).get()
+      warn("LLWW0 follower startup complete")
+      TestUtils.waitUntilTrue(() => {
+        val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
+        val currentLeader = topicDescMap.get(topic).partitions().get(0).leader()
+        currentLeader == follower
+      }, "LLWW0 the leadership cannot be transferred to the follower")
+      // produce the record in epoch 1
+      val recordMetadata2 = producer.send(record).get()
+      warn("LLWW0 2nd message produced at offset "+ recordMetadata2.offset())
 
+
+      producer.close()
+       */
     } catch {
-      case e: Exception => warn("got exception ", e)
+      case e: Exception => warn("LLWW0 got exception ", e)
     } finally {
       // for now avoid the shutting down phase to reduce noise
       Exit.exit(0)

--- a/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
@@ -1,13 +1,14 @@
 package integration.kafka.api
 
 import kafka.api.IntegrationTestHarness
+import kafka.controller.OfflinePartition
 import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.Implicits.PropertiesOps
 import kafka.utils.{Exit, TestUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig}
 import org.apache.kafka.clients.producer.{KafkaProducer, Producer, ProducerConfig, ProducerRecord}
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{ElectionType, TopicPartition}
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 import java.nio.charset.StandardCharsets
+import java.util
 import java.util.{Collections, Properties}
 import scala.collection.{Map, Seq}
 
@@ -30,6 +32,7 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
       // start servers in reverse order to ensure broker 2 becomes the controller
       val servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
       val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+      val controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
       assertTrue(controllerId == 2)
 
       // create the topic with min ISR of 2, which should allow one broker to shut down but should block subsequent
@@ -63,12 +66,13 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
       val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
         "value".getBytes(StandardCharsets.UTF_8))
       val recordMetadata0 = producer.send(record).get
-      warn("LLWW0 0th message produced at offset "+ recordMetadata0.offset())
+
       // wait until all servers get the message
-      // wait until truncation of the message in epoch 1 on the follower
       TestUtils.waitUntilTrue(() => {
-        followerBroker.replicaManager.getLog(tp).get.logEndOffset == 1
+        orderedBrokers.forall{broker => broker.replicaManager.getLog(tp).get.logEndOffset == 1}
       }, "some brokers cannot get the message")
+      warn("LLWW0 0th message produced at offset "+ recordMetadata0.offset())
+
 
       // shutdown the follower
       followerBroker.shutdown()
@@ -80,18 +84,45 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
       // shutdown the leader and startup the follower
       leaderBroker.shutdown()
       warn("LLWW0 leader shutdown complete")
+      TestUtils.waitUntilTrue(() => {
+        controller.controllerContext.partitionState(tp) == OfflinePartition
+      }, s"the partition $tp does not become offline after all replicas are shutdown")
+      warn("LLWW0 the partiton has become offline")
+
+
       followerBroker.startup()
       warn("LLWW0 follower startup complete")
 
 
-      TestUtils.waitUntilTrue(() => {
-        val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
-        val currentLeader = topicDescMap.get(topic).partitions().get(0).leader()
-        currentLeader == follower
-      }, "LLWW0 the leadership cannot be transferred to the follower")
+      def ensureLeader(desiredLeader: Int): Unit = {
+        TestUtils.waitUntilTrue(() => {
+          val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
+          val currentLeader = topicDescMap.get(topic).partitions().get(0).leader()
+          warn(s"LLWW0 current leader ${currentLeader.id()}, required leader: $desiredLeader")
+          desiredLeader.equals(currentLeader.id())
+        }, "LLWW0 the leadership cannot be transferred to the follower")
+      }
+      ensureLeader(follower)
       // produce the record in epoch 1
+
+      warn("LLWW0 producing the 2nd message")
       val recordMetadata2 = producer.send(record).get()
       warn("LLWW0 2nd message produced at offset "+ recordMetadata2.offset())
+
+      followerBroker.shutdown()
+      leaderBroker.startup()
+      ensureLeader(leader)
+      warn(s"LLWW0 the leadership has returned to original leader $leader")
+
+      followerBroker.startup()
+
+      // wait until the follower joins the ISR again
+      TestUtils.waitUntilTrue(() => {
+        val topicDescMap = adminClient.describeTopics(Collections.singleton(topic)).all().get()
+        val currentISR = topicDescMap.get(topic).partitions().get(0).isr()
+        currentISR.size() == 2
+      }, "the follower cannot rejoin the ISR")
+      warn("LLWW0 the ISR has converged to 2 again")
 
       adminClient.close()
       producer.close()

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -81,7 +81,7 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
 
   @BeforeEach
   override def setUp(): Unit = {
-    doSetup(createOffsetsTopic = true)
+    doSetup(createOffsetsTopic = false)
   }
 
   def doSetup(createOffsetsTopic: Boolean): Unit = {

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -129,6 +129,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     TestUtils.createTopic(zkClient, topic2, 1, 1, servers)
 
     val sumOfTopicNameLength = TestUtils.yammerMetricValue("SumOfTopicNameLength")
+    Thread.sleep(5000)
     assertEquals(topic1.size + topic2.size + 2 * KafkaController.topicNameBytesOverheadOnZk, sumOfTopicNameLength)
   }
 

--- a/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileTest.scala
@@ -16,12 +16,15 @@
   */
 package kafka.server.checkpoints
 
-import java.io.File
-
 import kafka.server.epoch.EpochEntry
+import kafka.server.{GlobalConfig, LogDirFailureChannel}
 import kafka.utils.Logging
+import org.apache.kafka.common.errors.KafkaStorageException
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.io.{BufferedWriter, File, FileOutputStream, OutputStreamWriter}
 
 class LeaderEpochCheckpointFileTest extends Logging {
 
@@ -66,5 +69,77 @@ class LeaderEpochCheckpointFileTest extends Logging {
 
     //The data should still be there
     assertEquals(epochs, checkpoint2.read())
+  }
+
+
+  @ParameterizedTest
+  @ValueSource(booleans =  Array(true, false))
+  def testCheckpointFileWithCorruptedVersion(liDropCorruptedFilesEnable: Boolean): Unit = {
+    testCheckpointFileWithCorruption(liDropCorruptedFilesEnable, bw => {
+      bw.write("100")
+      bw.newLine()
+    })
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans =  Array(true, false))
+  def testCheckpointFileWithIncorrectNumberOfEntries(liDropCorruptedFilesEnable: Boolean): Unit = {
+    testCheckpointFileWithCorruption(liDropCorruptedFilesEnable, bw => {
+      bw.write(0.toString)
+      bw.newLine()
+
+      bw.write(3.toString)
+      bw.newLine()
+    })
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans =  Array(true, false))
+  def testCheckpointFileWithCorruptedEntries(liDropCorruptedFilesEnable: Boolean): Unit = {
+    testCheckpointFileWithCorruption(liDropCorruptedFilesEnable, bw => {
+      bw.write(0.toString)
+      bw.newLine()
+
+      bw.write(1.toString)
+      bw.newLine()
+
+      val epoch = 100
+      bw.write(epoch.toString) // this line is malformed since there is only epoch without the starting offset
+    })
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans =  Array(true, false))
+  def testCheckpointFileWithNumberFormatExceptions(liDropCorruptedFilesEnable: Boolean): Unit = {
+    testCheckpointFileWithCorruption(liDropCorruptedFilesEnable, bw => {
+      bw.write(0.toString)
+      bw.newLine()
+
+      bw.write(1.toString)
+      bw.newLine()
+
+      bw.write("not-a-number 3") // this line is malformed since the first field cannot be converted to a number
+    })
+  }
+
+  private def testCheckpointFileWithCorruption(liDropCorruptedFilesEnable: Boolean, testFunc: BufferedWriter => Unit): Unit = {
+    GlobalConfig.liDropCorruptedFilesEnable = liDropCorruptedFilesEnable
+    val file = File.createTempFile("temp-checkpoint-file", System.nanoTime().toString)
+    file.deleteOnExit()
+
+    // create a file with corrupted version number
+    val bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file)))
+    testFunc(bw)
+    bw.close()
+
+    val checkpoint = new LeaderEpochCheckpointFile(file, new LogDirFailureChannel(1))
+    if (liDropCorruptedFilesEnable) {
+      val epochs = checkpoint.read()
+      assertTrue(epochs.isEmpty, "reading from a corrupted leader-epoch-checkpoint file should have returned an empty list of EpochEntries")
+      // verify that the file no longer exists
+      assertFalse(file.exists(), "the corrupted file should have been deleted")
+    } else {
+      assertThrows(classOf[KafkaStorageException], ()=> checkpoint.read())
+    }
   }
 }

--- a/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/LeaderEpochCheckpointFileTest.scala
@@ -24,7 +24,9 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+
 import java.io.{BufferedWriter, File, FileOutputStream, OutputStreamWriter}
+import java.nio.file.Files
 
 class LeaderEpochCheckpointFileTest extends Logging {
 
@@ -137,7 +139,8 @@ class LeaderEpochCheckpointFileTest extends Logging {
       val epochs = checkpoint.read()
       assertTrue(epochs.isEmpty, "reading from a corrupted leader-epoch-checkpoint file should have returned an empty list of EpochEntries")
       // verify that the file no longer exists
-      assertFalse(file.exists(), "the corrupted file should have been deleted")
+      assertTrue(file.exists(), "the file should still exists")
+      assertEquals(0, Files.size(file.toPath), "the content of the corrupted file should have been cleared")
     } else {
       assertThrows(classOf[KafkaStorageException], ()=> checkpoint.read())
     }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -252,7 +252,7 @@ object TestUtils extends Logging {
     */
   def createBrokerConfig(nodeId: Int,
                          zkConnect: String,
-                         enableControlledShutdown: Boolean = true,
+                         enableControlledShutdown: Boolean = false,
                          enableControlledShutdownSafetyCheck: Boolean = false,
                          enableDeleteTopic: Boolean = true,
                          port: Int = RandomPort,
@@ -299,6 +299,7 @@ object TestUtils extends Logging {
       props.put(KafkaConfig.LogDirsProp, logDirs)
     } else {
       props.put(KafkaConfig.LogDirProp, tempDir().getAbsolutePath)
+      warn(s"logDir for broker $nodeId: " + props.get(KafkaConfig.LogDirProp))
     }
     props.put(KafkaConfig.ZkConnectProp, zkConnect)
     props.put(KafkaConfig.ZkConnectionTimeoutMsProp, "10000")


### PR DESCRIPTION
TICKET = [LIKAFKA-47870](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-47870)
LI_DESCRIPTION =
During a power outage, various files can be corrupted and block the kafka broker startup.
This PR makes the following changes
1. adding a `li.drop.corrupted.files.enable` config to specify whether the corrupted files should be dropped automatically
2. detecting various types of corruption in the leader-epoch-checkpoint file and automatically truncate its size to 0 if the `li.drop.corrupted.files.enable` is enabled

EXIT_CRITERIA = N/A

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
