### PR TITLE
[LI-HOTFIX] Fix the majority of compilation warnings

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -28,7 +28,7 @@ case class MemberSummary(memberId: String,
                          metadata: Array[Byte],
                          assignment: Array[Byte])
 
-private object MemberMetadata {
+private[group] object MemberMetadata {
   def plainProtocolSet(supportedProtocols: List[(String, Array[Byte])]) = supportedProtocols.map(_._1).toSet
 }
 

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -181,7 +181,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
    * the log manager maintains. Compared with {@link grabFilthiestCompactedLogWithFineGrainedLock() grabFilthiestCompactedLogWithFineGrainedLock},
    * this method holds the lock while iterating through the logs to check which one is the filthiest.
    */
-  private def grabFilthiestCompactedLogWithLongLastingLock(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
+  private def grabFilthiestCompactedLogWithLongLastingLock(time: Time, preCleanStats: PreCleanStats): Option[LogToClean] = {
     inLock(lock) {
       val now = time.milliseconds
       this.timeOfLastRun = now
@@ -233,7 +233,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     * the log manager maintains. Compared with {@link grabFilthiestCompactedLogWithLongLastingLock() grabFilthiestCompactedLogWithLongLastingLock},
    * this method does NOT hold the lock while iterating through the logs to check which one is the filthiest.
     */
-  private def grabFilthiestCompactedLogWithFineGrainedLock(time: Time, preCleanStats: PreCleanStats = new PreCleanStats()): Option[LogToClean] = {
+  private def grabFilthiestCompactedLogWithFineGrainedLock(time: Time, preCleanStats: PreCleanStats): Option[LogToClean] = {
       info(s"Grabbing filthiest compacted log with fine grained lock")
       val now = time.milliseconds
       this.timeOfLastRun = now

--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -31,7 +31,7 @@ abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: Stri
   // package private for test
   private[server] val fetcherThreadMap = new mutable.HashMap[BrokerIdAndFetcherId, T]
   private val lock = new Object
-  private var numFetchersPerBroker = numFetchers
+  private val numFetchersPerBroker = numFetchers
   val failedPartitions = new FailedPartitions
   this.logIdent = "[" + name + "] "
 

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -53,7 +53,6 @@ abstract class DelayedOperation(override val delayMs: Long,
                                 lockOpt: Option[Lock] = None)
   extends TimerTask {
 
-  import DelayedOperation._
   private val completed = new AtomicBoolean(false)
   // Visible for testing
   private[server] val lock: Lock = lockOpt.getOrElse(new ReentrantLock)

--- a/core/src/main/scala/kafka/server/TransferLeaderManager.scala
+++ b/core/src/main/scala/kafka/server/TransferLeaderManager.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{ElectLeadersRequest, ElectLeadersResponse}
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.common.{ElectionType, TopicPartition}
+import org.apache.kafka.common.TopicPartition
 
 import java.util
 import java.util.concurrent.atomic.AtomicBoolean

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -19,7 +19,7 @@ package kafka.server
 import java.util
 import java.util.Properties
 
-import kafka.admin.{AdminOperationException, AdminUtils}
+import kafka.admin.AdminOperationException
 import kafka.common.TopicAlreadyMarkedForDeletionException
 import kafka.controller.KafkaController
 import kafka.log.LogConfig

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -34,7 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Utils
 import org.slf4j.event.Level
 
-import java.nio.file.{Files, Paths, StandardOpenOption}
+import java.nio.file.{Paths, StandardOpenOption}
 import java.util.concurrent.TimeUnit
 import scala.annotation.nowarn
 

--- a/core/src/main/scala/kafka/utils/NotNothing.scala
+++ b/core/src/main/scala/kafka/utils/NotNothing.scala
@@ -17,7 +17,7 @@
 
 package kafka.utils
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{implicitNotFound, nowarn}
 
 /**
   * This is a trick to prevent the compiler from inferring the `Nothing` type in cases where it would be a bug to do
@@ -37,5 +37,5 @@ trait NotNothing[T]
 object NotNothing {
   private val evidence: NotNothing[Any] = new Object with NotNothing[Any]
 
-  implicit def notNothingEvidence[T](implicit n: T =:= T): NotNothing[T] = evidence.asInstanceOf[NotNothing[T]]
+  implicit def notNothingEvidence[T](implicit @nowarn("cat=unused") n: T =:= T): NotNothing[T] = evidence.asInstanceOf[NotNothing[T]]
 }

--- a/core/src/main/scala/kafka/utils/json/DecodeJson.scala
+++ b/core/src/main/scala/kafka/utils/json/DecodeJson.scala
@@ -22,6 +22,7 @@ import scala.collection.compat._
 import scala.jdk.CollectionConverters._
 
 import com.fasterxml.jackson.databind.{JsonMappingException, JsonNode}
+import scala.language.higherKinds
 
 /**
  * A type class for parsing JSON. This should typically be used via `JsonValue.apply`.

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartit
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.{OffsetForLeaderPartition, OffsetForLeaderTopic, OffsetForLeaderTopicCollection}
 import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartitionState, StopReplicaTopicState}
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataEndpoint, UpdateMetadataPartitionState}
-import org.apache.kafka.common.message.{AddOffsetsToTxnRequestData, AlterPartitionReassignmentsRequestData, AlterReplicaLogDirsRequestData, ControlledShutdownRequestData, CreateAclsRequestData, CreatePartitionsRequestData, CreateTopicsRequestData, DeleteAclsRequestData, DeleteGroupsRequestData, DeleteRecordsRequestData, DeleteTopicsRequestData, DescribeClusterRequestData, DescribeConfigsRequestData, DescribeGroupsRequestData, DescribeLogDirsRequestData, DescribeProducersRequestData, DescribeTransactionsRequestData, FindCoordinatorRequestData, HeartbeatRequestData, IncrementalAlterConfigsRequestData, JoinGroupRequestData, ListPartitionReassignmentsRequestData, ListTransactionsRequestData, MetadataRequestData, OffsetCommitRequestData, ProduceRequestData, SyncGroupRequestData}
+import org.apache.kafka.common.message.{AddOffsetsToTxnRequestData, AlterPartitionReassignmentsRequestData, ControlledShutdownRequestData, CreateAclsRequestData, CreatePartitionsRequestData, CreateTopicsRequestData, DeleteAclsRequestData, DeleteGroupsRequestData, DeleteRecordsRequestData, DeleteTopicsRequestData, DescribeClusterRequestData, DescribeConfigsRequestData, DescribeGroupsRequestData, DescribeLogDirsRequestData, DescribeProducersRequestData, DescribeTransactionsRequestData, FindCoordinatorRequestData, HeartbeatRequestData, IncrementalAlterConfigsRequestData, JoinGroupRequestData, ListPartitionReassignmentsRequestData, ListTransactionsRequestData, MetadataRequestData, OffsetCommitRequestData, ProduceRequestData, SyncGroupRequestData}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, RecordBatch, SimpleRecord}
@@ -628,6 +628,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
         .setPermissionType(AclPermissionType.DENY.code)))
   ).build()
 
+  /*
   private def alterReplicaLogDirsRequest = {
     val dir = new AlterReplicaLogDirsRequestData.AlterReplicaLogDir()
       .setPath(logDir)
@@ -638,6 +639,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     data.dirs.add(dir)
     new AlterReplicaLogDirsRequest.Builder(data).build()
   }
+  */
 
   private def describeLogDirsRequest = new DescribeLogDirsRequest.Builder(new DescribeLogDirsRequestData().setTopics(new DescribeLogDirsRequestData.DescribableLogDirTopicCollection(Collections.singleton(
     new DescribeLogDirsRequestData.DescribableLogDirTopic().setTopic(tp.topic).setPartitions(Collections.singletonList(tp.partition))).iterator()))).build()

--- a/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
@@ -18,17 +18,15 @@
 package integration.kafka.api
 
 import kafka.controller.OfflinePartition
-import kafka.server.{KafkaConfig, KafkaServer, ReplicaManager}
-import kafka.utils.Implicits.PropertiesOps
+import kafka.server.{KafkaConfig, KafkaServer}
+import kafka.utils.TestUtils
 import kafka.utils.TestUtils.getBrokerListStrFromServers
-import kafka.utils.{Exit, TestUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig}
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.serialization.{ByteArraySerializer, Serializer}
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -16,7 +16,7 @@ import java.util.{Locale, Properties}
 import kafka.log.LogConfig
 import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.{JaasTestUtils, TestUtils}
-import com.yammer.metrics.core.{Gauge, Histogram, Meter}
+import com.yammer.metrics.core.{Histogram, Meter}
 import kafka.metrics.KafkaYammerMetrics
 import kafka.utils.TestUtils.{sendRecords, verifyYammerMetricRecorded, yammerMetricValue}
 import org.apache.kafka.clients.consumer.KafkaConsumer

--- a/core/src/test/scala/integration/kafka/api/MultiBrokerMetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MultiBrokerMetricsTest.scala
@@ -19,7 +19,6 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.serialization.ByteArraySerializer
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 
 import java.util.Properties

--- a/core/src/test/scala/integration/kafka/api/RecordHeaderProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/RecordHeaderProducerSendTest.scala
@@ -35,7 +35,7 @@ class RecordHeaderProducerSendTest extends BaseProducerSendTest {
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
     producerProps.put(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "true")
     val producer = new KafkaProducer[String, String](producerProps)
-    var invalidRecordHeaders = new RecordHeaders()
+    val invalidRecordHeaders = new RecordHeaders()
     invalidRecordHeaders.add("RecordHeaderKey", "RecordHeaderValue".getBytes)
     // The record is invalid because it contain header with keys that doesn't start with a "_"
     // Keys that do start with a "_" are internal to the clients and are dropped at the producer.

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -1662,7 +1662,7 @@ class ControllerIntegrationTest extends ZooKeeperTestHarness {
         }
         case _ => false
       }
-    }, "broker 0 never gets the metadata for the topic $topic")
+    }, s"broker 0 never gets the metadata for the topic $topic")
 
     info(s"original topic id $originalTopicId")
     // delete and then immediately recreate the topic

--- a/core/src/test/scala/unit/kafka/controller/PartitionLeaderElectionAlgorithmsTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionLeaderElectionAlgorithmsTest.scala
@@ -17,7 +17,7 @@
 package kafka.controller
 
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.Test
 
 class PartitionLeaderElectionAlgorithmsTest {
 

--- a/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
@@ -30,8 +30,6 @@ import scala.util.Random
 import kafka.utils.TestUtils
 import org.apache.kafka.common.errors.InvalidOffsetException
 
-import scala.annotation.nowarn
-
 class OffsetIndexTest {
   
   var idx: OffsetIndex = null
@@ -49,7 +47,6 @@ class OffsetIndexTest {
       this.idx.file.delete()
   }
 
-  @nowarn("cat=deprecation")
   @Test
   def randomLookupTest(): Unit = {
     assertEquals(OffsetPosition(idx.baseOffset, 0), idx.lookup(92L),

--- a/core/src/test/scala/unit/kafka/server/MultiClusterBaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MultiClusterBaseRequestTest.scala
@@ -21,7 +21,6 @@ import java.io.{DataInputStream, DataOutputStream}
 import java.net.Socket
 import java.nio.ByteBuffer
 import java.util.{EnumSet, Properties}
-
 import kafka.api.MultiClusterIntegrationTestHarness
 import kafka.network.SocketServer
 import kafka.utils.NotNothing
@@ -31,6 +30,7 @@ import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, Requ
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.metadata.BrokerState
 
+import scala.annotation.nowarn
 import scala.collection.Seq
 import scala.reflect.ClassTag
 
@@ -135,7 +135,7 @@ abstract class MultiClusterBaseRequestTest extends MultiClusterIntegrationTestHa
   }
 
   def receive[T <: AbstractResponse](socket: Socket, apiKey: ApiKeys, version: Short)
-                                    (implicit classTag: ClassTag[T], nn: NotNothing[T]): T = {
+                                    (implicit classTag: ClassTag[T], @nowarn("cat=unused") nn: NotNothing[T]): T = {
     val incoming = new DataInputStream(socket.getInputStream)
     val len = incoming.readInt()
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1585,7 +1585,7 @@ class ReplicaManagerTest {
                                                  localLogOffset: Option[Long] = None,
                                                  offsetFromLeader: Long = 5,
                                                  leaderEpochFromLeader: Int = 3,
-                                                 extraProps: Properties = new Properties(),
+                                                 extraProps: Properties,
                                                  topicId: Option[Uuid] = None) : (ReplicaManager, LogManager) = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect)
     props.put("log.dir", TestUtils.tempRelativeDir("data").getAbsolutePath)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -24,7 +24,7 @@ import java.nio.file.{Files, StandardOpenOption}
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import java.util.concurrent.{Callable, ExecutionException, Executors, ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.{Callable, ExecutionException, Executors, TimeUnit}
 import java.util.{Arrays, Collections, Optional, Properties}
 import com.yammer.metrics.core.{Gauge, Histogram, Meter}
 
@@ -988,7 +988,7 @@ object TestUtils extends Logging {
       } catch {
         // On unknown topic, it's wrapped inside an ExecutionException's cause
         case e: ExecutionException => e.getCause.getClass == classOf[UnknownTopicOrPartitionException]
-        case _ => false
+        case _: Exception => false
       }
     }
     waitUntilTrue(


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
Fix the majority of compilation warnings since they are annoying and can bury some really useful warnings.

There are still 2 types of warnings after this PR
1.  @nowarn annotation does not suppress any warnings.
    This type of warning would show up when compiling with scala 2.12 and would go away when compiling with scala 2.13.

2. lazy value logMessageFormatVersion in class KafkaConfig is deprecated: 3.0 
    It is a legitimate high-stake warning that we should constantly be reminded about.

EXIT_CRITERIA = N/A


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
