### PR TITLE
[LI-FIXUP] Allow LeaderAndIsrErrorCode in version 1 of the LiCombinedControlResponse

### DIFF
--- a/clients/src/main/resources/common/message/LiCombinedControlResponse.json
+++ b/clients/src/main/resources/common/message/LiCombinedControlResponse.json
@@ -29,7 +29,7 @@
     // fields from the LeaderAndIsr response
     { "name": "LeaderAndIsrErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
-    { "name": "LeaderAndIsrPartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "0",
+    { "name": "LeaderAndIsrPartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "0+",
       "about": "Each partition."},
     { "name":  "LeaderAndIsrTopics", "type": "[]LeaderAndIsrTopicError", "versions": "1+",
       "about": "Each topic", "fields": [


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
The current schema file had incorrectly pinned the `LeaderAndIsrPartitionErrors` field to only version 0.
This PR would allow a non-default LeaderAndIsrPartitionErrors in higher versions of the LiCombinedControlResponse.

EXIT_CRITERIA = The same as the LiCombinedControl feature.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
