### PR TITLE
[LI-HOTFIX] Fix the testSumOfTopicNameLength

### DIFF
--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -128,9 +128,10 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     val topic2 = "topic2"
     TestUtils.createTopic(zkClient, topic2, 1, 1, servers)
 
-    val sumOfTopicNameLength = TestUtils.yammerMetricValue("SumOfTopicNameLength")
-    assertEquals(topic1.size + topic2.size + 2 * KafkaController.topicNameBytesOverheadOnZk, sumOfTopicNameLength,
-      "all topics in the cluster " + zkClient.getAllTopicsInCluster())
+    TestUtils.waitUntilTrue(() => {
+      val sumOfTopicNameLength = TestUtils.yammerMetricValue("SumOfTopicNameLength")
+      topic1.size + topic2.size + 2 * KafkaController.topicNameBytesOverheadOnZk == sumOfTopicNameLength
+    }, "all topics in the cluster " + zkClient.getAllTopicsInCluster())
   }
 
   // This test case is used to ensure that there will be no correctness issue after we avoid sending out full


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
The test `testSumOfTopicNameLength` has been flaky, likely due to the fact that the yammer metrics get updated asynchronously by a background thread.
This PR fixes the test by waiting until the yammer metrics value converges to the desired result.
EXIT_CRITERIA = N/A

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
