### PR TITLE
[LI-HOTFIX] Reject invalid replica assignment cancellations

### DIFF
--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -21,7 +21,6 @@ import java.nio.file.{Files, NoSuchFileException}
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
 import kafka.common.LogSegmentOffsetOverflowException
-import kafka.log.Log.UnknownOffset
 import kafka.metrics.{KafkaMetricsGroup, KafkaTimer}
 import kafka.server.epoch.LeaderEpochFileCache
 import kafka.server.{FetchDataInfo, LogOffsetMetadata}


### PR DESCRIPTION
TICKET = https://issues.apache.org/jira/browse/KAFKA-14424 

LI_DESCRIPTION =
When reassigning replicas, Kafka runs a sanity check to ensure all of the target replicas are alive before allowing the reassignment request to proceed. However, for a request that cancels an ongoing reassignment, there is no such check. The result is that if the original replicas are offline, the cancellation may result in partitions without any leaders. This problem has been observed multiple times in our clusters.

This PR adds the sanity check to ensure all of the original replicas are online before approving the cancellation request.

EXIT_CRITERIA = When the issue is resolved in Apache Kafka and the fix is pulled in.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
