### PR TITLE
[LI-HOTFIX] Support broker epoch and error checking for the ElectLeaders request

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3468,7 +3468,11 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             public ElectLeadersRequest.Builder createRequest(int timeoutMs) {
-                return new ElectLeadersRequest.Builder(electionType, topicPartitions, recommendedLeaders, timeoutMs);
+                if (recommendedLeaders.isEmpty()) {
+                    return new ElectLeadersRequest.Builder(electionType, topicPartitions, timeoutMs);
+                } else {
+                    return new ElectLeadersRequest.Builder(-1, recommendedLeaders, timeoutMs);
+                }
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
@@ -38,20 +38,31 @@ import org.apache.kafka.common.protocol.MessageUtil;
 public class ElectLeadersRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<ElectLeadersRequest> {
         private final ElectionType electionType;
+        private final long brokerEpoch;
         private final Collection<TopicPartition> topicPartitions;
         private final Map<TopicPartition, Integer> recommendedLeaders;
         private final int timeoutMs;
 
         public Builder(ElectionType electionType, Collection<TopicPartition> topicPartitions,
             int timeoutMs) {
-            this(electionType, topicPartitions, Collections.emptyMap(), timeoutMs);
+            this(electionType, -1, topicPartitions, Collections.emptyMap(), timeoutMs);
         }
 
-        public Builder(ElectionType electionType, Collection<TopicPartition> topicPartitions,
+        // constructor for recommended leader election
+        public Builder(long brokerEpoch,
+            Map<TopicPartition, Integer> recommendedLeaders,
+            int timeoutMs) {
+            this(ElectionType.RECOMMENDED, brokerEpoch, recommendedLeaders.keySet(), recommendedLeaders, timeoutMs);
+        }
+
+        private Builder(ElectionType electionType,
+            long brokerEpoch,
+            Collection<TopicPartition> topicPartitions,
             Map<TopicPartition, Integer> recommendedLeaders,
             int timeoutMs) {
             super(ApiKeys.ELECT_LEADERS);
             this.electionType = electionType;
+            this.brokerEpoch = brokerEpoch;
             this.topicPartitions = topicPartitions;
             this.recommendedLeaders = recommendedLeaders;
             this.timeoutMs = timeoutMs;
@@ -102,7 +113,7 @@ public class ElectLeadersRequest extends AbstractRequest {
             }
 
             data.setElectionType(electionType.value);
-
+            data.setBrokerEpoch(brokerEpoch);
             return data;
         }
     }

--- a/clients/src/main/resources/common/message/ElectLeadersRequest.json
+++ b/clients/src/main/resources/common/message/ElectLeadersRequest.json
@@ -26,6 +26,8 @@
   "fields": [
     { "name": "ElectionType", "type": "int8", "versions": "1+",
       "about": "Type of elections to conduct for the partition. A value of '0' elects the preferred replica. A value of '1' elects the first live replica if there are no in-sync replica." },
+    { "name": "BrokerEpoch", "type": "int64", "versions": "2+", "default": "-1", "tag": 0, "taggedVersions": "2+",
+      "about": "The epoch of the requesting broker" },
     { "name": "TopicPartitions", "type": "[]TopicPartitions", "versions": "0+", "nullableVersions": "0+",
       "about": "The topic partitions to elect leaders.",
       "fields": [

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2624,19 +2624,17 @@ class KafkaController(val config: KafkaConfig,
     brokerEpoch: Long
   ): Unit = {
     if (!isActive) {
-      callback(Left(partitionsFromAdminClientOpt.fold(Map.empty[TopicPartition, Either[ApiError, Int]]) { partitions =>
-        partitions.iterator.map(partition => partition -> Left(new ApiError(Errors.NOT_CONTROLLER, null))).toMap
-      }))
+      callback(Right(Errors.NOT_CONTROLLER))
     } else {
       if (brokerId != -1) {
         val brokerEpochOpt = controllerContext.liveBrokerIdAndEpochs.get(brokerId)
         if (brokerEpochOpt.isEmpty) {
-          info(s"Ignoring AlterIsr due to unknown broker $brokerId")
+          info(s"Ignoring ElectLeaders due to unknown broker $brokerId")
           callback.apply(Right(Errors.STALE_BROKER_EPOCH))
           return
         }
         if (!brokerEpochOpt.contains(brokerEpoch)) {
-          info(s"Ignoring AlterIsr due to stale broker epoch $brokerEpoch and local broker epoch $brokerEpochOpt for broker $brokerId")
+          info(s"Ignoring ElectLeaders due to stale broker epoch in request $brokerEpoch and local broker epoch $brokerEpochOpt for broker $brokerId")
           callback.apply(Right(Errors.STALE_BROKER_EPOCH))
           return
         }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -61,7 +61,7 @@ object KafkaController extends Logging {
   val InitialControllerEpoch = 0
   val InitialControllerEpochZkVersion = 0
   val topicNameBytesOverheadOnZk = 4
-  type ElectLeadersCallback = Map[TopicPartition, Either[ApiError, Int]] => Unit
+  type ElectLeadersCallback = Either[Map[TopicPartition, Either[ApiError, Int]], Errors] => Unit
   type ListReassignmentsCallback = Either[Map[TopicPartition, ReplicaAssignment], ApiError] => Unit
   type AlterReassignmentsCallback = Either[Map[TopicPartition, ApiError], ApiError] => Unit
   type AlterIsrCallback = Either[Map[TopicPartition, Either[Errors, LeaderAndIsr]], Errors] => Unit
@@ -2619,13 +2619,29 @@ class KafkaController(val config: KafkaConfig,
     partitionRecommendedLeadersFromAdminClientOpt: Option[Map[TopicPartition, Int]],
     electionType: ElectionType,
     electionTrigger: ElectionTrigger,
-    callback: ElectLeadersCallback
+    callback: ElectLeadersCallback,
+    brokerId: Int,
+    brokerEpoch: Long
   ): Unit = {
     if (!isActive) {
-      callback(partitionsFromAdminClientOpt.fold(Map.empty[TopicPartition, Either[ApiError, Int]]) { partitions =>
+      callback(Left(partitionsFromAdminClientOpt.fold(Map.empty[TopicPartition, Either[ApiError, Int]]) { partitions =>
         partitions.iterator.map(partition => partition -> Left(new ApiError(Errors.NOT_CONTROLLER, null))).toMap
-      })
+      }))
     } else {
+      if (brokerId != -1) {
+        val brokerEpochOpt = controllerContext.liveBrokerIdAndEpochs.get(brokerId)
+        if (brokerEpochOpt.isEmpty) {
+          info(s"Ignoring AlterIsr due to unknown broker $brokerId")
+          callback.apply(Right(Errors.STALE_BROKER_EPOCH))
+          return
+        }
+        if (!brokerEpochOpt.contains(brokerEpoch)) {
+          info(s"Ignoring AlterIsr due to stale broker epoch $brokerEpoch and local broker epoch $brokerEpochOpt for broker $brokerId")
+          callback.apply(Right(Errors.STALE_BROKER_EPOCH))
+          return
+        }
+      }
+
       // We need to register the watcher if the path doesn't exist in order to detect future preferred replica
       // leader elections and we get the `path exists` check for free
       if (electionTrigger == AdminClientTriggered || zkClient.registerZNodeChangeHandlerAndCheckExistence(preferredReplicaElectionHandler)) {
@@ -2709,7 +2725,7 @@ class KafkaController(val config: KafkaConfig,
         )
 
         debug(s"Waiting for any successful result for election type ($electionType) by $electionTrigger for partitions: $results")
-        callback(results)
+        callback(Left(results))
       }
     }
   }
@@ -2999,8 +3015,8 @@ class KafkaController(val config: KafkaConfig,
           error("Received a ShutdownEventThread event. This type of event is supposed to be handle by ControllerEventThread")
         case AutoPreferredReplicaLeaderElection =>
           processAutoPreferredReplicaLeaderElection()
-        case ReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback) =>
-          processReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback)
+        case ReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback, brokerId, brokerEpoch) =>
+          processReplicaLeaderElection(partitions, partitionRecommendedLeaders, electionType, electionTrigger, callback, brokerId, brokerEpoch)
         case UncleanLeaderElectionEnable =>
           processUncleanLeaderElectionEnable()
         case TopicUncleanLeaderElectionEnable(topic) =>
@@ -3370,15 +3386,17 @@ case class ReplicaLeaderElection(
   partitionRecommendedLeadersFromAdminClientOpt: Option[Map[TopicPartition, Int]],
   electionType: ElectionType,
   electionTrigger: ElectionTrigger,
-  callback: ElectLeadersCallback = _ => {}
+  callback: ElectLeadersCallback = _ => {},
+  brokerId: Int = -1, // brokerId and epoch are only used for broker initiated leader election
+  brokerEpoch: Long = -1
 ) extends ControllerEvent {
   override def state: ControllerState = ControllerState.ManualLeaderBalance
 
-  override def preempt(): Unit = callback(
+  override def preempt(): Unit = callback(Left(
     partitionsFromAdminClientOpt.fold(Map.empty[TopicPartition, Either[ApiError, Int]]) { partitions =>
       partitions.iterator.map(partition => partition -> Left(new ApiError(Errors.NOT_CONTROLLER, null))).toMap
     }
-  )
+  ))
 }
 
 /**

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -3390,11 +3390,7 @@ case class ReplicaLeaderElection(
 ) extends ControllerEvent {
   override def state: ControllerState = ControllerState.ManualLeaderBalance
 
-  override def preempt(): Unit = callback(Left(
-    partitionsFromAdminClientOpt.fold(Map.empty[TopicPartition, Either[ApiError, Int]]) { partitions =>
-      partitions.iterator.map(partition => partition -> Left(new ApiError(Errors.NOT_CONTROLLER, null))).toMap
-    }
-  ))
+  override def preempt(): Unit = callback(Right(Errors.NOT_CONTROLLER))
 }
 
 /**

--- a/core/src/main/scala/kafka/server/DelayedElectLeader.scala
+++ b/core/src/main/scala/kafka/server/DelayedElectLeader.scala
@@ -31,7 +31,7 @@ class DelayedElectLeader(
   expectedLeaders: Map[TopicPartition, Int],
   results: Map[TopicPartition, ApiError],
   replicaManager: ReplicaManager,
-  responseCallback: Map[TopicPartition, ApiError] => Unit
+  responseCallback: Either[Map[TopicPartition, ApiError], Errors] => Unit
 ) extends DelayedOperation(delayMs) {
 
   import DelayedOperation._
@@ -55,7 +55,7 @@ class DelayedElectLeader(
     val timedOut = waitingPartitions.map {
       case (tp, _) => tp -> new ApiError(Errors.REQUEST_TIMED_OUT, null)
     }
-    responseCallback(timedOut ++ fullResults)
+    responseCallback(Left(timedOut ++ fullResults))
   }
 
   /**

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3055,42 +3055,42 @@ class KafkaApis(val requestChannel: RequestChannel,
               Collections.emptyList(),
               electionRequest.version
             )
-          case Left(results) =>
-            val adjustedResults = if (electionRequest.data.topicPartitions == null) {
-              /* When performing elections across all of the partitions we should only return
-               * partitions for which there was an eleciton or resulted in an error. In other
-               * words, partitions that didn't need election because they ready have the correct
-               * leader are not returned to the client.
-               */
-              results.filter { case (_, error) =>
-                error.error != Errors.ELECTION_NOT_NEEDED
-              }
-            } else results
+          case Left(results) => // To make the rebasing with upstream kafka easier, we don't indent the following block
+        val adjustedResults = if (electionRequest.data.topicPartitions == null) {
+          /* When performing elections across all of the partitions we should only return
+           * partitions for which there was an eleciton or resulted in an error. In other
+           * words, partitions that didn't need election because they ready have the correct
+           * leader are not returned to the client.
+           */
+          results.filter { case (_, error) =>
+            error.error != Errors.ELECTION_NOT_NEEDED
+          }
+        } else results
 
-            val electionResults = new util.ArrayList[ReplicaElectionResult]()
-            adjustedResults
-              .groupBy { case (tp, _) => tp.topic }
-              .forKeyValue { (topic, ps) =>
-                val electionResult = new ReplicaElectionResult()
+        val electionResults = new util.ArrayList[ReplicaElectionResult]()
+        adjustedResults
+          .groupBy { case (tp, _) => tp.topic }
+          .forKeyValue { (topic, ps) =>
+            val electionResult = new ReplicaElectionResult()
 
-                electionResult.setTopic(topic)
-                ps.forKeyValue { (topicPartition, error) =>
-                  val partitionResult = new PartitionResult()
-                  partitionResult.setPartitionId(topicPartition.partition)
-                  partitionResult.setErrorCode(error.error.code)
-                  partitionResult.setErrorMessage(error.message)
-                  electionResult.partitionResult.add(partitionResult)
-                }
+            electionResult.setTopic(topic)
+            ps.forKeyValue { (topicPartition, error) =>
+              val partitionResult = new PartitionResult()
+              partitionResult.setPartitionId(topicPartition.partition)
+              partitionResult.setErrorCode(error.error.code)
+              partitionResult.setErrorMessage(error.message)
+              electionResult.partitionResult.add(partitionResult)
+            }
 
-                electionResults.add(electionResult)
-              }
+            electionResults.add(electionResult)
+          }
 
-            new ElectLeadersResponse(
-              requestThrottleMs,
-              ApiError.NONE.error.code,
-              electionResults,
-              electionRequest.version
-            )
+        new ElectLeadersResponse(
+          requestThrottleMs,
+          ApiError.NONE.error.code,
+          electionResults,
+          electionRequest.version
+        )
         }
       })
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3044,55 +3044,59 @@ class KafkaApis(val requestChannel: RequestChannel,
     val electionRequest = request.body[ElectLeadersRequest]
 
     def sendResponseCallback(
-      error: ApiError
-    )(
-      results: Map[TopicPartition, ApiError]
+      topResults: Either[Map[TopicPartition, ApiError], Errors]
     ): Unit = {
       requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => {
-        val adjustedResults = if (electionRequest.data.topicPartitions == null) {
-          /* When performing elections across all of the partitions we should only return
-           * partitions for which there was an eleciton or resulted in an error. In other
-           * words, partitions that didn't need election because they ready have the correct
-           * leader are not returned to the client.
-           */
-          results.filter { case (_, error) =>
-            error.error != Errors.ELECTION_NOT_NEEDED
-          }
-        } else results
+        topResults match {
+          case Right(error) =>
+            new ElectLeadersResponse(
+              requestThrottleMs,
+              error.code,
+              Collections.emptyList(),
+              electionRequest.version
+            )
+          case Left(results) =>
+            val adjustedResults = if (electionRequest.data.topicPartitions == null) {
+              /* When performing elections across all of the partitions we should only return
+               * partitions for which there was an eleciton or resulted in an error. In other
+               * words, partitions that didn't need election because they ready have the correct
+               * leader are not returned to the client.
+               */
+              results.filter { case (_, error) =>
+                error.error != Errors.ELECTION_NOT_NEEDED
+              }
+            } else results
 
-        val electionResults = new util.ArrayList[ReplicaElectionResult]()
-        adjustedResults
-          .groupBy { case (tp, _) => tp.topic }
-          .forKeyValue { (topic, ps) =>
-            val electionResult = new ReplicaElectionResult()
+            val electionResults = new util.ArrayList[ReplicaElectionResult]()
+            adjustedResults
+              .groupBy { case (tp, _) => tp.topic }
+              .forKeyValue { (topic, ps) =>
+                val electionResult = new ReplicaElectionResult()
 
-            electionResult.setTopic(topic)
-            ps.forKeyValue { (topicPartition, error) =>
-              val partitionResult = new PartitionResult()
-              partitionResult.setPartitionId(topicPartition.partition)
-              partitionResult.setErrorCode(error.error.code)
-              partitionResult.setErrorMessage(error.message)
-              electionResult.partitionResult.add(partitionResult)
-            }
+                electionResult.setTopic(topic)
+                ps.forKeyValue { (topicPartition, error) =>
+                  val partitionResult = new PartitionResult()
+                  partitionResult.setPartitionId(topicPartition.partition)
+                  partitionResult.setErrorCode(error.error.code)
+                  partitionResult.setErrorMessage(error.message)
+                  electionResult.partitionResult.add(partitionResult)
+                }
 
-            electionResults.add(electionResult)
-          }
+                electionResults.add(electionResult)
+              }
 
-        new ElectLeadersResponse(
-          requestThrottleMs,
-          error.error.code,
-          electionResults,
-          electionRequest.version
-        )
+            new ElectLeadersResponse(
+              requestThrottleMs,
+              ApiError.NONE.error.code,
+              electionResults,
+              electionRequest.version
+            )
+        }
       })
     }
 
     if (!authHelper.authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME)) {
-      val error = new ApiError(Errors.CLUSTER_AUTHORIZATION_FAILED, null)
-      val partitionErrors: Map[TopicPartition, ApiError] =
-        electionRequest.topicPartitions.iterator.map(partition => partition -> error).toMap
-
-      sendResponseCallback(error)(partitionErrors)
+      sendResponseCallback(Right(Errors.CLUSTER_AUTHORIZATION_FAILED))
     } else {
       val partitions = if (electionRequest.data.topicPartitions == null) {
         metadataCache.getAllTopics().flatMap(metadataCache.getTopicPartitions)
@@ -3105,7 +3109,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         partitions,
         electionRequest.partitionRecommendedLeaders,
         electionRequest.electionType,
-        sendResponseCallback(ApiError.NONE),
+        sendResponseCallback,
         electionRequest.data.timeoutMs
       )
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2222,38 +2222,45 @@ class ReplicaManager(val config: KafkaConfig,
     partitions: Set[TopicPartition],
     partitionRecommendedLeaders: Map[TopicPartition, Int],
     electionType: ElectionType,
-    responseCallback: Map[TopicPartition, ApiError] => Unit,
+    responseCallback: Either[Map[TopicPartition, ApiError], Errors] => Unit,
     requestTimeout: Int
   ): Unit = {
 
     val deadline = time.milliseconds() + requestTimeout
 
-    def electionCallback(results: Map[TopicPartition, Either[ApiError, Int]]): Unit = {
+    def electionCallback(topResults: Either[Map[TopicPartition, Either[ApiError, Int]], Errors]): Unit = {
       val expectedLeaders = mutable.Map.empty[TopicPartition, Int]
       val failures = mutable.Map.empty[TopicPartition, ApiError]
-      results.foreach {
-        case (partition, Right(leader)) => expectedLeaders += partition -> leader
-        case (partition, Left(error)) => failures += partition -> error
-      }
-      if (expectedLeaders.nonEmpty) {
-        val watchKeys = expectedLeaders.iterator.map {
-          case (tp, _) => TopicPartitionOperationKey(tp)
-        }.toBuffer
+      topResults match {
+        case Right(error) =>
+          responseCallback(Right(error))
+        case Left(results) =>
+          results.foreach {
+            case (partition, Right(leader)) => expectedLeaders += partition -> leader
+            case (partition, Left(error)) => failures += partition -> error
+          }
+          if (expectedLeaders.nonEmpty) {
+            val watchKeys = expectedLeaders.iterator.map {
+              case (tp, _) => TopicPartitionOperationKey(tp)
+            }.toBuffer
 
-        delayedElectLeaderPurgatory.tryCompleteElseWatch(
-          new DelayedElectLeader(
-            math.max(0, deadline - time.milliseconds()),
-            expectedLeaders,
-            failures,
-            this,
-            responseCallback
-          ),
-          watchKeys
-        )
-      } else {
-          // There are no partitions actually being elected, so return immediately
-          responseCallback(failures)
+            delayedElectLeaderPurgatory.tryCompleteElseWatch(
+              new DelayedElectLeader(
+                math.max(0, deadline - time.milliseconds()),
+                expectedLeaders,
+                failures,
+                this,
+                responseCallback
+              ),
+              watchKeys
+            )
+          } else {
+            // There are no partitions actually being elected, so return immediately
+            responseCallback(Left(failures))
+          }
       }
+
+
     }
 
     controller.electLeaders(partitions, partitionRecommendedLeaders, electionType, electionCallback)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2234,30 +2234,30 @@ class ReplicaManager(val config: KafkaConfig,
       topResults match {
         case Right(error) =>
           responseCallback(Right(error))
-        case Left(results) =>
-          results.foreach {
-            case (partition, Right(leader)) => expectedLeaders += partition -> leader
-            case (partition, Left(error)) => failures += partition -> error
-          }
-          if (expectedLeaders.nonEmpty) {
-            val watchKeys = expectedLeaders.iterator.map {
-              case (tp, _) => TopicPartitionOperationKey(tp)
-            }.toBuffer
+        case Left(results) => // To make the rebasing with upstream kafka easier, we don't indent the following block
+      results.foreach {
+        case (partition, Right(leader)) => expectedLeaders += partition -> leader
+        case (partition, Left(error)) => failures += partition -> error
+      }
+      if (expectedLeaders.nonEmpty) {
+        val watchKeys = expectedLeaders.iterator.map {
+          case (tp, _) => TopicPartitionOperationKey(tp)
+        }.toBuffer
 
-            delayedElectLeaderPurgatory.tryCompleteElseWatch(
-              new DelayedElectLeader(
-                math.max(0, deadline - time.milliseconds()),
-                expectedLeaders,
-                failures,
-                this,
-                responseCallback
-              ),
-              watchKeys
-            )
-          } else {
-            // There are no partitions actually being elected, so return immediately
-            responseCallback(Left(failures))
-          }
+        delayedElectLeaderPurgatory.tryCompleteElseWatch(
+          new DelayedElectLeader(
+            math.max(0, deadline - time.milliseconds()),
+            expectedLeaders,
+            failures,
+            this,
+            responseCallback
+          ),
+          watchKeys
+        )
+      } else {
+        // There are no partitions actually being elected, so return immediately
+        responseCallback(Left(failures))
+      }
       }
 
 

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1096,12 +1096,16 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     val tp0 = new TopicPartition("t", 0)
     val tp1 = new TopicPartition("t", 1)
     val partitions = Set(tp0, tp1)
-    val event1 = ReplicaLeaderElection(Some(partitions), Some(Map.empty), ElectionType.PREFERRED, ZkTriggered, partitionsMap => {
-      for (partition <- partitionsMap) {
-        partition._2 match {
-          case Left(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())
-          case Right(_) => throw new AssertionError("replica leader election should error")
-        }
+    val event1 = ReplicaLeaderElection(Some(partitions), Some(Map.empty), ElectionType.PREFERRED, ZkTriggered, topResult => {
+      topResult match {
+        case Right(error) =>
+        case Left(partitionsMap) =>
+          for (partition <- partitionsMap) {
+            partition._2 match {
+              case Left(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())
+              case Right(_) => throw new AssertionError("replica leader election should error")
+            }
+          }
       }
     })
     val event2 = ControlledShutdown(0, 0, {

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1099,13 +1099,13 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     val event1 = ReplicaLeaderElection(Some(partitions), Some(Map.empty), ElectionType.PREFERRED, ZkTriggered, topResult => {
       topResult match {
         case Right(error) =>
-        case Left(partitionsMap) =>
-          for (partition <- partitionsMap) {
-            partition._2 match {
-              case Left(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())
-              case Right(_) => throw new AssertionError("replica leader election should error")
-            }
-          }
+        case Left(partitionsMap) => // To make the rebasing with upstream kafka easier, we don't indent the following block
+      for (partition <- partitionsMap) {
+        partition._2 match {
+          case Left(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())
+          case Right(_) => throw new AssertionError("replica leader election should error")
+        }
+      }
       }
     })
     val event2 = ControlledShutdown(0, 0, {


### PR DESCRIPTION
TICKET = [LIKAFKA-47596](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-47596)
LI_DESCRIPTION =
Since the ElectLeaders request will be initiated by a broker,
and a broker's epoch may become stale, this PR adds the brokerEpoch field
to the ElectLeaders request and also error reporting if the brokerEpoch is indeed stale.

This change will be used later for the broker-initiated leadership switch feature.

EXIT_CRITERIA = If and when this change is accepted in upstream kafka.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
