### PR TITLE
Add RequestMetrics for Produce/ConsumerFetch requests in different size buckets and acks

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -106,12 +106,12 @@ class SocketServer(val config: KafkaConfig,
   // data-plane
   private val dataPlaneProcessors = new ConcurrentHashMap[Int, Processor]()
   private[network] val dataPlaneAcceptors = new ConcurrentHashMap[EndPoint, Acceptor]()
-  val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneMetricPrefix, time, observer, apiVersionManager.newRequestMetrics(config.requestMetricsSizeBuckets))
+  val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneMetricPrefix, time, observer, apiVersionManager.newRequestMetrics(config))
   // control-plane
   private var controlPlaneProcessorOpt : Option[Processor] = None
   private[network] var controlPlaneAcceptorOpt : Option[Acceptor] = None
   val controlPlaneRequestChannelOpt: Option[RequestChannel] = config.controlPlaneListenerName.map(_ =>
-    new RequestChannel(20, ControlPlaneMetricPrefix, time, observer, apiVersionManager.newRequestMetrics(config.requestMetricsSizeBuckets)))
+    new RequestChannel(20, ControlPlaneMetricPrefix, time, observer, apiVersionManager.newRequestMetrics(config)))
 
   private var nextProcessorId = 0
   val connectionQuotas = new ConnectionQuotas(config, time, metrics)

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -106,12 +106,12 @@ class SocketServer(val config: KafkaConfig,
   // data-plane
   private val dataPlaneProcessors = new ConcurrentHashMap[Int, Processor]()
   private[network] val dataPlaneAcceptors = new ConcurrentHashMap[EndPoint, Acceptor]()
-  val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneMetricPrefix, time, observer, apiVersionManager.newRequestMetrics)
+  val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneMetricPrefix, time, observer, apiVersionManager.newRequestMetrics(config.requestMetricsSizeBuckets))
   // control-plane
   private var controlPlaneProcessorOpt : Option[Processor] = None
   private[network] var controlPlaneAcceptorOpt : Option[Acceptor] = None
   val controlPlaneRequestChannelOpt: Option[RequestChannel] = config.controlPlaneListenerName.map(_ =>
-    new RequestChannel(20, ControlPlaneMetricPrefix, time, observer, apiVersionManager.newRequestMetrics))
+    new RequestChannel(20, ControlPlaneMetricPrefix, time, observer, apiVersionManager.newRequestMetrics(config.requestMetricsSizeBuckets)))
 
   private var nextProcessorId = 0
   val connectionQuotas = new ConnectionQuotas(config, time, metrics)

--- a/core/src/main/scala/kafka/server/ApiVersionManager.scala
+++ b/core/src/main/scala/kafka/server/ApiVersionManager.scala
@@ -32,7 +32,7 @@ trait ApiVersionManager {
   def enabledApis: collection.Set[ApiKeys]
   def apiVersionResponse(throttleTimeMs: Int): ApiVersionsResponse
   def isApiEnabled(apiKey: ApiKeys): Boolean = enabledApis.contains(apiKey)
-  def newRequestMetrics: RequestChannel.Metrics = new network.RequestChannel.Metrics(enabledApis)
+  def newRequestMetrics(requestMetricsSizeBucketsConfig: String): RequestChannel.Metrics = new network.RequestChannel.Metrics(enabledApis, requestMetricsSizeBucketsConfig)
 }
 
 object ApiVersionManager {

--- a/core/src/main/scala/kafka/server/ApiVersionManager.scala
+++ b/core/src/main/scala/kafka/server/ApiVersionManager.scala
@@ -32,7 +32,7 @@ trait ApiVersionManager {
   def enabledApis: collection.Set[ApiKeys]
   def apiVersionResponse(throttleTimeMs: Int): ApiVersionsResponse
   def isApiEnabled(apiKey: ApiKeys): Boolean = enabledApis.contains(apiKey)
-  def newRequestMetrics(requestMetricsSizeBucketsConfig: String): RequestChannel.Metrics = new network.RequestChannel.Metrics(enabledApis, requestMetricsSizeBucketsConfig)
+  def newRequestMetrics(config: KafkaConfig): RequestChannel.Metrics = new network.RequestChannel.Metrics(enabledApis, config)
 }
 
 object ApiVersionManager {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -265,6 +265,7 @@ object Defaults {
   val MetricReporterClasses = ""
   val MetricRecordingLevel = Sensor.RecordingLevel.INFO.toString()
   val MetricReplaceOnDuplicate = false
+  val RequestMetricsSizeBuckets = "0,1,10,50,100"
 
 
   /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
@@ -615,6 +616,7 @@ object KafkaConfig {
   val MetricReporterClassesProp: String = CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG
   val MetricRecordingLevelProp: String = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG
   val MetricReplaceOnDuplicateProp: String = CommonClientConfigs.METRICS_REPLACE_ON_DUPLICATE_CONFIG
+  val RequestMetricsSizeBucketsProp: String = "request.metrics.size.buckets"
 
   /** ********* Kafka Yammer Metrics Reporters Configuration ***********/
   val KafkaMetricsReporterClassesProp = "kafka.metrics.reporters"
@@ -1058,6 +1060,7 @@ object KafkaConfig {
   val MetricReporterClassesDoc = CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC
   val MetricRecordingLevelDoc = CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC
   val MetricReplaceOnDuplicateDoc = CommonClientConfigs.METRICS_REPLACE_ON_DUPLICATE_DOC
+  val RequestMetricsSizeBucketsDoc = "The size buckets used to group requests to provide RequestMetrics for each group"
 
 
   /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
@@ -1381,6 +1384,7 @@ object KafkaConfig {
       .define(MetricReporterClassesProp, LIST, Defaults.MetricReporterClasses, LOW, MetricReporterClassesDoc)
       .define(MetricRecordingLevelProp, STRING, Defaults.MetricRecordingLevel, LOW, MetricRecordingLevelDoc)
       .define(MetricReplaceOnDuplicateProp, BOOLEAN, Defaults.MetricReplaceOnDuplicate, LOW, MetricReplaceOnDuplicateDoc)
+      .define(RequestMetricsSizeBucketsProp, STRING, Defaults.RequestMetricsSizeBuckets, LOW, RequestMetricsSizeBucketsDoc)
 
       /** ********* Kafka Yammer Metrics Reporter Configuration for docs ***********/
       .define(KafkaMetricsReporterClassesProp, LIST, Defaults.KafkaMetricReporterClasses, LOW, KafkaMetricsReporterClassesDoc)
@@ -1902,6 +1906,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val metricSampleWindowMs = getLong(KafkaConfig.MetricSampleWindowMsProp)
   val metricRecordingLevel = getString(KafkaConfig.MetricRecordingLevelProp)
   val metricReplaceOnDuplicate = getBoolean(KafkaConfig.MetricReplaceOnDuplicateProp)
+  val requestMetricsSizeBuckets = getString(KafkaConfig.RequestMetricsSizeBucketsProp)
 
   /** ********* SSL/SASL Configuration **************/
   // Security configs may be overridden for listeners, so it is not safe to use the base values

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -265,6 +265,7 @@ object Defaults {
   val MetricReporterClasses = ""
   val MetricRecordingLevel = Sensor.RecordingLevel.INFO.toString()
   val MetricReplaceOnDuplicate = false
+  val RequestMetricsSizeBuckets = "0,1,10,50,100"
 
 
   /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
@@ -617,6 +618,7 @@ object KafkaConfig {
   val MetricReporterClassesProp: String = CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG
   val MetricRecordingLevelProp: String = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG
   val MetricReplaceOnDuplicateProp: String = CommonClientConfigs.METRICS_REPLACE_ON_DUPLICATE_CONFIG
+  val RequestMetricsSizeBucketsProp: String = "request.metrics.size.buckets"
 
   /** ********* Kafka Yammer Metrics Reporters Configuration ***********/
   val KafkaMetricsReporterClassesProp = "kafka.metrics.reporters"
@@ -1061,6 +1063,7 @@ object KafkaConfig {
   val MetricReporterClassesDoc = CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC
   val MetricRecordingLevelDoc = CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC
   val MetricReplaceOnDuplicateDoc = CommonClientConfigs.METRICS_REPLACE_ON_DUPLICATE_DOC
+  val RequestMetricsSizeBucketsDoc = "The size buckets used to group requests to provide RequestMetrics for each group"
 
 
   /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
@@ -1385,6 +1388,7 @@ object KafkaConfig {
       .define(MetricReporterClassesProp, LIST, Defaults.MetricReporterClasses, LOW, MetricReporterClassesDoc)
       .define(MetricRecordingLevelProp, STRING, Defaults.MetricRecordingLevel, LOW, MetricRecordingLevelDoc)
       .define(MetricReplaceOnDuplicateProp, BOOLEAN, Defaults.MetricReplaceOnDuplicate, LOW, MetricReplaceOnDuplicateDoc)
+      .define(RequestMetricsSizeBucketsProp, STRING, Defaults.RequestMetricsSizeBuckets, LOW, RequestMetricsSizeBucketsDoc)
 
       /** ********* Kafka Yammer Metrics Reporter Configuration for docs ***********/
       .define(KafkaMetricsReporterClassesProp, LIST, Defaults.KafkaMetricReporterClasses, LOW, KafkaMetricsReporterClassesDoc)
@@ -1907,6 +1911,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val metricSampleWindowMs = getLong(KafkaConfig.MetricSampleWindowMsProp)
   val metricRecordingLevel = getString(KafkaConfig.MetricRecordingLevelProp)
   val metricReplaceOnDuplicate = getBoolean(KafkaConfig.MetricReplaceOnDuplicateProp)
+  val requestMetricsSizeBuckets = getString(KafkaConfig.RequestMetricsSizeBucketsProp)
 
   /** ********* SSL/SASL Configuration **************/
   // Security configs may be overridden for listeners, so it is not safe to use the base values

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -295,7 +295,7 @@ abstract class QuotaTestClients(topic: String,
     def yammerMetricValue(name: String): Double = {
       val allMetrics = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
       val (_, metric) = allMetrics.find { case (metricName, _) =>
-        metricName.getMBeanName.startsWith(name)
+        metricName.getMBeanName == name
       }.getOrElse(fail(s"Unable to find broker metric $name: allMetrics: ${allMetrics.keySet.map(_.getMBeanName)}"))
       metric match {
         case m: Meter => m.count.toDouble

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -128,9 +128,10 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
     val topic2 = "topic2"
     TestUtils.createTopic(zkClient, topic2, 1, 1, servers)
 
-    val sumOfTopicNameLength = TestUtils.yammerMetricValue("SumOfTopicNameLength")
-    assertEquals(topic1.size + topic2.size + 2 * KafkaController.topicNameBytesOverheadOnZk, sumOfTopicNameLength,
-      "all topics in the cluster " + zkClient.getAllTopicsInCluster())
+    TestUtils.waitUntilTrue(() => {
+      val sumOfTopicNameLength = TestUtils.yammerMetricValue("SumOfTopicNameLength")
+      topic1.size + topic2.size + 2 * KafkaController.topicNameBytesOverheadOnZk == sumOfTopicNameLength
+    }, "all topics in the cluster " + zkClient.getAllTopicsInCluster())
   }
 
   // This test case is used to ensure that there will be no correctness issue after we avoid sending out full

--- a/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
@@ -291,7 +291,7 @@ class RequestChannelTest {
     assertTrue(produceMetricsNameMaps.contains(-1))
     val flattenProduceMetricNames = metrics.getProduceRequestAcksSizeMetricNames
     assertEquals(12, flattenProduceMetricNames.size)
-    var i = 0
+
     for (i <- 0 until 3) {
       val ackKey = if (i == 2) -1 else i
       val ackKeyString = if(i == 2) "All" else i.toString
@@ -316,18 +316,18 @@ class RequestChannelTest {
 
     // test get the bucket name
     val metadataRequest = request(new MetadataRequest.Builder(List("topic").asJava, true).build(), metrics)
-    assertEquals(Seq.empty, metadataRequest.getConsumerFetchSizeBucketMetricName)
-    assertEquals(Seq.empty, metadataRequest.getProduceAckSizeBucketMetricName)
+    assertEquals(None, metadataRequest.getConsumerFetchSizeBucketMetricName)
+    assertEquals(None, metadataRequest.getProduceAckSizeBucketMetricName)
 
     var produceRequest = request(new ProduceRequest.Builder(0, 0,
       new ProduceRequestData().setAcks(1.toShort).setTimeoutMs(1000)).build(),
       metrics)
-    assertEquals(Seq.empty, produceRequest.getConsumerFetchSizeBucketMetricName)
-    assertEquals("Produce0To10MbAcks1", produceRequest.getProduceAckSizeBucketMetricName(0))
+    assertEquals(None, produceRequest.getConsumerFetchSizeBucketMetricName)
+    assertEquals(Some("Produce0To10MbAcks1"), produceRequest.getProduceAckSizeBucketMetricName)
     produceRequest = request(new ProduceRequest.Builder(0, 0,
       new ProduceRequestData().setAcks(-1).setTimeoutMs(1000)).build(),
       metrics)
-    assertEquals("Produce0To10MbAcksAll", produceRequest.getProduceAckSizeBucketMetricName(0))
+    assertEquals(Some("Produce0To10MbAcksAll"), produceRequest.getProduceAckSizeBucketMetricName)
 
     val tp = new TopicPartition("foo", 0)
     val fetchData = Map(tp -> new FetchRequest.PartitionData(0, 0, 1000,
@@ -335,12 +335,12 @@ class RequestChannelTest {
     val consumeFetchRequest = request(new FetchRequest.Builder(9, 9, -1, 100, 0, fetchData)
       .build(),
       metrics)
-    assertEquals("FetchConsumer0To10Mb", consumeFetchRequest.getConsumerFetchSizeBucketMetricName(0))
-    assertEquals(Seq.empty, consumeFetchRequest.getProduceAckSizeBucketMetricName)
+    assertEquals(Some("FetchConsumer0To10Mb"), consumeFetchRequest.getConsumerFetchSizeBucketMetricName)
+    assertEquals(None, consumeFetchRequest.getProduceAckSizeBucketMetricName)
     val followerFetchRequest = request(new FetchRequest.Builder(9, 9, 1, 100, 0, fetchData)
       .build(),
       metrics)
-    assertEquals(Seq.empty, followerFetchRequest.getConsumerFetchSizeBucketMetricName)
+    assertEquals(None, followerFetchRequest.getConsumerFetchSizeBucketMetricName)
 
     assertEquals("FetchConsumer0To10Mb", metrics.getRequestSizeBucketMetricName(metrics.consumerFetchRequestSizeMetricNameMap, 2*1024 *1024))
     assertEquals("Produce10To20MbAcks0", metrics.getRequestSizeBucketMetricName(metrics.produceRequestAcksSizeMetricNameMap(0), 10*1024 *1024))

--- a/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
@@ -268,19 +268,19 @@ class RequestChannelTest {
     var metrics = new Metrics(apis, config)
     val fetchMetricsNameMap = metrics.consumerFetchRequestSizeMetricNameMap
     assertEquals(4, fetchMetricsNameMap.size)
-    assertTrue(fetchMetricsNameMap.contains(0))
-    assertTrue(fetchMetricsNameMap.contains(10))
-    assertTrue(fetchMetricsNameMap.contains(20))
-    assertTrue(fetchMetricsNameMap.contains(200))
+    assertTrue(fetchMetricsNameMap.containsKey(0))
+    assertTrue(fetchMetricsNameMap.containsKey(10))
+    assertTrue(fetchMetricsNameMap.containsKey(20))
+    assertTrue(fetchMetricsNameMap.containsKey(200))
     val flattenFetchMetricNames = metrics.getConsumerFetchRequestSizeMetricNames
     assertEquals(4, flattenFetchMetricNames.size)
-    assertEquals("FetchConsumer0To10Mb", fetchMetricsNameMap(0))
+    assertEquals("FetchConsumer0To10Mb", fetchMetricsNameMap.get(0))
     assertTrue(flattenFetchMetricNames.contains("FetchConsumer0To10Mb"))
-    assertEquals("FetchConsumer10To20Mb", fetchMetricsNameMap(10))
+    assertEquals("FetchConsumer10To20Mb", fetchMetricsNameMap.get(10))
     assertTrue(flattenFetchMetricNames.contains("FetchConsumer10To20Mb"))
-    assertEquals("FetchConsumer20To200Mb", fetchMetricsNameMap(20))
+    assertEquals("FetchConsumer20To200Mb", fetchMetricsNameMap.get(20))
     assertTrue(flattenFetchMetricNames.contains("FetchConsumer20To200Mb"))
-    assertEquals("FetchConsumer200MbGreater", fetchMetricsNameMap(200))
+    assertEquals("FetchConsumer200MbGreater", fetchMetricsNameMap.get(200))
     assertTrue(flattenFetchMetricNames.contains("FetchConsumer200MbGreater"))
 
     val produceMetricsNameMaps = metrics.produceRequestAcksSizeMetricNameMap
@@ -296,21 +296,21 @@ class RequestChannelTest {
       val ackKey = if (i == 2) -1 else i
       val ackKeyString = if(i == 2) "All" else i.toString
       val produceMetricsNameMap = produceMetricsNameMaps(ackKey)
-      assertTrue(produceMetricsNameMap.contains(0))
-      assertTrue(produceMetricsNameMap.contains(10))
-      assertTrue(produceMetricsNameMap.contains(20))
-      assertTrue(produceMetricsNameMap.contains(200))
+      assertTrue(produceMetricsNameMap.containsKey(0))
+      assertTrue(produceMetricsNameMap.containsKey(10))
+      assertTrue(produceMetricsNameMap.containsKey(20))
+      assertTrue(produceMetricsNameMap.containsKey(200))
       var metricName = "Produce0To10MbAcks" + ackKeyString
-      assertEquals(metricName, produceMetricsNameMap(0))
+      assertEquals(metricName, produceMetricsNameMap.get(0))
       assertTrue(flattenProduceMetricNames.contains(metricName))
       metricName = "Produce10To20MbAcks" + ackKeyString
-      assertEquals(metricName, produceMetricsNameMap(10))
+      assertEquals(metricName, produceMetricsNameMap.get(10))
       assertTrue(flattenProduceMetricNames.contains(metricName))
       metricName = "Produce20To200MbAcks" + ackKeyString
-      assertEquals(metricName, produceMetricsNameMap(20))
+      assertEquals(metricName, produceMetricsNameMap.get(20))
       assertTrue(flattenProduceMetricNames.contains(metricName))
       metricName = "Produce200MbGreaterAcks" + ackKeyString
-      assertEquals(metricName, produceMetricsNameMap(200))
+      assertEquals(metricName, produceMetricsNameMap.get(200))
       assertTrue(flattenProduceMetricNames.contains(metricName))
     }
 
@@ -360,36 +360,35 @@ class RequestChannelTest {
     //default bucket "0,1,10,50,100"
     val fetchMetricsNameMap = metrics.consumerFetchRequestSizeMetricNameMap
     assertEquals(5, fetchMetricsNameMap.size)
-    assertTrue(fetchMetricsNameMap.contains(0))
-    assertTrue(fetchMetricsNameMap.contains(1))
-    assertTrue(fetchMetricsNameMap.contains(10))
-    assertTrue(fetchMetricsNameMap.contains(50))
-    assertTrue(fetchMetricsNameMap.contains(100))
-    assertEquals("FetchConsumer0To1Mb", fetchMetricsNameMap(0))
-    assertEquals("FetchConsumer1To10Mb", fetchMetricsNameMap(1))
-    assertEquals("FetchConsumer10To50Mb", fetchMetricsNameMap(10))
-    assertEquals("FetchConsumer50To100Mb", fetchMetricsNameMap(50))
-    assertEquals("FetchConsumer100MbGreater", fetchMetricsNameMap(100))
+    assertTrue(fetchMetricsNameMap.containsKey(0))
+    assertTrue(fetchMetricsNameMap.containsKey(1))
+    assertTrue(fetchMetricsNameMap.containsKey(10))
+    assertTrue(fetchMetricsNameMap.containsKey(50))
+    assertTrue(fetchMetricsNameMap.containsKey(100))
+    assertEquals("FetchConsumer0To1Mb", fetchMetricsNameMap.get(0))
+    assertEquals("FetchConsumer1To10Mb", fetchMetricsNameMap.get(1))
+    assertEquals("FetchConsumer10To50Mb", fetchMetricsNameMap.get(10))
+    assertEquals("FetchConsumer50To100Mb", fetchMetricsNameMap.get(50))
+    assertEquals("FetchConsumer100MbGreater", fetchMetricsNameMap.get(100))
     val produceMetricsNameMaps = metrics.produceRequestAcksSizeMetricNameMap
     assertEquals(3, produceMetricsNameMaps.size)
     assertTrue(produceMetricsNameMaps.contains(0))
     assertTrue(produceMetricsNameMaps.contains(1))
     assertTrue(produceMetricsNameMaps.contains(-1))
-    var i = 0
     for (i <- 0 until 3) {
       val ackKey = if (i == 2) -1 else i
       val ackKeyString = if(i == 2) "All" else i.toString
       val produceMetricsNameMap = produceMetricsNameMaps(ackKey)
-      assertTrue(produceMetricsNameMap.contains(0))
-      assertTrue(produceMetricsNameMap.contains(1))
-      assertTrue(produceMetricsNameMap.contains(10))
-      assertTrue(produceMetricsNameMap.contains(50))
-      assertTrue(produceMetricsNameMap.contains(100))
-      assertEquals("Produce0To1MbAcks" + ackKeyString, produceMetricsNameMap(0))
-      assertEquals("Produce1To10MbAcks" + ackKeyString, produceMetricsNameMap(1))
-      assertEquals("Produce10To50MbAcks" + ackKeyString, produceMetricsNameMap(10))
-      assertEquals("Produce50To100MbAcks" + ackKeyString, produceMetricsNameMap(50))
-      assertEquals("Produce100MbGreaterAcks" + ackKeyString, produceMetricsNameMap(100))
+      assertTrue(produceMetricsNameMap.containsKey(0))
+      assertTrue(produceMetricsNameMap.containsKey(1))
+      assertTrue(produceMetricsNameMap.containsKey(10))
+      assertTrue(produceMetricsNameMap.containsKey(50))
+      assertTrue(produceMetricsNameMap.containsKey(100))
+      assertEquals("Produce0To1MbAcks" + ackKeyString, produceMetricsNameMap.get(0))
+      assertEquals("Produce1To10MbAcks" + ackKeyString, produceMetricsNameMap.get(1))
+      assertEquals("Produce10To50MbAcks" + ackKeyString, produceMetricsNameMap.get(10))
+      assertEquals("Produce50To100MbAcks" + ackKeyString, produceMetricsNameMap.get(50))
+      assertEquals("Produce100MbGreaterAcks" + ackKeyString, produceMetricsNameMap.get(100))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -238,7 +238,7 @@ class ForwardingManagerTest {
       startTimeNanos = time.nanoseconds(),
       memoryPool = MemoryPool.NONE,
       buffer = requestBuffer,
-      metrics = new RequestChannel.Metrics(ListenerType.CONTROLLER),
+      metrics = new RequestChannel.Metrics(ListenerType.CONTROLLER, ""),
       envelope = None
     )
   }

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -18,9 +18,8 @@ package kafka.server
 
 import java.net.InetAddress
 import java.nio.ByteBuffer
-import java.util.Optional
+import java.util.{Optional, Properties}
 import java.util.concurrent.atomic.AtomicReference
-
 import kafka.network
 import kafka.network.RequestChannel
 import kafka.utils.MockTime
@@ -232,13 +231,17 @@ class ForwardingManagerTest {
       Optional.of(principalBuilder)
     )
 
+    val props = new Properties()
+    props.put(KafkaConfig.ZkConnectProp, "127.0.0.1:2181")
+    props.put(KafkaConfig.RequestMetricsSizeBucketsProp, "0, 10, 20, 200")
+    val config = KafkaConfig.fromProps(props)
     new network.RequestChannel.Request(
       processor = 1,
       context = requestContext,
       startTimeNanos = time.nanoseconds(),
       memoryPool = MemoryPool.NONE,
       buffer = requestBuffer,
-      metrics = new RequestChannel.Metrics(ListenerType.CONTROLLER, ""),
+      metrics = new RequestChannel.Metrics(ListenerType.CONTROLLER, config),
       envelope = None
     )
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -809,12 +809,11 @@ class KafkaConfigTest {
         //Kafka Yammer metrics reporter configs
         case KafkaConfig.KafkaMetricsReporterClassesProp => // ignore
         case KafkaConfig.KafkaMetricsPollingIntervalSecondsProp => //ignore
+        case KafkaConfig.RequestMetricsSizeBucketsProp =>  assertPropertyInvalid(baseProperties, name, "", "1", "1, 2, 5, not_a_number, 9")
 
         // Broker-side observer configs
         case KafkaConfig.ObserverClassNameProp => // ignore since even if the class name is invalid, a NoOpObserver class is used instead
         case KafkaConfig.ObserverShutdownTimeoutMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")
-
-        case KafkaConfig.RequestMetricsSizeBucketsProp => // ignore
 
         // Raft Quorum Configs
         case RaftConfig.QUORUM_VOTERS_CONFIG => // ignore string

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -814,6 +814,8 @@ class KafkaConfigTest {
         case KafkaConfig.ObserverClassNameProp => // ignore since even if the class name is invalid, a NoOpObserver class is used instead
         case KafkaConfig.ObserverShutdownTimeoutMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")
 
+        case KafkaConfig.RequestMetricsSizeBucketsProp => // ignore
+
         // Raft Quorum Configs
         case RaftConfig.QUORUM_VOTERS_CONFIG => // ignore string
         case RaftConfig.QUORUM_ELECTION_TIMEOUT_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number")


### PR DESCRIPTION
TICKET = [LIKAFKA-47556 Establish Kafka Server SLOs](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-47556) 
LI_DESCRIPTION =
This PR is to add separate RequestMetrics for produce requests in different request size buckets and of different acks and add separate RequestMetrics for consumer fetch requests in different response size buckets. With this, we could provide latency SLO for requests in each buckets. The size buckets are configurable.

EXIT_CRITERIA =

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
