### PR TITLE
[LI-FIXUP] Rollback to original replicas instead of original alive replicas on parition assignment cancellation

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2322,7 +2322,7 @@ class KafkaController(val config: KafkaConfig,
             val aliveOriginalReplicas = replicaAssignment.originReplicas.toSet.intersect(controllerContext.liveBrokerIds);
             if (aliveOriginalReplicas.size >= config.liMinOriginalAliveReplicas) {
               // If there are enough original replicas alive (to maintain minISR), we allow the cancellation to go through
-              Right(aliveOriginalReplicas.toSeq)
+              Right(replicaAssignment.originReplicas)
             } else {
               // If there are not enough alive replicas in the original set, we don't allow the cancellation to go though.
               Left(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,


### PR DESCRIPTION
This is a fix up for the previous PR #442 .

The change in #442 make Kafka to roll back to alive brokers during partition movement cancellation. This will cause RF to decrease if a broker is dead in orgininal replica set, and it is not recoverable by Kafka itself. Either CC or human intervention is needed to move the partition out of that state.

Instead, we should rollback to the original RS during cancellation. It doesn't matter even if there are dead brokers in the original RS. If the original leader dies, Kafka will move the leader to an alive broker of the original RS.