### PR TITLE
LIKAFKA-49497: Extend ZK pagination option to handle /config/topics

### DIFF
--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -548,8 +548,11 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
    */
   def getAllTopicsInCluster(registerWatch: Boolean = false): Set[String] = {
     val getChildrenResponse = retryRequestUntilConnected(
-      if (paginateTopics) GetChildrenPaginatedRequest(TopicsZNode.path, registerWatch)
-        else GetChildrenRequest(TopicsZNode.path, registerWatch))
+      if (paginateTopics) {
+        debug(s"upgrading GetChildrenRequest to GetChildrenPaginatedRequest for '${TopicsZNode.path}'")
+        GetChildrenPaginatedRequest(TopicsZNode.path, registerWatch)
+      } else
+        GetChildrenRequest(TopicsZNode.path, registerWatch))
     getChildrenResponse.resultCode match {
       case Code.OK => getChildrenResponse.children.toSet
       case Code.NONODE => Set.empty
@@ -893,12 +896,27 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
    * @return list of child node names
    */
   def getChildren(path : String): Seq[String] = {
-    val getChildrenResponse = retryRequestUntilConnected(GetChildrenRequest(path, registerWatch = true))
+    val getChildrenResponse = retryRequestUntilConnected(
+      if (shouldPaginate(path)) {
+        debug(s"upgrading GetChildrenRequest to GetChildrenPaginatedRequest for '${path}'")
+        GetChildrenPaginatedRequest(path, registerWatch = true)
+      } else
+        GetChildrenRequest(path, registerWatch = true))
     getChildrenResponse.resultCode match {
       case Code.OK => getChildrenResponse.children
       case Code.NONODE => Seq.empty
       case _ => throw getChildrenResponse.resultException.get
     }
+  }
+
+  /**
+   * Returns true if ZK pagination is enabled and the specified path may have an excessive number of children.
+   * (Sole concerns currently are /brokers/topics and /config/topics, both of which are nominally unbounded.)
+   * @param path Zookeeper path to enumerate
+   * @return whether to use GetChildrenPaginated for the request due to possible excessive response size
+   */
+  private def shouldPaginate(path : String): Boolean = {
+    paginateTopics && path.endsWith("/topics")
   }
 
   /**

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -900,8 +900,10 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
       if (shouldPaginate(path)) {
         debug(s"upgrading GetChildrenRequest to GetChildrenPaginatedRequest for '${path}'")
         GetChildrenPaginatedRequest(path, registerWatch = true)
-      } else
-        GetChildrenRequest(path, registerWatch = true))
+      } else {
+        GetChildrenRequest(path, registerWatch = true)
+      }
+    )
     getChildrenResponse.resultCode match {
       case Code.OK => getChildrenResponse.children
       case Code.NONODE => Seq.empty

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -551,8 +551,10 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
       if (paginateTopics) {
         debug(s"upgrading GetChildrenRequest to GetChildrenPaginatedRequest for '${TopicsZNode.path}'")
         GetChildrenPaginatedRequest(TopicsZNode.path, registerWatch)
-      } else
-        GetChildrenRequest(TopicsZNode.path, registerWatch))
+      } else {
+        GetChildrenRequest(TopicsZNode.path, registerWatch)
+      }
+    )
     getChildrenResponse.resultCode match {
       case Code.OK => getChildrenResponse.children.toSet
       case Code.NONODE => Set.empty


### PR DESCRIPTION
/config/topics is as big as /brokers/topics and therefore requires pagination as well, else the broker will fail to start when there are too many topics. (Specifically, the ZK server disconnects with "Packet len 4544613 is out of range!" but the broker sees only a session-timeout error and therefore retries indefinitely.)

Tested directly on a dev-test cluster with a topics-znode getChildren size as above; previously stuck brokers were able to start and function normally.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
