### PR TITLE
[LI-HOTFIX] Transfer leadership for UnderMinISR partitions

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -756,7 +756,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val interesting = mutable.ArrayBuffer[(TopicPartition, FetchRequest.PartitionData)]()
     if (fetchRequest.isFromFollower) {
       // The follower must have ClusterAction on ClusterResource in order to fetch partition data.
-      if (authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME)) {
+      if (authHelper.authorize(request.context, CLUSTER_ACTION, CLUSTER, CLUSTER_NAME) && !config.liDropFetchFollowerEnable) {
         fetchContext.foreachPartition { (topicPartition, data) =>
           if (!metadataCache.contains(topicPartition))
             erroneous += topicPartition -> FetchResponse.partitionResponse(topicPartition.partition, Errors.UNKNOWN_TOPIC_OR_PARTITION)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -323,6 +323,7 @@ object Defaults {
   /** Linkedin Internal states */
   val LiCombinedControlRequestEnabled = false
   val LiUpdateMetadataDelayMs = 0
+  val LiDropFetchFollowerEnable = false
   val LiAlterIsrEnabled = true
   val LiAsyncFetcherEnabled = false
   val LiNumControllerInitThreads = 1
@@ -441,6 +442,7 @@ object KafkaConfig {
   val LiAsyncFetcherEnableProp = "li.async.fetcher.enable"
   val LiCombinedControlRequestEnableProp = "li.combined.control.request.enable"
   val LiUpdateMetadataDelayMsProp = "li.update.metadata.delay.ms"
+  val LiDropFetchFollowerEnableProp = "li.stop.replication.enable"
   val LiAlterIsrEnableProp = "li.alter.isr.enable"
   val LiNumControllerInitThreadsProp = "li.num.controller.init.threads"
   val LiLogCleanerFineGrainedLockEnableProp = "li.log.cleaner.fine.grained.lock.enable"
@@ -781,6 +783,7 @@ object KafkaConfig {
   val LiCombinedControlRequestEnableDoc = "Specifies whether the controller should use the LiCombinedControlRequest."
   val LiUpdateMetadataDelayMsDoc = "Specifies how long a UpdateMetadata request with partitions should be delayed before its processing can start. This config is purely for testing the LiCombinedControl feature and should not be enabled in a production environment."
   val LiDropCorruptedFilesEnableDoc = "Specifies whether the broker should delete corrupted files during startup."
+  val LiDropFetchFollowerEnableDoc = "Specifies whether a leader should drop Fetch requests from followers. This config is used to simulate a slow leader and test the leader initiated leadership transfer"
   val LiAlterIsrEnabledDoc = "Specifies whether the brokers should use the AlterISR request to propagate ISR changes to the controller. If set to false, brokers will propagate the updates via Zookeeper."
   val LiNumControllerInitThreadsDoc = "Number of threads (and Zookeeper clients + connections) to be used while recursing the topic-partitions tree in Zookeeper during controller startup/failover."
   val LiLogCleanerFineGrainedLockEnableDoc = "Specifies whether the log cleaner should use fine grained locks when calculating the filthiest log to clean"
@@ -1222,6 +1225,7 @@ object KafkaConfig {
       .define(LiAsyncFetcherEnableProp, BOOLEAN, Defaults.LiAsyncFetcherEnabled, HIGH, LiAsyncFetcherEnableDoc)
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
       .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, atLeast(0), LOW, LiUpdateMetadataDelayMsDoc)
+      .define(LiDropFetchFollowerEnableProp, BOOLEAN, Defaults.LiDropFetchFollowerEnable, LOW, LiDropFetchFollowerEnableDoc)
       .define(LiAlterIsrEnableProp, BOOLEAN, Defaults.LiAlterIsrEnabled, HIGH, LiAlterIsrEnabledDoc)
       .define(LiNumControllerInitThreadsProp, INT, Defaults.LiNumControllerInitThreads, atLeast(1), LOW, LiNumControllerInitThreadsDoc)
       .define(LiLogCleanerFineGrainedLockEnableProp, BOOLEAN, Defaults.LiLogCleanerFineGrainedLockEnabled, LOW, LiLogCleanerFineGrainedLockEnableDoc)
@@ -1734,6 +1738,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val liAsyncFetcherEnable = getBoolean(KafkaConfig.LiAsyncFetcherEnableProp)
   def liCombinedControlRequestEnable = getBoolean(KafkaConfig.LiCombinedControlRequestEnableProp)
   def liUpdateMetadataDelayMs = getLong(KafkaConfig.LiUpdateMetadataDelayMsProp)
+  def liDropFetchFollowerEnable = getBoolean(KafkaConfig.LiDropFetchFollowerEnableProp)
   def liAlterIsrEnable = getBoolean(KafkaConfig.LiAlterIsrEnableProp)
   def liNumControllerInitThreads = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
   def liLogCleanerFineGrainedLockEnable = getBoolean(KafkaConfig.LiLogCleanerFineGrainedLockEnableProp)

--- a/core/src/test/scala/unit/kafka/integration/DegradedLeaderTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/DegradedLeaderTest.scala
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.integration
+
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.clients.admin.Admin
+import org.apache.kafka.clients.producer.{Producer, ProducerRecord}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.TopicConfig
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.{Collections, Properties}
+import scala.collection.JavaConverters._
+
+class DegradedLeaderTest extends ZooKeeperTestHarness {
+  @Test
+  def testLeadershipTransferByDegradedLeader(): Unit = {
+    // create brokers
+    val serverConfigs = TestUtils.createBrokerConfigs(5, zkConnect, false)
+      .map(props => {
+        if (props.get(KafkaConfig.BrokerIdProp).equals("0")) {
+          // let the leader drop Fetch requests from the followers, which will cause the partition to be UnderMinISR
+          props.setProperty(KafkaConfig.LiDropFetchFollowerEnableProp, "true")
+        }
+        props.put(KafkaConfig.ReplicaLagTimeMaxMsProp, "10000")
+        props
+      })
+      .map(KafkaConfig.fromProps)
+    // start servers in reverse order to ensure broker 4 becomes the controller
+    val servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+    // val controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
+    assertTrue(controllerId == 4)
+
+    // create the topic with min ISR of 2
+    val topic = "test"
+    val partition = 0
+    val tp = new TopicPartition(topic, partition)
+    val topicConfig = new Properties()
+    topicConfig.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+    val expectedReplicaAssignment = Map(0  -> List(0, 1, 2, 3))
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+
+    /**
+     * An out-of-sync replica is defined to be one whose log end offset is different from that of the leader,
+     * and whose lastCaughtUpTimeMs has been too long in the past.
+     * When no messages have been produced, the log end offsets of all replicas have the same vaule, i.e. 0.
+     * Thus there will be no UnderMinISR partitions.
+     * The UnderMinISR partitions will only happen after some messages are produced.
+     */
+
+    val adminClient = TestUtils.createAdminClient(servers)
+    val initialLeader = 0
+    assertTrue(getLeader(adminClient, tp) == initialLeader)
+
+    val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers))
+    produceRecord(producer, topic, partition)
+
+    TestUtils.waitUntilTrue(() => {
+      // wait until the leadership has switch to a different broker
+      val newLeader = getLeader(adminClient, tp)
+      newLeader != initialLeader
+    }, "the leadership hasn't switched")
+
+    // make sure after the leadership switch, the producing still works
+    produceRecord(producer, topic, partition)
+
+    adminClient.close()
+    producer.close()
+    servers.foreach(_.shutdown())
+  }
+
+  private def getLeader(adminClient: Admin, tp: TopicPartition): Int = {
+    val topicDescMap = adminClient.describeTopics(Collections.singleton(tp.topic())).all().get()
+    topicDescMap.get(tp.topic()).partitions().get(tp.partition()).leader().id()
+  }
+
+  private def produceRecord(producer: Producer[Array[Byte], Array[Byte]], topic: String, partition: Int) = {
+    val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
+      "value".getBytes(StandardCharsets.UTF_8))
+    producer.send(record).get()
+  }
+}

--- a/core/src/test/scala/unit/kafka/integration/DegradedLeaderTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/DegradedLeaderTest.scala
@@ -64,7 +64,7 @@ class DegradedLeaderTest extends ZooKeeperTestHarness {
     /**
      * An out-of-sync replica is defined to be one whose log end offset is different from that of the leader,
      * and whose lastCaughtUpTimeMs has been too long in the past.
-     * When no messages have been produced, the log end offsets of all replicas have the same vaule, i.e. 0.
+     * When no messages have been produced, the log end offsets of all replicas have the same value, i.e. 0.
      * Thus there will be no UnderMinISR partitions.
      * The UnderMinISR partitions will only happen after some messages are produced.
      */

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -435,6 +435,12 @@ object TestUtils extends Logging {
       server.groupCoordinator.offsetsTopicConfigs)
   }
 
+  def createAdminClient(servers: Seq[KafkaServer], props: Properties = new Properties): Admin = {
+    val bootstrapServers = TestUtils.bootstrapServers(servers, new ListenerName("PLAINTEXT"))
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    AdminClient.create(props)
+  }
+
   /**
    * Wrap a single record log buffer.
    */


### PR DESCRIPTION
TICKET = LIKAFKA-47596
LI_DESCRIPTION =
This PR adds the following change:

When a partition's ISR size is about to fall under the MinISR setting,
instead of letting it go under MinISR, the leader host would try to initiate a leadership transfer.
Currently, we chose the first replica in the ISR to be the new leader.

EXIT_CRITERIA = If and when this change is accepted in upstream Kafka.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
