### PR TITLE
[LI-HOTFIX] Add integration test for recovery of offline partitions

### DIFF
--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -141,7 +141,7 @@ abstract class KafkaServerTestHarness extends ZooKeeperTestHarness {
     TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment, servers)
 
   def createTopic(topic: String, partitionReplicaAssignment: collection.Map[Int, Seq[Int]],topicConfig: Properties): scala.collection.immutable.Map[Int, Int] =
-    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment, servers)
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment, servers, topicConfig)
 
 
   /**

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -140,6 +140,10 @@ abstract class KafkaServerTestHarness extends ZooKeeperTestHarness {
   def createTopic(topic: String, partitionReplicaAssignment: collection.Map[Int, Seq[Int]]): scala.collection.immutable.Map[Int, Int] =
     TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment, servers)
 
+  def createTopic(topic: String, partitionReplicaAssignment: collection.Map[Int, Seq[Int]],topicConfig: Properties): scala.collection.immutable.Map[Int, Int] =
+    TestUtils.createTopic(zkClient, topic, partitionReplicaAssignment, servers)
+
+
   /**
    * Pick a broker at random and kill it if it isn't already dead
    * Return the id of the broker killed

--- a/core/src/test/scala/unit/kafka/integration/PartitionLoggingTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/PartitionLoggingTest.scala
@@ -17,15 +17,19 @@
 
 package kafka.integration
 
+import com.yammer.metrics.core.Gauge
 import kafka.api.IntegrationTestHarness
+import kafka.metrics.KafkaYammerMetrics
 import kafka.server.HostedPartition.Online
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.TopicConfig
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 
 import java.util.Properties
+import scala.collection.Seq
+import scala.jdk.CollectionConverters.mapAsScalaMapConverter
 
 class PartitionLoggingTest extends IntegrationTestHarness{
   override protected def brokerCount: Int = 4
@@ -56,6 +60,43 @@ class PartitionLoggingTest extends IntegrationTestHarness{
     waitForPartitionUnderMinISRState(tp, false)
   }
 
+  @Test
+  def loggingOfflinePartitionTest(): Unit = {
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+    // create the test topic with three replicas
+    val topicConfig = new Properties()
+    topicConfig.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+    var nonControllerBrokerIds = servers.filter(s => s.config.brokerId != controllerId).map(_.config.brokerId)
+    if (nonControllerBrokerIds.size > 3) {
+      nonControllerBrokerIds = nonControllerBrokerIds.take(3)
+    }
+    assertEquals(3, nonControllerBrokerIds.size)
+    val topicName = "test_3replicas"
+    createTopic(topicName, Map(0 -> nonControllerBrokerIds), topicConfig)
+    val tp = new TopicPartition(topicName, 0)
+    checkPartitionOfflineStatus(false, tp)
+
+    // get the brokers that have the replicas
+    val partitionStateOpt = zkClient.getTopicPartitionState(tp)
+    assertTrue(partitionStateOpt.isDefined, "partitionState should exist for partition [test_3replicas,0]")
+    assertEquals(3, partitionStateOpt.get.leaderAndIsr.isr.size, "isr should be 3 for partition [test_3replicas,0]")
+    val brokersWithReplica = partitionStateOpt.get.leaderAndIsr.isr
+
+    // shutdown brokers to put the partition offline
+    val brokersToShutdown = servers.filter{s => brokersWithReplica.contains(s.config.brokerId)}
+    val controller = servers.filter(s => s.config.brokerId == controllerId).head.kafkaController
+    brokersToShutdown.map(broker => controller.skipControlledShutdownSafetyCheck(
+      broker.config.brokerId, controller.controllerContext.liveBrokerIdAndEpochs(broker.config.brokerId), {case _ => {}}));
+    brokersToShutdown(0).shutdown()
+    waitForPartitionUnderMinISRState(tp, false)
+    brokersToShutdown.takeRight(2).foreach(_.shutdown())
+    checkPartitionOfflineStatus(true, tp)
+
+    // bring up the brokers and check replicas are alive
+    brokersToShutdown.foreach(_.startup())
+    waitForPartitionUnderMinISRState(tp, false)
+    checkPartitionOfflineStatus(false, tp)
+  }
 
   private def waitForPartitionUnderMinISRState(tp: TopicPartition, shouldBeUnderMinISR: Boolean): Unit = {
     TestUtils.waitUntilTrue(() => {
@@ -69,5 +110,21 @@ class PartitionLoggingTest extends IntegrationTestHarness{
         case _ => false
       }
     }, "the partition's UnderMinISR state should be " + shouldBeUnderMinISR)
+  }
+
+  private def checkPartitionOfflineStatus(offlinePartitionExist: Boolean, tp: TopicPartition): Unit = {
+    TestUtils.waitUntilTrue(() => {
+      val partitionStateOpt = zkClient.getTopicPartitionState(tp)
+      offlinePartitionExist == (partitionStateOpt.get.leaderAndIsr.leader == -1)
+    }, "the partition should have leader " + {if (offlinePartitionExist)  "equal -1" else "not equal -1"})
+
+    val offlinePartitionsCountGauge = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .find { case (k, _) => k.getName.endsWith("OfflinePartitionsCount") }
+      .getOrElse(throw new AssertionError( "Unable to find metric OfflinePartitionsCount"))
+      ._2.asInstanceOf[Gauge[Int]]
+
+    // there are also other topics, e.g., 5 offset topics, so by shutting down brokers to result in offline partitions,
+    // we do not check the exact number of offlinePartitionsCount, but only check whether it is greater than 0
+    assertEquals(offlinePartitionExist, offlinePartitionsCountGauge.value() > 0)
   }
 }

--- a/core/src/test/scala/unit/kafka/integration/PartitionLoggingTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/PartitionLoggingTest.scala
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 
 import java.util.Properties
-import scala.collection.Seq
 import scala.jdk.CollectionConverters.mapAsScalaMapConverter
 
 class PartitionLoggingTest extends IntegrationTestHarness{

--- a/core/src/test/scala/unit/kafka/integration/PartitionLoggingTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/PartitionLoggingTest.scala
@@ -73,7 +73,7 @@ class PartitionLoggingTest extends IntegrationTestHarness{
     val topicName = "test_3replicas"
     createTopic(topicName, Map(0 -> nonControllerBrokerIds), topicConfig)
     val tp = new TopicPartition(topicName, 0)
-    checkPartitionOfflineStatus(false, tp)
+    checkPartitionOfflineExists(false, tp)
 
     // get the brokers that have the replicas
     val partitionStateOpt = zkClient.getTopicPartitionState(tp)
@@ -89,12 +89,12 @@ class PartitionLoggingTest extends IntegrationTestHarness{
     brokersToShutdown(0).shutdown()
     waitForPartitionUnderMinISRState(tp, false)
     brokersToShutdown.takeRight(2).foreach(_.shutdown())
-    checkPartitionOfflineStatus(true, tp)
+    checkPartitionOfflineExists(true, tp)
 
     // bring up the brokers and check replicas are alive
     brokersToShutdown.foreach(_.startup())
     waitForPartitionUnderMinISRState(tp, false)
-    checkPartitionOfflineStatus(false, tp)
+    checkPartitionOfflineExists(false, tp)
   }
 
   private def waitForPartitionUnderMinISRState(tp: TopicPartition, shouldBeUnderMinISR: Boolean): Unit = {
@@ -111,7 +111,7 @@ class PartitionLoggingTest extends IntegrationTestHarness{
     }, "the partition's UnderMinISR state should be " + shouldBeUnderMinISR)
   }
 
-  private def checkPartitionOfflineStatus(offlinePartitionExist: Boolean, tp: TopicPartition): Unit = {
+  private def checkPartitionOfflineExists(offlinePartitionExist: Boolean, tp: TopicPartition): Unit = {
     TestUtils.waitUntilTrue(() => {
       val partitionStateOpt = zkClient.getTopicPartitionState(tp)
       offlinePartitionExist == (partitionStateOpt.get.leaderAndIsr.leader == -1)


### PR DESCRIPTION
TICKET = LIKAFKA-49420
LI_DESCRIPTION = Add integration tests for testing the recovery of Offline Partitions. After shutting down all brokers hosting the partition replicas, the partition goes to offline; After bringing up those brokers again, the partition goes online.
EXIT_CRITERIA = N/A