### PR TITLE
[LI-HOTFIX] Disable the flaky test testThrottledRequest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -34,7 +34,7 @@ import org.apache.kafka.common.quota.ClientQuotaAlteration
 import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.{BeforeEach, Test, Disabled}
 
 import scala.collection.Map
 import scala.jdk.CollectionConverters._
@@ -158,6 +158,7 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   }
 
   @Test
+  @Disabled // this test seems to be flaky, disable it for now
   def testThrottledRequest(): Unit = {
     quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, 0.1)
     quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, 0.1)

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -21,7 +21,7 @@ import kafka.api.ApiVersion
 import kafka.utils.TestUtils
 import kafka.zk.ZooKeeperTestHarness
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNull, assertThrows, fail}
-import org.junit.jupiter.api.{Disabled, Test}
+import org.junit.jupiter.api.Test
 
 import java.util.Properties
 
@@ -116,7 +116,6 @@ class KafkaServerTest extends ZooKeeperTestHarness {
   }
 
   @Test
-  @Disabled // LIKAFKA-46520 Disabled since the AlterISR request is not efficient enough for the LI use case
   def testAlterIsrManager(): Unit = {
     val props = TestUtils.createBrokerConfigs(1, zkConnect).head
     props.put(KafkaConfig.InterBrokerProtocolVersionProp, ApiVersion.latestVersion.toString)


### PR DESCRIPTION
TICKET = https://issues.apache.org/jira/browse/KAFKA-8459 

LI_DESCRIPTION =
1. Disable the flaky test testThrottledRequest
2. Reenable the test testAlterIsrManager that should be applicable again now 

EXIT_CRITERIA = When upstream ticket is resolved

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
