### PR TITLE
[LI-HOTFIX] Refactor the AlterIsrManager and TransferLeaderManager to avoid duplicate code

### DIFF
--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -16,23 +16,19 @@
  */
 package kafka.server
 
-import java.util
-import java.util.concurrent.{BlockingQueue, ConcurrentHashMap, LinkedBlockingQueue, TimeUnit}
 import kafka.api.LeaderAndIsr
 import kafka.metrics.KafkaMetricsGroup
-import kafka.utils.{KafkaScheduler, Logging, Scheduler}
+import kafka.utils.{Logging, Scheduler}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.{AlterIsrRequestData, AlterIsrResponseData}
-import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.{AlterIsrRequest, AlterIsrResponse}
+import org.apache.kafka.common.requests.{AbstractRequest, AlterIsrRequest, AlterIsrResponse}
 import org.apache.kafka.common.utils.Time
 
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
 /**
@@ -54,47 +50,14 @@ trait AlterIsrManager {
 case class AlterIsrItem(topicPartition: TopicPartition,
                         leaderAndIsr: LeaderAndIsr,
                         callback: Either[Errors, LeaderAndIsr] => Unit,
-                        controllerEpoch: Int) // controllerEpoch needed for Zk impl
+                        controllerEpoch: Int) extends RequestItem // controllerEpoch needed for Zk impl
 
-object AlterIsrManager {
-
-  /**
-   * Factory to AlterIsr based implementation, used when IBP >= 2.7-IV2
-   */
-  def apply(
-    config: KafkaConfig,
-    metadataCache: MetadataCache,
-    scheduler: KafkaScheduler,
-    time: Time,
-    metrics: Metrics,
-    threadNamePrefix: Option[String],
-    brokerEpochSupplier: () => Long,
-    brokerId: Int
-  ): AlterIsrManager = {
-    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
-
-    val channelManager = BrokerToControllerChannelManager(
-      controllerNodeProvider = nodeProvider,
-      time = time,
-      metrics = metrics,
-      config = config,
-      channelName = "alterIsr",
-      threadNamePrefix = threadNamePrefix,
-      retryTimeoutMs = Long.MaxValue
-    )
-    new DefaultAlterIsrManager(
-      controllerChannelManager = channelManager,
-      scheduler = scheduler,
-      time = time,
-      brokerId = brokerId,
-      brokerEpochSupplier = brokerEpochSupplier
-    )
-  }
+object AlterIsrManagerFactory extends BrokerToControllerRequestManagerFactory[AlterIsrItem] {
 
   /**
    * Factory for ZK based implementation, used when IBP < 2.7-IV2
    */
-  def apply(
+  def create(
     scheduler: Scheduler,
     time: Time,
     zkClient: KafkaZkClient
@@ -102,118 +65,35 @@ object AlterIsrManager {
     new ZkIsrManager(scheduler, time, zkClient)
   }
 
+  override def create(controllerChannelManager: BrokerToControllerChannelManager, scheduler: Scheduler, time: Time, brokerId: Int, brokerEpochSupplier: () => Long): BrokerToControllerRequestManager[AlterIsrItem] = {
+    new DefaultAlterIsrManager(
+      controllerChannelManager = controllerChannelManager,
+      scheduler = scheduler,
+      time = time,
+      // TODO: populate this with a real cluster id
+      clusterId = "FIXME",
+      brokerId = brokerId,
+      brokerEpochSupplier = brokerEpochSupplier
+    )
+  }
 }
 
 class DefaultAlterIsrManager(
-  val controllerChannelManager: BrokerToControllerChannelManager,
-  val scheduler: Scheduler,
-  val time: Time,
-  val brokerId: Int,
-  val brokerEpochSupplier: () => Long
-) extends AlterIsrManager with Logging with KafkaMetricsGroup {
-
-  private[server] val unsentIsrQueue: BlockingQueue[AlterIsrItem] = new LinkedBlockingQueue()
-  // The inflightIsrUpdates map is populated by the unsentIsrQueue, and the items in it are removed in the response callback.
-  // Putting new items to the inflightIsrUpdates and removing items from it won't be performed at the same time, and the coordination is
-  // done via the inflightRequest flag.
-  private[server] val inflightIsrUpdates: util.Map[TopicPartition, AlterIsrItem] = new ConcurrentHashMap[TopicPartition, AlterIsrItem]()
-
-  // Used to allow only one in-flight request at a time
-  private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
-
-  override def start(): Unit = {
-    controllerChannelManager.start()
-  }
-
-  override def shutdown(): Unit = {
-    controllerChannelManager.shutdown()
-  }
-
-  override def submit(alterIsrItem: AlterIsrItem): Boolean = {
-    unsentIsrQueue.put(alterIsrItem)
-    maybePropagateIsrChanges()
-    true
-  }
-
-  private[server] def maybePropagateIsrChanges(): Unit = {
-    // Send all pending items if there is not already a request in-flight.
-    if ((!unsentIsrQueue.isEmpty || !inflightIsrUpdates.isEmpty) && inflightRequest.compareAndSet(false, true)) {
-      // Copy current unsent ISRs but don't remove from the map, they get cleared in the response handler
-      while (!unsentIsrQueue.isEmpty) {
-        val item = unsentIsrQueue.poll()
-        // if there are multiple AlterIsrItems for the same partition in the queue, the last one wins
-        // and the previous ones will be discarded
-        inflightIsrUpdates.put(item.topicPartition, item)
-      }
-      // Since the maybePropagateIsrChanges can be called from the response callback,
-      // there may be cases where right after the while loop, some new items are added to the unsentIsrQueue in the submit
-      // thread. In such a case, the newly added item will be sent in the next request
-
-      val inflightAlterIsrItems = new ListBuffer[AlterIsrItem]()
-      inflightIsrUpdates.values().forEach(item => inflightAlterIsrItems.append(item))
-      sendRequest(inflightAlterIsrItems)
-    }
-  }
-
-  private[server] def clearInFlightRequest(): Unit = {
-    if (!inflightRequest.compareAndSet(true, false)) {
-      warn("Attempting to clear AlterIsr in-flight flag when no apparent request is in-flight")
-    }
-  }
-
-  private def sendRequest(inflightAlterIsrItems: Seq[AlterIsrItem]): Unit = {
-    val message = buildRequest(inflightAlterIsrItems)
-    debug(s"Sending AlterIsr to controller $message")
-
-    // We will not timeout AlterISR request, instead letting it retry indefinitely
-    // until a response is received, or a new LeaderAndIsr overwrites the existing isrState
-    // which causes the response for those partitions to be ignored.
-    controllerChannelManager.sendRequest(new AlterIsrRequest.Builder(message),
-      new ControllerRequestCompletionHandler {
-        override def onComplete(response: ClientResponse): Unit = {
-          debug(s"Received AlterIsr response $response")
-          val error = try {
-            if (response.authenticationException != null) {
-              // For now we treat authentication errors as retriable. We use the
-              // `NETWORK_EXCEPTION` error code for lack of a good alternative.
-              // Note that `BrokerToControllerChannelManager` will still log the
-              // authentication errors so that users have a chance to fix the problem.
-              Errors.NETWORK_EXCEPTION
-            } else if (response.versionMismatch != null) {
-              Errors.UNSUPPORTED_VERSION
-            } else {
-              val body = response.responseBody().asInstanceOf[AlterIsrResponse]
-              handleAlterIsrResponse(body, message.brokerEpoch, inflightAlterIsrItems)
-            }
-          } finally {
-            // clear the flag so future requests can proceed
-            clearInFlightRequest()
-          }
-
-          // check if we need to send another request right away
-          error match {
-              case Errors.NONE =>
-                // In the normal case, check for pending updates to send immediately
-                maybePropagateIsrChanges()
-              case _ =>
-                // If we received a top-level error from the controller, retry the request in the near future
-                scheduler.schedule("send-alter-isr", () => maybePropagateIsrChanges(), 50, -1, TimeUnit.MILLISECONDS)
-            }
-        }
-
-        override def onTimeout(): Unit = {
-          throw new IllegalStateException("Encountered unexpected timeout when sending AlterIsr to the controller")
-        }
-      })
-  }
-
-  private def buildRequest(inflightAlterIsrItems: Seq[AlterIsrItem]): AlterIsrRequestData = {
+  controllerChannelManager: BrokerToControllerChannelManager,
+  scheduler: Scheduler,
+  time: Time,
+  clusterId: String,
+  brokerId: Int,
+  brokerEpochSupplier: () => Long
+) extends AbstractBrokerToControllerRequestManager[AlterIsrItem](controllerChannelManager, scheduler, time, brokerId, brokerEpochSupplier) with AlterIsrManager with Logging with KafkaMetricsGroup {
+  override def buildRequest(inflightItems: Seq[AlterIsrItem], brokerEpoch: Long): AbstractRequest.Builder[_ <: AbstractRequest] = {
     val message = new AlterIsrRequestData()
+      .setClusterId(clusterId)
       .setBrokerId(brokerId)
       .setBrokerEpoch(brokerEpochSupplier.apply())
       .setTopics(new util.ArrayList())
 
-    inflightAlterIsrItems.groupBy(_.topicPartition.topic).foreach(entry => {
+    inflightItems.groupBy(_.topicPartition.topic).foreach(entry => {
       val topicPart = new AlterIsrRequestData.TopicData()
         .setName(entry._1)
         .setPartitions(new util.ArrayList())
@@ -227,12 +107,12 @@ class DefaultAlterIsrManager(
         )
       })
     })
-    message
+    new AlterIsrRequest.Builder(message)
   }
 
-  def handleAlterIsrResponse(alterIsrResponse: AlterIsrResponse,
-                             sentBrokerEpoch: Long,
-                             inflightAlterIsrItems: Seq[AlterIsrItem]): Errors = {
+  override def handleResponse(clientResponse: ClientResponse, sentBrokerEpoch: Long, inflightItems: Seq[AlterIsrItem]): Errors = {
+    val alterIsrResponse = clientResponse.responseBody().asInstanceOf[AlterIsrResponse]
+
     val data: AlterIsrResponseData = alterIsrResponse.data
 
     Errors.forCode(data.errorCode) match {
@@ -263,13 +143,13 @@ class DefaultAlterIsrManager(
         // Iterate across the items we sent rather than what we received to ensure we run the callback even if a
         // partition was somehow erroneously excluded from the response. Note that these callbacks are run from
         // the leaderIsrUpdateLock write lock in Partition#sendAlterIsrRequest
-        inflightAlterIsrItems.foreach(inflightAlterIsr =>
+        inflightItems.foreach(inflightAlterIsr =>
           if (partitionResponses.contains(inflightAlterIsr.topicPartition)) {
             try {
               inflightAlterIsr.callback.apply(partitionResponses(inflightAlterIsr.topicPartition))
             } finally {
               // Regardless of callback outcome, we need to clear from the unsent updates map to unblock further updates
-              inflightIsrUpdates.remove(inflightAlterIsr.topicPartition)
+              removeInflightItem(inflightAlterIsr.topicPartition)
             }
           } else {
             // Don't remove this partition from the update map so it will get re-sent
@@ -282,4 +162,5 @@ class DefaultAlterIsrManager(
 
     Errors.forCode(data.errorCode)
   }
+
 }

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -83,7 +83,7 @@ object AlterIsrManager {
       time = time,
       metrics = metrics,
       config = config,
-      channelName = threadNamePrefix.getOrElse("BrokerToController"),
+      channelName = "AlterIsr",
       threadNamePrefix = threadNamePrefix,
       retryTimeoutMs = Long.MaxValue
     )

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -51,7 +51,7 @@ trait AlterIsrManager {
 case class AlterIsrItem(topicPartition: TopicPartition,
                         leaderAndIsr: LeaderAndIsr,
                         callback: Either[Errors, LeaderAndIsr] => Unit,
-                        controllerEpoch: Int) extends RequestItem // controllerEpoch needed for Zk impl
+                        controllerEpoch: Int) extends BrokerToControllerRequestItem // controllerEpoch needed for Zk impl
 
 object AlterIsrManager {
 
@@ -83,7 +83,7 @@ object AlterIsrManager {
       time = time,
       metrics = metrics,
       config = config,
-      channelName = "AlterIsr",
+      channelName = "alterIsr",
       threadNamePrefix = threadNamePrefix,
       retryTimeoutMs = Long.MaxValue
     )

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -18,11 +18,12 @@ package kafka.server
 
 import kafka.api.LeaderAndIsr
 import kafka.metrics.KafkaMetricsGroup
-import kafka.utils.{Logging, Scheduler}
+import kafka.utils.{KafkaScheduler, Logging, Scheduler}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.{AlterIsrRequestData, AlterIsrResponseData}
+import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AlterIsrRequest, AlterIsrResponse}
 import org.apache.kafka.common.utils.Time
@@ -40,9 +41,9 @@ import scala.jdk.CollectionConverters._
  * requests.
  */
 trait AlterIsrManager {
-  def start(): Unit = {}
+  def start(): Unit
 
-  def shutdown(): Unit = {}
+  def shutdown(): Unit
 
   def submit(alterIsrItem: AlterIsrItem): Boolean
 }
@@ -52,12 +53,12 @@ case class AlterIsrItem(topicPartition: TopicPartition,
                         callback: Either[Errors, LeaderAndIsr] => Unit,
                         controllerEpoch: Int) extends RequestItem // controllerEpoch needed for Zk impl
 
-object AlterIsrManagerFactory extends BrokerToControllerRequestManagerFactory[AlterIsrItem] {
+object AlterIsrManager {
 
   /**
    * Factory for ZK based implementation, used when IBP < 2.7-IV2
    */
-  def create(
+  def apply(
     scheduler: Scheduler,
     time: Time,
     zkClient: KafkaZkClient
@@ -65,13 +66,32 @@ object AlterIsrManagerFactory extends BrokerToControllerRequestManagerFactory[Al
     new ZkIsrManager(scheduler, time, zkClient)
   }
 
-  override def create(controllerChannelManager: BrokerToControllerChannelManager, scheduler: Scheduler, time: Time, brokerId: Int, brokerEpochSupplier: () => Long): BrokerToControllerRequestManager[AlterIsrItem] = {
+  def apply(
+    config: KafkaConfig,
+    metadataCache: MetadataCache,
+    scheduler: KafkaScheduler,
+    time: Time,
+    metrics: Metrics,
+    threadNamePrefix: Option[String],
+    brokerEpochSupplier: () => Long,
+    brokerId: Int
+  ): AlterIsrManager = {
+    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
+
+    val channelManager = BrokerToControllerChannelManager(
+      controllerNodeProvider = nodeProvider,
+      time = time,
+      metrics = metrics,
+      config = config,
+      channelName = threadNamePrefix.getOrElse("BrokerToController"),
+      threadNamePrefix = threadNamePrefix,
+      retryTimeoutMs = Long.MaxValue
+    )
+
     new DefaultAlterIsrManager(
-      controllerChannelManager = controllerChannelManager,
+      controllerChannelManager = channelManager,
       scheduler = scheduler,
       time = time,
-      // TODO: populate this with a real cluster id
-      clusterId = "FIXME",
       brokerId = brokerId,
       brokerEpochSupplier = brokerEpochSupplier
     )
@@ -82,13 +102,11 @@ class DefaultAlterIsrManager(
   controllerChannelManager: BrokerToControllerChannelManager,
   scheduler: Scheduler,
   time: Time,
-  clusterId: String,
   brokerId: Int,
   brokerEpochSupplier: () => Long
 ) extends AbstractBrokerToControllerRequestManager[AlterIsrItem](controllerChannelManager, scheduler, time, brokerId, brokerEpochSupplier) with AlterIsrManager with Logging with KafkaMetricsGroup {
   override def buildRequest(inflightItems: Seq[AlterIsrItem], brokerEpoch: Long): AbstractRequest.Builder[_ <: AbstractRequest] = {
     val message = new AlterIsrRequestData()
-      .setClusterId(clusterId)
       .setBrokerId(brokerId)
       .setBrokerEpoch(brokerEpochSupplier.apply())
       .setTopics(new util.ArrayList())

--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -30,11 +30,11 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{BlockingQueue, ConcurrentHashMap, LinkedBlockingQueue, TimeUnit}
 import scala.collection.mutable.ListBuffer
 
-trait RequestItem {
+trait BrokerToControllerRequestItem {
   def topicPartition(): TopicPartition
 }
 
-trait BrokerToControllerRequestManager[Item <: RequestItem] {
+trait BrokerToControllerRequestManager[Item <: BrokerToControllerRequestItem] {
   def start(): Unit
 
   def shutdown(): Unit
@@ -46,7 +46,7 @@ object BrokerToControllerRequestManager {
   val defaultTimeout = 60000
 }
 
-abstract class AbstractBrokerToControllerRequestManager[Item <: RequestItem](
+abstract class AbstractBrokerToControllerRequestManager[Item <: BrokerToControllerRequestItem](
   val controllerChannelManager: BrokerToControllerChannelManager,
   val scheduler: Scheduler,
   val time: Time,

--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -1,0 +1,182 @@
+package kafka.server
+
+import kafka.metrics.KafkaMetricsGroup
+import kafka.utils.{KafkaScheduler, Logging, Scheduler}
+import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{AbstractRequest, ElectLeadersResponse}
+import org.apache.kafka.common.utils.Time
+
+import java.util
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{BlockingQueue, ConcurrentHashMap, LinkedBlockingQueue, TimeUnit}
+import scala.collection.mutable.ListBuffer
+
+trait RequestItem {
+  def topicPartition(): TopicPartition
+}
+
+trait BrokerToControllerRequestManager[Item <: RequestItem] {
+  def start(): Unit
+
+  def shutdown(): Unit
+
+  def submit(item: Item): Boolean
+}
+
+object BrokerToControllerRequestManager {
+  val defaultTimeout = 60000
+}
+
+abstract class BrokerToControllerRequestManagerFactory[Item <: RequestItem] {
+  def create(
+    config: KafkaConfig,
+    metadataCache: MetadataCache,
+    scheduler: KafkaScheduler,
+    time: Time,
+    metrics: Metrics,
+    threadNamePrefix: Option[String],
+    brokerEpochSupplier: () => Long,
+    brokerId: Int
+  ): BrokerToControllerRequestManager[Item] = {
+    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
+
+    val channelManager = BrokerToControllerChannelManager(
+      controllerNodeProvider = nodeProvider,
+      time = time,
+      metrics = metrics,
+      config = config,
+      channelName = threadNamePrefix.getOrElse("BrokerToController"),
+      threadNamePrefix = threadNamePrefix,
+      retryTimeoutMs = Long.MaxValue
+    )
+    create(
+      controllerChannelManager = channelManager,
+      scheduler = scheduler,
+      time = time,
+      brokerId = brokerId,
+      brokerEpochSupplier = brokerEpochSupplier
+    )
+  }
+
+  def create(controllerChannelManager: BrokerToControllerChannelManager,
+    scheduler: Scheduler,
+    time: Time,
+    brokerId: Int,
+    brokerEpochSupplier: () => Long
+  ): BrokerToControllerRequestManager[Item]
+}
+
+
+abstract class AbstractBrokerToControllerRequestManager[Item <: RequestItem](
+  val controllerChannelManager: BrokerToControllerChannelManager,
+  val scheduler: Scheduler,
+  val time: Time,
+  val brokerId: Int,
+  val brokerEpochSupplier: () => Long
+) extends BrokerToControllerRequestManager[Item] with Logging with KafkaMetricsGroup {
+
+  private[server] val unsentItemQueue: BlockingQueue[Item] = new LinkedBlockingQueue()
+  // The inflightTransfers map is populated by the unsentTransferQueue, and the items in it are removed in the response callback.
+  // Putting new items to the inflightTransfers and removing items from it won't be performed at the same time, and the coordination is
+  // done via the inflightRequest flag.
+  private[server] val inflightItems: util.Map[TopicPartition, Item] = new ConcurrentHashMap[TopicPartition, Item]()
+
+  // Used to allow only one in-flight request at a time
+  private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
+
+  override def start(): Unit = {
+    controllerChannelManager.start()
+  }
+
+  override def shutdown(): Unit = {
+    controllerChannelManager.shutdown()
+  }
+
+  override def submit(item: Item): Boolean = {
+    unsentItemQueue.put(item)
+    maybeSendRequest()
+    true
+  }
+
+  private[server] def maybeSendRequest(): Unit = {
+    // Send all pending items if there is not already a request in-flight.
+    if ((!unsentItemQueue.isEmpty || !inflightItems.isEmpty) && inflightRequest.compareAndSet(false, true)) {
+      // Copy current unsent ISRs but don't remove from the map, they get cleared in the response handler
+      while (!unsentItemQueue.isEmpty) {
+        val item = unsentItemQueue.poll()
+        // if there are multiple items for the same partition in the queue, the last one wins
+        // and the previous ones will be discarded
+        inflightItems.put(item.topicPartition, item)
+      }
+      // Since the maybeSendRequest can be called from the response callback,
+      // there may be cases where right after the while loop, some new items are added to the unsentIsrQueue in the submit
+      // thread. In such a case, the newly added item will be sent in the next request
+
+      val itemsToSend = new ListBuffer[Item]()
+      inflightItems.values().forEach(item => itemsToSend.append(item))
+      sendRequest(itemsToSend)
+    }
+  }
+
+  def removeInflightItem(topicPartition: TopicPartition): Unit = {
+    inflightItems.remove(topicPartition)
+  }
+
+  private[server] def clearInFlightRequest(): Unit = {
+    if (!inflightRequest.compareAndSet(true, false)) {
+      warn("Attempting to clear in-flight flag when no apparent request is in-flight")
+    }
+  }
+
+  private def sendRequest(itemsToSend: Seq[Item]): Unit = {
+    val brokerEpoch = brokerEpochSupplier.apply()
+    val request = buildRequest(itemsToSend, brokerEpoch)
+    debug(s"Sending to controller $request")
+
+    // We will not timeout the ElectLeaders request, instead letting it retry indefinitely
+    // until a response is received.
+    controllerChannelManager.sendRequest(request,
+      new ControllerRequestCompletionHandler {
+        override def onComplete(response: ClientResponse): Unit = {
+          debug(s"Received response $response")
+          val error = try {
+            if (response.authenticationException != null) {
+              // For now we treat authentication errors as retriable. We use the
+              // `NETWORK_EXCEPTION` error code for lack of a good alternative.
+              // Note that `BrokerToControllerChannelManager` will still log the
+              // authentication errors so that users have a chance to fix the problem.
+              Errors.NETWORK_EXCEPTION
+            } else if (response.versionMismatch != null) {
+              Errors.UNSUPPORTED_VERSION
+            } else {
+              handleResponse(response, brokerEpoch, itemsToSend)
+            }
+          } finally {
+            // clear the flag so future requests can proceed
+            clearInFlightRequest()
+          }
+
+          // check if we need to send another request right away
+          error match {
+            case Errors.NONE =>
+              // In the normal case, check for pending updates to send immediately
+              maybeSendRequest()
+            case _ =>
+              // If we received a top-level error from the controller, retry the request in the near future
+              scheduler.schedule("send-alter-isr", () => maybeSendRequest(), 50, -1, TimeUnit.MILLISECONDS)
+          }
+        }
+
+        override def onTimeout(): Unit = {
+          throw new IllegalStateException("Encountered unexpected timeout when sending request to the controller")
+        }
+      })
+  }
+
+  def buildRequest(inflightItems: Seq[Item], brokerEpoch: Long): AbstractRequest.Builder[_ <: AbstractRequest]
+
+  def handleResponse(clientResponse: ClientResponse, sentBrokerEpoch: Long, itemsToSend: Seq[Item]): Errors
+}

--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -1,12 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kafka.server
 
 import kafka.metrics.KafkaMetricsGroup
-import kafka.utils.{KafkaScheduler, Logging, Scheduler}
+import kafka.utils.{Logging, Scheduler}
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.{AbstractRequest, ElectLeadersResponse}
+import org.apache.kafka.common.requests.AbstractRequest
 import org.apache.kafka.common.utils.Time
 
 import java.util
@@ -30,46 +46,6 @@ object BrokerToControllerRequestManager {
   val defaultTimeout = 60000
 }
 
-abstract class BrokerToControllerRequestManagerFactory[Item <: RequestItem] {
-  def create(
-    config: KafkaConfig,
-    metadataCache: MetadataCache,
-    scheduler: KafkaScheduler,
-    time: Time,
-    metrics: Metrics,
-    threadNamePrefix: Option[String],
-    brokerEpochSupplier: () => Long,
-    brokerId: Int
-  ): BrokerToControllerRequestManager[Item] = {
-    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
-
-    val channelManager = BrokerToControllerChannelManager(
-      controllerNodeProvider = nodeProvider,
-      time = time,
-      metrics = metrics,
-      config = config,
-      channelName = threadNamePrefix.getOrElse("BrokerToController"),
-      threadNamePrefix = threadNamePrefix,
-      retryTimeoutMs = Long.MaxValue
-    )
-    create(
-      controllerChannelManager = channelManager,
-      scheduler = scheduler,
-      time = time,
-      brokerId = brokerId,
-      brokerEpochSupplier = brokerEpochSupplier
-    )
-  }
-
-  def create(controllerChannelManager: BrokerToControllerChannelManager,
-    scheduler: Scheduler,
-    time: Time,
-    brokerId: Int,
-    brokerEpochSupplier: () => Long
-  ): BrokerToControllerRequestManager[Item]
-}
-
-
 abstract class AbstractBrokerToControllerRequestManager[Item <: RequestItem](
   val controllerChannelManager: BrokerToControllerChannelManager,
   val scheduler: Scheduler,
@@ -79,8 +55,8 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: RequestItem](
 ) extends BrokerToControllerRequestManager[Item] with Logging with KafkaMetricsGroup {
 
   private[server] val unsentItemQueue: BlockingQueue[Item] = new LinkedBlockingQueue()
-  // The inflightTransfers map is populated by the unsentTransferQueue, and the items in it are removed in the response callback.
-  // Putting new items to the inflightTransfers and removing items from it won't be performed at the same time, and the coordination is
+  // The inflightItems map is populated by the unsentItemQueue, and the items in it are removed in the response callback.
+  // Putting new items to the inflightItems and removing items from it won't be performed at the same time, and the coordination is
   // done via the inflightRequest flag.
   private[server] val inflightItems: util.Map[TopicPartition, Item] = new ConcurrentHashMap[TopicPartition, Item]()
 
@@ -136,7 +112,7 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: RequestItem](
     val request = buildRequest(itemsToSend, brokerEpoch)
     debug(s"Sending to controller $request")
 
-    // We will not timeout the ElectLeaders request, instead letting it retry indefinitely
+    // We will not timeout the request, instead letting it retry indefinitely
     // until a response is received.
     controllerChannelManager.sendRequest(request,
       new ControllerRequestCompletionHandler {

--- a/core/src/main/scala/kafka/server/TransferLeaderManager.scala
+++ b/core/src/main/scala/kafka/server/TransferLeaderManager.scala
@@ -17,10 +17,11 @@
 package kafka.server
 
 import kafka.metrics.KafkaMetricsGroup
-import kafka.utils.{Logging, Scheduler}
+import kafka.utils.{KafkaScheduler, Logging, Scheduler}
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.ElectLeadersResponseData
+import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, ElectLeadersRequest, ElectLeadersResponse}
 import org.apache.kafka.common.utils.Time
@@ -40,10 +41,28 @@ case class TransferLeaderItem(topicPartition: TopicPartition,
   newLeader: Int,
   callback: Either[Errors, TopicPartition] => Unit) extends RequestItem
 
-object TransferLeaderManagerFactory extends BrokerToControllerRequestManagerFactory[TransferLeaderItem] {
-  override def create(controllerChannelManager: BrokerToControllerChannelManager, scheduler: Scheduler, time: Time, brokerId: Int, brokerEpochSupplier: () => Long): BrokerToControllerRequestManager[TransferLeaderItem] = {
+object TransferLeaderManager {
+  def apply( config: KafkaConfig,
+    metadataCache: MetadataCache,
+    scheduler: KafkaScheduler,
+    time: Time,
+    metrics: Metrics,
+    threadNamePrefix: Option[String],
+    brokerEpochSupplier: () => Long,
+    brokerId: Int): TransferLeaderManager = {
+    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
+
+    val channelManager = BrokerToControllerChannelManager(
+      controllerNodeProvider = nodeProvider,
+      time = time,
+      metrics = metrics,
+      config = config,
+      channelName = threadNamePrefix.getOrElse("BrokerToController"),
+      threadNamePrefix = threadNamePrefix,
+      retryTimeoutMs = Long.MaxValue
+    )
     new DefaultTransferLeaderManager(
-      controllerChannelManager = controllerChannelManager,
+      controllerChannelManager = channelManager,
       scheduler = scheduler,
       time = time,
       brokerId = brokerId,
@@ -58,7 +77,7 @@ class DefaultTransferLeaderManager(
   time: Time,
   brokerId: Int,
   brokerEpochSupplier: () => Long
-) extends AbstractBrokerToControllerRequestManager[TransferLeaderItem](controllerChannelManager, scheduler, time, brokerId, brokerEpochSupplier) with Logging with KafkaMetricsGroup {
+) extends AbstractBrokerToControllerRequestManager[TransferLeaderItem](controllerChannelManager, scheduler, time, brokerId, brokerEpochSupplier) with TransferLeaderManager with Logging with KafkaMetricsGroup {
   override def buildRequest(inflightItems: Seq[TransferLeaderItem], brokerEpoch: Long): AbstractRequest.Builder[_ <: AbstractRequest] = {
     val recommendedLeaders = new util.HashMap[TopicPartition, Integer]()
 

--- a/core/src/main/scala/kafka/server/TransferLeaderManager.scala
+++ b/core/src/main/scala/kafka/server/TransferLeaderManager.scala
@@ -17,63 +17,33 @@
 package kafka.server
 
 import kafka.metrics.KafkaMetricsGroup
-import kafka.utils.{KafkaScheduler, Logging, Scheduler}
+import kafka.utils.{Logging, Scheduler}
 import org.apache.kafka.clients.ClientResponse
-import org.apache.kafka.common.message.ElectLeadersResponseData
-import org.apache.kafka.common.metrics.Metrics
-import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.{ElectLeadersRequest, ElectLeadersResponse}
-import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.ElectLeadersResponseData
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{AbstractRequest, ElectLeadersRequest, ElectLeadersResponse}
+import org.apache.kafka.common.utils.Time
 
 import java.util
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.{BlockingQueue, ConcurrentHashMap, LinkedBlockingQueue, TimeUnit}
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 
 /**
  * Transferring the leadership is an asynchronous operation, so partitions will learn about the result of their
  * request through a callback.
  *
  */
-trait TransferLeaderManager {
-  def start(): Unit = {}
-
-  def shutdown(): Unit = {}
-
-  def submit(transferLeaderItem: TransferLeaderItem): Unit
+trait TransferLeaderManager extends BrokerToControllerRequestManager[TransferLeaderItem] {
 }
 
 case class TransferLeaderItem(topicPartition: TopicPartition,
   newLeader: Int,
-  callback: Either[Errors, TopicPartition] => Unit)
+  callback: Either[Errors, TopicPartition] => Unit) extends RequestItem
 
-object TransferLeaderManager {
-  val defaultTimeout = 60000
-  def apply(
-    config: KafkaConfig,
-    metadataCache: MetadataCache,
-    scheduler: KafkaScheduler,
-    time: Time,
-    metrics: Metrics,
-    threadNamePrefix: Option[String],
-    brokerEpochSupplier: () => Long,
-    brokerId: Int
-  ): TransferLeaderManager = {
-    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
-
-    val channelManager = BrokerToControllerChannelManager(
-      controllerNodeProvider = nodeProvider,
-      time = time,
-      metrics = metrics,
-      config = config,
-      channelName = "transferLeader",
-      threadNamePrefix = threadNamePrefix,
-      retryTimeoutMs = Long.MaxValue
-    )
+object TransferLeaderManagerFactory extends BrokerToControllerRequestManagerFactory[TransferLeaderItem] {
+  override def create(controllerChannelManager: BrokerToControllerChannelManager, scheduler: Scheduler, time: Time, brokerId: Int, brokerEpochSupplier: () => Long): BrokerToControllerRequestManager[TransferLeaderItem] = {
     new DefaultTransferLeaderManager(
-      controllerChannelManager = channelManager,
+      controllerChannelManager = controllerChannelManager,
       scheduler = scheduler,
       time = time,
       brokerId = brokerId,
@@ -83,121 +53,25 @@ object TransferLeaderManager {
 }
 
 class DefaultTransferLeaderManager(
-  val controllerChannelManager: BrokerToControllerChannelManager,
-  val scheduler: Scheduler,
-  val time: Time,
-  val brokerId: Int,
-  val brokerEpochSupplier: () => Long
-) extends TransferLeaderManager with Logging with KafkaMetricsGroup {
-
-  private[server] val unsentTransferQueue: BlockingQueue[TransferLeaderItem] = new LinkedBlockingQueue()
-  // The inflightTransfers map is populated by the unsentTransferQueue, and the items in it are removed in the response callback.
-  // Putting new items to the inflightTransfers and removing items from it won't be performed at the same time, and the coordination is
-  // done via the inflightRequest flag.
-  private[server] val inflightTransfers: util.Map[TopicPartition, TransferLeaderItem] = new ConcurrentHashMap[TopicPartition, TransferLeaderItem]()
-
-  // Used to allow only one in-flight request at a time
-  private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
-
-  override def start(): Unit = {
-    controllerChannelManager.start()
-  }
-
-  override def shutdown(): Unit = {
-    controllerChannelManager.shutdown()
-  }
-
-  override def submit(transferLeaderItem: TransferLeaderItem): Unit = {
-    unsentTransferQueue.put(transferLeaderItem)
-    maybeTransferLeader()
-  }
-
-  private[server] def maybeTransferLeader(): Unit = {
-    // Send all pending items if there is not already a request in-flight.
-    if ((!unsentTransferQueue.isEmpty || !inflightTransfers.isEmpty) && inflightRequest.compareAndSet(false, true)) {
-      // Copy current unsent ISRs but don't remove from the map, they get cleared in the response handler
-      while (!unsentTransferQueue.isEmpty) {
-        val item = unsentTransferQueue.poll()
-        // if there are multiple TransferLeaderItems for the same partition in the queue, the last one wins
-        // and the previous ones will be discarded
-        inflightTransfers.put(item.topicPartition, item)
-      }
-      // Since the maybeTransferLeader can be called from the response callback,
-      // there may be cases where right after the while loop, some new items are added to the unsentIsrQueue in the submit
-      // thread. In such a case, the newly added item will be sent in the next request
-
-      val inflightTransferLeaderItems = new ListBuffer[TransferLeaderItem]()
-      inflightTransfers.values().forEach(item => inflightTransferLeaderItems.append(item))
-      sendRequest(inflightTransferLeaderItems)
-    }
-  }
-
-  private[server] def clearInFlightRequest(): Unit = {
-    if (!inflightRequest.compareAndSet(true, false)) {
-      warn("Attempting to clear TransferLeader in-flight flag when no apparent request is in-flight")
-    }
-  }
-
-  private def sendRequest(inflightTransferLeaderItems: Seq[TransferLeaderItem]): Unit = {
-    val brokerEpoch = brokerEpochSupplier.apply()
-    val request = buildRequest(inflightTransferLeaderItems, brokerEpoch)
-    debug(s"Sending TransferLeader to controller $request")
-
-    // We will not timeout the ElectLeaders request, instead letting it retry indefinitely
-    // until a response is received.
-    controllerChannelManager.sendRequest(request,
-      new ControllerRequestCompletionHandler {
-        override def onComplete(response: ClientResponse): Unit = {
-          debug(s"Received TransferLeader response $response")
-          val error = try {
-            if (response.authenticationException != null) {
-              // For now we treat authentication errors as retriable. We use the
-              // `NETWORK_EXCEPTION` error code for lack of a good alternative.
-              // Note that `BrokerToControllerChannelManager` will still log the
-              // authentication errors so that users have a chance to fix the problem.
-              Errors.NETWORK_EXCEPTION
-            } else if (response.versionMismatch != null) {
-              Errors.UNSUPPORTED_VERSION
-            } else {
-              val body = response.responseBody().asInstanceOf[ElectLeadersResponse]
-              handleTransferLeaderResponse(body, brokerEpoch, inflightTransferLeaderItems)
-            }
-          } finally {
-            // clear the flag so future requests can proceed
-            clearInFlightRequest()
-          }
-
-          // check if we need to send another request right away
-          error match {
-              case Errors.NONE =>
-                // In the normal case, check for pending updates to send immediately
-                maybeTransferLeader()
-              case _ =>
-                // If we received a top-level error from the controller, retry the request in the near future
-                scheduler.schedule("send-alter-isr", () => maybeTransferLeader(), 50, -1, TimeUnit.MILLISECONDS)
-            }
-        }
-
-        override def onTimeout(): Unit = {
-          throw new IllegalStateException("Encountered unexpected timeout when sending TransferLeader to the controller")
-        }
-      })
-  }
-
-  private def buildRequest(inflightTransferLeaderItems: Seq[TransferLeaderItem], brokerEpoch: Long): ElectLeadersRequest.Builder = {
+  controllerChannelManager: BrokerToControllerChannelManager,
+  scheduler: Scheduler,
+  time: Time,
+  brokerId: Int,
+  brokerEpochSupplier: () => Long
+) extends AbstractBrokerToControllerRequestManager[TransferLeaderItem](controllerChannelManager, scheduler, time, brokerId, brokerEpochSupplier) with Logging with KafkaMetricsGroup {
+  override def buildRequest(inflightItems: Seq[TransferLeaderItem], brokerEpoch: Long): AbstractRequest.Builder[_ <: AbstractRequest] = {
     val recommendedLeaders = new util.HashMap[TopicPartition, Integer]()
 
-    inflightTransferLeaderItems.groupBy(_.topicPartition.topic).foreach(entry => {
+    inflightItems.groupBy(_.topicPartition.topic).foreach(entry => {
       entry._2.foreach(item => {
         recommendedLeaders.put(item.topicPartition, item.newLeader)
       })
     })
-    new ElectLeadersRequest.Builder(brokerEpoch, recommendedLeaders, TransferLeaderManager.defaultTimeout)
+    new ElectLeadersRequest.Builder(brokerEpoch, recommendedLeaders, BrokerToControllerRequestManager.defaultTimeout)
   }
 
-  def handleTransferLeaderResponse(transferLeaderResponse: ElectLeadersResponse,
-                             sentBrokerEpoch: Long,
-                             inflightTransferLeaderItems: Seq[TransferLeaderItem]): Errors = {
+  override def handleResponse(clientResponse: ClientResponse, sentBrokerEpoch: Long, itemsToSend: Seq[TransferLeaderItem]): Errors = {
+    val transferLeaderResponse = clientResponse.responseBody().asInstanceOf[ElectLeadersResponse]
     val data: ElectLeadersResponseData = transferLeaderResponse.data
 
     Errors.forCode(data.errorCode) match {
@@ -225,13 +99,13 @@ class DefaultTransferLeaderManager(
 
         // Iterate across the items we sent rather than what we received to ensure we run the callback even if a
         // partition was somehow erroneously excluded from the response.
-        inflightTransferLeaderItems.foreach(inflightTransferLeader =>
+        itemsToSend.foreach(inflightTransferLeader =>
           if (partitionResponses.contains(inflightTransferLeader.topicPartition)) {
             try {
               inflightTransferLeader.callback.apply(partitionResponses(inflightTransferLeader.topicPartition))
             } finally {
               // Regardless of callback outcome, we need to clear from the unsent updates map to unblock further updates
-              inflightTransfers.remove(inflightTransferLeader.topicPartition)
+              removeInflightItem(inflightTransferLeader.topicPartition)
             }
           } else {
             // Don't remove this partition from the update map so it will get re-sent

--- a/core/src/main/scala/kafka/server/TransferLeaderManager.scala
+++ b/core/src/main/scala/kafka/server/TransferLeaderManager.scala
@@ -39,7 +39,7 @@ trait TransferLeaderManager extends BrokerToControllerRequestManager[TransferLea
 
 case class TransferLeaderItem(topicPartition: TopicPartition,
   newLeader: Int,
-  callback: Either[Errors, TopicPartition] => Unit) extends RequestItem
+  callback: Either[Errors, TopicPartition] => Unit) extends BrokerToControllerRequestItem
 
 object TransferLeaderManager {
   def apply( config: KafkaConfig,
@@ -57,7 +57,7 @@ object TransferLeaderManager {
       time = time,
       metrics = metrics,
       config = config,
-      channelName = "TransferLeader",
+      channelName = "transferLeader",
       threadNamePrefix = threadNamePrefix,
       retryTimeoutMs = Long.MaxValue
     )

--- a/core/src/main/scala/kafka/server/TransferLeaderManager.scala
+++ b/core/src/main/scala/kafka/server/TransferLeaderManager.scala
@@ -57,7 +57,7 @@ object TransferLeaderManager {
       time = time,
       metrics = metrics,
       config = config,
-      channelName = threadNamePrefix.getOrElse("BrokerToController"),
+      channelName = "TransferLeader",
       threadNamePrefix = threadNamePrefix,
       retryTimeoutMs = Long.MaxValue
     )

--- a/core/src/main/scala/kafka/server/ZkIsrManager.scala
+++ b/core/src/main/scala/kafka/server/ZkIsrManager.scala
@@ -100,4 +100,6 @@ class ZkIsrManager(scheduler: Scheduler, time: Time, zkClient: KafkaZkClient) ex
       }
     }
   }
+
+  override def shutdown(): Unit = {}
 }

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -190,7 +190,7 @@ class AlterIsrManagerTest {
     callbackCapture.getValue.onComplete(response)
 
     // Any top-level error, we want to retry, so we don't clear items from the pending map
-    assertTrue(alterIsrManager.inflightIsrUpdates.containsKey(tp0))
+    assertTrue(alterIsrManager.inflightItems.containsKey(tp0))
 
     EasyMock.reset(brokerToController)
     EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).times(1)
@@ -208,7 +208,7 @@ class AlterIsrManagerTest {
 
     EasyMock.verify(brokerToController)
 
-    assertFalse(alterIsrManager.inflightIsrUpdates.containsKey(tp0))
+    assertFalse(alterIsrManager.inflightItems.containsKey(tp0))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1186,10 +1186,18 @@ object TestUtils extends Logging {
         fail("Expected an in-flight ISR update, but there was none")
       }
     }
+
+    override def start(): Unit = {}
+
+    override def shutdown(): Unit = {}
   }
 
   class MockTransferLeaderManager extends TransferLeaderManager {
-    override def submit(transferLeaderItem: TransferLeaderItem): Unit = ???
+    override def submit(transferLeaderItem: TransferLeaderItem): Boolean = ???
+
+    override def start(): Unit = {}
+
+    override def shutdown(): Unit = {}
   }
 
   def createAlterIsrManager(): MockAlterIsrManager = {


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION =
Currently, the AlterIsrManager and the TransferLeaderManager have some code duplications.
This PR refactored the duplicate logic into a common BrokerToControllerRequestManager.

EXIT_CRITERIA = When this change is accepted upstream and pulled to this repo.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
