### PR TITLE
[LI-HOTFIX] Handle fast topic deletion and recreation in the ControllerRequestMerger

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCombinedControlRequest.java
@@ -181,6 +181,11 @@ public class LiCombinedControlRequest extends AbstractControlRequest {
                 bld.append("\t" + partitionState + "\n");
             }
 
+            bld.append("topicIds=\n");
+            for (Map.Entry<String, Uuid> topicId: topicIds.entrySet()) {
+                bld.append(topicId.getKey() + "->" + topicId.getValue());
+            }
+
             return bld.toString();
         }
 

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -243,7 +243,7 @@ class RequestSendThread(val controllerId: Int,
                         val controllerChannelManager: ControllerChannelManager)
   extends ShutdownableThread(name = name) with KafkaMetricsGroup {
 
-  logIdent = s"[RequestSendThread controllerId=$controllerId] "
+  logIdent = s"[RequestSendThread controllerId=$controllerId brokerId=${brokerNode.id()}] "
 
   private val MaxRequestAgeMetricName = "maxRequestAge"
 

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -97,7 +97,7 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     topicIds.forEach((topicName, topicId) => {
       val existingTopicId = aggregateTopicIds.get(topicName)
       if (existingTopicId != null && !existingTopicId.equals(topicId)) {
-        warn(s"topic $topicName associated with the topic id $existingTopicId is given a new topic id $topicId" +
+        warn(s"topic $topicName associated with the topic id $existingTopicId is given a new topic id $topicId " +
           "clearing relevant requests associated with previous topic ids")
 
         def clearObsoleteEntriesInMap(map: mutable.Map[TopicIdPartition, _]) = {

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -97,11 +97,19 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     topicIds.forEach((topicName, topicId) => {
       val existingTopicId = aggregateTopicIds.get(topicName)
       if (existingTopicId != null && !existingTopicId.equals(topicId)) {
-        // TODO: A topic name may be associated with multiple topicIds if a topic is recreated under the same name
-        //  while the controller has not finished sending requests with the previous topic id.
-        //  Currently, that is not supported, and we may add support for it in the future.
-        throw new IllegalStateException("topic " + topicName + " associated with the topic id " +
-          existingTopicId + " is given a new topic id " + topicId)
+        warn(s"topic $topicName associated with the topic id $existingTopicId is given a new topic id $topicId" +
+          "clearing relevant requests associated with previous topic ids")
+
+        def clearObsoleteEntriesInMap(map: mutable.Map[TopicIdPartition, _]) = {
+          val obsoletePartitions = map.filterKeys{
+            topicIdPartition => topicIdPartition.topicPartition().topic().equals(topicName) && !topicIdPartition.topicId().equals(topicId)}
+          obsoletePartitions.foreach{
+            case (topicIdPartition, _) => map.remove(topicIdPartition)}
+        }
+
+        clearObsoleteEntriesInMap(leaderAndIsrPartitionStates)
+        clearObsoleteEntriesInMap(updateMetadataPartitionStates)
+        clearObsoleteEntriesInMap(stopReplicaPartitionStates)
       }
     })
     aggregateTopicIds.putAll(topicIds)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -364,6 +364,11 @@ class KafkaApis(val requestChannel: RequestChannel,
     val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
     val correlationId = request.header.correlationId
     val updateMetadataRequest = request.body[UpdateMetadataRequest]
+    if (config.liUpdateMetadataDelayMs > 0 && !updateMetadataRequest.topicStates().isEmpty) {
+      warn(s"Sleeping for ${config.liUpdateMetadataDelayMs}ms before processing the UpdateMetadata request")
+      Thread.sleep(config.liUpdateMetadataDelayMs)
+    }
+
 
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     if (isBrokerEpochStale(zkSupport, updateMetadataRequest.brokerEpoch, updateMetadataRequest.maxBrokerEpoch)) {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -322,6 +322,7 @@ object Defaults {
 
   /** Linkedin Internal states */
   val LiCombinedControlRequestEnabled = false
+  val LiUpdateMetadataDelayMs = 0
   val LiAlterIsrEnabled = false
   val LiAsyncFetcherEnabled = false
   val LiNumControllerInitThreads = 1
@@ -438,6 +439,7 @@ object KafkaConfig {
   val PreferredControllerProp = "preferred.controller"
   val LiAsyncFetcherEnableProp = "li.async.fetcher.enable"
   val LiCombinedControlRequestEnableProp = "li.combined.control.request.enable"
+  val LiUpdateMetadataDelayMsProp = "li.update.metadata.delay.ms"
   val LiAlterIsrEnableProp = "li.alter.isr.enable"
   val LiNumControllerInitThreadsProp = "li.num.controller.init.threads"
   val LiLogCleanerFineGrainedLockEnableProp = "li.log.cleaner.fine.grained.lock.enable"
@@ -775,6 +777,7 @@ object KafkaConfig {
   val PreferredControllerDoc = "Specifies whether the broker is a dedicated controller node. If set to true, the broker is a preferred controller node."
   val LiAsyncFetcherEnableDoc = "Specifies whether the event-based async fetcher should be used."
   val LiCombinedControlRequestEnableDoc = "Specifies whether the controller should use the LiCombinedControlRequest."
+  val LiUpdateMetadataDelayMsDoc = "Specifies how long a UpdateMetadata request with partitions should be delayed before its processing can start. This config is purely for stress testing the LiCombinedControl feature and should not be enabled in a production environment."
   val LiAlterIsrEnabledDoc = "Specifies whether the brokers should use the AlterISR request to propagate ISR changes to the controller. If set to false, brokers will propagate the updates via Zookeeper."
   val LiNumControllerInitThreadsDoc = "Number of threads (and Zookeeper clients + connections) to be used while recursing the topic-partitions tree in Zookeeper during controller startup/failover."
   val LiLogCleanerFineGrainedLockEnableDoc = "Specifies whether the log cleaner should use fine grained locks when calculating the filthiest log to clean"
@@ -1215,6 +1218,7 @@ object KafkaConfig {
       .define(PreferredControllerProp, BOOLEAN, Defaults.PreferredController, HIGH, PreferredControllerDoc)
       .define(LiAsyncFetcherEnableProp, BOOLEAN, Defaults.LiAsyncFetcherEnabled, HIGH, LiAsyncFetcherEnableDoc)
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
+      .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, LOW, LiUpdateMetadataDelayMsDoc)
       .define(LiAlterIsrEnableProp, BOOLEAN, Defaults.LiAlterIsrEnabled, HIGH, LiAlterIsrEnabledDoc)
       .define(LiNumControllerInitThreadsProp, INT, Defaults.LiNumControllerInitThreads, atLeast(1), LOW, LiNumControllerInitThreadsDoc)
       .define(LiLogCleanerFineGrainedLockEnableProp, BOOLEAN, Defaults.LiLogCleanerFineGrainedLockEnabled, LOW, LiLogCleanerFineGrainedLockEnableDoc)
@@ -1725,6 +1729,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
 
   val liAsyncFetcherEnable = getBoolean(KafkaConfig.LiAsyncFetcherEnableProp)
   def liCombinedControlRequestEnable = getBoolean(KafkaConfig.LiCombinedControlRequestEnableProp)
+  def liUpdateMetadataDelayMs = getLong(KafkaConfig.LiUpdateMetadataDelayMsProp)
   def liAlterIsrEnable = getBoolean(KafkaConfig.LiAlterIsrEnableProp)
   def liNumControllerInitThreads = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
   def liLogCleanerFineGrainedLockEnable = getBoolean(KafkaConfig.LiLogCleanerFineGrainedLockEnableProp)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -777,7 +777,7 @@ object KafkaConfig {
   val PreferredControllerDoc = "Specifies whether the broker is a dedicated controller node. If set to true, the broker is a preferred controller node."
   val LiAsyncFetcherEnableDoc = "Specifies whether the event-based async fetcher should be used."
   val LiCombinedControlRequestEnableDoc = "Specifies whether the controller should use the LiCombinedControlRequest."
-  val LiUpdateMetadataDelayMsDoc = "Specifies how long a UpdateMetadata request with partitions should be delayed before its processing can start. This config is purely for stress testing the LiCombinedControl feature and should not be enabled in a production environment."
+  val LiUpdateMetadataDelayMsDoc = "Specifies how long a UpdateMetadata request with partitions should be delayed before its processing can start. This config is purely for testing the LiCombinedControl feature and should not be enabled in a production environment."
   val LiAlterIsrEnabledDoc = "Specifies whether the brokers should use the AlterISR request to propagate ISR changes to the controller. If set to false, brokers will propagate the updates via Zookeeper."
   val LiNumControllerInitThreadsDoc = "Number of threads (and Zookeeper clients + connections) to be used while recursing the topic-partitions tree in Zookeeper during controller startup/failover."
   val LiLogCleanerFineGrainedLockEnableDoc = "Specifies whether the log cleaner should use fine grained locks when calculating the filthiest log to clean"

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1218,7 +1218,7 @@ object KafkaConfig {
       .define(PreferredControllerProp, BOOLEAN, Defaults.PreferredController, HIGH, PreferredControllerDoc)
       .define(LiAsyncFetcherEnableProp, BOOLEAN, Defaults.LiAsyncFetcherEnabled, HIGH, LiAsyncFetcherEnableDoc)
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
-      .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, LOW, LiUpdateMetadataDelayMsDoc)
+      .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, atLeast(0), LOW, LiUpdateMetadataDelayMsDoc)
       .define(LiAlterIsrEnableProp, BOOLEAN, Defaults.LiAlterIsrEnabled, HIGH, LiAlterIsrEnabledDoc)
       .define(LiNumControllerInitThreadsProp, INT, Defaults.LiNumControllerInitThreads, atLeast(1), LOW, LiNumControllerInitThreadsDoc)
       .define(LiLogCleanerFineGrainedLockEnableProp, BOOLEAN, Defaults.LiLogCleanerFineGrainedLockEnabled, LOW, LiLogCleanerFineGrainedLockEnableDoc)

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1597,7 +1597,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
   def testFastTopicDeletionAndRecreation(): Unit = {
     val topic = "t1"
     val tp = new TopicPartition(topic, 0)
-    // delay the 2nd broker's LiCombinedControl requests by 10s
+    // delay the 2nd broker's UpdateMetadata
     servers = makeServers(2, liUpdateMetadataDelayMap = Map(0 -> 0, 1 -> 5000))
 
     val assignment = Map(0 -> Seq(0))
@@ -1631,7 +1631,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
         val topicMetadataOpt = server.metadataCache.getTopicMetadata(Set(topic), ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)).find(_.name() == topic)
         val result = topicMetadataOpt.isDefined && !topicMetadataOpt.get.topicId().equals(originalTopicId)
         if (result) {
-          warn(s"server ${server.config.brokerId} got new topic id ${topicMetadataOpt.get.topicId()}")
+          info(s"server ${server.config.brokerId} got new topic id ${topicMetadataOpt.get.topicId()}")
         }
         result
       }

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -129,7 +129,8 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     TestUtils.createTopic(zkClient, topic2, 1, 1, servers)
 
     val sumOfTopicNameLength = TestUtils.yammerMetricValue("SumOfTopicNameLength")
-    assertEquals(topic1.size + topic2.size + 2 * KafkaController.topicNameBytesOverheadOnZk, sumOfTopicNameLength)
+    assertEquals(topic1.size + topic2.size + 2 * KafkaController.topicNameBytesOverheadOnZk, sumOfTopicNameLength,
+      "all topics in the cluster " + zkClient.getAllTopicsInCluster())
   }
 
   // This test case is used to ensure that there will be no correctness issue after we avoid sending out full

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -17,30 +17,30 @@
 
 package kafka.controller
 
-import java.util.Properties
-import java.util.concurrent.{CompletableFuture, CountDownLatch, LinkedBlockingQueue, TimeUnit}
-
 import com.yammer.metrics.core.Timer
 import kafka.api.{ApiVersion, KAFKA_2_6_IV0, KAFKA_2_7_IV0, LeaderAndIsr}
 import kafka.controller.KafkaController.AlterIsrCallback
 import kafka.metrics.KafkaYammerMetrics
 import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.{LogCaptureAppender, TestUtils}
-import kafka.zk.{FeatureZNodeStatus, _}
-import org.apache.kafka.common.errors.{ControllerMovedException, NotEnoughReplicasException, StaleBrokerEpochException}
-import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig, AlterConfigsResult, Config, ConfigEntry}
+import kafka.zk._
+import org.apache.kafka.clients.admin._
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
+import org.apache.kafka.common.errors.{ControllerMovedException, NotEnoughReplicasException, StaleBrokerEpochException}
 import org.apache.kafka.common.feature.Features
 import org.apache.kafka.common.metrics.KafkaMetric
+import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.{ElectionType, TopicPartition, Uuid}
 import org.apache.log4j.Level
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.Mockito.{doAnswer, spy, verify}
 import org.mockito.invocation.InvocationOnMock
-import org.apache.kafka.common.network.ListenerName
 
+import java.util.Properties
+import java.util.concurrent.{CompletableFuture, CountDownLatch, LinkedBlockingQueue, TimeUnit}
 import scala.annotation.nowarn
 import scala.collection.{Map, Seq, mutable}
 import scala.jdk.CollectionConverters._
@@ -1593,6 +1593,51 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
   }
 
   @Test
+  def testFastTopicDeletionAndRecreation(): Unit = {
+    val topic = "t1"
+    val tp = new TopicPartition(topic, 0)
+    // delay the 2nd broker's LiCombinedControl requests by 10s
+    servers = makeServers(2, liUpdateMetadataDelayMap = Map(0 -> 0, 1 -> 5000))
+
+    val assignment = Map(0 -> Seq(0))
+    adminZkClient.createTopicWithAssignment(topic, new Properties(), assignment)
+    // wait until broker 0 has the metadata for the topic
+    // Note that broker 1 won't get the metadata since its processing of the UpdateMetadata is delayed
+    var originalTopicId: Uuid = Uuid.ZERO_UUID
+    TestUtils.waitUntilTrue(() => {
+      val topicMetadataSeq = servers.find(_.config.brokerId == 0).get.metadataCache.getTopicMetadata(Set(topic), ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))
+      topicMetadataSeq.find(_.name() == topic) match {
+        case Some(topicMetadata) => {
+          originalTopicId = topicMetadata.topicId()
+          true
+        }
+        case _ => false
+      }
+    }, "broker 0 never gets the metadata for the topic $topic")
+
+    info(s"original topic id $originalTopicId")
+    // delete and then immediately recreate the topic
+    info("deleting the 1st topic")
+    adminZkClient.deleteTopic(topic)
+    TestUtils.waitUntilTrue(() => {
+      !zkClient.pathExists(TopicZNode.path(tp.topic()))
+    }, "The topic cannot be deleted")
+
+    info("creating topic for the 2nd time")
+    TestUtils.createTopic(zkClient, topic, assignment, servers)
+    TestUtils.waitUntilTrue(() => {
+      servers.forall { server =>
+        val topicMetadataOpt = server.metadataCache.getTopicMetadata(Set(topic), ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)).find(_.name() == topic)
+        val result = topicMetadataOpt.isDefined && !topicMetadataOpt.get.topicId().equals(originalTopicId)
+        if (result) {
+          warn(s"server ${server.config.brokerId} got new topic id ${topicMetadataOpt.get.topicId()}")
+        }
+        result
+      }
+    }, "Now all servers end up with the new topic id in its metadata cache")
+  }
+
+  @Test
   def testTopicIdUpgradeAfterReassigningPartitions(): Unit = {
     val tp = new TopicPartition("t", 0)
     val reassignment = Map(tp -> Some(Seq(0)))
@@ -1772,13 +1817,16 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
                           controlPlaneListenerName : Option[String] = None,
                           interBrokerProtocolVersion: Option[ApiVersion] = None,
                           logDirCount: Int = 1,
-                          startingIdNumber: Int = 0) = {
+                          startingIdNumber: Int = 0,
+                          liUpdateMetadataDelayMap: Map[Int, Long] = Map.empty) = {
     val configs = TestUtils.createBrokerConfigs(numConfigs, zkConnect, enableControlledShutdown = enableControlledShutdown, logDirCount = logDirCount, startingIdNumber = startingIdNumber )
     configs.foreach { config =>
       config.setProperty(KafkaConfig.AutoLeaderRebalanceEnableProp, autoLeaderRebalanceEnable.toString)
       config.setProperty(KafkaConfig.UncleanLeaderElectionEnableProp, uncleanLeaderElectionEnable.toString)
       config.setProperty(KafkaConfig.LeaderImbalanceCheckIntervalSecondsProp, "1")
       config.setProperty(KafkaConfig.LiCombinedControlRequestEnableProp, "true")
+      val brokerId: Int = config.get(KafkaConfig.BrokerIdProp).toString.toInt
+      config.setProperty(KafkaConfig.LiUpdateMetadataDelayMsProp, liUpdateMetadataDelayMap.getOrElse(brokerId, 0).toString)
       listeners.foreach(listener => config.setProperty(KafkaConfig.ListenersProp, listener))
       listenerSecurityProtocolMap.foreach(listenerMap => config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, listenerMap))
       controlPlaneListenerName.foreach(controlPlaneListener => config.setProperty(KafkaConfig.ControlPlaneListenerNameProp, controlPlaneListener))


### PR DESCRIPTION
TICKET = [LIKAFKA-47500](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-47500)
LI_DESCRIPTION =
In the current implementation, if a topic is deleted and immediately recreated, the ControllerRequestMerger would 
detect the inconsistent topic ids, and hence trigger an IllegalStateException.
This PR adds protection against this case by clearing all the states associated with the previous topic id.

To support reproducing the case inside a test, we also added a new config `li.update.metadata.delay.ms` so that the state with the previous topic id can be accumulated inside the ControllerRequestMerger.

EXIT_CRITERIA = The same as the LiCombinedControl request.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
