### PR TITLE
[LI-FIXUP] Populate the error fields of the LiCombinedControlResponse properly

### DIFF
--- a/clients/src/main/resources/common/message/LiCombinedControlResponse.json
+++ b/clients/src/main/resources/common/message/LiCombinedControlResponse.json
@@ -29,7 +29,7 @@
     // fields from the LeaderAndIsr response
     { "name": "LeaderAndIsrErrorCode", "type": "int16", "versions": "0+",
       "about": "The error code, or 0 if there was no error." },
-    { "name": "LeaderAndIsrPartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "0+",
+    { "name": "LeaderAndIsrPartitionErrors", "type": "[]LeaderAndIsrPartitionError", "versions": "0",
       "about": "Each partition."},
     { "name":  "LeaderAndIsrTopics", "type": "[]LeaderAndIsrTopicError", "versions": "1+",
       "about": "Each topic", "fields": [


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
This PR reverts commit a2ac1c2f9eeeaa2819ade05e6dfe37a491c7ebc2 (#408) 
The original commit is incorrect and has a backward incompatible schema change on the LiCombinedControlResponse.json. This PR reverts the original schema change, and addresses the original problem properly:
1. when the LiCombinedControl request version is below 1, the response populates the LeaderAndIsrPartitionErrors field with the error code. When the version is at or greater than 1, it populates the LeaderAndIsrTopics field.

2. When the LiCombinedControl request version is below 1, the StopReplicaPartitionErrors field of the LiCombinedControlResponse should be populated according to the StopReplicaPartitionStates of the LiCombinedControlRequest. When the version is at or greater than 1, the StopReplicaPartitionErrors field should be populated according to the StopReplicaTopicStates of the LiCombinedControlRequest.

EXIT_CRITERIA = The same as the LiCombinedControlRequest feature.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
