### PR TITLE
[LI-HOTFIX] Disable totalTimeBucketHist on non-fetch/produce requests

### DIFF
--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1122,7 +1122,8 @@ class SocketServerTest {
 
       val requestMetrics = channel.metrics(request.header.apiKey.name)
       def totalTimeHistCount(): Long = requestMetrics.totalTimeHist.count
-      def getTotalTimeBucketHistCount(): Map[Int, Long] = requestMetrics.totalTimeBucketHist.boundaryCounterMap
+      assertTrue(requestMetrics.totalTimeBucketHist.isDefined)
+      def getTotalTimeBucketHistCount(): Map[Int, Long] = requestMetrics.totalTimeBucketHist.get.boundaryCounterMap
         .map({case (boundary, (name, counter)) => (boundary, counter.count())}).toMap
       val originalTotalTimeBucketHistCount = getTotalTimeBucketHistCount()
       val send = new NetworkSend(request.context.connectionId, ByteBufferSend.sizePrefixed(ByteBuffer.allocate(responseBufferSize)))


### PR DESCRIPTION
LI_DESCRIPTION =
This PR is to disable totalTimeBucketHist on non-fetch/produce requests. totalTimeBucketHist is used for latency SLOs estimation, so we do not really need these metrics for request types other than fetch and produce type. If we enable totalTimeBucketHist on all request types, we would have a total number of [numberOfBuckets * numberOfRequestTypes] metrics on each broker. Now we are adding a relatively big number of buckets, so the total number of metrics related to totalTimeBucketHist is relatively big if we still enable it for all request types (e.g., 16 buckets would result in more than 2400 metrics). 

EXIT_CRITERIA = N/A