### PR TITLE
[LI-HOTFIX] Support full LeaderAndISR through LiCombinedControl requests

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -253,8 +253,6 @@ class RequestSendThread(val controllerId: Int,
 
   private var firstUpdateMetadataWithPartitionsSent = false
 
-  private var firstFullLeaderAndIsrSent = false
-
   @volatile private var latestRequestStatus = LatestRequestStatus(isInFlight = false, isInQueue = false, 0)
 
   // This metric reports the queued time of the latest request from the queue
@@ -286,13 +284,7 @@ class RequestSendThread(val controllerId: Int,
       (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1 &&
         config.liCombinedControlRequestEnable &&
         firstUpdateMetadataWithPartitionsSent &&
-        // The LeaderAndIsrRequest starts having the full/incremental flag since IBP KAFKA_2_8_IV1.
-        // Thus, we require the firstFullLeaderAndIsrSent to be set only when IBP >= KAFKA_2_8_IV1
-        (config.interBrokerProtocolVersion < KAFKA_2_8_IV1 || firstFullLeaderAndIsrSent ||
-          // Brokers that don't host any replicas will never receive a LeaderAndIsr request, including
-          // the preferred controllers and maintenance brokers. We treat them specially here
-          // so that they can have the LiCombinedControl requests enabled.
-          controllerContext.partitionsOnBroker(brokerNode.id()).isEmpty))) {
+        config.interBrokerProtocolVersion < KAFKA_2_8_IV1)) {
       // Only start the merging logic after the first UpdateMetadata request with partitions,
       // since the first UpdateMetadata request with partitions may contain hundreds of thousands of partitions,
       // and thus needs to be cached and shared by all brokers in order to prevent OOM
@@ -304,10 +296,11 @@ class RequestSendThread(val controllerId: Int,
       // case 4: queue empty, merger empty {action: block and wait until queue becomes non-empty, then transition to case 1 or 3}
 
       // handle case 4 first
+      var shouldStopMerging = false
       if (!controllerRequestMerger.hasPendingRequests()) {
         val QueueItem(apiKey, requestBuilder, callback, enqueueTimeMs) = queue.take()
         latestRequestStatus = LatestRequestStatus(isInFlight = true, isInQueue = false, enqueueTimeMs)
-        mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
+        shouldStopMerging = mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
       }
 
       // now we are guaranteed that the controllerRequestMerger is not empty (case 1 or 3)
@@ -315,9 +308,9 @@ class RequestSendThread(val controllerId: Int,
       // one concurrent access case considering the producer of the queue:
       // an item is put to the queue right after the condition check below.
       // That behavior does not change correctness since the inserted item will be picked up in the next round
-      while (!queue.isEmpty) {
+      while (!queue.isEmpty && !shouldStopMerging) {
         val QueueItem(apiKey, requestBuilder, callback, enqueueTimeMs) = queue.take()
-        mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
+        shouldStopMerging = mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
       }
 
       val requestBuilder = controllerRequestMerger.pollLatestRequest()
@@ -383,10 +376,6 @@ class RequestSendThread(val controllerId: Int,
         if (api == ApiKeys.UPDATE_METADATA && !requestBuilder.asInstanceOf[UpdateMetadataRequest.Builder].partitionStates().isEmpty) {
           firstUpdateMetadataWithPartitionsSent = true
         }
-        if (api == ApiKeys.LEADER_AND_ISR &&
-          requestBuilder.asInstanceOf[LeaderAndIsrRequest.Builder].`type`() == LeaderAndIsrRequestType.FULL) {
-          firstFullLeaderAndIsrSent = true
-        }
 
         val response = clientResponse.responseBody
 
@@ -413,9 +402,10 @@ class RequestSendThread(val controllerId: Int,
    * @param apiKey
    * @param requestBuilder
    * @param callback
+   * @return This method should return true if the merging should continue, and false otherwise.
    */
   def mergeControlRequest(enqueueTimeMs: Long, apiKey: ApiKeys, requestBuilder: AbstractControlRequest.Builder[_ <: AbstractControlRequest],
-    callback: AbstractResponse => Unit): Unit = {
+    callback: AbstractResponse => Unit): Boolean = {
     updateMetrics(apiKey, enqueueTimeMs)
     controllerRequestMerger.addRequest(requestBuilder, callback)
   }

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -283,8 +283,7 @@ class RequestSendThread(val controllerId: Int,
     if (controllerRequestMerger.hasPendingRequests() ||
       (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1 &&
         config.liCombinedControlRequestEnable &&
-        firstUpdateMetadataWithPartitionsSent &&
-        config.interBrokerProtocolVersion < KAFKA_2_8_IV1)) {
+        firstUpdateMetadataWithPartitionsSent)) {
       // Only start the merging logic after the first UpdateMetadata request with partitions,
       // since the first UpdateMetadata request with partitions may contain hundreds of thousands of partitions,
       // and thus needs to be cached and shared by all brokers in order to prevent OOM

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -295,11 +295,11 @@ class RequestSendThread(val controllerId: Int,
       // case 4: queue empty, merger empty {action: block and wait until queue becomes non-empty, then transition to case 1 or 3}
 
       // handle case 4 first
-      var shouldStopMerging = false
+      var shouldContinueMerging = true
       if (!controllerRequestMerger.hasPendingRequests()) {
         val QueueItem(apiKey, requestBuilder, callback, enqueueTimeMs) = queue.take()
         latestRequestStatus = LatestRequestStatus(isInFlight = true, isInQueue = false, enqueueTimeMs)
-        shouldStopMerging = mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
+        shouldContinueMerging = mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
       }
 
       // now we are guaranteed that the controllerRequestMerger is not empty (case 1 or 3)
@@ -307,9 +307,9 @@ class RequestSendThread(val controllerId: Int,
       // one concurrent access case considering the producer of the queue:
       // an item is put to the queue right after the condition check below.
       // That behavior does not change correctness since the inserted item will be picked up in the next round
-      while (!queue.isEmpty && !shouldStopMerging) {
+      while (!queue.isEmpty && shouldContinueMerging) {
         val QueueItem(apiKey, requestBuilder, callback, enqueueTimeMs) = queue.take()
-        shouldStopMerging = mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
+        shouldContinueMerging = mergeControlRequest(enqueueTimeMs, apiKey, requestBuilder, callback)
       }
 
       val requestBuilder = controllerRequestMerger.pollLatestRequest()

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -39,6 +39,7 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     if (config.interBrokerProtocolVersion >= KAFKA_3_0_IV0) 1
     else 0
 
+  var isFullLeaderAndIsr: Boolean = false
   val leaderAndIsrPartitionStates: mutable.Map[TopicIdPartition, util.LinkedList[LeaderAndIsrPartitionState]] = mutable.HashMap.empty
   var leaderAndIsrLiveLeaders: util.Collection[Node] = new util.ArrayList[Node]()
 
@@ -58,8 +59,11 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
   var stopReplicaCallback: AbstractResponse => Unit = null
   val aggregateTopicIds: util.Map[String, Uuid] = new util.HashMap[String, Uuid]()
 
+  /**
+   *@return This method should return true if the merging should continue, and false otherwise.
+   */
   def addRequest(request: AbstractControlRequest.Builder[_ <: AbstractControlRequest],
-    callback: AbstractResponse => Unit = null): Unit = {
+    callback: AbstractResponse => Unit = null): Boolean = {
     val newControllerState = new RequestControllerState(request.controllerId(), request.controllerEpoch())
     if (controllerState != null) {
       if (!controllerState.equals(newControllerState)) {
@@ -116,8 +120,12 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
   }
 
   private def addLeaderAndIsrRequest(request: LeaderAndIsrRequest.Builder,
-                                     callback: AbstractResponse => Unit): Unit = {
+                                     callback: AbstractResponse => Unit): Boolean = {
     mergeTopicIds(request.topicIds())
+
+    if (request.`type`().equals(LeaderAndIsrRequestType.FULL)) {
+      isFullLeaderAndIsr = true
+    }
 
     request.partitionStates().forEach{partitionState => {
       val transformedPartitionState = LiCombinedControlTransformer.transformLeaderAndIsrPartition(partitionState, request.maxBrokerEpoch())
@@ -135,13 +143,15 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     }}
     leaderAndIsrLiveLeaders = request.liveLeaders()
     leaderAndIsrCallback = callback
+    // we should stop the merging when a full LeaderAndISR request is encountered
+    !isFullLeaderAndIsr
   }
 
   private def clearLeaderAndIsrPartitionState(topicIdPartition: TopicIdPartition): Unit = {
     leaderAndIsrPartitionStates.remove(topicIdPartition)
   }
 
-  private def addUpdateMetadataRequest(request: UpdateMetadataRequest.Builder): Unit = {
+  private def addUpdateMetadataRequest(request: UpdateMetadataRequest.Builder): Boolean = {
     mergeTopicIds(request.topicIds())
 
     request.partitionStates().forEach{partitionState => {
@@ -157,6 +167,7 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     request.liveBrokers().forEach{liveBroker =>
       updateMetadataLiveBrokers.add(LiCombinedControlTransformer.transformUpdateMetadataBroker(liveBroker))
     }
+    true
   }
 
   def isStopReplicaReplaceable(newState: StopReplicaPartitionState, currentState: StopReplicaPartitionState): Boolean = {
@@ -176,7 +187,7 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
   }
 
   private def addStopReplicaRequest(request: StopReplicaRequest.Builder,
-                                    callback: AbstractResponse => Unit): Unit = {
+                                    callback: AbstractResponse => Unit): Boolean = {
     request.topicStates().forEach{topicState => {
       topicState.partitionStates().forEach{ partitionState =>
         val topicName = topicState.topicName()
@@ -206,6 +217,7 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     // To preserve correctness, we require that the later callback and the earlier callback
     // must have the same sideeffects when they are provided with the same StopReplica response.
     stopReplicaCallback = callback
+    true
   }
   private def clearStopReplicaPartitionState(topicIdPartition: TopicIdPartition): Unit = {
     stopReplicaPartitionStates.remove(topicIdPartition)
@@ -227,6 +239,8 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
       }
     }
 
+    // clear the isFullLeaderAndISR flag
+    isFullLeaderAndIsr = false
     latestPartitionStates
   }
 
@@ -275,9 +289,14 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     } else {
       val (latestUpdateMetadataPartitions, liveBrokers) = pollLatestUpdateMetadataInfo()
 
+      /**
+       * note that calling the pollLatestLeaderAndIsrPartitions() method below will clear the isFullLeaderAndIsr field
+       * thus we explicitly save the isFullLeaderAndIsr state before constructing the LiCombinedControlRequest
+       */
+      val fullLeaderAndIsr = isFullLeaderAndIsr
       val latestRequest = new LiCombinedControlRequest.Builder(
         liCombinedControlRequestVersion, controllerState.controllerId, controllerState.controllerEpoch,
-        pollLatestLeaderAndIsrPartitions(), leaderAndIsrLiveLeaders,
+        fullLeaderAndIsr, pollLatestLeaderAndIsrPartitions(), leaderAndIsrLiveLeaders,
         latestUpdateMetadataPartitions, liveBrokers,
         pollLatestStopReplicaPartitions(), ImmutableMap.copyOf(aggregateTopicIds)
       )

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -119,6 +119,9 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     aggregateTopicIds.putAll(topicIds)
   }
 
+  /**
+   *@return This method should return true if the merging should continue, and false otherwise.
+   */
   private def addLeaderAndIsrRequest(request: LeaderAndIsrRequest.Builder,
                                      callback: AbstractResponse => Unit): Boolean = {
     mergeTopicIds(request.topicIds())
@@ -156,6 +159,9 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     leaderAndIsrPartitionStates.remove(topicIdPartition)
   }
 
+  /**
+   *@return This method should return true if the merging should continue, and false otherwise.
+   */
   private def addUpdateMetadataRequest(request: UpdateMetadataRequest.Builder): Boolean = {
     mergeTopicIds(request.topicIds())
 
@@ -191,6 +197,9 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     }
   }
 
+  /**
+   *@return This method should return true if the merging should continue, and false otherwise.
+   */
   private def addStopReplicaRequest(request: StopReplicaRequest.Builder,
                                     callback: AbstractResponse => Unit): Boolean = {
     request.topicStates().forEach{topicState => {

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -129,8 +129,8 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     if (request.`type`().equals(LeaderAndIsrRequestType.FULL)) {
       // There should be no other LeaderAndISR partitions in the merger when a full LeaderAndISR request is sent
       if (!leaderAndIsrPartitionStates.isEmpty) {
-        throw new IllegalStateException("A Full LeaderAndISR request is received while some LeaderAndISR partitions are already " +
-        "ControllerRequest merger")
+        throw new IllegalStateException("A Full LeaderAndISR request is received " +
+          "while some LeaderAndISR partitions are already in the ControllerRequest merger")
       }
       isFullLeaderAndIsr = true
     }

--- a/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
+++ b/core/src/main/scala/kafka/controller/ControllerRequestMerger.scala
@@ -124,6 +124,11 @@ class ControllerRequestMerger(config: KafkaConfig) extends Logging {
     mergeTopicIds(request.topicIds())
 
     if (request.`type`().equals(LeaderAndIsrRequestType.FULL)) {
+      // There should be no other LeaderAndISR partitions in the merger when a full LeaderAndISR request is sent
+      if (!leaderAndIsrPartitionStates.isEmpty) {
+        throw new IllegalStateException("A Full LeaderAndISR request is received while some LeaderAndISR partitions are already " +
+        "ControllerRequest merger")
+      }
       isFullLeaderAndIsr = true
     }
 

--- a/core/src/main/scala/kafka/utils/LiDecomposedControlRequestUtils.scala
+++ b/core/src/main/scala/kafka/utils/LiDecomposedControlRequestUtils.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrParti
 import org.apache.kafka.common.message.LiCombinedControlRequestData
 import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartitionState, StopReplicaTopicState}
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataPartitionState}
-import org.apache.kafka.common.requests.{LeaderAndIsrRequest, LiCombinedControlRequest, StopReplicaRequest, UpdateMetadataRequest}
+import org.apache.kafka.common.requests.{LeaderAndIsrRequest, LeaderAndIsrRequestType, LiCombinedControlRequest, StopReplicaRequest, UpdateMetadataRequest}
 import org.apache.kafka.common.utils.LiCombinedControlTransformer
 
 import scala.collection.JavaConverters._
@@ -81,7 +81,8 @@ object LiDecomposedControlRequestUtils {
       }
 
       Some(new LeaderAndIsrRequest.Builder(leaderAndIsrRequestVersion, request.controllerId(), request.controllerEpoch(),
-        request.brokerEpoch(), request.maxBrokerEpoch(), effectivePartitionStates, topicIds, leaderNodes
+        request.brokerEpoch(), request.maxBrokerEpoch(), effectivePartitionStates, topicIds, leaderNodes,
+        request.leaderAndIsrType() == LeaderAndIsrRequestType.FULL.code()
       ).build())
     }
   }

--- a/core/src/test/scala/integration/kafka/api/LiCombinedControlRequestTest.scala
+++ b/core/src/test/scala/integration/kafka/api/LiCombinedControlRequestTest.scala
@@ -111,7 +111,7 @@ class LiCombinedControlRequestTest extends KafkaServerTestHarness  with Logging 
     topicIds.put("topic2", topic2Uuid)
     topicIds.put("topic3", topic3Uuid)
 
-    val liCombinedControlRequest = new LiCombinedControlRequest.Builder(1, 0, 0, leaderAndIsrPartitionStates,
+    val liCombinedControlRequest = new LiCombinedControlRequest.Builder(1, 0, 0, false, leaderAndIsrPartitionStates,
       new util.ArrayList[Node](), updateMetadataPartitionStates, new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataBroker](),
       stopReplicaPartitionStates, topicIds).build()
 

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -653,7 +653,8 @@ class RequestQuotaTest extends BaseRequestTest {
             ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK.latestVersion)
 
         case ApiKeys.LI_COMBINED_CONTROL =>
-          new LiCombinedControlRequest.Builder(ApiKeys.LI_COMBINED_CONTROL.latestVersion, brokerId, 0, new util.ArrayList[LiCombinedControlRequestData.LeaderAndIsrPartitionState](),
+          new LiCombinedControlRequest.Builder(ApiKeys.LI_COMBINED_CONTROL.latestVersion, brokerId, 0,
+            false, new util.ArrayList[LiCombinedControlRequestData.LeaderAndIsrPartitionState](),
             new util.ArrayList[Node](), new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataPartitionState](), new util.ArrayList[LiCombinedControlRequestData.UpdateMetadataBroker](),
             new util.ArrayList[LiCombinedControlRequestData.StopReplicaPartitionState](), Collections.emptyMap())
 


### PR DESCRIPTION
TICKET = LIKAFKA-49560
LI_DESCRIPTION =
As described in the ticket, we found that the LiCombinedControl requests can be disabled for newly
added brokers. The newly added brokers experience the following behavior

1. the LiCombinedContrel requests are enabled when the broker starts up and host 0 replicas
2. the LiCombinedControl requests are disabled when some replicas are assigned to the broker
3. the LiCombinedControl requests can only be re-enabled after the broker is restarted

The reason for the problem in step 2 is that once the LiCombinedControl request is enabled
and a full LeaderAndISR request needs to be sent, it will try to merge the request while
doesn't honor the full request type. As a result, brokers receive the LeaderAndISR as
part of the LiCombinedControl, and treat it as an incremental LeaderAndISR instead of a full
request.

This PR tries to address the problem by having the full support of the LeaderAndISR request type
within LiCombinedControl.

EXIT_CRITERIA = The same as the LiCombinedControl request.