### PR TITLE
[LI-HOTFIX] Add the TransferLeaderManager

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -97,7 +97,8 @@ object Partition extends KafkaMetricsGroup {
       delayedOperations = delayedOperations,
       metadataCache = replicaManager.metadataCache,
       logManager = replicaManager.logManager,
-      alterIsrManager = replicaManager.alterIsrManager)
+      alterIsrManager = replicaManager.alterIsrManager,
+      transferLeaderManager = replicaManager.transferLeaderManager)
   }
 
   def removeMetrics(topicPartition: TopicPartition): Unit = {
@@ -219,7 +220,8 @@ class Partition(val topicPartition: TopicPartition,
                 delayedOperations: DelayedOperations,
                 metadataCache: MetadataCache,
                 logManager: LogManager,
-                alterIsrManager: AlterIsrManager) extends Logging with KafkaMetricsGroup {
+                alterIsrManager: AlterIsrManager,
+                transferLeaderManager: TransferLeaderManager) extends Logging with KafkaMetricsGroup {
 
   def topic: String = topicPartition.topic
   def partitionId: Int = topicPartition.partition

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -155,6 +155,8 @@ class KafkaServer(
 
   var alterIsrManager: AlterIsrManager = null
 
+  var transferLeaderManager: TransferLeaderManager = null
+
   var kafkaScheduler: KafkaScheduler = null
 
   var metadataCache: ZkMetadataCache = null
@@ -353,6 +355,18 @@ class KafkaServer(
         }
         alterIsrManager.start()
 
+        transferLeaderManager = TransferLeaderManager(
+          config = config,
+          metadataCache = metadataCache,
+          scheduler = kafkaScheduler,
+          time = time,
+          metrics = metrics,
+          threadNamePrefix = threadNamePrefix,
+          brokerEpochSupplier = () => kafkaController.brokerEpoch,
+          config.brokerId
+        )
+        transferLeaderManager.start()
+
         _replicaManager = createReplicaManager(isShuttingDown)
         replicaManager.startup()
 
@@ -522,7 +536,7 @@ class KafkaServer(
 
   protected def createReplicaManager(isShuttingDown: AtomicBoolean): ReplicaManager = {
     new ReplicaManager(config, metrics, time, Some(zkClient), kafkaScheduler, logManager, Option.apply(remoteLogManager),
-      isShuttingDown, quotaManagers, brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager)
+      isShuttingDown, quotaManagers, brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager, transferLeaderManager)
   }
 
   private def initZkClient(time: Time): Unit = {
@@ -823,6 +837,9 @@ class KafkaServer(
 
         if (alterIsrManager != null)
           CoreUtils.swallow(alterIsrManager.shutdown(), this)
+
+        if (transferLeaderManager != null)
+          CoreUtils.swallow(transferLeaderManager.shutdown(), this)
 
         if (clientToControllerChannelManager != null)
           CoreUtils.swallow(clientToControllerChannelManager.shutdown(), this)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -203,7 +203,8 @@ class ReplicaManager(val config: KafkaConfig,
                      val delayedElectLeaderPurgatory: DelayedOperationPurgatory[DelayedElectLeader],
                      val delayedRemoteFetchPurgatory: DelayedOperationPurgatory[DelayedRemoteFetch],
                      threadNamePrefix: Option[String],
-                     val alterIsrManager: AlterIsrManager) extends Logging with KafkaMetricsGroup {
+                     val alterIsrManager: AlterIsrManager,
+                     val transferLeaderManager: TransferLeaderManager) extends Logging with KafkaMetricsGroup {
 
   def this(config: KafkaConfig,
            metrics: Metrics,
@@ -218,6 +219,7 @@ class ReplicaManager(val config: KafkaConfig,
            metadataCache: MetadataCache,
            logDirFailureChannel: LogDirFailureChannel,
            alterIsrManager: AlterIsrManager,
+           transferLeaderManager: TransferLeaderManager,
            threadNamePrefix: Option[String] = None) = {
     this(config, metrics, time, zkClient, scheduler, logManager, remoteLogManager, isShuttingDown,
       quotaManagers, brokerTopicStats, metadataCache, logDirFailureChannel,
@@ -234,7 +236,7 @@ class ReplicaManager(val config: KafkaConfig,
         purgatoryName = "ElectLeader", brokerId = config.brokerId),
       DelayedOperationPurgatory[DelayedRemoteFetch](
         purgatoryName = "RemoteFetch", brokerId = config.brokerId),
-      threadNamePrefix, alterIsrManager)
+      threadNamePrefix, alterIsrManager, transferLeaderManager)
   }
 
   /* epoch of the controller that last changed the leader */

--- a/core/src/main/scala/kafka/server/TransferLeaderManager.scala
+++ b/core/src/main/scala/kafka/server/TransferLeaderManager.scala
@@ -36,8 +36,6 @@ import scala.collection.mutable.ListBuffer
  * Transferring the leadership is an asynchronous operation, so partitions will learn about the result of their
  * request through a callback.
  *
- * Note that ISR state changes can still be initiated by the controller and sent to the partitions via LeaderAndIsr
- * requests.
  */
 trait TransferLeaderManager {
   def start(): Unit = {}
@@ -53,9 +51,6 @@ case class TransferLeaderItem(topicPartition: TopicPartition,
 
 object TransferLeaderManager {
   val defaultTimeout = 60000
-  /**
-   * Factory to TransferLeader based implementation, used when IBP >= 2.7-IV2
-   */
   def apply(
     config: KafkaConfig,
     metadataCache: MetadataCache,
@@ -96,8 +91,8 @@ class DefaultTransferLeaderManager(
 ) extends TransferLeaderManager with Logging with KafkaMetricsGroup {
 
   private[server] val unsentTransferQueue: BlockingQueue[TransferLeaderItem] = new LinkedBlockingQueue()
-  // The inflightIsrUpdates map is populated by the unsentIsrQueue, and the items in it are removed in the response callback.
-  // Putting new items to the inflightIsrUpdates and removing items from it won't be performed at the same time, and the coordination is
+  // The inflightTransfers map is populated by the unsentTransferQueue, and the items in it are removed in the response callback.
+  // Putting new items to the inflightTransfers and removing items from it won't be performed at the same time, and the coordination is
   // done via the inflightRequest flag.
   private[server] val inflightTransfers: util.Map[TopicPartition, TransferLeaderItem] = new ConcurrentHashMap[TopicPartition, TransferLeaderItem]()
 
@@ -127,7 +122,7 @@ class DefaultTransferLeaderManager(
         // and the previous ones will be discarded
         inflightTransfers.put(item.topicPartition, item)
       }
-      // Since the maybePropagateIsrChanges can be called from the response callback,
+      // Since the maybeTransferLeader can be called from the response callback,
       // there may be cases where right after the while loop, some new items are added to the unsentIsrQueue in the submit
       // thread. In such a case, the newly added item will be sent in the next request
 
@@ -148,9 +143,8 @@ class DefaultTransferLeaderManager(
     val request = buildRequest(inflightTransferLeaderItems, brokerEpoch)
     debug(s"Sending TransferLeader to controller $request")
 
-    // We will not timeout AlterISR request, instead letting it retry indefinitely
-    // until a response is received, or a new LeaderAndIsr overwrites the existing isrState
-    // which causes the response for those partitions to be ignored.
+    // We will not timeout the ElectLeaders request, instead letting it retry indefinitely
+    // until a response is received.
     controllerChannelManager.sendRequest(request,
       new ControllerRequestCompletionHandler {
         override def onComplete(response: ClientResponse): Unit = {
@@ -191,12 +185,10 @@ class DefaultTransferLeaderManager(
   }
 
   private def buildRequest(inflightTransferLeaderItems: Seq[TransferLeaderItem], brokerEpoch: Long): ElectLeadersRequest.Builder = {
-    val topicPartitions = new util.ArrayList[TopicPartition]()
     val recommendedLeaders = new util.HashMap[TopicPartition, Integer]()
 
     inflightTransferLeaderItems.groupBy(_.topicPartition.topic).foreach(entry => {
       entry._2.foreach(item => {
-        topicPartitions.add(item.topicPartition)
         recommendedLeaders.put(item.topicPartition, item.newLeader)
       })
     })
@@ -232,8 +224,7 @@ class DefaultTransferLeaderManager(
         }
 
         // Iterate across the items we sent rather than what we received to ensure we run the callback even if a
-        // partition was somehow erroneously excluded from the response. Note that these callbacks are run from
-        // the leaderIsrUpdateLock write lock in Partition#sendTransferLeaderRequest
+        // partition was somehow erroneously excluded from the response.
         inflightTransferLeaderItems.foreach(inflightTransferLeader =>
           if (partitionResponses.contains(inflightTransferLeader.topicPartition)) {
             try {

--- a/core/src/main/scala/kafka/server/TransferLeaderManager.scala
+++ b/core/src/main/scala/kafka/server/TransferLeaderManager.scala
@@ -1,0 +1,256 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import kafka.metrics.KafkaMetricsGroup
+import kafka.utils.{KafkaScheduler, Logging, Scheduler}
+import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.message.ElectLeadersResponseData
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{ElectLeadersRequest, ElectLeadersResponse}
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{ElectionType, TopicPartition}
+
+import java.util
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{BlockingQueue, ConcurrentHashMap, LinkedBlockingQueue, TimeUnit}
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Transferring the leadership is an asynchronous operation, so partitions will learn about the result of their
+ * request through a callback.
+ *
+ * Note that ISR state changes can still be initiated by the controller and sent to the partitions via LeaderAndIsr
+ * requests.
+ */
+trait TransferLeaderManager {
+  def start(): Unit = {}
+
+  def shutdown(): Unit = {}
+
+  def submit(transferLeaderItem: TransferLeaderItem): Unit
+}
+
+case class TransferLeaderItem(topicPartition: TopicPartition,
+  newLeader: Int,
+  callback: Either[Errors, TopicPartition] => Unit)
+
+object TransferLeaderManager {
+  val defaultTimeout = 60000
+  /**
+   * Factory to TransferLeader based implementation, used when IBP >= 2.7-IV2
+   */
+  def apply(
+    config: KafkaConfig,
+    metadataCache: MetadataCache,
+    scheduler: KafkaScheduler,
+    time: Time,
+    metrics: Metrics,
+    threadNamePrefix: Option[String],
+    brokerEpochSupplier: () => Long,
+    brokerId: Int
+  ): TransferLeaderManager = {
+    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
+
+    val channelManager = BrokerToControllerChannelManager(
+      controllerNodeProvider = nodeProvider,
+      time = time,
+      metrics = metrics,
+      config = config,
+      channelName = "transferLeader",
+      threadNamePrefix = threadNamePrefix,
+      retryTimeoutMs = Long.MaxValue
+    )
+    new DefaultTransferLeaderManager(
+      controllerChannelManager = channelManager,
+      scheduler = scheduler,
+      time = time,
+      brokerId = brokerId,
+      brokerEpochSupplier = brokerEpochSupplier
+    )
+  }
+}
+
+class DefaultTransferLeaderManager(
+  val controllerChannelManager: BrokerToControllerChannelManager,
+  val scheduler: Scheduler,
+  val time: Time,
+  val brokerId: Int,
+  val brokerEpochSupplier: () => Long
+) extends TransferLeaderManager with Logging with KafkaMetricsGroup {
+
+  private[server] val unsentTransferQueue: BlockingQueue[TransferLeaderItem] = new LinkedBlockingQueue()
+  // The inflightIsrUpdates map is populated by the unsentIsrQueue, and the items in it are removed in the response callback.
+  // Putting new items to the inflightIsrUpdates and removing items from it won't be performed at the same time, and the coordination is
+  // done via the inflightRequest flag.
+  private[server] val inflightTransfers: util.Map[TopicPartition, TransferLeaderItem] = new ConcurrentHashMap[TopicPartition, TransferLeaderItem]()
+
+  // Used to allow only one in-flight request at a time
+  private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
+
+  override def start(): Unit = {
+    controllerChannelManager.start()
+  }
+
+  override def shutdown(): Unit = {
+    controllerChannelManager.shutdown()
+  }
+
+  override def submit(transferLeaderItem: TransferLeaderItem): Unit = {
+    unsentTransferQueue.put(transferLeaderItem)
+    maybeTransferLeader()
+  }
+
+  private[server] def maybeTransferLeader(): Unit = {
+    // Send all pending items if there is not already a request in-flight.
+    if ((!unsentTransferQueue.isEmpty || !inflightTransfers.isEmpty) && inflightRequest.compareAndSet(false, true)) {
+      // Copy current unsent ISRs but don't remove from the map, they get cleared in the response handler
+      while (!unsentTransferQueue.isEmpty) {
+        val item = unsentTransferQueue.poll()
+        // if there are multiple TransferLeaderItems for the same partition in the queue, the last one wins
+        // and the previous ones will be discarded
+        inflightTransfers.put(item.topicPartition, item)
+      }
+      // Since the maybePropagateIsrChanges can be called from the response callback,
+      // there may be cases where right after the while loop, some new items are added to the unsentIsrQueue in the submit
+      // thread. In such a case, the newly added item will be sent in the next request
+
+      val inflightTransferLeaderItems = new ListBuffer[TransferLeaderItem]()
+      inflightTransfers.values().forEach(item => inflightTransferLeaderItems.append(item))
+      sendRequest(inflightTransferLeaderItems)
+    }
+  }
+
+  private[server] def clearInFlightRequest(): Unit = {
+    if (!inflightRequest.compareAndSet(true, false)) {
+      warn("Attempting to clear TransferLeader in-flight flag when no apparent request is in-flight")
+    }
+  }
+
+  private def sendRequest(inflightTransferLeaderItems: Seq[TransferLeaderItem]): Unit = {
+    val brokerEpoch = brokerEpochSupplier.apply()
+    val request = buildRequest(inflightTransferLeaderItems, brokerEpoch)
+    debug(s"Sending TransferLeader to controller $request")
+
+    // We will not timeout AlterISR request, instead letting it retry indefinitely
+    // until a response is received, or a new LeaderAndIsr overwrites the existing isrState
+    // which causes the response for those partitions to be ignored.
+    controllerChannelManager.sendRequest(request,
+      new ControllerRequestCompletionHandler {
+        override def onComplete(response: ClientResponse): Unit = {
+          debug(s"Received TransferLeader response $response")
+          val error = try {
+            if (response.authenticationException != null) {
+              // For now we treat authentication errors as retriable. We use the
+              // `NETWORK_EXCEPTION` error code for lack of a good alternative.
+              // Note that `BrokerToControllerChannelManager` will still log the
+              // authentication errors so that users have a chance to fix the problem.
+              Errors.NETWORK_EXCEPTION
+            } else if (response.versionMismatch != null) {
+              Errors.UNSUPPORTED_VERSION
+            } else {
+              val body = response.responseBody().asInstanceOf[ElectLeadersResponse]
+              handleTransferLeaderResponse(body, brokerEpoch, inflightTransferLeaderItems)
+            }
+          } finally {
+            // clear the flag so future requests can proceed
+            clearInFlightRequest()
+          }
+
+          // check if we need to send another request right away
+          error match {
+              case Errors.NONE =>
+                // In the normal case, check for pending updates to send immediately
+                maybeTransferLeader()
+              case _ =>
+                // If we received a top-level error from the controller, retry the request in the near future
+                scheduler.schedule("send-alter-isr", () => maybeTransferLeader(), 50, -1, TimeUnit.MILLISECONDS)
+            }
+        }
+
+        override def onTimeout(): Unit = {
+          throw new IllegalStateException("Encountered unexpected timeout when sending TransferLeader to the controller")
+        }
+      })
+  }
+
+  private def buildRequest(inflightTransferLeaderItems: Seq[TransferLeaderItem], brokerEpoch: Long): ElectLeadersRequest.Builder = {
+    val topicPartitions = new util.ArrayList[TopicPartition]()
+    val recommendedLeaders = new util.HashMap[TopicPartition, Integer]()
+
+    inflightTransferLeaderItems.groupBy(_.topicPartition.topic).foreach(entry => {
+      entry._2.foreach(item => {
+        topicPartitions.add(item.topicPartition)
+        recommendedLeaders.put(item.topicPartition, item.newLeader)
+      })
+    })
+    new ElectLeadersRequest.Builder(brokerEpoch, recommendedLeaders, TransferLeaderManager.defaultTimeout)
+  }
+
+  def handleTransferLeaderResponse(transferLeaderResponse: ElectLeadersResponse,
+                             sentBrokerEpoch: Long,
+                             inflightTransferLeaderItems: Seq[TransferLeaderItem]): Errors = {
+    val data: ElectLeadersResponseData = transferLeaderResponse.data
+
+    Errors.forCode(data.errorCode) match {
+      case Errors.STALE_BROKER_EPOCH =>
+        warn(s"Broker had a stale broker epoch ($sentBrokerEpoch), retrying.")
+      case Errors.CLUSTER_AUTHORIZATION_FAILED =>
+        error(s"Broker is not authorized to send TransferLeader to controller",
+          Errors.CLUSTER_AUTHORIZATION_FAILED.exception("Broker is not authorized to send TransferLeader to controller"))
+      case Errors.NONE =>
+        // Collect partition-level responses to pass to the callbacks
+        val partitionResponses: mutable.Map[TopicPartition, Either[Errors, TopicPartition]] =
+          new mutable.HashMap[TopicPartition, Either[Errors, TopicPartition]]()
+        data.replicaElectionResults().forEach { topicResult =>
+          topicResult.partitionResult().forEach(partitionResult => {
+            val tp = new TopicPartition(topicResult.topic, partitionResult.partitionId())
+            val error = Errors.forCode(partitionResult.errorCode())
+            debug(s"Controller successfully handled TransferLeader request for $tp: $partitionResult")
+            if (error == Errors.NONE) {
+              partitionResponses(tp) = Right(tp)
+            } else {
+              partitionResponses(tp) = Left(error)
+            }
+          })
+        }
+
+        // Iterate across the items we sent rather than what we received to ensure we run the callback even if a
+        // partition was somehow erroneously excluded from the response. Note that these callbacks are run from
+        // the leaderIsrUpdateLock write lock in Partition#sendTransferLeaderRequest
+        inflightTransferLeaderItems.foreach(inflightTransferLeader =>
+          if (partitionResponses.contains(inflightTransferLeader.topicPartition)) {
+            try {
+              inflightTransferLeader.callback.apply(partitionResponses(inflightTransferLeader.topicPartition))
+            } finally {
+              // Regardless of callback outcome, we need to clear from the unsent updates map to unblock further updates
+              inflightTransfers.remove(inflightTransferLeader.topicPartition)
+            }
+          } else {
+            // Don't remove this partition from the update map so it will get re-sent
+            warn(s"Partition ${inflightTransferLeader.topicPartition} was sent but not included in the response")
+          }
+        )
+      case e: Errors =>
+        warn(s"Controller returned an unexpected top-level error when handling TransferLeader request: $e")
+    }
+
+    Errors.forCode(data.errorCode)
+  }
+}

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -18,7 +18,7 @@ package kafka.cluster
 
 import kafka.api.ApiVersion
 import kafka.log.{CleanerConfig, LogConfig, LogManager}
-import kafka.server.{Defaults, MetadataCache}
+import kafka.server.{Defaults, MetadataCache, TransferLeaderManager}
 import kafka.server.checkpoints.OffsetCheckpoints
 import kafka.server.metadata.MockConfigRepository
 import kafka.utils.TestUtils.{MockAlterIsrManager, MockIsrChangeListener}
@@ -33,7 +33,6 @@ import org.mockito.Mockito.{mock, when}
 
 import java.io.File
 import java.util.Properties
-
 import scala.jdk.CollectionConverters._
 
 object AbstractPartitionTest {
@@ -50,6 +49,7 @@ class AbstractPartitionTest {
   var logDir2: File = _
   var logManager: LogManager = _
   var alterIsrManager: MockAlterIsrManager = _
+  var transferLeaderManager: TransferLeaderManager = _
   var isrChangeListener: MockIsrChangeListener = _
   var logConfig: LogConfig = _
   var configRepository: MockConfigRepository = _
@@ -74,6 +74,7 @@ class AbstractPartitionTest {
     logManager.startup(Set.empty)
 
     alterIsrManager = TestUtils.createAlterIsrManager()
+    transferLeaderManager = TestUtils.createTransferLeaderManager()
     isrChangeListener = TestUtils.createIsrChangeListener()
     partition = new Partition(topicPartition,
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
@@ -84,7 +85,8 @@ class AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     when(offsetCheckpoints.fetch(ArgumentMatchers.anyString, ArgumentMatchers.eq(topicPartition)))
       .thenReturn(None)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -258,6 +258,7 @@ class PartitionLockTest extends Logging {
     val metadataCache: MetadataCache = mock(classOf[MetadataCache])
     val offsetCheckpoints: OffsetCheckpoints = mock(classOf[OffsetCheckpoints])
     val alterIsrManager: AlterIsrManager = mock(classOf[AlterIsrManager])
+    val transferLeaderManager: TransferLeaderManager = mock(classOf[TransferLeaderManager])
 
     logManager.startup(Set.empty)
     val partition = new Partition(topicPartition,
@@ -269,7 +270,8 @@ class PartitionLockTest extends Logging {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager) {
+      alterIsrManager,
+      transferLeaderManager) {
 
       override def shrinkIsr(newIsr: Set[Int]): Unit = {
         shrinkIsrSemaphore.acquire()

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -205,7 +205,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager) {
+      alterIsrManager,
+      transferLeaderManager) {
 
       override def createLog(isNew: Boolean, isFutureReplica: Boolean, offsetCheckpoints: OffsetCheckpoints, topicId: Option[Uuid]): Log = {
         val log = super.createLog(isNew, isFutureReplica, offsetCheckpoints, None)
@@ -1596,7 +1597,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      zkIsrManager)
+      zkIsrManager,
+      transferLeaderManager)
 
     val log = logManager.getOrCreateLog(topicPartition, topicId = None)
     seedLogData(log, numRecords = 10, leaderEpoch = 4)
@@ -1696,7 +1698,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     // partition2 should not yet be associated with the log, but should be able to get ID
     assertTrue(partition2.topicId.isDefined)
@@ -1740,7 +1743,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       logManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     // partition2 should not yet be associated with the log, but should be able to get ID
     assertTrue(partition2.topicId.isDefined)
@@ -1817,7 +1821,7 @@ class PartitionTest extends AbstractPartitionTest {
     val partition = new Partition(
       topicPartition, 1000, ApiVersion.latestVersion, 0,
       new SystemTime(), mock(classOf[IsrChangeListener]), mock(classOf[DelayedOperations]),
-      mock(classOf[MetadataCache]), mock(classOf[LogManager]), mock(classOf[AlterIsrManager]))
+      mock(classOf[MetadataCache]), mock(classOf[LogManager]), mock(classOf[AlterIsrManager]), mock(classOf[TransferLeaderManager]))
 
     val replicas = Seq(0, 1, 2, 3)
     val isr = Set(0, 1, 2, 3)
@@ -1865,7 +1869,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       spyLogManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None)
 
@@ -1903,7 +1908,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       spyLogManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None)
 
@@ -1944,7 +1950,8 @@ class PartitionTest extends AbstractPartitionTest {
       delayedOperations,
       metadataCache,
       spyLogManager,
-      alterIsrManager)
+      alterIsrManager,
+      transferLeaderManager)
 
     partition.createLog(isNew = true, isFutureReplica = false, offsetCheckpoints, topicId = None)
 

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -158,7 +158,7 @@ object AbstractCoordinatorConcurrencyTest {
   }
 
   class TestReplicaManager extends ReplicaManager(
-    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null) {
+    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null, null) {
 
     @volatile var logs: mutable.Map[TopicPartition, (Log, Long)] = _
     var producePurgatory: DelayedOperationPurgatory[DelayedProduce] = _

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -48,6 +48,8 @@ class HighwatermarkPersistenceTest {
 
   val alterIsrManager = TestUtils.createAlterIsrManager()
 
+  val transferLeaderManager = TestUtils.createTransferLeaderManager()
+
   @AfterEach
   def teardown(): Unit = {
     for (manager <- logManagers; dir <- manager.liveLogDirs)
@@ -65,7 +67,7 @@ class HighwatermarkPersistenceTest {
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, None, scheduler,
       logManagers.head, None, new AtomicBoolean(false), quotaManager,
-      new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager)
+      new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager, transferLeaderManager)
     replicaManager.startup()
     try {
       replicaManager.checkpointHighWatermarks()
@@ -114,7 +116,7 @@ class HighwatermarkPersistenceTest {
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, None,
       scheduler, logManagers.head, None, new AtomicBoolean(false), quotaManager,
-      new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager)
+      new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager, transferLeaderManager)
     replicaManager.startup()
     try {
       replicaManager.checkpointHighWatermarks()

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -54,7 +54,7 @@ class IsrExpirationTest {
 
   var quotaManager: QuotaManagers = null
   var replicaManager: ReplicaManager = null
-
+  var transferLeaderManager: TransferLeaderManager = TestUtils.createTransferLeaderManager()
   var alterIsrManager: MockAlterIsrManager = _
 
   @BeforeEach
@@ -68,7 +68,7 @@ class IsrExpirationTest {
     replicaManager = new ReplicaManager(configs.head, metrics, time, None, null, logManager, None,
       new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(configs.head.brokerId), new LogDirFailureChannel(configs.head.logDirs.size),
-      alterIsrManager)
+      alterIsrManager, transferLeaderManager)
   }
 
   @AfterEach

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -238,12 +238,12 @@ class ReplicaManagerQuotasTest {
     replay(logManager)
 
     val alterIsrManager: AlterIsrManager = createMock(classOf[AlterIsrManager])
-
+    val transferLeaderManager: TransferLeaderManager = createMock(classOf[TransferLeaderManager])
     val leaderBrokerId = configs.head.brokerId
     quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     replicaManager = new ReplicaManager(configs.head, metrics, time, None, scheduler, logManager, None,
       new AtomicBoolean(false), quotaManager,
-      new BrokerTopicStats, MetadataCache.zkMetadataCache(leaderBrokerId), new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager)
+      new BrokerTopicStats, MetadataCache.zkMetadataCache(leaderBrokerId), new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager, transferLeaderManager)
 
     //create the two replicas
     for ((p, _) <- fetchInfo) {

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -41,6 +41,7 @@ class OffsetsForLeaderEpochTest {
   private val time = new MockTime
   private val metrics = new Metrics
   private val alterIsrManager = TestUtils.createAlterIsrManager()
+  private val transferLeaderManager = TestUtils.createTransferLeaderManager()
   private val tp = new TopicPartition("topic", 1)
   private var replicaManager: ReplicaManager = _
   private var quotaManager: QuotaManagers = _
@@ -67,7 +68,7 @@ class OffsetsForLeaderEpochTest {
     // create a replica manager with 1 partition that has 1 replica
     replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
-      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
+      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager, transferLeaderManager)
     val partition = replicaManager.createPartition(tp)
     partition.setLog(mockLog, isFutureLog = false)
     partition.leaderReplicaIdOpt = Some(config.brokerId)
@@ -90,7 +91,7 @@ class OffsetsForLeaderEpochTest {
     //create a replica manager with 1 partition that has 0 replica
     replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
-      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
+      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager, transferLeaderManager)
     replicaManager.createPartition(tp)
 
     //Given
@@ -115,7 +116,7 @@ class OffsetsForLeaderEpochTest {
     //create a replica manager with 0 partition
     replicaManager = new ReplicaManager(config, metrics, time, None, null, logManager, None, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats,
-      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
+      MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager, transferLeaderManager)
 
     //Given
     val epochRequested: Integer = 5

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1182,8 +1182,16 @@ object TestUtils extends Logging {
     }
   }
 
+  class MockTransferLeaderManager extends TransferLeaderManager {
+    override def submit(transferLeaderItem: TransferLeaderItem): Unit = ???
+  }
+
   def createAlterIsrManager(): MockAlterIsrManager = {
     new MockAlterIsrManager()
+  }
+
+  def createTransferLeaderManager(): MockTransferLeaderManager = {
+    new MockTransferLeaderManager()
   }
 
   class MockIsrChangeListener extends IsrChangeListener {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -40,6 +40,7 @@ import kafka.server.OffsetTruncationState;
 import kafka.server.ReplicaFetcherThread;
 import kafka.server.ReplicaManager;
 import kafka.server.ReplicaQuota;
+import kafka.server.TransferLeaderManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
@@ -162,9 +163,10 @@ public class ReplicaFetcherThreadBenchmark {
             OffsetCheckpoints offsetCheckpoints = Mockito.mock(OffsetCheckpoints.class);
             Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), tp)).thenReturn(Option.apply(0L));
             AlterIsrManager isrChannelManager = Mockito.mock(AlterIsrManager.class);
+            TransferLeaderManager transferLeaderManager = Mockito.mock(TransferLeaderManager.class);
             Partition partition = new Partition(tp, 100, ApiVersion$.MODULE$.latestVersion(),
                     0, Time.SYSTEM, isrChangeListener, new DelayedOperationsMock(tp),
-                    Mockito.mock(MetadataCache.class), logManager, isrChannelManager);
+                    Mockito.mock(MetadataCache.class), logManager, isrChannelManager, transferLeaderManager);
 
             partition.makeFollower(partitionState, offsetCheckpoints, topicId);
             pool.put(tp, partition);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -30,6 +30,7 @@ import kafka.server.AlterIsrManager;
 import kafka.server.BrokerTopicStats;
 import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
+import kafka.server.TransferLeaderManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
@@ -128,10 +129,11 @@ public class PartitionMakeFollowerBenchmark {
         Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), tp)).thenReturn(Option.apply(0L));
         IsrChangeListener isrChangeListener = Mockito.mock(IsrChangeListener.class);
         AlterIsrManager alterIsrManager = Mockito.mock(AlterIsrManager.class);
+        TransferLeaderManager transferLeaderManager = Mockito.mock(TransferLeaderManager.class);
         partition = new Partition(tp, 100,
             ApiVersion$.MODULE$.latestVersion(), 0, Time.SYSTEM,
             isrChangeListener, delayedOperations,
-            Mockito.mock(MetadataCache.class), logManager, alterIsrManager);
+            Mockito.mock(MetadataCache.class), logManager, alterIsrManager, transferLeaderManager);
         partition.createLogIfNotExists(true, false, offsetCheckpoints, topicId);
         executorService.submit((Runnable) () -> {
             SimpleRecord[] simpleRecords = new SimpleRecord[] {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -31,6 +31,7 @@ import kafka.server.BrokerTopicStats;
 import kafka.server.LogDirFailureChannel;
 import kafka.server.LogOffsetMetadata;
 import kafka.server.MetadataCache;
+import kafka.server.TransferLeaderManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
@@ -125,10 +126,11 @@ public class UpdateFollowerFetchStateBenchmark {
             .setIsNew(true);
         IsrChangeListener isrChangeListener = Mockito.mock(IsrChangeListener.class);
         AlterIsrManager alterIsrManager = Mockito.mock(AlterIsrManager.class);
+        TransferLeaderManager transferLeaderManager = Mockito.mock(TransferLeaderManager.class);
         partition = new Partition(topicPartition, 100,
                 ApiVersion$.MODULE$.latestVersion(), 0, Time.SYSTEM,
                 isrChangeListener, delayedOperations,
-                Mockito.mock(MetadataCache.class), logManager, alterIsrManager);
+                Mockito.mock(MetadataCache.class), logManager, alterIsrManager, transferLeaderManager);
         partition.makeLeader(partitionState, offsetCheckpoints, topicId);
     }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -28,6 +28,7 @@ import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
+import kafka.server.TransferLeaderManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
@@ -91,6 +92,7 @@ public class CheckpointBench {
     private LogDirFailureChannel failureChannel;
     private LogManager logManager;
     private AlterIsrManager alterIsrManager;
+    private TransferLeaderManager transferLeaderManager;
 
 
     @SuppressWarnings("deprecation")
@@ -121,6 +123,7 @@ public class CheckpointBench {
                         this.time, "");
 
         this.alterIsrManager = TestUtils.createAlterIsrManager();
+        this.transferLeaderManager = TestUtils.createTransferLeaderManager();
         this.replicaManager = new ReplicaManager(
                 this.brokerProperties,
                 this.metrics,
@@ -135,6 +138,7 @@ public class CheckpointBench {
                 metadataCache,
                 this.failureChannel,
                 alterIsrManager,
+                transferLeaderManager,
                 Option.empty());
         replicaManager.startup();
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -31,6 +31,7 @@ import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
+import kafka.server.TransferLeaderManager;
 import kafka.server.ZkMetadataCache;
 import kafka.server.checkpoints.OffsetCheckpoints;
 import kafka.server.metadata.ConfigRepository;
@@ -96,6 +97,7 @@ public class PartitionCreationBench {
     private LogDirFailureChannel failureChannel;
     private LogManager logManager;
     private AlterIsrManager alterIsrManager;
+    private TransferLeaderManager transferLeaderManager;
     private List<TopicPartition> topicPartitions;
 
     @SuppressWarnings("deprecation")
@@ -156,6 +158,7 @@ public class PartitionCreationBench {
             }
         };
         this.alterIsrManager = TestUtils.createAlterIsrManager();
+        this.transferLeaderManager = TestUtils.createTransferLeaderManager();
         this.replicaManager = new ReplicaManager(
                 this.brokerProperties,
                 this.metrics,
@@ -170,6 +173,7 @@ public class PartitionCreationBench {
                 metadataCache,
                 this.failureChannel,
                 alterIsrManager,
+                transferLeaderManager,
                 Option.empty());
         replicaManager.startup();
         replicaManager.checkpointHighWatermarks();


### PR DESCRIPTION
TICKET = LIKAFKA-47596
LI_DESCRIPTION =
Add the TransferLeaderManager, which will be used for sending ElectLeaders requests to the controller.
The TransferLeaderManager implementation is almost identical to that of the AlterISRManager, except that the request type sent is ElectLeaders.

EXIT_CRITERIA = If and when this change is accepted in upstream Kafka.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
