### PR TITLE
Add support for request TotalTimeMs latency histograms

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent._
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.scalalogging.Logger
-import com.yammer.metrics.core.{Histogram, Meter}
+import com.yammer.metrics.core.{Counter, Histogram, Meter}
 import kafka.metrics.KafkaMetricsGroup
 import kafka.network
 import kafka.server.{BrokerMetadataStats, KafkaConfig, Observer}
@@ -80,7 +80,7 @@ object RequestChannel extends Logging {
       Seq(RequestMetrics.consumerFetchMetricName, RequestMetrics.followFetchMetricName) ++
       getConsumerFetchRequestSizeMetricNames ++
       getProduceRequestAcksSizeMetricNames)
-      .foreach { name => metricsMap.put(name, new RequestMetrics(name))
+      .foreach { name => metricsMap.put(name, new RequestMetrics(name, config))
     }
 
     def apply(metricName: String): RequestMetrics = metricsMap(metricName)
@@ -90,20 +90,12 @@ object RequestChannel extends Logging {
     }
 
     // generate map[request/responseSize, metricName] for requests of different size
-    def getRequestSizeMetricNameMap(requestType: String):util.TreeMap[Int, String] = {
+    def getRequestSizeMetricNameMap(requestType: String): util.TreeMap[Int, String] = {
       val buckets = config.requestMetricsSizeBuckets
       // get size and corresponding term to be used in metric name
-      // [0,1,10,50,100] => requestSizeBuckets:Seq((0, "0To1Mb"), (1, "1To10Mb"), (10, "10To50Mb"), (50, "50To100Mb"),
-      // (100, "100MbGreater"))
-      val requestSizeBuckets = for (i <- 0 until buckets.length) yield {
-        val size = buckets(i)
-        if (i == buckets.length - 1) (size, s"${size}MbGreater")
-        else (size, s"${size}To${buckets(i + 1)}Mb")
-      }
-      val treeMap = new util.TreeMap[Int, String]
-      requestSizeBuckets.map(bucket => (bucket._1, s"${requestType}${bucket._2}")).toMap
-        .foreach{case (size, bucket) => treeMap.put(size, bucket)}
-      treeMap
+      // [0,1,10,50,100] => Seq((0, "Produce0To1Mb"), (1, "Produce1To10Mb"), (10, "Produce10To50Mb"),
+      // (50, "Produce50To100Mb"),(100, "Produce100MbGreater"))
+      RequestMetrics.getBucketBoundaryObjectMap(buckets, requestType, "Mb", name => name)
     }
 
     // generate map[acks, map[requestSize, metricName]] for produce requests of different request size and acks
@@ -138,8 +130,7 @@ object RequestChannel extends Logging {
     // the bucket is [left, right)
     def getRequestSizeBucketMetricName(sizeMetricNameMap: util.TreeMap[Int, String], sizeBytes: Long): String = {
       val sizeMb = sizeBytes / 1024 / 1024
-      if(sizeMb < sizeMetricNameMap.firstKey()) sizeMetricNameMap.firstEntry().getValue
-      else sizeMetricNameMap.floorEntry(sizeMb.toInt).getValue
+      RequestMetrics.getBucketObject(sizeMetricNameMap, sizeMb.toInt)
     }
   }
 
@@ -346,6 +337,7 @@ object RequestChannel extends Logging {
         m.responseQueueTimeHist.update(Math.round(responseQueueTimeMs))
         m.responseSendTimeHist.update(Math.round(responseSendTimeMs))
         m.totalTimeHist.update(Math.round(totalTimeMs))
+        m.totalTimeBucketHist.update(totalTimeMs)
         m.requestBytesHist.update(sizeOfBodyInBytes)
         m.responseBytesHist.update(responseBytes)
         m.messageConversionsTimeHist.foreach(_.update(Math.round(messageConversionsTimeMs)))
@@ -690,9 +682,33 @@ object RequestMetrics {
   val MessageConversionsTimeMs = "MessageConversionsTimeMs"
   val TemporaryMemoryBytes = "TemporaryMemoryBytes"
   val ErrorsPerSec = "ErrorsPerSec"
+
+  // generate map[bucketLeftBoundary, object] for buckets
+  def getBucketBoundaryObjectMap[T](buckets: Array[Int], namePrefix: String, namePostfix: String,
+    createValueFunc: String => T): util.TreeMap[Int, T] = {
+    // get bin boundary and corresponding name to be used in createValueFunc
+    // [0,1,10,50,100], prefix=Produce, postfix=Mb =>
+    // leftBoundaryBucketNames:Seq((0, "Produce0To1Mb"), (1, "Produce1To10Mb"), (10, "Produce10To50Mb"),
+    // (50, "Produce50To100Mb"),(100, "Produce100MbGreater"))
+    val leftBoundaryBucketNames = for (i <- 0 until buckets.length) yield {
+      val bucket = buckets(i)
+      if (i == buckets.length - 1) (bucket, s"${namePrefix}${bucket}${namePostfix}Greater")
+      else (bucket, s"${namePrefix}${bucket}To${buckets(i + 1)}${namePostfix}")
+    }
+    val treeMap = new util.TreeMap[Int, T]
+    leftBoundaryBucketNames.foreach{case (boundary, name) => treeMap.put(boundary, createValueFunc(name))}
+    treeMap
+  }
+
+  // get object for a given bucket boundary. the bucket is [left, right)
+  def getBucketObject[T](bucketBoundaryObjectMap: util.TreeMap[Int, T], boundary: Int): T = {
+    if(boundary < bucketBoundaryObjectMap.firstKey()) bucketBoundaryObjectMap.firstEntry().getValue
+    else bucketBoundaryObjectMap.floorEntry(boundary).getValue
+  }
+
 }
 
-class RequestMetrics(name: String) extends KafkaMetricsGroup {
+class RequestMetrics(name: String, config: KafkaConfig) extends KafkaMetricsGroup {
 
   import RequestMetrics._
 
@@ -732,6 +748,9 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
     else
       None
 
+  // metrics to count the number of requests in different total time buckets.
+  val totalTimeBucketHist = new Histogram("TotalTime", "Ms", config.requestMetricsTotalTimeBuckets)
+
   private val errorMeters = mutable.Map[Errors, ErrorMeter]()
   Errors.values.foreach(error => errorMeters.put(error, new ErrorMeter(name, error)))
 
@@ -766,6 +785,29 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
     }
   }
 
+  class Histogram(val metricNamePrefix: String, val metricNamePostfix: String, val binBoundaries: Array[Int]) {
+    // binLeftBoundary => (name, Counter)
+    val boundaryCounterMap = createHistogram()
+
+    def update(value: Double): Unit = {
+      val valueLong = Math.round(value)
+      // bin boundary with Int type should be good for current usages
+      val valueInt = if(valueLong > Int.MaxValue) Int.MaxValue else valueLong.toInt
+      val counter = getBucketObject(boundaryCounterMap, valueInt)._2
+      counter.inc()
+    }
+
+    def removeHistogram(): Unit = {
+      boundaryCounterMap.values.forEach(nameCounter => removeMetric(nameCounter._1, tags))
+    }
+
+    // [0,10,50], namePrefix="TotalTime" => Map(0 => ("TotalTime0To10Ms", counter), 10 => ("TotalTime10To50Ms", , counter),
+    // 50 => ("TotalTime50MsGreater", counter))
+    private def createHistogram(): util.TreeMap[Int, (String, Counter)] = {
+      getBucketBoundaryObjectMap(binBoundaries, metricNamePrefix, metricNamePostfix, name => (name, newCounter(name, tags)))
+    }
+  }
+
   def markErrorMeter(error: Errors, count: Int): Unit = {
     errorMeters(error).getOrCreateMeter().mark(count.toLong)
   }
@@ -790,5 +832,6 @@ class RequestMetrics(name: String) extends KafkaMetricsGroup {
     }
     errorMeters.values.foreach(_.removeMeter())
     errorMeters.clear()
+    totalTimeBucketHist.removeHistogram()
   }
 }

--- a/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
@@ -23,6 +23,7 @@ import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.util.{Collections, Optional, Properties}
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.yammer.metrics.core.Counter
 import kafka.network
 import kafka.network.RequestChannel.Metrics
 import kafka.server.KafkaConfig
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api._
 import org.mockito.{ArgumentCaptor, Mockito}
 
+import java.util
 import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
 
@@ -354,6 +356,71 @@ class RequestChannelTest {
     config = KafkaConfig.fromProps(props)
     metrics = new Metrics(apis, config)
     testMetricsRequestSizeBucketDefault(metrics)
+  }
+  @Test
+  def testHistogram(): Unit = {
+    var props = new Properties()
+    props.put(KafkaConfig.ZkConnectProp, "127.0.0.1:2181")
+    props.put(KafkaConfig.RequestMetricsTotalTimeBucketsProp, "0, 10, 20, 267")
+    var config = KafkaConfig.fromProps(props)
+    val requestMetrics = new RequestMetrics("RequestMetrics", config)
+    val boundaries = Array(0, 10, 30, 300)
+    val histogram = new requestMetrics.Histogram("TotalTime", "Ms", boundaries)
+    val counterMap = histogram.boundaryCounterMap
+
+    assertEquals(4, counterMap.size())
+    assertTrue(counterMap.containsKey(0))
+    assertTrue(counterMap.containsKey(10))
+    assertTrue(counterMap.containsKey(30))
+    assertTrue(counterMap.containsKey(300))
+
+    assertEquals("TotalTime0To10Ms", counterMap.get(0)._1)
+    assertEquals("TotalTime10To30Ms", counterMap.get(10)._1)
+    assertEquals("TotalTime30To300Ms", counterMap.get(30)._1)
+    assertEquals("TotalTime300MsGreater", counterMap.get(300)._1)
+
+    testHistogramCounts(counterMap, Array(0, 0, 0, 0), boundaries)
+
+    histogram.update(0)
+    testHistogramCounts(counterMap, Array(1, 0, 0, 0), boundaries)
+
+    histogram.update(10.0)
+    testHistogramCounts(counterMap, Array(1, 1, 0, 0), boundaries)
+
+    histogram.update(15.345)
+    testHistogramCounts(counterMap, Array(1, 2, 0, 0), boundaries)
+
+    histogram.update(26.345)
+    testHistogramCounts(counterMap, Array(1, 3, 0, 0), boundaries)
+
+    histogram.update(6.345)
+    testHistogramCounts(counterMap, Array(2, 3, 0, 0), boundaries)
+
+    histogram.update(66.345)
+    testHistogramCounts(counterMap, Array(2, 3, 1, 0), boundaries)
+
+    histogram.update(166.345)
+    testHistogramCounts(counterMap, Array(2, 3, 2, 0), boundaries)
+
+    histogram.update(366.345)
+    testHistogramCounts(counterMap, Array(2, 3, 2, 1), boundaries)
+
+    histogram.update(30066.345)
+    testHistogramCounts(counterMap, Array(2, 3, 2, 2), boundaries)
+
+    histogram.update(-1)
+    testHistogramCounts(counterMap, Array(3, 3, 2, 2), boundaries)
+
+    assertEquals(4, requestMetrics.totalTimeBucketHist.boundaryCounterMap.size())
+    assertTrue(requestMetrics.totalTimeBucketHist.boundaryCounterMap.containsKey(267))
+    assertEquals("TotalTime267MsGreater", requestMetrics.totalTimeBucketHist.boundaryCounterMap.get(267)._1)
+  }
+
+  private def testHistogramCounts(counterMap: util.TreeMap[Int, (String, Counter)], counts: Array[Int],
+    boundaries: Array[Int]): Unit = {
+    for(i <- 0 until counts.length) {
+      assertEquals(counts(i), counterMap.get(boundaries(i))._2.count())
+    }
   }
 
   private def testMetricsRequestSizeBucketDefault(metrics: Metrics): Unit = {

--- a/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
@@ -361,7 +361,7 @@ class RequestChannelTest {
   def testHistogram(): Unit = {
     var props = new Properties()
     props.put(KafkaConfig.ZkConnectProp, "127.0.0.1:2181")
-    props.put(KafkaConfig.RequestMetricsTotalTimeBucketsProp, "0, 10, 20, 267")
+    props.put(KafkaConfig.RequestMetricsTotalTimeBucketsProp, "0, 10, 30, 300")
     var config = KafkaConfig.fromProps(props)
     val requestMetrics = new RequestMetrics("RequestMetrics", config)
     val boundaries = Array(0, 10, 30, 300)
@@ -374,10 +374,10 @@ class RequestChannelTest {
     assertTrue(counterMap.containsKey(30))
     assertTrue(counterMap.containsKey(300))
 
-    assertEquals("TotalTime0To10Ms", counterMap.get(0)._1)
-    assertEquals("TotalTime10To30Ms", counterMap.get(10)._1)
-    assertEquals("TotalTime30To300Ms", counterMap.get(30)._1)
-    assertEquals("TotalTime300MsGreater", counterMap.get(300)._1)
+    assertEquals("TotalTime_Bin1_0To10Ms", counterMap.get(0)._1)
+    assertEquals("TotalTime_Bin2_10To30Ms", counterMap.get(10)._1)
+    assertEquals("TotalTime_Bin3_30To300Ms", counterMap.get(30)._1)
+    assertEquals("TotalTime_Bin4_300MsGreater", counterMap.get(300)._1)
 
     testHistogramCounts(counterMap, Array(0, 0, 0, 0), boundaries)
 
@@ -412,8 +412,8 @@ class RequestChannelTest {
     testHistogramCounts(counterMap, Array(3, 3, 2, 2), boundaries)
 
     assertEquals(4, requestMetrics.totalTimeBucketHist.boundaryCounterMap.size())
-    assertTrue(requestMetrics.totalTimeBucketHist.boundaryCounterMap.containsKey(267))
-    assertEquals("TotalTime267MsGreater", requestMetrics.totalTimeBucketHist.boundaryCounterMap.get(267)._1)
+    assertTrue(requestMetrics.totalTimeBucketHist.boundaryCounterMap.containsKey(300))
+    assertEquals("TotalTime_Bin4_300MsGreater", requestMetrics.totalTimeBucketHist.boundaryCounterMap.get(300)._1)
   }
 
   private def testHistogramCounts(counterMap: util.TreeMap[Int, (String, Counter)], counts: Array[Int],

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1133,21 +1133,25 @@ class SocketServerTest {
       val expectedTotalTimeCount = totalTimeHistCount() + 1
       TestUtils.waitUntilTrue(() => totalTimeHistCount() == expectedTotalTimeCount,
         s"request metrics not updated, expected: $expectedTotalTimeCount, actual: ${totalTimeHistCount()}")
-      Thread.sleep(10)
-      val updatedTotalTimeBucketHistCount = getTotalTimeBucketHistCount()
-      assertTrue(updatedTotalTimeBucketHistCount.size > 0)
-      assertEquals(originalTotalTimeBucketHistCount.size, updatedTotalTimeBucketHistCount.size)
-      var increaseCount = 0
-      // only one bucket should be updated
-      for(boundary <- originalTotalTimeBucketHistCount.keySet) {
-        val originalCount = originalTotalTimeBucketHistCount.get(boundary).get
-        val updatedCount = updatedTotalTimeBucketHistCount.get(boundary).get
-        if(originalCount != updatedCount) {
-          assertEquals(originalCount + 1, updatedCount)
-          increaseCount += 1
+
+      TestUtils.waitUntilTrue(() => {
+        val updatedTotalTimeBucketHistCount = getTotalTimeBucketHistCount()
+        assertTrue(updatedTotalTimeBucketHistCount.size > 0)
+        assertEquals(originalTotalTimeBucketHistCount.size, updatedTotalTimeBucketHistCount.size)
+        var increaseCount = 0
+        // only one bucket should be updated
+        for(boundary <- originalTotalTimeBucketHistCount.keySet) {
+          val originalCount = originalTotalTimeBucketHistCount.get(boundary).get
+          val updatedCount = updatedTotalTimeBucketHistCount.get(boundary).get
+          if(originalCount != updatedCount) {
+            assertEquals(originalCount + 1, updatedCount)
+            increaseCount += 1
+          }
         }
-      }
-      assertEquals(1, increaseCount)
+        assertTrue(increaseCount <= 1)
+        increaseCount == 1
+      },
+      "totalTimeBucketHist is not updated")
     } finally {
       shutdownServerAndMetrics(overrideServer)
     }

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -51,6 +51,7 @@ import org.apache.log4j.Level
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api._
 
+import scala.collection.convert.ImplicitConversions.`map AsScala`
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -1121,6 +1122,9 @@ class SocketServerTest {
 
       val requestMetrics = channel.metrics(request.header.apiKey.name)
       def totalTimeHistCount(): Long = requestMetrics.totalTimeHist.count
+      def getTotalTimeBucketHistCount(): Map[Int, Long] = requestMetrics.totalTimeBucketHist.boundaryCounterMap
+        .map({case (boundary, (name, counter)) => (boundary, counter.count())}).toMap
+      val originalTotalTimeBucketHistCount = getTotalTimeBucketHistCount()
       val send = new NetworkSend(request.context.connectionId, ByteBufferSend.sizePrefixed(ByteBuffer.allocate(responseBufferSize)))
       val headerLog = new ObjectNode(JsonNodeFactory.instance)
       headerLog.set("response", new TextNode("someResponse"))
@@ -1129,7 +1133,21 @@ class SocketServerTest {
       val expectedTotalTimeCount = totalTimeHistCount() + 1
       TestUtils.waitUntilTrue(() => totalTimeHistCount() == expectedTotalTimeCount,
         s"request metrics not updated, expected: $expectedTotalTimeCount, actual: ${totalTimeHistCount()}")
-
+      Thread.sleep(10)
+      val updatedTotalTimeBucketHistCount = getTotalTimeBucketHistCount()
+      assertTrue(updatedTotalTimeBucketHistCount.size > 0)
+      assertEquals(originalTotalTimeBucketHistCount.size, updatedTotalTimeBucketHistCount.size)
+      var increaseCount = 0
+      // only one bucket should be updated
+      for(boundary <- originalTotalTimeBucketHistCount.keySet) {
+        val originalCount = originalTotalTimeBucketHistCount.get(boundary).get
+        val updatedCount = updatedTotalTimeBucketHistCount.get(boundary).get
+        if(originalCount != updatedCount) {
+          assertEquals(originalCount + 1, updatedCount)
+          increaseCount += 1
+        }
+      }
+      assertEquals(1, increaseCount)
     } finally {
       shutdownServerAndMetrics(overrideServer)
     }


### PR DESCRIPTION
TICKET = LIKAFKA-47556 Establish Kafka Server SLOs
LI_DESCRIPTION =
This PR is to add support for request TotalTimeMs latency histograms such that we could counter the number of requests in different latency ranges. The bin boundaries are configurable.

EXIT_CRITERIA = N/A