### PR TITLE
[LI-HOTFIX] Improve the DefaultAlterIsrManager and use it by default

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -323,7 +323,7 @@ object Defaults {
   /** Linkedin Internal states */
   val LiCombinedControlRequestEnabled = false
   val LiUpdateMetadataDelayMs = 0
-  val LiAlterIsrEnabled = false
+  val LiAlterIsrEnabled = true
   val LiAsyncFetcherEnabled = false
   val LiNumControllerInitThreads = 1
   val LiLogCleanerFineGrainedLockEnabled = true


### PR DESCRIPTION
TICKET = LIKAFKA-46520
LI_DESCRIPTION =
In PR #386, we switched to using the ZkIsrManager by default, since we were seeing the following error after the 3.0 upgrade.
`Failed to enqueue ISR change state LeaderAndIsr(leader=..., leaderEpoch=.., isr=List(...), zkVersion=...) for partition ...`

However, for unknown reasons, the ZkIsrManager isn't stable either. We saw that the request to update ZK isr was blocked in several clusters when the change was rolled out.

This PR tries to improve the DefaultAlterIsrManager and switch it back to the default. Specifically, we add a new unsentIsrQueue such that submission of an AlterIsrItem would always succeed. 
EXIT_CRITERIA = When this change is submitted upstream and pulled back

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
