### PR TITLE
[LI-FIXUP] Fix checkstyle warning RequestChannelTest.scala

### DIFF
--- a/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
@@ -359,10 +359,10 @@ class RequestChannelTest {
   }
   @Test
   def testHistogram(): Unit = {
-    var props = new Properties()
+    val props = new Properties()
     props.put(KafkaConfig.ZkConnectProp, "127.0.0.1:2181")
     props.put(KafkaConfig.RequestMetricsTotalTimeBucketsProp, "0, 10, 30, 300")
-    var config = KafkaConfig.fromProps(props)
+    val config = KafkaConfig.fromProps(props)
     val requestMetrics = new RequestMetrics("RequestMetrics", config)
     val boundaries = Array(0, 10, 30, 300)
     val histogram = new requestMetrics.Histogram("TotalTime", "Ms", boundaries)


### PR DESCRIPTION
This should be a direct fix-up to 
- `e99f81c` Add support for request TotalTimeMs latency histograms (#423)

EXIT_CRITERIA = N/A

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
