### PR TITLE
[LI-HOTFIX] LIKAFKA-49108: Include topic names and/or broker IDs in ApiError exception messages

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1989,7 +1989,7 @@ public class KafkaAdminClient extends AdminClient {
                     KafkaFutureImpl<TopicDescription> future = entry.getValue();
                     Errors topicError = errors.get(topicName);
                     if (topicError != null) {
-                        future.completeExceptionally(topicError.exception());
+                        future.completeExceptionally(topicError.exception(topicError.message() + " (topic: " + topicName + ")"));
                         continue;
                     }
                     if (!cluster.topics().contains(topicName)) {

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -347,7 +347,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     assertThrows(classOf[TopicAuthorizationException], () => consumeRecords(consumer, numRecords, topic = tp.topic))
     val adminClient = createAdminClient()
     val e1 = assertThrows(classOf[ExecutionException], () => adminClient.describeTopics(Set(topic).asJava).all().get())
-    assertTrue(e1.getCause.isInstanceOf[TopicAuthorizationException], "Unexpected exception " + e1.getCause)
+    assertTrue(e1.getCause.isInstanceOf[TopicAuthorizationException], "Expected TopicAuthorizationException, not " + e1.getCause)
 
     // Verify successful produce/consume/describe on another topic using the same producer, consumer and adminClient
     val topic2 = "topic2"
@@ -359,7 +359,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     val describeResults = adminClient.describeTopics(Set(topic, topic2).asJava).values
     assertEquals(1, describeResults.get(topic2).get().partitions().size())
     val e2 = assertThrows(classOf[ExecutionException], () => adminClient.describeTopics(Set(topic).asJava).all().get())
-    assertTrue(e2.getCause.isInstanceOf[TopicAuthorizationException], "Unexpected exception " + e2.getCause)
+    assertTrue(e2.getCause.isInstanceOf[TopicAuthorizationException], "Expected TopicAuthorizationException, not " + e2.getCause)
 
     // Verify that consumer manually assigning both authorized and unauthorized topic doesn't consume
     // from the unauthorized topic and throw; since we can now return data during the time we are updating

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -610,7 +610,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     e = assertThrows(classOf[ExecutionException], () => alterResult.values.get(topic1).get,
       () => "Expect InvalidTopicException when the topic is queued for deletion")
     assertTrue(e.getCause.isInstanceOf[InvalidTopicException])
-    assertEquals("The topic is queued for deletion.", e.getCause.getMessage)
+    assertTrue(e.getCause.getMessage.startsWith("Topic is queued for deletion"))
+    assertTrue(e.getCause.getMessage.endsWith(topic1))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/DeleteOffsetsConsumerGroupCommandIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteOffsetsConsumerGroupCommandIntegrationTest.scala
@@ -136,8 +136,11 @@ class DeleteOffsetsConsumerGroupCommandIntegrationTest extends ConsumerGroupComm
       }
       if (expectedError == Errors.NONE)
         assertNull(partitions(tp))
-      else
-        assertEquals(expectedError.exception, partitions(tp).getCause)
+      else {
+        assertEquals(expectedError.exception.getClass, partitions(tp).getCause.getClass)
+        // actual error's message can now be that of whichever Errors.FOO + " (topic: <topicName>)"
+        assertTrue(partitions(tp).getCause.getMessage.startsWith(expectedError.exception.getMessage)) 
+      }
     }
   }
 


### PR DESCRIPTION
Existing broker-side API errors, including the very common UNKNOWN_TOPIC_OR_PARTITION, do not include relevant information about the error such as the topic name in question or the broker reporting the error. This can lead to particularly confusing client-side logs with no hints about the specific problem:

```
2022/12/14 18:26:30.961 ERROR [KafkaMonitoring] [Thread-36] [kafka-monitoring] [] Error when running KafkaMonitoringThread. System.exit() will be called.
java.lang.reflect.InvocationTargetException: null 
    at jdk.internal.reflect.GeneratedConstructorAccessor90.newInstance(Unknown Source) ~[?:?]
    at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
    [...]
Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.
    at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45) ~[kafka-clients-2.4.1.65.jar:?]
    [...]
```

This change adds such basic information for unknown topics, authorization errors, topics about to be deleted, etc.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
