### PR TITLE
[LI-HOTFIX] Handle any type of Exception during log recovery

### DIFF
--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -423,6 +423,8 @@ object LogLoader extends Logging {
           try {
             recoverSegment(segment, params)
           } catch {
+            case ooe: LogSegmentOffsetOverflowException =>
+              throw ooe
             case e: Exception =>
               val startOffset = segment.baseOffset
               warn(s"${params.logIdentifier}Found exception during recovery. Deleting the" +

--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -19,13 +19,13 @@ package kafka.log
 
 import java.io.{File, IOException}
 import java.nio.file.{Files, NoSuchFileException}
-
 import kafka.common.LogSegmentOffsetOverflowException
 import kafka.log.Log.{CleanedFileSuffix, DeletedFileSuffix, SwapFileSuffix, isIndexFile, isLogFile, offsetFromFile}
-import kafka.server.{GlobalConfig, LogDirFailureChannel, LogOffsetMetadata}
+import kafka.server.{GlobalConfig, KafkaConfig, LogDirFailureChannel, LogOffsetMetadata}
 import kafka.server.epoch.LeaderEpochFileCache
 import kafka.utils.{CoreUtils, Logging, Scheduler}
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.InvalidOffsetException
 import org.apache.kafka.common.utils.Time
 
 import scala.collection.{Set, mutable}
@@ -426,10 +426,14 @@ object LogLoader extends Logging {
             case ooe: LogSegmentOffsetOverflowException =>
               throw ooe
             case e: Exception =>
-              val startOffset = segment.baseOffset
-              warn(s"${params.logIdentifier}Found exception during recovery. Deleting the" +
-                s" corrupt segment and creating an empty one with starting offset $startOffset", e)
-              segment.truncateTo(startOffset).bytesTruncated
+              if (e.isInstanceOf[InvalidOffsetException] || GlobalConfig.liDropCorruptedFilesEnable) {
+                val startOffset = segment.baseOffset
+                warn(s"${params.logIdentifier}Found exception during recovery. Deleting the" +
+                  s" corrupt segment and creating an empty one with starting offset $startOffset", e)
+                segment.truncateTo(startOffset).bytesTruncated
+              } else {
+                throw new IllegalStateException(s"Found corruption during log recovery and the ${KafkaConfig.LiDropCorruptedFilesEnableProp} property is set to false")
+              }
           }
         if (truncatedBytes > 0) {
           // we had an invalid message, delete all remaining log

--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -26,7 +26,6 @@ import kafka.server.{GlobalConfig, LogDirFailureChannel, LogOffsetMetadata}
 import kafka.server.epoch.LeaderEpochFileCache
 import kafka.utils.{CoreUtils, Logging, Scheduler}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.InvalidOffsetException
 import org.apache.kafka.common.utils.Time
 
 import scala.collection.{Set, mutable}

--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -22,7 +22,7 @@ import java.nio.file.{Files, NoSuchFileException}
 
 import kafka.common.LogSegmentOffsetOverflowException
 import kafka.log.Log.{CleanedFileSuffix, DeletedFileSuffix, SwapFileSuffix, isIndexFile, isLogFile, offsetFromFile}
-import kafka.server.{LogDirFailureChannel, LogOffsetMetadata}
+import kafka.server.{GlobalConfig, LogDirFailureChannel, LogOffsetMetadata}
 import kafka.server.epoch.LeaderEpochFileCache
 import kafka.utils.{CoreUtils, Logging, Scheduler}
 import org.apache.kafka.common.TopicPartition
@@ -351,6 +351,12 @@ object LogLoader extends Logging {
    * @throws LogSegmentOffsetOverflowException if the segment contains messages that cause index offset overflow
    */
   private def recoverSegment(segment: LogSegment, params: LoadLogParams): Int = {
+    if (GlobalConfig.logRecoveryShouldThrowException) {
+      // we should only trigger the exception once
+      GlobalConfig.logRecoveryShouldThrowException = false
+      throw new IllegalStateException("Explicitly trigger an exception to test the log recovery logic")
+    }
+
     val producerStateManager = new ProducerStateManager(
       params.topicPartition,
       params.dir,
@@ -418,10 +424,10 @@ object LogLoader extends Logging {
           try {
             recoverSegment(segment, params)
           } catch {
-            case _: InvalidOffsetException =>
+            case e: Exception =>
               val startOffset = segment.baseOffset
-              warn(s"${params.logIdentifier}Found invalid offset during recovery. Deleting the" +
-                s" corrupt segment and creating an empty one with starting offset $startOffset")
+              warn(s"${params.logIdentifier}Found exception during recovery. Deleting the" +
+                s" corrupt segment and creating an empty one with starting offset $startOffset", e)
               segment.truncateTo(startOffset).bytesTruncated
           }
         if (truncatedBytes > 0) {

--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -419,7 +419,7 @@ object LogLoader extends Logging {
       while (unflushed.hasNext && !truncated) {
         val segment = unflushed.next()
         info(s"${params.logIdentifier}Recovering unflushed segment ${segment.baseOffset}")
-        val truncatedBytes =
+        val truncatedBytes: Long =
           try {
             recoverSegment(segment, params)
           } catch {

--- a/core/src/main/scala/kafka/server/GlobalConfig.scala
+++ b/core/src/main/scala/kafka/server/GlobalConfig.scala
@@ -20,5 +20,6 @@ package kafka.server
 object GlobalConfig {
   // a global flag to indicate whether the corrupted files should be dropped
   var liDropCorruptedFilesEnable = false
+  // The logRecoveryShouldThrowException should only be used for testing purposes. Never turn in on in a real cluster!
   @volatile var logRecoveryShouldThrowException = false
 }

--- a/core/src/main/scala/kafka/server/GlobalConfig.scala
+++ b/core/src/main/scala/kafka/server/GlobalConfig.scala
@@ -20,4 +20,5 @@ package kafka.server
 object GlobalConfig {
   // a global flag to indicate whether the corrupted files should be dropped
   var liDropCorruptedFilesEnable = false
+  @volatile var logRecoveryShouldThrowException = false
 }

--- a/core/src/main/scala/kafka/server/GlobalConfig.scala
+++ b/core/src/main/scala/kafka/server/GlobalConfig.scala
@@ -20,6 +20,6 @@ package kafka.server
 object GlobalConfig {
   // a global flag to indicate whether the corrupted files should be dropped
   var liDropCorruptedFilesEnable = false
-  // The logRecoveryShouldThrowException should only be used for testing purposes. Never turn in on in a real cluster!
+  // The logRecoveryShouldThrowException should only be used for testing purposes. Never turn it on in a real cluster!
   @volatile var logRecoveryShouldThrowException = false
 }

--- a/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
@@ -197,7 +197,7 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
     bw.close()
   }
 
-  private def setupSingleBrokerClusterWithTopic(segmentBytes: Long): (KafkaServer, KafkaProducer[Array[Byte], Array[Byte]]) = {
+  private def setupSingleDataBrokerClusterWithTopic(segmentBytes: Long): (KafkaServer, KafkaProducer[Array[Byte], Array[Byte]]) = {
     // create brokers
     val serverConfigs = TestUtils.createBrokerConfigs(2, zkConnect, false)
       .map { props => {
@@ -228,7 +228,7 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
 
   @Test
   def testCorruptedLog(): Unit = {
-    val (dataBroker, producer) = setupSingleBrokerClusterWithTopic(100)
+    val (dataBroker, producer) = setupSingleDataBrokerClusterWithTopic(100)
 
     val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
       "value".getBytes(StandardCharsets.UTF_8))
@@ -273,7 +273,7 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
 
   @Test
   def testUnexpectedExceptionDuringLogLoading(): Unit = {
-    val (dataBroker, producer) = setupSingleBrokerClusterWithTopic(100)
+    val (dataBroker, producer) = setupSingleDataBrokerClusterWithTopic(100)
 
     val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
       "value".getBytes(StandardCharsets.UTF_8))

--- a/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
+++ b/core/src/test/scala/integration/kafka/api/DropCorruptedFilesTest.scala
@@ -18,24 +18,42 @@
 package integration.kafka.api
 
 import kafka.controller.OfflinePartition
-import kafka.server.{KafkaConfig, KafkaServer}
+import kafka.log.Log
+import kafka.log.LogManager.RecoveryPointCheckpointFile
+import kafka.server.{GlobalConfig, KafkaConfig, KafkaServer}
 import kafka.utils.TestUtils
 import kafka.utils.TestUtils.getBrokerListStrFromServers
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.clients.admin.{Admin, AdminClient, AdminClientConfig}
-import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.network.ListenerName
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import org.apache.kafka.common.record.LegacyRecord
+import org.apache.kafka.common.record.Records.{HEADER_SIZE_UP_TO_MAGIC, SIZE_OFFSET}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{AfterEach, Test}
 
-import java.io.{BufferedWriter, FileOutputStream, OutputStreamWriter}
+import java.io.{BufferedWriter, File, FileOutputStream, OutputStreamWriter, RandomAccessFile}
+import java.nio.channels.FileChannel
 import java.nio.charset.StandardCharsets
 import java.util.{Collections, Properties}
 import scala.collection.{Map, Seq}
 
 class DropCorruptedFilesTest extends ZooKeeperTestHarness {
+  val topic = "test"
+  val partition = 0
+  val tp = new TopicPartition(topic, partition)
+  var servers: Seq[KafkaServer] = _
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    if (servers != null) {
+      TestUtils.shutdownServers(servers)
+    }
+    super.tearDown()
+  }
+
   /**
    * This test goes through the following stages with 2 data brokers, with broker0 being the initial leader
    * and broker1 being the initial follower of one partition. The partition's leadership will switch in different
@@ -76,19 +94,16 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
       }}
       .map(KafkaConfig.fromProps)
     // start servers in reverse order to ensure broker 2 becomes the controller
-    val servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    servers = serverConfigs.reverseMap{s => TestUtils.createServer(s)}
     val controllerId = TestUtils.waitUntilControllerElected(zkClient)
     val controller = servers.find(p => p.config.brokerId == controllerId).get.kafkaController
     assertTrue(controllerId == 2)
 
     // create a topic
-    val topic = "test"
-    val partition = 0
-    val tp = new TopicPartition(topic, partition)
     val topicConfig = new Properties()
     topicConfig.put(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
     val expectedReplicaAssignment = Map(0 -> List(0, 1))
-    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers, topicConfig = topicConfig)
 
 
     // collect the data brokers
@@ -165,7 +180,6 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
 
     adminClient.close()
     producer.close()
-    servers.foreach{_.shutdown()}
   }
 
   private def createAdminClient(servers: Seq[KafkaServer]): Admin = {
@@ -183,5 +197,118 @@ class DropCorruptedFilesTest extends ZooKeeperTestHarness {
     bw.close()
   }
 
+  private def setupSingleBrokerClusterWithTopic(segmentBytes: Long): (KafkaServer, KafkaProducer[Array[Byte], Array[Byte]]) = {
+    // create brokers
+    val serverConfigs = TestUtils.createBrokerConfigs(2, zkConnect, false)
+      .map { props => {
+        props.setProperty(KafkaConfig.LiDropCorruptedFilesEnableProp, "true")
+        // set the max segment size to a small value so that each path lands in a separate segment file
+        props.setProperty(KafkaConfig.LogSegmentBytesProp, segmentBytes.toString)
+        props.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false")
+        props
+      }}
+      .map(KafkaConfig.fromProps)
+    // start servers in reverse order to ensure broker 1 becomes the controller
+    servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+    assertTrue(controllerId == 1)
+
+    // create a topic
+    val topicConfig = new Properties()
+    topicConfig.put(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+    val expectedReplicaAssignment = Map(0 -> List(0))
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+    val dataBroker = servers.find(_.config.brokerId == 0).get
+
+    val producerConfigs = new Properties()
+    producerConfigs.put(ProducerConfig.ACKS_CONFIG, "-1")
+    val producer = TestUtils.createProducer(getBrokerListStrFromServers(servers))
+    (dataBroker, producer)
+  }
+
+  @Test
+  def testCorruptedLog(): Unit = {
+    val (dataBroker, producer) = setupSingleBrokerClusterWithTopic(100)
+
+    val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
+      "value".getBytes(StandardCharsets.UTF_8))
+    // produce 3 message
+    val totalMessages = 3
+    for (_ <- 0 until totalMessages)
+      producer.send(record).get
+
+    def segmentsOnBroker = dataBroker.replicaManager.logManager.getLog(tp).get.segments
+
+    assertEquals(totalMessages, segmentsOnBroker.numberOfSegments)
+
+    // create corruption in the middle segment
+    val middleSegment = segmentsOnBroker.get(1).get
+    val segmentFile = middleSegment.log.file()
+    val raf = new RandomAccessFile(segmentFile, "rw")
+    val mappedLogSegment = raf.getChannel.map(FileChannel.MapMode.READ_WRITE, 0, HEADER_SIZE_UP_TO_MAGIC)
+    val currentSize = mappedLogSegment.getInt(SIZE_OFFSET)
+    assertTrue(currentSize >= LegacyRecord.RECORD_OVERHEAD_V0)
+    // set the size to a value that's smaller than the smallest overhead to cause a corruption
+    mappedLogSegment.putInt(SIZE_OFFSET, 1)
+
+    dataBroker.shutdown()
+    // delete the broker's clean shutdown file, so that it tries to recover log segments upon startup
+    val logDir = dataBroker.config.logDirs(0)
+    val cleanShutdownFile = new File(logDir, Log.CleanShutdownFile)
+    cleanShutdownFile.delete()
+
+    // delete the recovery-point-offset-checkpoint file so that all log segments need to go through recovery
+    val recoveryPointCheckpointFile = new File(logDir, RecoveryPointCheckpointFile)
+    recoveryPointCheckpointFile.delete()
+
+    dataBroker.replicaManager.logManager
+    dataBroker.startup()
+
+    // verify that the segments after the corrupted are deleted and the corrupted segment is truncated to size 0
+    assertEquals(2, segmentsOnBroker.numberOfSegments)
+    assertEquals(0, segmentsOnBroker.lastSegment.get.size)
+
+    producer.close()
+  }
+
+  @Test
+  def testUnexpectedExceptionDuringLogLoading(): Unit = {
+    val (dataBroker, producer) = setupSingleBrokerClusterWithTopic(100)
+
+    val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
+      "value".getBytes(StandardCharsets.UTF_8))
+    // produce 3 message
+    val totalMessages = 3
+    for (_ <- 0 until totalMessages)
+      producer.send(record).get
+
+    def segmentsOnBroker = dataBroker.replicaManager.logManager.getLog(tp).get.segments
+
+    assertEquals(totalMessages, segmentsOnBroker.numberOfSegments)
+
+    dataBroker.shutdown()
+    // delete the broker's clean shutdown file, so that it tries to recover log segments upon startup
+    val logDir = dataBroker.config.logDirs(0)
+    val cleanShutdownFile = new File(logDir, Log.CleanShutdownFile)
+    cleanShutdownFile.delete()
+    // delete the recovery-point-offset-checkpoint file so that all log segments need to go through recovery
+    val recoveryPointCheckpointFile = new File(logDir, RecoveryPointCheckpointFile)
+    recoveryPointCheckpointFile.delete()
+
+    GlobalConfig.logRecoveryShouldThrowException = true
+    dataBroker.replicaManager.logManager
+    dataBroker.startup()
+
+    // verify that only the active segment is left with a size of 0
+    assertEquals(1, segmentsOnBroker.numberOfSegments)
+    assertEquals(0, segmentsOnBroker.lastSegment.get.size)
+
+    // verify that we can still produce messages after the log dir has been cleaned
+    // produce 3 message
+    for (i <- 0 until totalMessages)
+      assertEquals(i, producer.send(record).get.offset())
+    assertEquals(totalMessages, segmentsOnBroker.numberOfSegments)
+    producer.close()
+  }
 
 }


### PR DESCRIPTION
TICKET = [LIKAFKA-47870](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-47870)
LI_DESCRIPTION =
In the current implementation, only the InvalidOffsetException is handled during log recovery.
This PR changes the implementation so that any other types of Exception would also cause a log truncation,
and hence not block the broker startup.

We are also adding tests to verify that brokers can successfully startup after corruption is found in the size field of a batch, or an unexpected exception is thrown.
EXIT_CRITERIA = N/A

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
