### PR TITLE
[LI-FIXUP] Fix log truncation metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -313,10 +313,25 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * @param startingPosition The starting position in the file to begin searching from.
      */
     public LogOffsetPosition searchForOffsetWithSize(long targetOffset, int startingPosition) {
+        FileChannelRecordBatch batch = searchForBatchOffsetIsAt(targetOffset, startingPosition);
+        return batch == null
+            ? null
+            : new LogOffsetPosition(batch.lastOffset(), batch.position(), batch.sizeInBytes());
+    }
+
+    /**
+     * Search forward for the {@link FileChannelRecordBatch} of the last offset that is greater than or equal to the target offset
+     * and return the batch object containing the offset & physical position info. If no such offsets are found, return null.
+     *
+     * @param targetOffset The offset to search for.
+     * @param startingPosition The starting position in the file to begin searching from.
+     * @return FileChannelRecordBatch that lastOffset is greater than or equal to targetOffset, null if not found
+     */
+    public FileChannelRecordBatch searchForBatchOffsetIsAt(long targetOffset, int startingPosition) {
         for (FileChannelRecordBatch batch : batchesFrom(startingPosition)) {
-            long offset = batch.lastOffset();
-            if (offset >= targetOffset)
-                return new LogOffsetPosition(offset, batch.position(), batch.sizeInBytes());
+            if (batch.lastOffset() >= targetOffset) {
+                return batch;
+            }
         }
         return null;
     }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2037,6 +2037,11 @@ class Log(@volatile private var _dir: File,
             bytesTruncated += removeAndDeleteSegments(deletable, asyncDelete = true, LogTruncation)
             val activeSegmentTruncationInfo = activeSegment.truncateTo(targetOffset)
             bytesTruncated += activeSegmentTruncationInfo.bytesTruncated
+            // TODO:
+            //  Note that .offsetTruncatedTo can be inaccurate, but since this is for estimation, we accept it for now.
+            //  See details inside LogSegment#truncateTo
+            offsetTruncatedTo = activeSegmentTruncationInfo.offsetTruncatedTo
+            messagesTruncated = originalLogEndOffset - offsetTruncatedTo
 
             leaderEpochCache.foreach(_.truncateFromEnd(targetOffset))
 
@@ -2045,8 +2050,6 @@ class Log(@volatile private var _dir: File,
               localLogStartOffset = math.min(targetOffset, localLogStartOffset),
               endOffset = targetOffset
             )
-            offsetTruncatedTo = activeSegmentTruncationInfo.offsetTruncatedTo
-            messagesTruncated = originalLogEndOffset - offsetTruncatedTo
           }
           // FIXME: this code path involves not only data plane segments but also KRaft metadata logs.  Should find a way to distinguish after moving to KRaft.
           warn(s"Attempted truncating to offset $targetOffset. Resulted in truncated to $offsetTruncatedTo from the original log end offset $originalLogEndOffset, " +

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2022,16 +2022,21 @@ class Log(@volatile private var _dir: File,
         false
       } else {
         var bytesTruncated = 0L
+        var messagesTruncated = 0L
         val originalLogEndOffset = logEndOffset
+        var offsetTruncatedTo = UnknownOffset
         lock synchronized {
           checkIfMemoryMappedBufferClosed()
           if (segments.firstSegment.get.baseOffset > targetOffset) {
+            bytesTruncated = logSegments.map(_.size).sum
+            messagesTruncated = logEndOffset - logStartOffset
             truncateFullyAndStartAt(targetOffset)
-            bytesTruncated += logSegments.map(_.size).sum
+            offsetTruncatedTo = targetOffset
           } else {
             val deletable = logSegments.filter(segment => segment.baseOffset > targetOffset)
             bytesTruncated += removeAndDeleteSegments(deletable, asyncDelete = true, LogTruncation)
-            bytesTruncated += activeSegment.truncateTo(targetOffset)
+            val activeSegmentTruncationInfo = activeSegment.truncateTo(targetOffset)
+            bytesTruncated += activeSegmentTruncationInfo.bytesTruncated
 
             leaderEpochCache.foreach(_.truncateFromEnd(targetOffset))
 
@@ -2040,9 +2045,11 @@ class Log(@volatile private var _dir: File,
               localLogStartOffset = math.min(targetOffset, localLogStartOffset),
               endOffset = targetOffset
             )
+            offsetTruncatedTo = activeSegmentTruncationInfo.offsetTruncatedTo
+            messagesTruncated = originalLogEndOffset - offsetTruncatedTo
           }
-          val messagesTruncated = originalLogEndOffset - targetOffset
-          warn(s"Truncated to offset $targetOffset from the log end offset $originalLogEndOffset " +
+          // FIXME: this code path involves not only data plane segments but also KRaft metadata logs.  Should find a way to distinguish after moving to KRaft.
+          warn(s"Attempted truncating to offset $targetOffset. Resulted in truncated to $offsetTruncatedTo from the original log end offset $originalLogEndOffset, " +
             s"with $messagesTruncated messages and $bytesTruncated bytes truncated")
           LogTruncationStats.logTruncatedBytesRate.mark(bytesTruncated)
           LogTruncationStats.logTruncatedMessagesRate.mark(messagesTruncated)

--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -422,7 +422,7 @@ object LogLoader extends Logging {
               val startOffset = segment.baseOffset
               warn(s"${params.logIdentifier}Found invalid offset during recovery. Deleting the" +
                 s" corrupt segment and creating an empty one with starting offset $startOffset")
-              segment.truncateTo(startOffset)
+              segment.truncateTo(startOffset).bytesTruncated
           }
         if (truncatedBytes > 0) {
           // we had an invalid message, delete all remaining log

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -21,6 +21,7 @@ import java.nio.file.{Files, NoSuchFileException}
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
 import kafka.common.LogSegmentOffsetOverflowException
+import kafka.log.Log.UnknownOffset
 import kafka.metrics.{KafkaMetricsGroup, KafkaTimer}
 import kafka.server.epoch.LeaderEpochFileCache
 import kafka.server.{FetchDataInfo, LogOffsetMetadata}
@@ -428,8 +429,9 @@ class LogSegment private[log] (val log: FileRecords,
     // in case we truncate the full index
     val startingFilePosition = 0
     val batch = log.searchForBatchOffsetIsAt(offset, max(offsetIndex.lookup(offset).position, startingFilePosition))
-    val mapping = if (batch == null) null
-                  else new LogOffsetPosition(batch.lastOffset(), batch.position(), batch.sizeInBytes())
+    // The offset methods on file records cannot be re-invoked because they're file channel based.  Capture them first
+    val (batchBaseOffset, batchPosition) = if (batch == null) (Option.empty[Long], Option.empty[Int])
+                                           else (Some(batch.baseOffset()), Some(batch.position()))
 
     offsetIndex.truncateTo(offset)
     timeIndex.truncateTo(offset)
@@ -439,16 +441,33 @@ class LogSegment private[log] (val log: FileRecords,
     offsetIndex.resize(offsetIndex.maxIndexSize)
     timeIndex.resize(timeIndex.maxIndexSize)
 
-    val bytesTruncated = if (mapping == null) 0 else log.truncateTo(mapping.position)
+    val bytesTruncated = batchPosition match {
+      case Some(position) => log.truncateTo(position)
+      case None => 0
+    }
     if (log.sizeInBytes == 0) {
       created = time.milliseconds
       rollingBasedTimestamp = None
     }
 
     bytesSinceLastIndexEntry = 0
-    if (maxTimestampSoFar >= 0)
+    if (maxTimestampSoFar >= 0) {
       loadLargestTimestamp()
-    SegmentTruncationResult(bytesTruncated = bytesTruncated, offsetTruncatedTo = batch.baseOffset())
+    }
+    SegmentTruncationResult(bytesTruncated = bytesTruncated,
+                            offsetTruncatedTo = batchBaseOffset match {
+                              case Some(i) => i
+                              // TODO:
+                              //  Note that this estimation can be inaccurate if non-consecutive offsets exists in the
+                              //  segments (e.g. missing segment files, KIP-319).  The flow won't be able to find the
+                              //  correct batch if the target falls in the offset gaps.  Also, offsetIndex.lastOffset may
+                              //  not have been flushed yet, causing the lastOffset inaccurate.
+                              //  If we want to have correct offset, we'll have to extract the search for target offset loop,
+                              //  looking into batches, and find out the exact nextOffset.  That can be make the implementation
+                              //  too hard to reason, and since we expose this only for the truncation metrics, which doesn't
+                              //  have to be very accurate, so we use this sub-optimal approach for now.
+                              case None => offsetIndex.lastOffset + 1
+                            })
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -412,18 +412,25 @@ class LogSegment private[log] (val log: FileRecords,
     ", largestRecordTimestamp=" + largestRecordTimestamp +
     ")"
 
+  case class SegmentTruncationResult(bytesTruncated: Long, offsetTruncatedTo: Long)
+
   /**
    * Truncate off all index and log entries with offsets >= the given offset.
    * If the given offset is larger than the largest message in this segment, do nothing.
    *
    * @param offset The offset to truncate to
-   * @return The number of log bytes truncated
+   * @return SegmentTruncationResult containing the number of log bytes truncated and the offset after truncate,
+   *         which may differ from the offset parameter because log segment truncation must be performed over a batch
    */
   @nonthreadsafe
-  def truncateTo(offset: Long): Int = {
+  def truncateTo(offset: Long): SegmentTruncationResult = {
     // Do offset translation before truncating the index to avoid needless scanning
     // in case we truncate the full index
-    val mapping = translateOffset(offset)
+    val startingFilePosition = 0
+    val batch = log.searchForBatchOffsetIsAt(offset, max(offsetIndex.lookup(offset).position, startingFilePosition))
+    val mapping = if (batch == null) null
+                  else new LogOffsetPosition(batch.lastOffset(), batch.position(), batch.sizeInBytes())
+
     offsetIndex.truncateTo(offset)
     timeIndex.truncateTo(offset)
     txnIndex.truncateTo(offset)
@@ -441,7 +448,7 @@ class LogSegment private[log] (val log: FileRecords,
     bytesSinceLastIndexEntry = 0
     if (maxTimestampSoFar >= 0)
       loadLargestTimestamp()
-    bytesTruncated
+    SegmentTruncationResult(bytesTruncated = bytesTruncated, offsetTruncatedTo = batch.baseOffset())
   }
 
   /**


### PR DESCRIPTION
[LI-FIXUP] Fix log truncation metrics

This should be a direct fix-up to the commit
- bb83f42 [LI-HOTFIX] Generate logs to help estimate the amount of data loss during ULE (#99)

For the bytesTruncated metric, under the original implementation,
the size was computed *after* truncation during the full truncation path, which results in always 0.

For the messageTruncated metric, the original implementation calculated it based on start/end offset & target offset.
However, in Kafka, truncation is performed on the unit of a batch.
This [KIP](https://cwiki.apache.org/confluence/display/KAFKA/KIP-279%3A+Fix+log+divergence+between+leader+and+follower+after+fast+leader+fail+over) also mentions the behavior.
> _Since this is in the middle of the batch, it will truncate all the way to ..._.

In that sense, the original calculation ignores the messages from `batch.baseOffset` to `targetOffset`.

This patch fixes the calculation by exposing the batch searched when performing the truncation,
and a unit test for the metric is added.
However, it is still not 100% accurate; the current approach assumes "non-consecutive offsets" are
rare cases, and to strike a balance between code maintainability and the need for accuracy
(the truncation metric is for estimation, no need to be very accurate), we go for a best-effort estimation.


*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
