### PR TITLE
[LI-HOTFIX] Broker to controller request should not use cached controller node

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -351,6 +351,14 @@ class BrokerToControllerRequestThread(
     }
   }
 
+  override def doWork(): Unit = {
+    /**
+     * Poll with a timeout long enough to make sure the controller has enough time to process the request.
+     * If it takes longer than 600s for a single poll operation, most likely something has gone wrong.
+     */
+    super.pollOnce(maxTimeoutMs = 600000)
+  }
+
   override def start(): Unit = {
     super.start()
     started = true

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -18,8 +18,6 @@
 package kafka.server
 
 import java.util.concurrent.LinkedBlockingDeque
-import java.util.concurrent.atomic.AtomicReference
-
 import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
 import kafka.raft.RaftManager
 import kafka.utils.Logging
@@ -224,7 +222,6 @@ class BrokerToControllerChannelManagerImpl(
 
     new BrokerToControllerRequestThread(
       networkClient,
-      manualMetadataUpdater,
       controllerNodeProvider,
       config,
       time,
@@ -276,7 +273,6 @@ case class BrokerToControllerQueueItem(
 
 class BrokerToControllerRequestThread(
   networkClient: KafkaClient,
-  metadataUpdater: ManualMetadataUpdater,
   controllerNodeProvider: ControllerNodeProvider,
   config: KafkaConfig,
   time: Time,

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -351,10 +351,6 @@ class BrokerToControllerRequestThread(
     }
   }
 
-  override def doWork(): Unit = {
-    super.pollOnce(maxTimeoutMs = 30000)
-  }
-
   override def start(): Unit = {
     super.start()
     started = true

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -285,18 +285,13 @@ class BrokerToControllerRequestThread(
 ) extends InterBrokerSendThread(threadName, networkClient, config.controllerSocketTimeoutMs, time, isInterruptible = false) {
 
   private val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
-  private val activeController = new AtomicReference[Node](null)
 
   // Used for testing
   @volatile
   private[server] var started = false
 
   def activeControllerAddress(): Option[Node] = {
-    Option(activeController.get())
-  }
-
-  private def updateControllerAddress(newActiveController: Node): Unit = {
-    activeController.set(newActiveController)
+    controllerNodeProvider.get()
   }
 
   def enqueue(request: BrokerToControllerQueueItem): Unit = {
@@ -347,13 +342,11 @@ class BrokerToControllerRequestThread(
         response.versionMismatch)
       queueItem.callback.onComplete(response)
     } else if (response.wasDisconnected()) {
-      updateControllerAddress(null)
       requestQueue.putFirst(queueItem)
     } else if (response.responseBody().errorCounts().containsKey(Errors.NOT_CONTROLLER)) {
       // just close the controller connection and wait for metadata cache update in doWork
       activeControllerAddress().foreach { controllerAddress => {
         networkClient.disconnect(controllerAddress.idString)
-        updateControllerAddress(null)
       }}
 
       requestQueue.putFirst(queueItem)
@@ -363,21 +356,7 @@ class BrokerToControllerRequestThread(
   }
 
   override def doWork(): Unit = {
-    if (activeControllerAddress().isDefined) {
-      super.pollOnce(Long.MaxValue)
-    } else {
-      debug("Controller isn't cached, looking for local metadata changes")
-      controllerNodeProvider.get() match {
-        case Some(controllerNode) =>
-          info(s"Recorded new controller, from now on will use broker $controllerNode")
-          updateControllerAddress(controllerNode)
-          metadataUpdater.setNodes(Seq(controllerNode).asJava)
-        case None =>
-          // need to backoff to avoid tight loops
-          debug("No controller defined in metadata cache, retrying after backoff")
-          super.pollOnce(maxTimeoutMs = 100)
-      }
-    }
+    super.pollOnce(maxTimeoutMs = 30000)
   }
 
   override def start(): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3284,7 +3284,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
     val alterIsrRequest = request.body[AlterIsrRequest]
     if (config.liDenyAlterIsr) {
-      throw new ClusterAuthorizationException(s"Request $request is not authorized.")
+      throw new ClusterAuthorizationException(s"Request $request is denied in controller "+
+        "due to the li.deny.alter.isr config being true, which is not expected in a real cluster. "+
+        "If this happens in a real cluster, set li.deny.alter.isr to false")
     }
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3283,6 +3283,9 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleAlterIsrRequest(request: RequestChannel.Request): Unit = {
     val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
     val alterIsrRequest = request.body[AlterIsrRequest]
+    if (config.liDenyAlterIsr) {
+      throw new ClusterAuthorizationException(s"Request $request is not authorized.")
+    }
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
 
     if (!zkSupport.controller.isActive)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -329,7 +329,6 @@ object Defaults {
   val LiDenyAlterIsr = false
   val LiAsyncFetcherEnabled = false
   val LiNumControllerInitThreads = 1
-  val LiForceAuthorizationFailure = false
   val LiLogCleanerFineGrainedLockEnabled = true
   val LiDropCorruptedFilesEnabled = false
   val LiConsumerFetchSampleRatio = 0.01
@@ -449,7 +448,6 @@ object KafkaConfig {
   val LiDropFetchFollowerEnableProp = "li.stop.replication.enable"
   val LiDenyAlterIsrProp = "li.deny.alter.isr"
   val LiNumControllerInitThreadsProp = "li.num.controller.init.threads"
-  val LiForceAuthorizationFailure = "li.force.authorization.failure"
   val LiLogCleanerFineGrainedLockEnableProp = "li.log.cleaner.fine.grained.lock.enable"
   val LiDropCorruptedFilesEnableProp = "li.drop.corrupted.files.enable"
   val LiConsumerFetchSampleRatioProp = "li.consumer.fetch.sample.ratio"
@@ -795,7 +793,6 @@ object KafkaConfig {
   val LiDropFetchFollowerEnableDoc = "Specifies whether a leader should drop Fetch requests from followers. This config is used to simulate a slow leader and test the leader initiated leadership transfer"
   val LiDenyAlterIsrDoc = "Test only config, and never enable this in a real cluster. Specifies whether controller should deny the AlterISRRequest."
   val LiNumControllerInitThreadsDoc = "Number of threads (and Zookeeper clients + connections) to be used while recursing the topic-partitions tree in Zookeeper during controller startup/failover."
-  val LiForceAuthorizationFailureDoc = "Test only config. Whether or not the authorizer should always return an authorization failure error"
   val LiLogCleanerFineGrainedLockEnableDoc = "Specifies whether the log cleaner should use fine grained locks when calculating the filthiest log to clean"
   // Although AllowPreferredControllerFallback is expected to be configured dynamically at per cluster level, providing a static configuration entry
   // here allows its value to be obtained without holding the dynamic broker configuration lock.

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -326,9 +326,10 @@ object Defaults {
   val LiCombinedControlRequestEnabled = false
   val LiUpdateMetadataDelayMs = 0
   val LiDropFetchFollowerEnable = false
-  val LiAlterIsrEnabled = true
+  val LiDenyAlterIsr = false
   val LiAsyncFetcherEnabled = false
   val LiNumControllerInitThreads = 1
+  val LiForceAuthorizationFailure = false
   val LiLogCleanerFineGrainedLockEnabled = true
   val LiDropCorruptedFilesEnabled = false
   val LiConsumerFetchSampleRatio = 0.01
@@ -446,8 +447,9 @@ object KafkaConfig {
   val LiCombinedControlRequestEnableProp = "li.combined.control.request.enable"
   val LiUpdateMetadataDelayMsProp = "li.update.metadata.delay.ms"
   val LiDropFetchFollowerEnableProp = "li.stop.replication.enable"
-  val LiAlterIsrEnableProp = "li.alter.isr.enable"
+  val LiDenyAlterIsrProp = "li.deny.alter.isr"
   val LiNumControllerInitThreadsProp = "li.num.controller.init.threads"
+  val LiForceAuthorizationFailure = "li.force.authorization.failure"
   val LiLogCleanerFineGrainedLockEnableProp = "li.log.cleaner.fine.grained.lock.enable"
   val LiDropCorruptedFilesEnableProp = "li.drop.corrupted.files.enable"
   val LiConsumerFetchSampleRatioProp = "li.consumer.fetch.sample.ratio"
@@ -791,8 +793,9 @@ object KafkaConfig {
   val LiDropCorruptedFilesEnableDoc = "Specifies whether the broker should delete corrupted files during startup."
   val LiConsumerFetchSampleRatioDoc = "Specifies the ratio of consumer Fetch requests to sample, which must be a number in the range [0.0, 1.0]. For now, the sampling is used to derive the age of consumed data."
   val LiDropFetchFollowerEnableDoc = "Specifies whether a leader should drop Fetch requests from followers. This config is used to simulate a slow leader and test the leader initiated leadership transfer"
-  val LiAlterIsrEnabledDoc = "Specifies whether the brokers should use the AlterISR request to propagate ISR changes to the controller. If set to false, brokers will propagate the updates via Zookeeper."
+  val LiDenyAlterIsrDoc = "Test only config, and never enable this in a real cluster. Specifies whether controller should deny the AlterISRRequest."
   val LiNumControllerInitThreadsDoc = "Number of threads (and Zookeeper clients + connections) to be used while recursing the topic-partitions tree in Zookeeper during controller startup/failover."
+  val LiForceAuthorizationFailureDoc = "Test only config. Whether or not the authorizer should always return an authorization failure error"
   val LiLogCleanerFineGrainedLockEnableDoc = "Specifies whether the log cleaner should use fine grained locks when calculating the filthiest log to clean"
   // Although AllowPreferredControllerFallback is expected to be configured dynamically at per cluster level, providing a static configuration entry
   // here allows its value to be obtained without holding the dynamic broker configuration lock.
@@ -1235,7 +1238,7 @@ object KafkaConfig {
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
       .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, atLeast(0), LOW, LiUpdateMetadataDelayMsDoc)
       .define(LiDropFetchFollowerEnableProp, BOOLEAN, Defaults.LiDropFetchFollowerEnable, LOW, LiDropFetchFollowerEnableDoc)
-      .define(LiAlterIsrEnableProp, BOOLEAN, Defaults.LiAlterIsrEnabled, HIGH, LiAlterIsrEnabledDoc)
+      .define(LiDenyAlterIsrProp, BOOLEAN, Defaults.LiDenyAlterIsr, HIGH, LiDenyAlterIsrDoc)
       .define(LiNumControllerInitThreadsProp, INT, Defaults.LiNumControllerInitThreads, atLeast(1), LOW, LiNumControllerInitThreadsDoc)
       .define(LiLogCleanerFineGrainedLockEnableProp, BOOLEAN, Defaults.LiLogCleanerFineGrainedLockEnabled, LOW, LiLogCleanerFineGrainedLockEnableDoc)
       .define(LiDropCorruptedFilesEnableProp, BOOLEAN, Defaults.LiDropCorruptedFilesEnabled, HIGH, LiDropCorruptedFilesEnableDoc)
@@ -1779,7 +1782,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   def liCombinedControlRequestEnable = getBoolean(KafkaConfig.LiCombinedControlRequestEnableProp)
   def liUpdateMetadataDelayMs = getLong(KafkaConfig.LiUpdateMetadataDelayMsProp)
   def liDropFetchFollowerEnable = getBoolean(KafkaConfig.LiDropFetchFollowerEnableProp)
-  def liAlterIsrEnable = getBoolean(KafkaConfig.LiAlterIsrEnableProp)
+  def liDenyAlterIsr = getBoolean(KafkaConfig.LiDenyAlterIsrProp)
   def liNumControllerInitThreads = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
   def liLogCleanerFineGrainedLockEnable = getBoolean(KafkaConfig.LiLogCleanerFineGrainedLockEnableProp)
   val liDropCorruptedFilesEnable = getBoolean(KafkaConfig.LiDropCorruptedFilesEnableProp)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -342,7 +342,7 @@ class KafkaServer(
         socketServer.startup(startProcessingRequests = false)
 
         /* start replica manager */
-        alterIsrManager = if (config.interBrokerProtocolVersion.isAlterIsrSupported && config.liAlterIsrEnable) {
+        alterIsrManager = if (config.interBrokerProtocolVersion.isAlterIsrSupported) {
           AlterIsrManager(
             config = config,
             metadataCache = metadataCache,

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
 import org.apache.kafka.common.utils.MockTime
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.{Disabled, Test}
 import org.mockito.Mockito._
 
 
@@ -109,6 +109,7 @@ class BrokerToControllerRequestThreadTest {
   }
 
   @Test
+  @Disabled // after changing the logic to always query the NodeProvider, this test is no longer applicable
   def testControllerChanged(): Unit = {
     // in this test the current broker is 1, and the controller changes from 2 -> 3 then back: 3 -> 2
     val time = new MockTime()
@@ -156,6 +157,7 @@ class BrokerToControllerRequestThreadTest {
   }
 
   @Test
+  @Disabled // after changing the logic to always query the NodeProvider, this test is no longer applicable
   def testNotController(): Unit = {
     val time = new MockTime()
     val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
@@ -214,6 +216,7 @@ class BrokerToControllerRequestThreadTest {
   }
 
   @Test
+  @Disabled // after changing the logic to always query the NodeProvider, this test is no longer applicable
   def testEnvelopeResponseWithNotControllerError(): Unit = {
     val time = new MockTime()
     val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
@@ -284,6 +287,7 @@ class BrokerToControllerRequestThreadTest {
   }
 
   @Test
+  @Disabled // after changing the logic to always query the NodeProvider, this test is no longer applicable
   def testRetryTimeout(): Unit = {
     val time = new MockTime()
     val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 import java.util.Collections
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import kafka.utils.TestUtils
-import org.apache.kafka.clients.{ClientResponse, ManualMetadataUpdater, Metadata, MockClient, NodeApiVersions}
+import org.apache.kafka.clients.{ClientResponse, Metadata, MockClient, NodeApiVersions}
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.message.{EnvelopeResponseData, MetadataRequestData}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
@@ -47,7 +47,7 @@ class BrokerToControllerRequestThreadTest {
     when(controllerNodeProvider.get()).thenReturn(None)
 
     val retryTimeoutMs = 30000
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), controllerNodeProvider,
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, controllerNodeProvider,
       config, time, "", retryTimeoutMs)
     testRequestThread.started = true
 
@@ -84,7 +84,7 @@ class BrokerToControllerRequestThreadTest {
     when(controllerNodeProvider.get()).thenReturn(Some(activeController))
 
     val expectedResponse = RequestTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", 2))
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), controllerNodeProvider,
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, controllerNodeProvider,
       config, time, "", retryTimeoutMs = Long.MaxValue)
     testRequestThread.started = true
     mockClient.prepareResponse(expectedResponse)
@@ -126,7 +126,7 @@ class BrokerToControllerRequestThreadTest {
     when(controllerNodeProvider.get()).thenReturn(Some(oldController), Some(newController))
 
     val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", 2))
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient,
       controllerNodeProvider, config, time, "", retryTimeoutMs = Long.MaxValue)
     testRequestThread.started = true
 
@@ -176,7 +176,7 @@ class BrokerToControllerRequestThreadTest {
       Collections.singletonMap("a", Errors.NOT_CONTROLLER),
       Collections.singletonMap("a", 2))
     val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", 2))
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), controllerNodeProvider,
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, controllerNodeProvider,
       config, time, "", retryTimeoutMs = Long.MaxValue)
     testRequestThread.started = true
 
@@ -239,7 +239,7 @@ class BrokerToControllerRequestThreadTest {
     // response for retry request after receiving NOT_CONTROLLER error
     val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", 2))
 
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), controllerNodeProvider,
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, controllerNodeProvider,
       config, time, "", retryTimeoutMs = Long.MaxValue)
     testRequestThread.started = true
 
@@ -301,7 +301,7 @@ class BrokerToControllerRequestThreadTest {
     val responseWithNotControllerError = RequestTestUtils.metadataUpdateWith("cluster1", 2,
       Collections.singletonMap("a", Errors.NOT_CONTROLLER),
       Collections.singletonMap("a", 2))
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), controllerNodeProvider,
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, controllerNodeProvider,
       config, time, "", retryTimeoutMs)
     testRequestThread.started = true
 
@@ -359,7 +359,7 @@ class BrokerToControllerRequestThreadTest {
 
     mockClient.prepareUnsupportedVersionResponse(request => request.apiKey == ApiKeys.METADATA)
 
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), controllerNodeProvider,
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, controllerNodeProvider,
       config, time, "", retryTimeoutMs = Long.MaxValue)
     testRequestThread.started = true
 
@@ -396,7 +396,7 @@ class BrokerToControllerRequestThreadTest {
 
     mockClient.createPendingAuthenticationError(activeController, 50)
 
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), controllerNodeProvider,
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, controllerNodeProvider,
       config, time, "", retryTimeoutMs = Long.MaxValue)
     testRequestThread.started = true
 
@@ -416,7 +416,7 @@ class BrokerToControllerRequestThreadTest {
 
     val controllerNodeProvider = mock(classOf[ControllerNodeProvider])
 
-    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), controllerNodeProvider,
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, controllerNodeProvider,
       config, time, "", retryTimeoutMs = Long.MaxValue)
 
     val completionHandler = new TestRequestCompletionHandler(None)

--- a/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
@@ -1,0 +1,86 @@
+package unit.kafka.integration
+
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.clients.admin.{Admin, MoveControllerOptions}
+import org.apache.kafka.clients.producer.{Producer, ProducerRecord}
+import org.apache.kafka.common.{Node, TopicPartition}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.{Collections, Properties}
+
+class AlterIsrRequestTest extends ZooKeeperTestHarness {
+  @Test
+  def testUnauthorizedAlterISRRequest(): Unit = {
+    // create brokers
+    val totalBrokers = 4
+    val serverConfigs = TestUtils.createBrokerConfigs(totalBrokers, zkConnect, false)
+      .map(props => {
+        if (props.get(KafkaConfig.BrokerIdProp).equals((totalBrokers - 1).toString)) {
+          // let the leader drop Fetch requests from the followers, which will cause the partition to be UnderMinISR
+          props.setProperty(KafkaConfig.LiDenyAlterIsrProp, "true")
+        }
+        props
+      })
+      .map(KafkaConfig.fromProps)
+    // start servers in reverse order to ensure the last broker becomes the controller
+    val servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
+    val firstControllerId = TestUtils.waitUntilControllerElected(zkClient)
+    assertTrue(firstControllerId == totalBrokers - 1)
+
+    val topic = "test"
+    val partition = 0
+    val tp = new TopicPartition(topic, partition)
+    val topicConfig = new Properties()
+    val expectedReplicaAssignment = Map(0  -> List(0, 1, 2))
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment = expectedReplicaAssignment, servers = servers, topicConfig = topicConfig)
+
+    // ensure the ISR has a size of 3
+    val adminClient = TestUtils.createAdminClient(servers)
+    assertEquals(3, getISR(adminClient, tp).size())
+
+    // shutdown 1 follower
+    val follower = servers.find(_.config.brokerId == 2).get
+    follower.shutdown()
+
+    /**
+     * Produce 1 message to trigger a mismatch of log end offset between the leader and followers.
+     * This should further trigger an AlterISRRequest from the leader to the controller
+     */
+    val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers))
+    produceRecord(producer, topic, partition)
+
+    Thread.sleep(60000)
+    /*
+    TestUtils.waitUntilTrue(() => {
+      adminClient.moveController(new MoveControllerOptions())
+      val secondController = TestUtils.waitUntilControllerElected(zkClient)
+      secondController != firstControllerId
+    }, "unable to elect a different controller")
+
+    info(s"Elected new controller ${zkClient.getControllerId.get}")
+
+
+    // Ensure that the AlterISR request can go through with the new controller
+    TestUtils.waitUntilTrue(() => {
+      getISR(adminClient, tp).size() == 2
+    }, "Unable to update the ISR despite a new controller")
+     */
+  }
+
+  private def getISR(adminClient: Admin, tp: TopicPartition): util.List[Node] = {
+    val topicDescMap = adminClient.describeTopics(Collections.singleton(tp.topic())).all().get()
+    topicDescMap.get(tp.topic()).partitions().get(tp.partition()).isr()
+  }
+
+  private def produceRecord(producer: Producer[Array[Byte], Array[Byte]], topic: String, partition: Int) = {
+    val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, "key".getBytes(StandardCharsets.UTF_8),
+      "value".getBytes(StandardCharsets.UTF_8))
+    producer.send(record).get()
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
@@ -21,9 +21,13 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
     val serverConfigs = TestUtils.createBrokerConfigs(totalBrokers, zkConnect, false)
       .map(props => {
         if (props.get(KafkaConfig.BrokerIdProp).equals((totalBrokers - 1).toString)) {
-          // let the leader drop Fetch requests from the followers, which will cause the partition to be UnderMinISR
           props.setProperty(KafkaConfig.LiDenyAlterIsrProp, "true")
         }
+        if (props.get(KafkaConfig.BrokerIdProp).equals("0")) {
+          // let the leader drop Fetch requests from the followers, which will cause the partition to shrink its ISR
+          props.setProperty(KafkaConfig.LiDropFetchFollowerEnableProp, "true")
+        }
+        props.setProperty(KafkaConfig.ReplicaLagTimeMaxMsProp, "10000")
         props
       })
       .map(KafkaConfig.fromProps)
@@ -31,6 +35,7 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
     val servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
     val firstControllerId = TestUtils.waitUntilControllerElected(zkClient)
     assertTrue(firstControllerId == totalBrokers - 1)
+    info(s"First elected controller is $firstControllerId")
 
     val topic = "test"
     val partition = 0
@@ -41,35 +46,36 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
 
     // ensure the ISR has a size of 3
     val adminClient = TestUtils.createAdminClient(servers)
-    assertEquals(3, getISR(adminClient, tp).size())
-
-    // shutdown 1 follower
-    val follower = servers.find(_.config.brokerId == 2).get
-    follower.shutdown()
+    val initialISR = getISR(adminClient, tp)
+    assertEquals(3, initialISR.size())
+    info(s"The initial ISR size is $initialISR")
 
     /**
      * Produce 1 message to trigger a mismatch of log end offset between the leader and followers.
      * This should further trigger an AlterISRRequest from the leader to the controller
      */
-    val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers))
+    val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers), acks=1)
     produceRecord(producer, topic, partition)
 
-    Thread.sleep(60000)
-    /*
     TestUtils.waitUntilTrue(() => {
       adminClient.moveController(new MoveControllerOptions())
       val secondController = TestUtils.waitUntilControllerElected(zkClient)
+      info(s"Elected new controller $secondController")
       secondController != firstControllerId
     }, "unable to elect a different controller")
-
-    info(s"Elected new controller ${zkClient.getControllerId.get}")
 
 
     // Ensure that the AlterISR request can go through with the new controller
     TestUtils.waitUntilTrue(() => {
-      getISR(adminClient, tp).size() == 2
-    }, "Unable to update the ISR despite a new controller")
-     */
+      val currentISR = getISR(adminClient, tp)
+      info(s"current isr $currentISR")
+      currentISR.size() == 1
+    }, "Unable to update the ISR despite a new controller", pause = 2000)
+
+
+    producer.close()
+    adminClient.close()
+    servers.foreach(_.shutdown())
   }
 
   private def getISR(adminClient: Admin, tp: TopicPartition): util.List[Node] = {

--- a/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
@@ -57,8 +57,8 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
     val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers), acks=1)
     produceRecord(producer, topic, partition)
 
+    adminClient.moveController(new MoveControllerOptions())
     TestUtils.waitUntilTrue(() => {
-      adminClient.moveController(new MoveControllerOptions())
       val secondController = TestUtils.waitUntilControllerElected(zkClient)
       info(s"Elected new controller $secondController")
       secondController != firstControllerId
@@ -73,6 +73,7 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
     }, "Unable to update the ISR despite a new controller", pause = 2000)
 
 
+    info("Test has finished, shutting down the clients and servers")
     producer.close()
     adminClient.close()
     servers.foreach(_.shutdown())

--- a/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
@@ -34,6 +34,7 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
     // start servers in reverse order to ensure the last broker becomes the controller
     val servers = serverConfigs.reverseMap(s => TestUtils.createServer(s))
     val firstControllerId = TestUtils.waitUntilControllerElected(zkClient)
+    val firstControllerEpoch = zkClient.getControllerEpoch.get._1
     assertTrue(firstControllerId == totalBrokers - 1)
     info(s"First elected controller is $firstControllerId")
 
@@ -57,13 +58,7 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
     val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers), acks=1)
     produceRecord(producer, topic, partition)
 
-    adminClient.moveController(new MoveControllerOptions())
-    TestUtils.waitUntilTrue(() => {
-      val secondController = TestUtils.waitUntilControllerElected(zkClient)
-      info(s"Elected new controller $secondController")
-      secondController != firstControllerId
-    }, "unable to elect a different controller")
-
+    waitForDifferentController(adminClient, firstControllerId, firstControllerEpoch)
 
     // Ensure that the AlterISR request can go through with the new controller
     TestUtils.waitUntilTrue(() => {
@@ -71,7 +66,6 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
       info(s"current isr $currentISR")
       currentISR.size() == 1
     }, "Unable to update the ISR despite a new controller", pause = 2000)
-
 
     info("Test has finished, shutting down the clients and servers")
     producer.close()
@@ -90,4 +84,17 @@ class AlterIsrRequestTest extends ZooKeeperTestHarness {
     producer.send(record).get()
   }
 
+  def waitForDifferentController(adminClient: Admin, firstControllerId: Int, firstControllerEpoch: Int) = {
+    var latestController = firstControllerId
+    while (latestController == firstControllerId) {
+      adminClient.moveController(new MoveControllerOptions())
+
+      TestUtils.waitUntilTrue(() => {
+        zkClient.getControllerEpoch.get._1 != firstControllerEpoch
+      }, "The controller epoch does not change after a controller move")
+
+      latestController = zkClient.getControllerId.get
+    }
+    info(s"Elected new controller $latestController")
+  }
 }

--- a/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/AlterIsrRequestTest.scala
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package unit.kafka.integration
 
 import kafka.server.KafkaConfig


### PR DESCRIPTION
TICKET = [LIKAFKA-49304](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-49304)
LI_DESCRIPTION =
Per the slack discussions
https://linkedin-randd.slack.com/archives/C014EKBE170/p1669951054188429?thread_ts=1667860160.319959&cid=C014EKBE170,
the current implementation of broker-to-controller requests results in Unauthorized errors if the cached controller node has been migrated to a different cluster and is still alive.

The impact is that any broker-to-controller requests, including the AlterISR requests, will be blocked, resulting in the permanent inconsistency of ISR info. We should handle such migrated controllers gracefully and use the correct controller instead of the previously cached obsolete controller.

This PR has the following changes
1. replace the "li.alter.isr.enable" config with the "li.deny.alter.isr" config, since the former is no longer needed and the latter is used for constructing an integration test to reproduce the problem above
2. change the logic in `BrokerToControllerRequestThread` such that we always query the latest controller node when a request is constructed. Doing this should not result in performance degradation since the `ControllerNodeProvider` is either a MetadataCacheControllerNodeProvider or RaftControllerNodeProvider, both of which retrieve the controller from the local cache.

EXIT_CRITERIA = When this change is accepted upstream and pulled into this repo.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behavior change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
