### PR TITLE
[LI-HOTFIX] Skipping controlled shutdown should bypass the leadership transfer check

### DIFF
--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -775,6 +775,10 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
   def testSkipShutdownCheck(): Unit = {
     // create brokers
     val serverConfigs = TestUtils.createBrokerConfigs(3, zkConnect, true, enableControlledShutdownSafetyCheck = true)
+      .map{props => {
+        props.setProperty(KafkaConfig.ControlledShutdownMaxRetriesProp, Integer.MAX_VALUE.toString)
+        props
+      }}
       .map(KafkaConfig.fromProps)
     // create the servers in reverse order so that broker 2 becomes the controller
     servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -769,6 +769,45 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilTrue(() => newController.controllerContext.topicMinIsrConfig.getOrElse(topic, -1) == 1, "Controller never saw min.insync.replicas config change for topic.")
   }
 
+  // This test is to verify that skipping the shutdown check would allow the broker to shutdown
+  // even though it may lead to offline partitions
+  @Test
+  def testSkipShutdownCheck(): Unit = {
+    // create brokers
+    val serverConfigs = TestUtils.createBrokerConfigs(3, zkConnect, true, enableControlledShutdownSafetyCheck = true)
+      .map(KafkaConfig.fromProps)
+    // create the servers in reverse order so that broker 2 becomes the controller
+    servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+    assertTrue(controllerId == 2)
+    val controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+
+    val topicConfig = new Properties()
+    val expectedReplicaAssignment = Map(0  -> List(0, 1))
+    val topic = "test"
+    val tp = new TopicPartition(topic, 0)
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+
+    // skip shutdown safety check for all data brokers
+    val dataBrokers = servers.filterNot(_.config.brokerId == controllerId)
+
+    val brokerIdAndEpochs = dataBrokers.map{s => (s.config.brokerId, s.kafkaController.brokerEpoch)}
+    for (brokerEntry <- brokerIdAndEpochs) {
+      @volatile var skipSafetyCheckSucceeded = false
+      controller.skipControlledShutdownSafetyCheck(brokerEntry._1, brokerEntry._2, {
+        case scala.util.Failure(t) => throw t
+        case _ => skipSafetyCheckSucceeded = true
+      })
+      TestUtils.waitUntilTrue(() => skipSafetyCheckSucceeded, s"Failed to skip shutdown safety check for $brokerEntry")
+    }
+    dataBrokers.foreach {s => s.shutdown()}
+
+    // verify that the partition has become Offline
+    TestUtils.waitUntilTrue(() => {
+      controller.controllerContext.partitionState(tp) == OfflinePartition
+    }, s"the partition $tp does not become offline after all replicas are shutdown")
+  }
+
   @nowarn("cat=deprecation")
   private def alterTopicConfigs(adminClient: Admin, topic: String, topicConfigs: Properties): AlterConfigsResult = {
     val configEntries = topicConfigs.asScala.map { case (k, v) => new ConfigEntry(k, v) }.toList.asJava


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
In the current implementation, there are essentially 2 types of checks performed during the controlled shutdown check
1. The ISR check to ensure shutting down the broker would leave enough replicas for all partitions
2. The leadership switch transfer check to ensure all partitions' leadership has been successfully transferred away from the shutting down broker

The KafkaAdminClient.skipShutdownSafetyCheck API would bypass the 1st check, but not the 2nd.
In that case, the usual action is to hard kill the broker, which results in a lengthy sanity check during the next broker startup. This PR allows the API to bypass both types of checks so that a broker can be allowed to shutdown even with the risk of generating OfflinePartitions.
EXIT_CRITERIA = The same as the KafkaAdminClient.skipShutdownSafetyCheck API.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
