### PR TITLE
[LI-CHERRY-PICK] KAFKA-9023: Log request destination when the Producer gets disconnected

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -704,8 +704,8 @@ public class Sender implements Runnable {
      * e.g "NETWORK_EXCEPTION. Error Message: Disconnected from node 0"
      */
     private String formatErrMsg(ProduceResponse.PartitionResponse response) {
-    String errorMessageSuffix = (response.errorMessage == null || response.errorMessage.isEmpty()) ?
-        "" : String.format(". Error Message: %s", response.errorMessage);
+        String errorMessageSuffix = (response.errorMessage == null || response.errorMessage.isEmpty()) ?
+            "" : String.format(". Error Message: %s", response.errorMessage);
         return String.format("%s%s", response.error, errorMessageSuffix);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -330,6 +330,10 @@ public class ProduceResponse extends AbstractResponse {
             this(error, INVALID_OFFSET, RecordBatch.NO_TIMESTAMP, INVALID_OFFSET);
         }
 
+        public PartitionResponse(Errors error, String errorMessage) {
+            this(error, INVALID_OFFSET, RecordBatch.NO_TIMESTAMP, INVALID_OFFSET, Collections.emptyList(), errorMessage);
+        }
+
         public PartitionResponse(Errors error, long baseOffset, long logAppendTime, long logStartOffset) {
             this(error, baseOffset, logAppendTime, logStartOffset, Collections.emptyList(), null);
         }


### PR DESCRIPTION
As a part of pm action of [GCN-38555](https://jira01.corp.linkedin.com:8443/browse/GCN-38555), we want to add broker information when producer gets disconnected. This change has already being made in open source kafka 2.8 version in [KAFKA-9023](https://issues.apache.org/jira/browse/KAFKA-9023) which is being back-ported. 

Internal Issue link - https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-51879


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
