### PR TITLE
Add metric for total connection count

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -17,6 +17,8 @@
 
 package kafka.network
 
+import com.yammer.metrics.core.Gauge
+
 import java.io.IOException
 import java.net._
 import java.nio.ByteBuffer
@@ -1299,7 +1301,7 @@ object ConnectionQuotas {
   }
 }
 
-class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extends Logging with AutoCloseable {
+class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extends Logging with KafkaMetricsGroup with AutoCloseable {
 
   @volatile private var defaultMaxConnectionsPerIp: Int = config.maxConnectionsPerIp
   @volatile private var maxConnectionsPerIpOverrides = config.maxConnectionsPerIpOverrides.map { case (host, count) => (InetAddress.getByName(host), count) }
@@ -1310,6 +1312,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   // Listener counts and configs are synchronized on `counts`
   private val listenerCounts = mutable.Map[ListenerName, Int]()
   private[network] val maxConnectionsPerListener = mutable.Map[ListenerName, ListenerConnectionQuota]()
+  private val TotalConnectionCountMetricName = "totalConnectionCount"
   @volatile private var totalCount = 0
   // updates to defaultConnectionRatePerIp or connectionRatePerIp must be synchronized on `counts`
   @volatile private var defaultConnectionRatePerIp = QuotaConfigs.IP_CONNECTION_RATE_DEFAULT.intValue()
@@ -1317,6 +1320,11 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   // sensor that tracks broker-wide connection creation rate and limit (quota)
   private val brokerConnectionRateSensor = getOrCreateConnectionRateQuotaSensor(config.maxConnectionCreationRate, BrokerQuotaEntity)
   private val maxThrottleTimeMs = TimeUnit.SECONDS.toMillis(config.quotaWindowSizeSeconds.toLong)
+
+  val totalConnectionCountGauge = newGauge(
+    TotalConnectionCountMetricName,
+    new Gauge[Long] { def value: Long = totalCount }
+  )
 
   def inc(listenerName: ListenerName, address: InetAddress, acceptorBlockedPercentMeter: com.yammer.metrics.core.Meter): Unit = {
     counts.synchronized {

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1312,7 +1312,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   // Listener counts and configs are synchronized on `counts`
   private val listenerCounts = mutable.Map[ListenerName, Int]()
   private[network] val maxConnectionsPerListener = mutable.Map[ListenerName, ListenerConnectionQuota]()
-  private val TotalConnectionCountMetricName = "totalConnectionCount"
+  private val TotalConnectionCountMetricName = "TotalConnectionCount"
   @volatile private var totalCount = 0
   // updates to defaultConnectionRatePerIp or connectionRatePerIp must be synchronized on `counts`
   @volatile private var defaultConnectionRatePerIp = QuotaConfigs.IP_CONNECTION_RATE_DEFAULT.intValue()
@@ -1321,10 +1321,8 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   private val brokerConnectionRateSensor = getOrCreateConnectionRateQuotaSensor(config.maxConnectionCreationRate, BrokerQuotaEntity)
   private val maxThrottleTimeMs = TimeUnit.SECONDS.toMillis(config.quotaWindowSizeSeconds.toLong)
 
-  val totalConnectionCountGauge = newGauge(
-    TotalConnectionCountMetricName,
-    new Gauge[Long] { def value: Long = totalCount }
-  )
+  // sensor that emits the total broker connection count including external, admin, and replication connections
+  val totalConnectionCountGauge = newGauge(TotalConnectionCountMetricName, () => totalCount)
 
   def inc(listenerName: ListenerName, address: InetAddress, acceptorBlockedPercentMeter: com.yammer.metrics.core.Meter): Unit = {
     counts.synchronized {


### PR DESCRIPTION
This metric is added for showing the total client connection count to a broker. The metric will be useful when we monitor the connection count and measure the max connections of a broker.

The metric added is a gauge that emits value of the "totalCount" var of ConnectionQuotas of the SocketServer of the kafka server. Whenever there's a new connection added, the total count will increment: https://github.com/linkedin/kafka/blob/8c5b1ec033577cb6ca2b445a70e7347581d5b7c6/core/src/main/scala/kafka/network/SocketServer.scala#L728

TICKET = N/A
LI_DESCRIPTION = LIKAFKA-49259
EXIT_CRITERIA = When upstream implement similar sensors

