### PR TITLE
[LI-HOTFIX] Avoid UnderMinISR partitions via broker initiated leadership transfer (part 1 of 2)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3468,7 +3468,11 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             public ElectLeadersRequest.Builder createRequest(int timeoutMs) {
-                return new ElectLeadersRequest.Builder(electionType, topicPartitions, recommendedLeaders, timeoutMs);
+                if (recommendedLeaders.isEmpty()) {
+                    return new ElectLeadersRequest.Builder(electionType, topicPartitions, timeoutMs);
+                } else {
+                    return new ElectLeadersRequest.Builder(-1, recommendedLeaders, timeoutMs);
+                }
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
@@ -38,20 +38,31 @@ import org.apache.kafka.common.protocol.MessageUtil;
 public class ElectLeadersRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<ElectLeadersRequest> {
         private final ElectionType electionType;
+        private final long brokerEpoch;
         private final Collection<TopicPartition> topicPartitions;
         private final Map<TopicPartition, Integer> recommendedLeaders;
         private final int timeoutMs;
 
         public Builder(ElectionType electionType, Collection<TopicPartition> topicPartitions,
             int timeoutMs) {
-            this(electionType, topicPartitions, Collections.emptyMap(), timeoutMs);
+            this(electionType, -1, topicPartitions, Collections.emptyMap(), timeoutMs);
         }
 
-        public Builder(ElectionType electionType, Collection<TopicPartition> topicPartitions,
+        // constructor for recommended leader election
+        public Builder(long brokerEpoch,
+            Map<TopicPartition, Integer> recommendedLeaders,
+            int timeoutMs) {
+           this(ElectionType.RECOMMENDED, brokerEpoch, recommendedLeaders.keySet(), recommendedLeaders, timeoutMs);
+        }
+
+        private Builder(ElectionType electionType,
+            long brokerEpoch,
+            Collection<TopicPartition> topicPartitions,
             Map<TopicPartition, Integer> recommendedLeaders,
             int timeoutMs) {
             super(ApiKeys.ELECT_LEADERS);
             this.electionType = electionType;
+            this.brokerEpoch = brokerEpoch;
             this.topicPartitions = topicPartitions;
             this.recommendedLeaders = recommendedLeaders;
             this.timeoutMs = timeoutMs;
@@ -102,7 +113,7 @@ public class ElectLeadersRequest extends AbstractRequest {
             }
 
             data.setElectionType(electionType.value);
-
+            data.setBrokerEpoch(brokerEpoch);
             return data;
         }
     }

--- a/clients/src/main/resources/common/message/ElectLeadersRequest.json
+++ b/clients/src/main/resources/common/message/ElectLeadersRequest.json
@@ -26,6 +26,8 @@
   "fields": [
     { "name": "ElectionType", "type": "int8", "versions": "1+",
       "about": "Type of elections to conduct for the partition. A value of '0' elects the preferred replica. A value of '1' elects the first live replica if there are no in-sync replica." },
+    { "name": "BrokerEpoch", "type": "int64", "versions": "2+", "default": "-1", "tag": 0, "taggedVersions": "2+",
+      "about": "The epoch of the requesting broker" },
     { "name": "TopicPartitions", "type": "[]TopicPartitions", "versions": "0+", "nullableVersions": "0+",
       "about": "The topic partitions to elect leaders.",
       "fields": [

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -97,7 +97,8 @@ object Partition extends KafkaMetricsGroup {
       delayedOperations = delayedOperations,
       metadataCache = replicaManager.metadataCache,
       logManager = replicaManager.logManager,
-      alterIsrManager = replicaManager.alterIsrManager)
+      alterIsrManager = replicaManager.alterIsrManager,
+      transferLeaderManager = replicaManager.transferLeaderManager)
   }
 
   def removeMetrics(topicPartition: TopicPartition): Unit = {
@@ -219,7 +220,8 @@ class Partition(val topicPartition: TopicPartition,
                 delayedOperations: DelayedOperations,
                 metadataCache: MetadataCache,
                 logManager: LogManager,
-                alterIsrManager: AlterIsrManager) extends Logging with KafkaMetricsGroup {
+                alterIsrManager: AlterIsrManager,
+                transferLeaderManager: TransferLeaderManager) extends Logging with KafkaMetricsGroup {
 
   def topic: String = topicPartition.topic
   def partitionId: Int = topicPartition.partition
@@ -1388,7 +1390,11 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   private[cluster] def transferToNewLeader(newLeader: Int): Unit = {
+    transferLeaderManager.submit(TransferLeaderItem(topicPartition, newLeader, handleTransferLeaderResponse))
+  }
 
+  private def handleTransferLeaderResponse(response: Either[Errors, TopicPartition]): Unit = {
+    info(s"Received TransferLeader response $response")
   }
 
   private def sendAlterIsrRequest(proposedIsrState: IsrState): Unit = {

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1394,7 +1394,12 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   private def handleTransferLeaderResponse(response: Either[Errors, TopicPartition]): Unit = {
-    info(s"Received TransferLeader response $response")
+    response match {
+      case Right(tp) =>
+        info(s"Successfully transferred the leadership for $topicPartition")
+      case Left(e) =>
+        error(s"Received error when transferring leadership for $topicPartition", e.exception())
+    }
   }
 
   private def sendAlterIsrRequest(proposedIsrState: IsrState): Unit = {

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -968,8 +968,39 @@ class Partition(val topicPartition: TopicPartition,
       tryCompleteDelayedRequests()
   }
 
+  /**
+   * We should only shrink the ISR if the ISR set is >= minISR after the shrinking.
+   * When ISR set needs to be dropped under MinISR, a leadership switch would be triggered.
+   */
   private def needsShrinkIsr(): Boolean = {
-    leaderLogIfLocal.exists { _ => getOutOfSyncReplicas(replicaLagTimeMaxMs).nonEmpty }
+    leaderLogIfLocal.exists { log =>
+      val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
+      outOfSyncReplicaIds.nonEmpty && (inSyncReplicaIds -- outOfSyncReplicaIds).size >= log.config.minInSyncReplicas
+    }
+  }
+
+  def maybeTransferToNewLeader(): Unit = {
+    val recommendedNewLeader = inReadLock(leaderIsrUpdateLock) {
+      needsLeadershipTransfer()
+    }
+
+    recommendedNewLeader match {
+      case Some(newLeader) =>
+        transferToNewLeader(newLeader)
+      case None => // do nothing
+    }
+  }
+  /**
+   * We should transfer the leadership if the ISR needs to be dropped to be below MinISR
+   * @return the recommended new leader for the partition, which is a random broker in the ISR
+   */
+  private def needsLeadershipTransfer(): Option[Int] = {
+    leaderLogIfLocal.flatMap { log =>
+      val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
+      if ((inSyncReplicaIds -- outOfSyncReplicaIds).size < log.config.minInSyncReplicas) {
+        inSyncReplicaIds.find(_ != localBrokerId)
+      } else None
+    }
   }
 
   private def isFollowerOutOfSync(replicaId: Int,
@@ -1354,6 +1385,10 @@ class Partition(val topicPartition: TopicPartition,
     } else {
       trace(s"ISR update in-flight, not removing out-of-sync replicas $outOfSyncReplicas")
     }
+  }
+
+  private[cluster] def transferToNewLeader(newLeader: Int): Unit = {
+
   }
 
   private def sendAlterIsrRequest(proposedIsrState: IsrState): Unit = {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -61,7 +61,7 @@ object KafkaController extends Logging {
   val InitialControllerEpoch = 0
   val InitialControllerEpochZkVersion = 0
   val topicNameBytesOverheadOnZk = 4
-  type ElectLeadersCallback = Map[TopicPartition, Either[ApiError, Int]] => Unit
+  type ElectLeadersCallback = Either[Map[TopicPartition, Either[ApiError, Int]], Errors] => Unit
   type ListReassignmentsCallback = Either[Map[TopicPartition, ReplicaAssignment], ApiError] => Unit
   type AlterReassignmentsCallback = Either[Map[TopicPartition, ApiError], ApiError] => Unit
   type AlterIsrCallback = Either[Map[TopicPartition, Either[Errors, LeaderAndIsr]], Errors] => Unit
@@ -2619,13 +2619,29 @@ class KafkaController(val config: KafkaConfig,
     partitionRecommendedLeadersFromAdminClientOpt: Option[Map[TopicPartition, Int]],
     electionType: ElectionType,
     electionTrigger: ElectionTrigger,
-    callback: ElectLeadersCallback
+    callback: ElectLeadersCallback,
+    brokerId: Int,
+    brokerEpoch: Long
   ): Unit = {
     if (!isActive) {
-      callback(partitionsFromAdminClientOpt.fold(Map.empty[TopicPartition, Either[ApiError, Int]]) { partitions =>
+      callback(Left(partitionsFromAdminClientOpt.fold(Map.empty[TopicPartition, Either[ApiError, Int]]) { partitions =>
         partitions.iterator.map(partition => partition -> Left(new ApiError(Errors.NOT_CONTROLLER, null))).toMap
-      })
+      }))
     } else {
+      if (brokerId != -1) {
+        val brokerEpochOpt = controllerContext.liveBrokerIdAndEpochs.get(brokerId)
+        if (brokerEpochOpt.isEmpty) {
+          info(s"Ignoring AlterIsr due to unknown broker $brokerId")
+          callback.apply(Right(Errors.STALE_BROKER_EPOCH))
+          return
+        }
+        if (!brokerEpochOpt.contains(brokerEpoch)) {
+          info(s"Ignoring AlterIsr due to stale broker epoch $brokerEpoch and local broker epoch $brokerEpochOpt for broker $brokerId")
+          callback.apply(Right(Errors.STALE_BROKER_EPOCH))
+          return
+        }
+      }
+
       // We need to register the watcher if the path doesn't exist in order to detect future preferred replica
       // leader elections and we get the `path exists` check for free
       if (electionTrigger == AdminClientTriggered || zkClient.registerZNodeChangeHandlerAndCheckExistence(preferredReplicaElectionHandler)) {
@@ -2709,7 +2725,7 @@ class KafkaController(val config: KafkaConfig,
         )
 
         debug(s"Waiting for any successful result for election type ($electionType) by $electionTrigger for partitions: $results")
-        callback(results)
+        callback(Left(results))
       }
     }
   }
@@ -2999,8 +3015,8 @@ class KafkaController(val config: KafkaConfig,
           error("Received a ShutdownEventThread event. This type of event is supposed to be handle by ControllerEventThread")
         case AutoPreferredReplicaLeaderElection =>
           processAutoPreferredReplicaLeaderElection()
-        case ReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback) =>
-          processReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback)
+        case ReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback, brokerId, brokerEpoch) =>
+          processReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback, brokerId, brokerEpoch)
         case UncleanLeaderElectionEnable =>
           processUncleanLeaderElectionEnable()
         case TopicUncleanLeaderElectionEnable(topic) =>
@@ -3370,15 +3386,17 @@ case class ReplicaLeaderElection(
   partitionRecommendedLeadersFromAdminClientOpt: Option[Map[TopicPartition, Int]],
   electionType: ElectionType,
   electionTrigger: ElectionTrigger,
-  callback: ElectLeadersCallback = _ => {}
+  callback: ElectLeadersCallback = _ => {},
+  brokerId: Int = -1, // brokerId and epoch are only used for broker initiated leader election
+  brokerEpoch: Long = -1
 ) extends ControllerEvent {
   override def state: ControllerState = ControllerState.ManualLeaderBalance
 
-  override def preempt(): Unit = callback(
+  override def preempt(): Unit = callback(Left(
     partitionsFromAdminClientOpt.fold(Map.empty[TopicPartition, Either[ApiError, Int]]) { partitions =>
       partitions.iterator.map(partition => partition -> Left(new ApiError(Errors.NOT_CONTROLLER, null))).toMap
     }
-  )
+  ))
 }
 
 /**

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -51,6 +51,10 @@ trait AlterIsrManager {
   def submit(alterIsrItem: AlterIsrItem): Boolean
 }
 
+case class TransferToLeaderItem(topicPartition: TopicPartition,
+  newLeader: Int,
+  callback: Either[Errors, LeaderAndIsr] => Unit)
+
 case class AlterIsrItem(topicPartition: TopicPartition,
                         leaderAndIsr: LeaderAndIsr,
                         callback: Either[Errors, LeaderAndIsr] => Unit,

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -528,6 +528,9 @@ class BrokerServer(
       if (alterIsrManager != null)
         CoreUtils.swallow(alterIsrManager.shutdown(), this)
 
+      if (transferLeaderManager != null)
+        CoreUtils.swallow(transferLeaderManager.shutdown(), this)
+
       if (clientToControllerChannelManager != null)
         CoreUtils.swallow(clientToControllerChannelManager.shutdown(), this)
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -134,6 +134,8 @@ class BrokerServer(
 
   var alterIsrManager: AlterIsrManager = null
 
+  var transferLeaderManager: TransferLeaderManager = null
+
   var autoTopicCreationManager: AutoTopicCreationManager = null
 
   var kafkaScheduler: KafkaScheduler = null
@@ -262,9 +264,21 @@ class BrokerServer(
       )
       alterIsrManager.start()
 
+      transferLeaderManager = TransferLeaderManager(
+        config = config,
+        metadataCache = metadataCache,
+        scheduler = kafkaScheduler,
+        time = time,
+        metrics = metrics,
+        threadNamePrefix = threadNamePrefix,
+        brokerEpochSupplier = () => lifecycleManager.brokerEpoch,
+        config.brokerId
+      )
+      transferLeaderManager.start()
+
       this._replicaManager = new ReplicaManager(config, metrics, time, None,
         kafkaScheduler, logManager, Option.apply(remoteLogManager), isShuttingDown, quotaManagers,
-        brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager,
+        brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager, transferLeaderManager,
         threadNamePrefix)
 
       /* start token manager */

--- a/core/src/main/scala/kafka/server/DelayedElectLeader.scala
+++ b/core/src/main/scala/kafka/server/DelayedElectLeader.scala
@@ -31,7 +31,7 @@ class DelayedElectLeader(
   expectedLeaders: Map[TopicPartition, Int],
   results: Map[TopicPartition, ApiError],
   replicaManager: ReplicaManager,
-  responseCallback: Map[TopicPartition, ApiError] => Unit
+  responseCallback: Either[Map[TopicPartition, ApiError], Errors] => Unit
 ) extends DelayedOperation(delayMs) {
 
   import DelayedOperation._
@@ -55,7 +55,7 @@ class DelayedElectLeader(
     val timedOut = waitingPartitions.map {
       case (tp, _) => tp -> new ApiError(Errors.REQUEST_TIMED_OUT, null)
     }
-    responseCallback(timedOut ++ fullResults)
+    responseCallback(Left(timedOut ++ fullResults))
   }
 
   /**

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -756,7 +756,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val interesting = mutable.ArrayBuffer[(TopicPartition, FetchRequest.PartitionData)]()
     if (fetchRequest.isFromFollower) {
       // The follower must have ClusterAction on ClusterResource in order to fetch partition data.
-      if (authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME)) {
+      if (authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME) && !config.liDropFetchFollowerEnable) {
         fetchContext.foreachPartition { (topicPartition, data) =>
           if (!metadataCache.contains(topicPartition))
             erroneous += topicPartition -> FetchResponse.partitionResponse(topicPartition.partition, Errors.UNKNOWN_TOPIC_OR_PARTITION)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3044,55 +3044,59 @@ class KafkaApis(val requestChannel: RequestChannel,
     val electionRequest = request.body[ElectLeadersRequest]
 
     def sendResponseCallback(
-      error: ApiError
-    )(
-      results: Map[TopicPartition, ApiError]
+      topResults: Either[Map[TopicPartition, ApiError], Errors]
     ): Unit = {
       requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => {
-        val adjustedResults = if (electionRequest.data.topicPartitions == null) {
-          /* When performing elections across all of the partitions we should only return
-           * partitions for which there was an eleciton or resulted in an error. In other
-           * words, partitions that didn't need election because they ready have the correct
-           * leader are not returned to the client.
-           */
-          results.filter { case (_, error) =>
-            error.error != Errors.ELECTION_NOT_NEEDED
-          }
-        } else results
+        topResults match {
+          case Right(error) =>
+            new ElectLeadersResponse(
+              requestThrottleMs,
+              error.code,
+              Collections.emptyList(),
+              electionRequest.version
+            )
+          case Left(results) =>
+            val adjustedResults = if (electionRequest.data.topicPartitions == null) {
+              /* When performing elections across all of the partitions we should only return
+               * partitions for which there was an eleciton or resulted in an error. In other
+               * words, partitions that didn't need election because they ready have the correct
+               * leader are not returned to the client.
+               */
+              results.filter { case (_, error) =>
+                error.error != Errors.ELECTION_NOT_NEEDED
+              }
+            } else results
 
-        val electionResults = new util.ArrayList[ReplicaElectionResult]()
-        adjustedResults
-          .groupBy { case (tp, _) => tp.topic }
-          .forKeyValue { (topic, ps) =>
-            val electionResult = new ReplicaElectionResult()
+            val electionResults = new util.ArrayList[ReplicaElectionResult]()
+            adjustedResults
+              .groupBy { case (tp, _) => tp.topic }
+              .forKeyValue { (topic, ps) =>
+                val electionResult = new ReplicaElectionResult()
 
-            electionResult.setTopic(topic)
-            ps.forKeyValue { (topicPartition, error) =>
-              val partitionResult = new PartitionResult()
-              partitionResult.setPartitionId(topicPartition.partition)
-              partitionResult.setErrorCode(error.error.code)
-              partitionResult.setErrorMessage(error.message)
-              electionResult.partitionResult.add(partitionResult)
-            }
+                electionResult.setTopic(topic)
+                ps.forKeyValue { (topicPartition, error) =>
+                  val partitionResult = new PartitionResult()
+                  partitionResult.setPartitionId(topicPartition.partition)
+                  partitionResult.setErrorCode(error.error.code)
+                  partitionResult.setErrorMessage(error.message)
+                  electionResult.partitionResult.add(partitionResult)
+                }
 
-            electionResults.add(electionResult)
-          }
+                electionResults.add(electionResult)
+              }
 
-        new ElectLeadersResponse(
-          requestThrottleMs,
-          error.error.code,
-          electionResults,
-          electionRequest.version
-        )
+            new ElectLeadersResponse(
+              requestThrottleMs,
+              ApiError.NONE.error.code,
+              electionResults,
+              electionRequest.version
+            )
+        }
       })
     }
 
     if (!authHelper.authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME)) {
-      val error = new ApiError(Errors.CLUSTER_AUTHORIZATION_FAILED, null)
-      val partitionErrors: Map[TopicPartition, ApiError] =
-        electionRequest.topicPartitions.iterator.map(partition => partition -> error).toMap
-
-      sendResponseCallback(error)(partitionErrors)
+      sendResponseCallback(Right(Errors.CLUSTER_AUTHORIZATION_FAILED))
     } else {
       val partitions = if (electionRequest.data.topicPartitions == null) {
         metadataCache.getAllTopics().flatMap(metadataCache.getTopicPartitions)
@@ -3105,7 +3109,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         partitions,
         electionRequest.partitionRecommendedLeaders,
         electionRequest.electionType,
-        sendResponseCallback(ApiError.NONE),
+        sendResponseCallback,
         electionRequest.data.timeoutMs
       )
     }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -323,6 +323,7 @@ object Defaults {
   /** Linkedin Internal states */
   val LiCombinedControlRequestEnabled = false
   val LiUpdateMetadataDelayMs = 0
+  val LiDropFetchFollowerEnable = false
   val LiAlterIsrEnabled = true
   val LiAsyncFetcherEnabled = false
   val LiNumControllerInitThreads = 1
@@ -440,6 +441,7 @@ object KafkaConfig {
   val LiAsyncFetcherEnableProp = "li.async.fetcher.enable"
   val LiCombinedControlRequestEnableProp = "li.combined.control.request.enable"
   val LiUpdateMetadataDelayMsProp = "li.update.metadata.delay.ms"
+  val LiDropFetchFollowerEnableProp = "li.stop.replication.enable"
   val LiAlterIsrEnableProp = "li.alter.isr.enable"
   val LiNumControllerInitThreadsProp = "li.num.controller.init.threads"
   val LiLogCleanerFineGrainedLockEnableProp = "li.log.cleaner.fine.grained.lock.enable"
@@ -778,6 +780,7 @@ object KafkaConfig {
   val LiAsyncFetcherEnableDoc = "Specifies whether the event-based async fetcher should be used."
   val LiCombinedControlRequestEnableDoc = "Specifies whether the controller should use the LiCombinedControlRequest."
   val LiUpdateMetadataDelayMsDoc = "Specifies how long a UpdateMetadata request with partitions should be delayed before its processing can start. This config is purely for testing the LiCombinedControl feature and should not be enabled in a production environment."
+  val LiDropFetchFollowerEnableDoc = "Specifies whether a leader should drop Fetch requests from followers. This config is used to simulate a slow leader and test the leader initiated leadership transfer"
   val LiAlterIsrEnabledDoc = "Specifies whether the brokers should use the AlterISR request to propagate ISR changes to the controller. If set to false, brokers will propagate the updates via Zookeeper."
   val LiNumControllerInitThreadsDoc = "Number of threads (and Zookeeper clients + connections) to be used while recursing the topic-partitions tree in Zookeeper during controller startup/failover."
   val LiLogCleanerFineGrainedLockEnableDoc = "Specifies whether the log cleaner should use fine grained locks when calculating the filthiest log to clean"
@@ -1219,6 +1222,7 @@ object KafkaConfig {
       .define(LiAsyncFetcherEnableProp, BOOLEAN, Defaults.LiAsyncFetcherEnabled, HIGH, LiAsyncFetcherEnableDoc)
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
       .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, atLeast(0), LOW, LiUpdateMetadataDelayMsDoc)
+      .define(LiDropFetchFollowerEnableProp, BOOLEAN, Defaults.LiDropFetchFollowerEnable, LOW, LiDropFetchFollowerEnableDoc)
       .define(LiAlterIsrEnableProp, BOOLEAN, Defaults.LiAlterIsrEnabled, HIGH, LiAlterIsrEnabledDoc)
       .define(LiNumControllerInitThreadsProp, INT, Defaults.LiNumControllerInitThreads, atLeast(1), LOW, LiNumControllerInitThreadsDoc)
       .define(LiLogCleanerFineGrainedLockEnableProp, BOOLEAN, Defaults.LiLogCleanerFineGrainedLockEnabled, LOW, LiLogCleanerFineGrainedLockEnableDoc)
@@ -1730,6 +1734,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val liAsyncFetcherEnable = getBoolean(KafkaConfig.LiAsyncFetcherEnableProp)
   def liCombinedControlRequestEnable = getBoolean(KafkaConfig.LiCombinedControlRequestEnableProp)
   def liUpdateMetadataDelayMs = getLong(KafkaConfig.LiUpdateMetadataDelayMsProp)
+  def liDropFetchFollowerEnable = getBoolean(KafkaConfig.LiDropFetchFollowerEnableProp)
   def liAlterIsrEnable = getBoolean(KafkaConfig.LiAlterIsrEnableProp)
   def liNumControllerInitThreads = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
   def liLogCleanerFineGrainedLockEnable = getBoolean(KafkaConfig.LiLogCleanerFineGrainedLockEnableProp)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -155,6 +155,8 @@ class KafkaServer(
 
   var alterIsrManager: AlterIsrManager = null
 
+  var transferLeaderManager: TransferLeaderManager = null
+
   var kafkaScheduler: KafkaScheduler = null
 
   var metadataCache: ZkMetadataCache = null
@@ -353,6 +355,18 @@ class KafkaServer(
         }
         alterIsrManager.start()
 
+        transferLeaderManager = TransferLeaderManager(
+          config = config,
+          metadataCache = metadataCache,
+          scheduler = kafkaScheduler,
+          time = time,
+          metrics = metrics,
+          threadNamePrefix = threadNamePrefix,
+          brokerEpochSupplier = () => kafkaController.brokerEpoch,
+          config.brokerId
+        )
+        transferLeaderManager.start()
+
         _replicaManager = createReplicaManager(isShuttingDown)
         replicaManager.startup()
 
@@ -522,7 +536,7 @@ class KafkaServer(
 
   protected def createReplicaManager(isShuttingDown: AtomicBoolean): ReplicaManager = {
     new ReplicaManager(config, metrics, time, Some(zkClient), kafkaScheduler, logManager, Option.apply(remoteLogManager),
-      isShuttingDown, quotaManagers, brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager)
+      isShuttingDown, quotaManagers, brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager, transferLeaderManager)
   }
 
   private def initZkClient(time: Time): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -838,6 +838,9 @@ class KafkaServer(
         if (alterIsrManager != null)
           CoreUtils.swallow(alterIsrManager.shutdown(), this)
 
+        if (transferLeaderManager != null)
+          CoreUtils.swallow(transferLeaderManager.shutdown(), this)
+
         if (clientToControllerChannelManager != null)
           CoreUtils.swallow(clientToControllerChannelManager.shutdown(), this)
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -203,7 +203,8 @@ class ReplicaManager(val config: KafkaConfig,
                      val delayedElectLeaderPurgatory: DelayedOperationPurgatory[DelayedElectLeader],
                      val delayedRemoteFetchPurgatory: DelayedOperationPurgatory[DelayedRemoteFetch],
                      threadNamePrefix: Option[String],
-                     val alterIsrManager: AlterIsrManager) extends Logging with KafkaMetricsGroup {
+                     val alterIsrManager: AlterIsrManager,
+                     val transferLeaderManager: TransferLeaderManager) extends Logging with KafkaMetricsGroup {
 
   def this(config: KafkaConfig,
            metrics: Metrics,
@@ -218,6 +219,7 @@ class ReplicaManager(val config: KafkaConfig,
            metadataCache: MetadataCache,
            logDirFailureChannel: LogDirFailureChannel,
            alterIsrManager: AlterIsrManager,
+           transferLeaderManager: TransferLeaderManager,
            threadNamePrefix: Option[String] = None) = {
     this(config, metrics, time, zkClient, scheduler, logManager, remoteLogManager, isShuttingDown,
       quotaManagers, brokerTopicStats, metadataCache, logDirFailureChannel,
@@ -234,7 +236,7 @@ class ReplicaManager(val config: KafkaConfig,
         purgatoryName = "ElectLeader", brokerId = config.brokerId),
       DelayedOperationPurgatory[DelayedRemoteFetch](
         purgatoryName = "RemoteFetch", brokerId = config.brokerId),
-      threadNamePrefix, alterIsrManager)
+      threadNamePrefix, alterIsrManager, transferLeaderManager)
   }
 
   /* epoch of the controller that last changed the leader */

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -320,7 +320,7 @@ class ReplicaManager(val config: KafkaConfig,
   def startup(): Unit = {
     // start ISR expiration thread
     // A follower can lag behind leader for up to config.replicaLagTimeMaxMs x 1.5 before it is removed from ISR
-    scheduler.schedule("isr-expiration", maybeShrinkIsr _, period = config.replicaLagTimeMaxMs / 2, unit = TimeUnit.MILLISECONDS)
+    scheduler.schedule("isr-expiration", maybeShrinkIsrOrTransferToNewLeader _, period = config.replicaLagTimeMaxMs / 2, unit = TimeUnit.MILLISECONDS)
     // scheduler.schedule("shutdown-idle-replica-alter-log-dirs-thread", shutdownIdleReplicaAlterLogDirsThread _, period = 10000L, unit = TimeUnit.MILLISECONDS)
 
     // If inter-broker protocol (IBP) < 1.0, the controller will send LeaderAndIsrRequest V0 which does not include isNew field.
@@ -1981,12 +1981,17 @@ class ReplicaManager(val config: KafkaConfig,
       log.highWatermark
   }
 
-  private def maybeShrinkIsr(): Unit = {
+  private def maybeShrinkIsrOrTransferToNewLeader(): Unit = {
     trace("Evaluating ISR list of partitions to see which replicas can be removed from the ISR")
 
     // Shrink ISRs for non offline partitions
     allPartitions.keys.foreach { topicPartition =>
       onlinePartition(topicPartition).foreach(_.maybeShrinkIsr())
+    }
+
+    // Transfer leadership for non offline partitions
+    allPartitions.keys.foreach { topicPartition =>
+      onlinePartition(topicPartition).foreach(_.maybeTransferToNewLeader())
     }
   }
 
@@ -2222,38 +2227,45 @@ class ReplicaManager(val config: KafkaConfig,
     partitions: Set[TopicPartition],
     partitionRecommendedLeaders: Map[TopicPartition, Int],
     electionType: ElectionType,
-    responseCallback: Map[TopicPartition, ApiError] => Unit,
+    responseCallback: Either[Map[TopicPartition, ApiError], Errors] => Unit,
     requestTimeout: Int
   ): Unit = {
 
     val deadline = time.milliseconds() + requestTimeout
 
-    def electionCallback(results: Map[TopicPartition, Either[ApiError, Int]]): Unit = {
+    def electionCallback(topResults: Either[Map[TopicPartition, Either[ApiError, Int]], Errors]): Unit = {
       val expectedLeaders = mutable.Map.empty[TopicPartition, Int]
       val failures = mutable.Map.empty[TopicPartition, ApiError]
-      results.foreach {
-        case (partition, Right(leader)) => expectedLeaders += partition -> leader
-        case (partition, Left(error)) => failures += partition -> error
-      }
-      if (expectedLeaders.nonEmpty) {
-        val watchKeys = expectedLeaders.iterator.map {
-          case (tp, _) => TopicPartitionOperationKey(tp)
-        }.toBuffer
+      topResults match {
+        case Right(error) =>
+          responseCallback(Right(error))
+        case Left(results) =>
+          results.foreach {
+            case (partition, Right(leader)) => expectedLeaders += partition -> leader
+            case (partition, Left(error)) => failures += partition -> error
+          }
+          if (expectedLeaders.nonEmpty) {
+            val watchKeys = expectedLeaders.iterator.map {
+              case (tp, _) => TopicPartitionOperationKey(tp)
+            }.toBuffer
 
-        delayedElectLeaderPurgatory.tryCompleteElseWatch(
-          new DelayedElectLeader(
-            math.max(0, deadline - time.milliseconds()),
-            expectedLeaders,
-            failures,
-            this,
-            responseCallback
-          ),
-          watchKeys
-        )
-      } else {
-          // There are no partitions actually being elected, so return immediately
-          responseCallback(failures)
+            delayedElectLeaderPurgatory.tryCompleteElseWatch(
+              new DelayedElectLeader(
+                math.max(0, deadline - time.milliseconds()),
+                expectedLeaders,
+                failures,
+                this,
+                responseCallback
+              ),
+              watchKeys
+            )
+          } else {
+            // There are no partitions actually being elected, so return immediately
+            responseCallback(Left(failures))
+          }
       }
+
+
     }
 
     controller.electLeaders(partitions, partitionRecommendedLeaders, electionType, electionCallback)

--- a/core/src/main/scala/kafka/server/TransferLeaderManager.scala
+++ b/core/src/main/scala/kafka/server/TransferLeaderManager.scala
@@ -1,0 +1,256 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import kafka.metrics.KafkaMetricsGroup
+import kafka.utils.{KafkaScheduler, Logging, Scheduler}
+import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.message.ElectLeadersResponseData
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{ElectLeadersRequest, ElectLeadersResponse}
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{ElectionType, TopicPartition}
+
+import java.util
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{BlockingQueue, ConcurrentHashMap, LinkedBlockingQueue, TimeUnit}
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Transferring the leadership is an asynchronous operation, so partitions will learn about the result of their
+ * request through a callback.
+ *
+ * Note that ISR state changes can still be initiated by the controller and sent to the partitions via LeaderAndIsr
+ * requests.
+ */
+trait TransferLeaderManager {
+  def start(): Unit = {}
+
+  def shutdown(): Unit = {}
+
+  def submit(transferLeaderItem: TransferLeaderItem): Unit
+}
+
+case class TransferLeaderItem(topicPartition: TopicPartition,
+  newLeader: Int,
+  callback: Either[Errors, TopicPartition] => Unit)
+
+object TransferLeaderManager {
+  val defaultTimeout = 60000
+  /**
+   * Factory to TransferLeader based implementation, used when IBP >= 2.7-IV2
+   */
+  def apply(
+    config: KafkaConfig,
+    metadataCache: MetadataCache,
+    scheduler: KafkaScheduler,
+    time: Time,
+    metrics: Metrics,
+    threadNamePrefix: Option[String],
+    brokerEpochSupplier: () => Long,
+    brokerId: Int
+  ): TransferLeaderManager = {
+    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
+
+    val channelManager = BrokerToControllerChannelManager(
+      controllerNodeProvider = nodeProvider,
+      time = time,
+      metrics = metrics,
+      config = config,
+      channelName = "transferLeader",
+      threadNamePrefix = threadNamePrefix,
+      retryTimeoutMs = Long.MaxValue
+    )
+    new DefaultTransferLeaderManager(
+      controllerChannelManager = channelManager,
+      scheduler = scheduler,
+      time = time,
+      brokerId = brokerId,
+      brokerEpochSupplier = brokerEpochSupplier
+    )
+  }
+}
+
+class DefaultTransferLeaderManager(
+  val controllerChannelManager: BrokerToControllerChannelManager,
+  val scheduler: Scheduler,
+  val time: Time,
+  val brokerId: Int,
+  val brokerEpochSupplier: () => Long
+) extends TransferLeaderManager with Logging with KafkaMetricsGroup {
+
+  private[server] val unsentTransferQueue: BlockingQueue[TransferLeaderItem] = new LinkedBlockingQueue()
+  // The inflightIsrUpdates map is populated by the unsentIsrQueue, and the items in it are removed in the response callback.
+  // Putting new items to the inflightIsrUpdates and removing items from it won't be performed at the same time, and the coordination is
+  // done via the inflightRequest flag.
+  private[server] val inflightTransfers: util.Map[TopicPartition, TransferLeaderItem] = new ConcurrentHashMap[TopicPartition, TransferLeaderItem]()
+
+  // Used to allow only one in-flight request at a time
+  private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
+
+  override def start(): Unit = {
+    controllerChannelManager.start()
+  }
+
+  override def shutdown(): Unit = {
+    controllerChannelManager.shutdown()
+  }
+
+  override def submit(transferLeaderItem: TransferLeaderItem): Unit = {
+    unsentTransferQueue.put(transferLeaderItem)
+    maybeTransferLeader()
+  }
+
+  private[server] def maybeTransferLeader(): Unit = {
+    // Send all pending items if there is not already a request in-flight.
+    if ((!unsentTransferQueue.isEmpty || !inflightTransfers.isEmpty) && inflightRequest.compareAndSet(false, true)) {
+      // Copy current unsent ISRs but don't remove from the map, they get cleared in the response handler
+      while (!unsentTransferQueue.isEmpty) {
+        val item = unsentTransferQueue.poll()
+        // if there are multiple TransferLeaderItems for the same partition in the queue, the last one wins
+        // and the previous ones will be discarded
+        inflightTransfers.put(item.topicPartition, item)
+      }
+      // Since the maybePropagateIsrChanges can be called from the response callback,
+      // there may be cases where right after the while loop, some new items are added to the unsentIsrQueue in the submit
+      // thread. In such a case, the newly added item will be sent in the next request
+
+      val inflightTransferLeaderItems = new ListBuffer[TransferLeaderItem]()
+      inflightTransfers.values().forEach(item => inflightTransferLeaderItems.append(item))
+      sendRequest(inflightTransferLeaderItems)
+    }
+  }
+
+  private[server] def clearInFlightRequest(): Unit = {
+    if (!inflightRequest.compareAndSet(true, false)) {
+      warn("Attempting to clear TransferLeader in-flight flag when no apparent request is in-flight")
+    }
+  }
+
+  private def sendRequest(inflightTransferLeaderItems: Seq[TransferLeaderItem]): Unit = {
+    val brokerEpoch = brokerEpochSupplier.apply()
+    val request = buildRequest(inflightTransferLeaderItems, brokerEpoch)
+    debug(s"Sending TransferLeader to controller $request")
+
+    // We will not timeout AlterISR request, instead letting it retry indefinitely
+    // until a response is received, or a new LeaderAndIsr overwrites the existing isrState
+    // which causes the response for those partitions to be ignored.
+    controllerChannelManager.sendRequest(request,
+      new ControllerRequestCompletionHandler {
+        override def onComplete(response: ClientResponse): Unit = {
+          debug(s"Received TransferLeader response $response")
+          val error = try {
+            if (response.authenticationException != null) {
+              // For now we treat authentication errors as retriable. We use the
+              // `NETWORK_EXCEPTION` error code for lack of a good alternative.
+              // Note that `BrokerToControllerChannelManager` will still log the
+              // authentication errors so that users have a chance to fix the problem.
+              Errors.NETWORK_EXCEPTION
+            } else if (response.versionMismatch != null) {
+              Errors.UNSUPPORTED_VERSION
+            } else {
+              val body = response.responseBody().asInstanceOf[ElectLeadersResponse]
+              handleTransferLeaderResponse(body, brokerEpoch, inflightTransferLeaderItems)
+            }
+          } finally {
+            // clear the flag so future requests can proceed
+            clearInFlightRequest()
+          }
+
+          // check if we need to send another request right away
+          error match {
+              case Errors.NONE =>
+                // In the normal case, check for pending updates to send immediately
+                maybeTransferLeader()
+              case _ =>
+                // If we received a top-level error from the controller, retry the request in the near future
+                scheduler.schedule("send-alter-isr", () => maybeTransferLeader(), 50, -1, TimeUnit.MILLISECONDS)
+            }
+        }
+
+        override def onTimeout(): Unit = {
+          throw new IllegalStateException("Encountered unexpected timeout when sending TransferLeader to the controller")
+        }
+      })
+  }
+
+  private def buildRequest(inflightTransferLeaderItems: Seq[TransferLeaderItem], brokerEpoch: Long): ElectLeadersRequest.Builder = {
+    val topicPartitions = new util.ArrayList[TopicPartition]()
+    val recommendedLeaders = new util.HashMap[TopicPartition, Integer]()
+
+    inflightTransferLeaderItems.groupBy(_.topicPartition.topic).foreach(entry => {
+      entry._2.foreach(item => {
+        topicPartitions.add(item.topicPartition)
+        recommendedLeaders.put(item.topicPartition, item.newLeader)
+      })
+    })
+    new ElectLeadersRequest.Builder(brokerEpoch, recommendedLeaders, TransferLeaderManager.defaultTimeout)
+  }
+
+  def handleTransferLeaderResponse(transferLeaderResponse: ElectLeadersResponse,
+                             sentBrokerEpoch: Long,
+                             inflightTransferLeaderItems: Seq[TransferLeaderItem]): Errors = {
+    val data: ElectLeadersResponseData = transferLeaderResponse.data
+
+    Errors.forCode(data.errorCode) match {
+      case Errors.STALE_BROKER_EPOCH =>
+        warn(s"Broker had a stale broker epoch ($sentBrokerEpoch), retrying.")
+      case Errors.CLUSTER_AUTHORIZATION_FAILED =>
+        error(s"Broker is not authorized to send TransferLeader to controller",
+          Errors.CLUSTER_AUTHORIZATION_FAILED.exception("Broker is not authorized to send TransferLeader to controller"))
+      case Errors.NONE =>
+        // Collect partition-level responses to pass to the callbacks
+        val partitionResponses: mutable.Map[TopicPartition, Either[Errors, TopicPartition]] =
+          new mutable.HashMap[TopicPartition, Either[Errors, TopicPartition]]()
+        data.replicaElectionResults().forEach { topicResult =>
+          topicResult.partitionResult().forEach(partitionResult => {
+            val tp = new TopicPartition(topicResult.topic, partitionResult.partitionId())
+            val error = Errors.forCode(partitionResult.errorCode())
+            debug(s"Controller successfully handled TransferLeader request for $tp: $partitionResult")
+            if (error == Errors.NONE) {
+              partitionResponses(tp) = Right(tp)
+            } else {
+              partitionResponses(tp) = Left(error)
+            }
+          })
+        }
+
+        // Iterate across the items we sent rather than what we received to ensure we run the callback even if a
+        // partition was somehow erroneously excluded from the response. Note that these callbacks are run from
+        // the leaderIsrUpdateLock write lock in Partition#sendTransferLeaderRequest
+        inflightTransferLeaderItems.foreach(inflightTransferLeader =>
+          if (partitionResponses.contains(inflightTransferLeader.topicPartition)) {
+            try {
+              inflightTransferLeader.callback.apply(partitionResponses(inflightTransferLeader.topicPartition))
+            } finally {
+              // Regardless of callback outcome, we need to clear from the unsent updates map to unblock further updates
+              inflightTransfers.remove(inflightTransferLeader.topicPartition)
+            }
+          } else {
+            // Don't remove this partition from the update map so it will get re-sent
+            warn(s"Partition ${inflightTransferLeader.topicPartition} was sent but not included in the response")
+          }
+        )
+      case e: Errors =>
+        warn(s"Controller returned an unexpected top-level error when handling TransferLeader request: $e")
+    }
+
+    Errors.forCode(data.errorCode)
+  }
+}

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -18,7 +18,7 @@ package kafka.cluster
 
 import kafka.api.ApiVersion
 import kafka.log.{CleanerConfig, LogConfig, LogManager}
-import kafka.server.{Defaults, MetadataCache}
+import kafka.server.{Defaults, MetadataCache, TransferLeaderManager}
 import kafka.server.checkpoints.OffsetCheckpoints
 import kafka.server.metadata.MockConfigRepository
 import kafka.utils.TestUtils.{MockAlterIsrManager, MockIsrChangeListener}
@@ -33,7 +33,6 @@ import org.mockito.Mockito.{mock, when}
 
 import java.io.File
 import java.util.Properties
-
 import scala.jdk.CollectionConverters._
 
 object AbstractPartitionTest {
@@ -50,6 +49,7 @@ class AbstractPartitionTest {
   var logDir2: File = _
   var logManager: LogManager = _
   var alterIsrManager: MockAlterIsrManager = _
+  var transferLeaderManager: TransferLeaderManager = _
   var isrChangeListener: MockIsrChangeListener = _
   var logConfig: LogConfig = _
   var configRepository: MockConfigRepository = _
@@ -74,6 +74,7 @@ class AbstractPartitionTest {
     logManager.startup(Set.empty)
 
     alterIsrManager = TestUtils.createAlterIsrManager()
+    transferLeaderManager = TestUtils.createTransferLeaderManager()
     isrChangeListener = TestUtils.createIsrChangeListener()
     partition = new Partition(topicPartition,
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
@@ -84,7 +85,8 @@ class AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     when(offsetCheckpoints.fetch(ArgumentMatchers.anyString, ArgumentMatchers.eq(topicPartition)))
       .thenReturn(None)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -258,6 +258,7 @@ class PartitionLockTest extends Logging {
     val metadataCache: MetadataCache = mock(classOf[MetadataCache])
     val offsetCheckpoints: OffsetCheckpoints = mock(classOf[OffsetCheckpoints])
     val alterIsrManager: AlterIsrManager = mock(classOf[AlterIsrManager])
+    val transferLeaderManager: TransferLeaderManager = mock(classOf[TransferLeaderManager])
 
     logManager.startup(Set.empty)
     val partition = new Partition(topicPartition,
@@ -269,7 +270,8 @@ class PartitionLockTest extends Logging {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager) {
+      alterIsrManager,
+      transferLeaderManager) {
 
       override def shrinkIsr(newIsr: Set[Int]): Unit = {
         shrinkIsrSemaphore.acquire()

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -205,7 +205,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager) {
+      alterIsrManager,
+      transferLeaderManager) {
 
       override def createLog(isNew: Boolean, isFutureReplica: Boolean, offsetCheckpoints: OffsetCheckpoints, topicId: Option[Uuid]): Log = {
         val log = super.createLog(isNew, isFutureReplica, offsetCheckpoints, None)
@@ -1596,7 +1597,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      zkIsrManager)
+      zkIsrManager,
+      transferLeaderManager)
 
     val log = logManager.getOrCreateLog(topicPartition, topicId = None)
     seedLogData(log, numRecords = 10, leaderEpoch = 4)
@@ -1696,7 +1698,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     // partition2 should not yet be associated with the log, but should be able to get ID
     assertTrue(partition2.topicId.isDefined)
@@ -1740,7 +1743,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     // partition2 should not yet be associated with the log, but should be able to get ID
     assertTrue(partition2.topicId.isDefined)
@@ -1817,7 +1821,7 @@ class PartitionTest extends AbstractPartitionTest {
     val partition = new Partition(
       topicPartition, 1000, ApiVersion.latestVersion, 0,
       new SystemTime(), mock(classOf[IsrChangeListener]), mock(classOf[DelayedOperations]),
-      mock(classOf[MetadataCache]), mock(classOf[LogManager]), mock(classOf[AlterIsrManager]))
+      mock(classOf[MetadataCache]), mock(classOf[LogManager]), mock(classOf[AlterIsrManager]), mock(classOf[TransferLeaderManager]))
 
     val replicas = Seq(0, 1, 2, 3)
     val isr = Set(0, 1, 2, 3)
@@ -1865,7 +1869,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       spyLogManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None)
 
@@ -1903,7 +1908,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       spyLogManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None)
 
@@ -1944,7 +1950,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       spyLogManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None)
 

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1096,12 +1096,16 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     val tp0 = new TopicPartition("t", 0)
     val tp1 = new TopicPartition("t", 1)
     val partitions = Set(tp0, tp1)
-    val event1 = ReplicaLeaderElection(Some(partitions), Some(Map.empty), ElectionType.PREFERRED, ZkTriggered, partitionsMap => {
-      for (partition <- partitionsMap) {
-        partition._2 match {
-          case Left(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())
-          case Right(_) => throw new AssertionError("replica leader election should error")
-        }
+    val event1 = ReplicaLeaderElection(Some(partitions), Some(Map.empty), ElectionType.PREFERRED, ZkTriggered, topResult => {
+      topResult match {
+        case Right(error) =>
+        case Left(partitionsMap) =>
+          for (partition <- partitionsMap) {
+            partition._2 match {
+              case Left(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())
+              case Right(_) => throw new AssertionError("replica leader election should error")
+            }
+          }
       }
     })
     val event2 = ControlledShutdown(0, 0, {

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -158,7 +158,7 @@ object AbstractCoordinatorConcurrencyTest {
   }
 
   class TestReplicaManager extends ReplicaManager(
-    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null) {
+    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null, null) {
 
     @volatile var logs: mutable.Map[TopicPartition, (Log, Long)] = _
     var producePurgatory: DelayedOperationPurgatory[DelayedProduce] = _

--- a/core/src/test/scala/unit/kafka/integration/DegradedLeaderTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/DegradedLeaderTest.scala
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.integration
+
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.clients.admin.Admin
+import org.apache.kafka.clients.producer.{Producer, ProducerRecord}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.TopicConfig
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.{Collections, Properties}
+import scala.collection.JavaConverters._
+
+class DegradedLeaderTest extends ZooKeeperTestHarness {
+  @Test
+  def testLeadershipTransferByDegradedLeader(): Unit = {
+    // create brokers
+    val serverConfigs = TestUtils.createBrokerConfigs(5, zkConnect, false)
+      .map(props => {
+        if (props.get(KafkaConfig.BrokerIdProp).equals("0")) {
+          // let the leader drop Fetch requests from the followers, which will cause the partition to be UnderMinISR
+          props.setProperty(KafkaConfig.LiDropFetchFollowerEnableProp, "true")
+        }
+        props.put(KafkaConfig.ReplicaLagTimeMaxMsProp, "10000")
+        props
+      })
+      .map(KafkaConfig.fromProps)
+    // start servers in reverse order to ensure broker 4 becomes the controller
+    val servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+    // val controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+    assertTrue(controllerId == 4)
+
+    // create the topic with min ISR of 2
+    val topic = "test"
+    val partition = 0
+    val tp = new TopicPartition(topic, partition)
+    val topicConfig = new Properties()
+    topicConfig.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+    val expectedReplicaAssignment = Map(0  -> List(0, 1, 2, 3))
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+
+    val adminClient = TestUtils.createAdminClient(servers)
+    val initialLeader = 0
+    assertTrue(getLeader(adminClient, tp) == initialLeader)
+
+    val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
+      deliveryTimeoutMs = 30 * 1000,
+      lingerMs = 0,
+      requestTimeoutMs = 20 * 1000)
+    produceRecord(producer, topic, partition)
+
+    TestUtils.waitUntilTrue(() => {
+      // wait until the leadership has switch to a different broker
+      val newLeader = getLeader(adminClient, tp)
+      newLeader != initialLeader
+    }, "the leadership hasn't switched")
+
+    // make sure after the leadership switch, the producing still works
+    produceRecord(producer, topic, partition)
+
+    adminClient.close()
+    producer.close()
+    servers.foreach(_.shutdown())
+  }
+
+  private def getLeader(adminClient: Admin, tp: TopicPartition): Int = {
+    val topicDescMap = adminClient.describeTopics(Collections.singleton(tp.topic())).all().get()
+    topicDescMap.get(tp.topic()).partitions().get(tp.partition()).leader().id()
+  }
+
+  private def getISR(adminClient: Admin, tp: TopicPartition): Seq[Int] = {
+    val topicDescMap = adminClient.describeTopics(Collections.singleton(tp.topic())).all().get()
+    topicDescMap.get(tp.topic()).partitions().get(tp.partition()).isr().asScala.map(node => node.id())
+  }
+
+  private def produceRecord(producer: Producer[Array[Byte], Array[Byte]], topic: String, partition: Int) = {
+    val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
+      "value".getBytes(StandardCharsets.UTF_8))
+    producer.send(record).get()
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -48,6 +48,8 @@ class HighwatermarkPersistenceTest {
 
   val alterIsrManager = TestUtils.createAlterIsrManager()
 
+  val transferLeaderManager = TestUtils.createTransferLeaderManager()
+
   @AfterEach
   def teardown(): Unit = {
     for (manager <- logManagers; dir <- manager.liveLogDirs)
@@ -65,7 +67,7 @@ class HighwatermarkPersistenceTest {
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, None, scheduler,
       logManagers.head, None, new AtomicBoolean(false), quotaManager,
-      new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager)
+      new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager, transferLeaderManager)
     replicaManager.startup()
     try {
       replicaManager.checkpointHighWatermarks()
@@ -114,7 +116,7 @@ class HighwatermarkPersistenceTest {
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, None,
       scheduler, logManagers.head, None, new AtomicBoolean(false), quotaManager,
-      new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager)
+      new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager, transferLeaderManager)
     replicaManager.startup()
     try {
       replicaManager.checkpointHighWatermarks()

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -54,7 +54,7 @@ class IsrExpirationTest {
 
   var quotaManager: QuotaManagers = null
   var replicaManager: ReplicaManager = null
-
+  var transferLeaderManager: TransferLeaderManager = TestUtils.createTransferLeaderManager()
   var alterIsrManager: MockAlterIsrManager = _
 
   @BeforeEach
@@ -68,7 +68,7 @@ class IsrExpirationTest {
     replicaManager = new ReplicaManager(configs.head, metrics, time, None, null, logManager, None,
       new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(configs.head.brokerId), new LogDirFailureChannel(configs.head.logDirs.size),
-      alterIsrManager)
+      alterIsrManager, transferLeaderManager)
   }
 
   @AfterEach

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -238,12 +238,12 @@ class ReplicaManagerQuotasTest {
     replay(logManager)
 
     val alterIsrManager: AlterIsrManager = createMock(classOf[AlterIsrManager])
-
+    val transferLeaderManager: TransferLeaderManager = createMock(classOf[TransferLeaderManager])
     val leaderBrokerId = configs.head.brokerId
     quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     replicaManager = new ReplicaManager(configs.head, metrics, time, None, scheduler, logManager, None,
       new AtomicBoolean(false), quotaManager,
-      new BrokerTopicStats, MetadataCache.zkMetadataCache(leaderBrokerId), new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager)
+      new BrokerTopicStats, MetadataCache.zkMetadataCache(leaderBrokerId), new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager, transferLeaderManager)
 
     //create the two replicas
     for ((p, _) <- fetchInfo) {

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -41,6 +41,7 @@ class OffsetsForLeaderEpochTest {
   private val time = new MockTime
   private val metrics = new Metrics
   private val alterIsrManager = TestUtils.createAlterIsrManager()
+  private val transferLeaderManager = TestUtils.createTransferLeaderManager()
   private val tp = new TopicPartition("topic", 1)
   private var replicaManager: ReplicaManager = _
   private var quotaManager: QuotaManagers = _
@@ -67,7 +68,7 @@ class OffsetsForLeaderEpochTest {
     // create a replica manager with 1 partition that has 1 replica
     replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
-      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
+      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager, transferLeaderManager)
     val partition = replicaManager.createPartition(tp)
     partition.setLog(mockLog, isFutureLog = false)
     partition.leaderReplicaIdOpt = Some(config.brokerId)
@@ -90,7 +91,7 @@ class OffsetsForLeaderEpochTest {
     //create a replica manager with 1 partition that has 0 replica
     replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
-      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
+      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager, transferLeaderManager)
     replicaManager.createPartition(tp)
 
     //Given
@@ -115,7 +116,7 @@ class OffsetsForLeaderEpochTest {
     //create a replica manager with 0 partition
     replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
-      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
+      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager, transferLeaderManager)
 
     //Given
     val epochRequested: Integer = 5

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1182,8 +1182,16 @@ object TestUtils extends Logging {
     }
   }
 
+  class MockTransferLeaderManager extends TransferLeaderManager {
+    override def submit(transferLeaderItem: TransferLeaderItem): Unit = ???
+  }
+
   def createAlterIsrManager(): MockAlterIsrManager = {
     new MockAlterIsrManager()
+  }
+
+  def createTransferLeaderManager(): MockTransferLeaderManager = {
+    new MockTransferLeaderManager()
   }
 
   class MockIsrChangeListener extends IsrChangeListener {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -435,6 +435,12 @@ object TestUtils extends Logging {
       server.groupCoordinator.offsetsTopicConfigs)
   }
 
+  def createAdminClient(servers: Seq[KafkaServer], props: Properties = new Properties): Admin = {
+    val bootstrapServers = TestUtils.bootstrapServers(servers, new ListenerName("PLAINTEXT"))
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    AdminClient.create(props)
+  }
+
   /**
    * Wrap a single record log buffer.
    */

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -40,6 +40,7 @@ import kafka.server.OffsetTruncationState;
 import kafka.server.ReplicaFetcherThread;
 import kafka.server.ReplicaManager;
 import kafka.server.ReplicaQuota;
+import kafka.server.TransferLeaderManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
@@ -162,9 +163,10 @@ public class ReplicaFetcherThreadBenchmark {
             OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
             Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), tp)).thenReturn(Option.apply(0L));
             AlterIsrManager isrChannelManager = Mockito.mock(AlterIsrManager.class);
+            TransferLeaderManager transferLeaderManager = Mockito.mock(TransferLeaderManager.class);
             Partition partition = new Partition(tp, 100, ApiVersion$.MODULE$.latestVersion(),
                     0, Time.SYSTEM, isrChangeListener, new DelayedOperationsMock(tp),
-                    Mockito.mock(MetadataCache.class), logManager, isrChannelManager);
+                    Mockito.mock(MetadataCache.class), logManager, isrChannelManager, transferLeaderManager);
 
             partition.makeFollower(partitionState, offsetCheckpoints, topicId);
             pool.put(tp, partition);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -30,6 +30,7 @@ import kafka.server.AlterIsrManager;
 import kafka.server.BrokerTopicStats;
 import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
+import kafka.server.TransferLeaderManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
@@ -128,10 +129,11 @@ public class PartitionMakeFollowerBenchmark {
         Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), tp)).thenReturn(Option.apply(0L));
         IsrChangeListener isrChangeListener = Mockito.mock(IsrChangeListener.class);
         AlterIsrManager alterIsrManager = Mockito.mock(AlterIsrManager.class);
+        TransferLeaderManager transferLeaderManager = Mockito.mock(TransferLeaderManager.class);
         partition = new Partition(tp, 100,
             ApiVersion$.MODULE$.latestVersion(), 0, Time.SYSTEM,
             isrChangeListener, delayedOperations,
-            Mockito.mock(MetadataCache.class), logManager, alterIsrManager);
+            Mockito.mock(MetadataCache.class), logManager, alterIsrManager, transferLeaderManager);
         partition.createLogIfNotExists(true, false, offsetCheckpoints, topicId);
         executorService.submit((Runnable) () -> {
             SimpleRecord[] simpleRecords = new SimpleRecord[] {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -31,6 +31,7 @@ import kafka.server.BrokerTopicStats;
 import kafka.server.LogDirFailureChannel;
 import kafka.server.LogOffsetMetadata;
 import kafka.server.MetadataCache;
+import kafka.server.TransferLeaderManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
@@ -125,10 +126,11 @@ public class UpdateFollowerFetchStateBenchmark {
             .setIsNew(true);
         IsrChangeListener isrChangeListener = Mockito.mock(IsrChangeListener.class);
         AlterIsrManager alterIsrManager = Mockito.mock(AlterIsrManager.class);
+        TransferLeaderManager transferLeaderManager = Mockito.mock(TransferLeaderManager.class);
         partition = new Partition(topicPartition, 100,
                 ApiVersion$.MODULE$.latestVersion(), 0, Time.SYSTEM,
                 isrChangeListener, delayedOperations,
-                Mockito.mock(MetadataCache.class), logManager, alterIsrManager);
+                Mockito.mock(MetadataCache.class), logManager, alterIsrManager, transferLeaderManager);
         partition.makeLeader(partitionState, offsetCheckpoints, topicId);
     }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -28,6 +28,7 @@ import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
+import kafka.server.TransferLeaderManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
@@ -91,6 +92,7 @@ public class CheckpointBench {
     private LogDirFailureChannel failureChannel;
     private LogManager logManager;
     private AlterIsrManager alterIsrManager;
+    private TransferLeaderManager transferLeaderManager;
 
 
     @SuppressWarnings("deprecation")
@@ -121,6 +123,7 @@ public class CheckpointBench {
                         this.time, "");
 
         this.alterIsrManager = TestUtils.createAlterIsrManager();
+        this.transferLeaderManager = TestUtils.createTransferLeaderManager();
         this.replicaManager = new ReplicaManager(
                 this.brokerProperties,
                 this.metrics,
@@ -135,6 +138,7 @@ public class CheckpointBench {
                 metadataCache,
                 this.failureChannel,
                 alterIsrManager,
+                transferLeaderManager,
                 Option.empty());
         replicaManager.startup();
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -31,6 +31,7 @@ import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
+import kafka.server.TransferLeaderManager;
 import kafka.server.ZkMetadataCache;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.ConfigRepository;
@@ -96,6 +97,7 @@ public class PartitionCreationBench {
     private LogDirFailureChannel failureChannel;
     private LogManager logManager;
     private AlterIsrManager alterIsrManager;
+    private TransferLeaderManager transferLeaderManager;
     private List<TopicPartition> topicPartitions;
 
     @SuppressWarnings("deprecation")
@@ -156,6 +158,7 @@ public class PartitionCreationBench {
             }
         };
         this.alterIsrManager = TestUtils.createAlterIsrManager();
+        this.transferLeaderManager = TestUtils.createTransferLeaderManager();
         this.replicaManager = new ReplicaManager(
                 this.brokerProperties,
                 this.metrics,
@@ -170,6 +173,7 @@ public class PartitionCreationBench {
                 metadataCache,
                 this.failureChannel,
                 alterIsrManager,
+                transferLeaderManager,
                 Option.empty());
         replicaManager.startup();
         replicaManager.checkpointHighWatermarks();


### PR DESCRIPTION
TICKET = [LIKAFKA-47596](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-47596)
LI_DESCRIPTION =
This PR leverages the broker-initiated leadership transfer to avoid UnderMinISR partitions under the following scenarios:
1. the leader broker is heavily overloaded and thus cannot serve the Fetch requests fast enough
2. the network path from the leader broker to followers are broken

EXIT_CRITERIA =
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
