### PR TITLE
[LI-HOTFIX] Fix race condition that blocks alterIsr request queue

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -342,7 +342,12 @@ class BrokerToControllerRequestThread(
     } else if (response.responseBody().errorCounts().containsKey(Errors.NOT_CONTROLLER)) {
       // just close the controller connection and wait for metadata cache update in doWork
       activeControllerAddress().foreach { controllerAddress => {
-        networkClient.disconnect(controllerAddress.idString)
+        try {
+          // We don't care if disconnect has an error, just log it and get a new network client
+          networkClient.disconnect(controllerAddress.idString)
+        } catch {
+          case t: Throwable => error("Had an error while disconnecting from NetworkClient.", t)
+        }
       }}
 
       requestQueue.putFirst(queueItem)


### PR DESCRIPTION
TICKET = LIKAFKA-52126 LIKAFKA-52185
EXIT_CRITERIA = Until rebasing to a release that includes apache/kafka#13159

The patch is included as a part of apache/kafka#13159.

There's a race condition that can cause an unchecked exception thrown
```
2023/04/11 00:45:31.342 ERROR [NetworkClient] [BrokerToControllerChannelManager broker=5678 name=alterIsr] [kafka-server] [] [BrokerToControllerChannelManager broker=5678 name=alterIsr] Uncaught error in request completion:
java.lang.IllegalStateException: No entry found for connection 5674
```

in this loop
```scala
activeControllerAddress().foreach { controllerAddress => {
  networkClient.disconnect(controllerAddress.idString)
}}
```

When this happens, the following line is not executed,
```scala
requestQueue.putFirst(queueItem)
```
 and the `queueItem` is lost forever.

This cause the corresponding [`clearInFlightRequest()`](https://github.com/linkedin/kafka/blob/bb63ee6a4d375d7dd2cef7109acf21562640e17a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala#L135) never executed, and the **whole alterIsrRequest queue is blocked forever**.

This basically ruins the foundation of Kafka's monitoring and operations, because almost everything relies on ISR expansion, and fail to expand ISR basically prevents us from doing any kind of surgery.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
