### PR TITLE
[LI-HOTFIX] Add observability into AlterIsrManager

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -267,11 +267,6 @@ class Partition(val topicPartition: TopicPartition,
 
   private val tags = Map("topic" -> topic, "partition" -> partitionId.toString)
 
-//  val isrStatesToCreateMetrics: Set[Class[_ <: IsrState]] = Set(
-//    classOf[PendingExpandIsr],
-//    classOf[PendingShrinkIsr],
-//    classOf[CommittedIsr],
-//  )
   newGauge("UnderReplicated", () => if (isUnderReplicated) 1 else 0, tags)
   newGauge("InSyncReplicasCount", () => if (isLeader) isrState.isr.size else 0, tags)
   newGauge("UnderMinIsr", () => if (isUnderMinIsr) 1 else 0, tags)

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -19,6 +19,7 @@ package kafka.cluster
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.Optional
 import kafka.api.{ApiVersion, LeaderAndIsr}
+import kafka.cluster.Partition.ISR_STATES_TO_CREATE_METRICS
 import kafka.common.UnexpectedAppendOffsetException
 import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log._
@@ -66,6 +67,11 @@ class DelayedOperations(topicPartition: TopicPartition,
 }
 
 object Partition extends KafkaMetricsGroup {
+  val ISR_STATES_TO_CREATE_METRICS: Set[Class[_ <: IsrState]] = Set(
+    classOf[PendingExpandIsr],
+    classOf[PendingShrinkIsr],
+    classOf[CommittedIsr],
+  )
   def apply(topicPartition: TopicPartition,
             time: Time,
             replicaManager: ReplicaManager): Partition = {
@@ -109,6 +115,7 @@ object Partition extends KafkaMetricsGroup {
     removeMetric("ReplicasCount", tags)
     removeMetric("LastStableOffsetLag", tags)
     removeMetric("AtMinIsr", tags)
+    ISR_STATES_TO_CREATE_METRICS.foreach(c => removeMetric(s"${c.getSimpleName}", tags))
   }
 }
 
@@ -260,19 +267,18 @@ class Partition(val topicPartition: TopicPartition,
 
   private val tags = Map("topic" -> topic, "partition" -> partitionId.toString)
 
+//  val isrStatesToCreateMetrics: Set[Class[_ <: IsrState]] = Set(
+//    classOf[PendingExpandIsr],
+//    classOf[PendingShrinkIsr],
+//    classOf[CommittedIsr],
+//  )
   newGauge("UnderReplicated", () => if (isUnderReplicated) 1 else 0, tags)
   newGauge("InSyncReplicasCount", () => if (isLeader) isrState.isr.size else 0, tags)
   newGauge("UnderMinIsr", () => if (isUnderMinIsr) 1 else 0, tags)
   newGauge("AtMinIsr", () => if (isAtMinIsr) 1 else 0, tags)
   newGauge("ReplicasCount", () => if (isLeader) assignmentState.replicationFactor else 0, tags)
   newGauge("LastStableOffsetLag", () => log.map(_.lastStableOffsetLag).getOrElse(0), tags)
-  Seq(
-    classOf[PendingExpandIsr],
-    classOf[PendingShrinkIsr],
-    classOf[CommittedIsr],
-  ).foreach((c: Class[_ <: IsrState]) =>
-    newGauge(s"${c.getSimpleName}", () => if (isrStateClass.equals(c)) 1 else 0, tags)
-  )
+  ISR_STATES_TO_CREATE_METRICS.foreach(c => newGauge(s"${c.getSimpleName}", () => if (isrStateClass.equals(c)) 1 else 0, tags))
 
   def isrStateClass: Class[_ <: IsrState] = isrState.getClass
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -266,6 +266,15 @@ class Partition(val topicPartition: TopicPartition,
   newGauge("AtMinIsr", () => if (isAtMinIsr) 1 else 0, tags)
   newGauge("ReplicasCount", () => if (isLeader) assignmentState.replicationFactor else 0, tags)
   newGauge("LastStableOffsetLag", () => log.map(_.lastStableOffsetLag).getOrElse(0), tags)
+  Seq(
+    classOf[PendingExpandIsr],
+    classOf[PendingShrinkIsr],
+    classOf[CommittedIsr],
+  ).foreach((c: Class[_ <: IsrState]) =>
+    newGauge(s"${c.getName}", () => if (isrStateClass.equals(c)) 1 else 0, tags)
+  )
+
+  def isrStateClass: Class[_ <: IsrState] = isrState.getClass
 
   def isUnderReplicated: Boolean = isLeader && (assignmentState.replicationFactor - isrState.isr.size) > 0
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -271,7 +271,7 @@ class Partition(val topicPartition: TopicPartition,
     classOf[PendingShrinkIsr],
     classOf[CommittedIsr],
   ).foreach((c: Class[_ <: IsrState]) =>
-    newGauge(s"${c.getName}", () => if (isrStateClass.equals(c)) 1 else 0, tags)
+    newGauge(s"${c.getSimpleName}", () => if (isrStateClass.equals(c)) 1 else 0, tags)
   )
 
   def isrStateClass: Class[_ <: IsrState] = isrState.getClass

--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -63,6 +63,15 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: BrokerToControll
   // Used to allow only one in-flight request at a time
   private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
 
+  // Additional observability into the internal states
+  private val baseMetricTags = Map("class" -> getClass.getName)
+  @volatile private var lastInflightRequestLockTimeMs = time.milliseconds()
+  newGauge("unsentItemQueueSize", () => unsentItemQueue.size, baseMetricTags)
+  newGauge("inflightRequest", () => if (inflightRequest.get()) 1 else 0)
+  // This is to indicate how long the latest request is waiting for response (either completed, timeout, error, or retried)
+  newGauge("currentInflightRequestElapsedTimeMs",
+           () => if (!inflightRequest.get()) 0 else time.milliseconds() - lastInflightRequestLockTimeMs)
+
   override def start(): Unit = {
     controllerChannelManager.start()
   }
@@ -80,6 +89,8 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: BrokerToControll
   private[server] def maybeSendRequest(): Unit = {
     // Send all pending items if there is not already a request in-flight.
     if ((!unsentItemQueue.isEmpty || !inflightItems.isEmpty) && inflightRequest.compareAndSet(false, true)) {
+      lastInflightRequestLockTimeMs = time.milliseconds()
+
       // Copy current unsent ISRs but don't remove from the map, they get cleared in the response handler
       while (!unsentItemQueue.isEmpty) {
         val item = unsentItemQueue.poll()

--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -68,12 +68,13 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: BrokerToControll
   private val baseMetricTags = Map("class" -> getClass.getName)
   @volatile private var lastInflightRequestLockTimeMs = time.milliseconds()
   @VisibleForTesting private[server] val unsentItemQueueSizeGauge = newGauge("unsentItemQueueSize", () => unsentItemQueue.size, baseMetricTags)
-  @VisibleForTesting private[server] val inflightRequestGauge = newGauge("inflightRequest", () => if (inflightRequest.get()) 1 else 0)
+  @VisibleForTesting private[server] val inflightRequestGauge = newGauge("inflightRequest", () => if (inflightRequest.get()) 1 else 0, baseMetricTags)
   // This is to indicate how long the latest request is waiting for response (either completed, timeout, error, or retried)
   @VisibleForTesting private[server] val currentInflightRequestElapsedTimeGauge =
     newGauge("currentInflightRequestElapsedTimeMs",
              () => if (!inflightRequest.get()) 0
-                   else time.milliseconds() - lastInflightRequestLockTimeMs)
+                   else time.milliseconds() - lastInflightRequestLockTimeMs,
+             baseMetricTags)
 
   override def start(): Unit = {
     controllerChannelManager.start()

--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -71,8 +71,9 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: BrokerToControll
   @VisibleForTesting private[server] val inflightRequestGauge = newGauge("inflightRequest", () => if (inflightRequest.get()) 1 else 0)
   // This is to indicate how long the latest request is waiting for response (either completed, timeout, error, or retried)
   @VisibleForTesting private[server] val currentInflightRequestElapsedTimeGauge =
-    newGauge("currentInflightRequestElapsedTimeMs", () => if (!inflightRequest.get()) 0
-                                                                 else time.milliseconds() - lastInflightRequestLockTimeMs)
+    newGauge("currentInflightRequestElapsedTimeMs",
+             () => if (!inflightRequest.get()) 0
+                   else time.milliseconds() - lastInflightRequestLockTimeMs)
 
   override def start(): Unit = {
     controllerChannelManager.start()

--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import com.google.common.annotations.VisibleForTesting
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils.{Logging, Scheduler}
 import org.apache.kafka.clients.ClientResponse
@@ -66,11 +67,12 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: BrokerToControll
   // Additional observability into the internal states
   private val baseMetricTags = Map("class" -> getClass.getName)
   @volatile private var lastInflightRequestLockTimeMs = time.milliseconds()
-  newGauge("unsentItemQueueSize", () => unsentItemQueue.size, baseMetricTags)
-  newGauge("inflightRequest", () => if (inflightRequest.get()) 1 else 0)
+  @VisibleForTesting private[server] val unsentItemQueueSizeGauge = newGauge("unsentItemQueueSize", () => unsentItemQueue.size, baseMetricTags)
+  @VisibleForTesting private[server] val inflightRequestGauge = newGauge("inflightRequest", () => if (inflightRequest.get()) 1 else 0)
   // This is to indicate how long the latest request is waiting for response (either completed, timeout, error, or retried)
-  newGauge("currentInflightRequestElapsedTimeMs",
-           () => if (!inflightRequest.get()) 0 else time.milliseconds() - lastInflightRequestLockTimeMs)
+  @VisibleForTesting private[server] val currentInflightRequestElapsedTimeGauge =
+    newGauge("currentInflightRequestElapsedTimeMs", () => if (!inflightRequest.get()) 0
+                                                                 else time.milliseconds() - lastInflightRequestLockTimeMs)
 
   override def start(): Unit = {
     controllerChannelManager.start()

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -288,7 +288,7 @@ class ReplicaManager(val config: KafkaConfig,
     classOf[PendingShrinkIsr],
     classOf[CommittedIsr],
   ).foreach((c: Class[_ <: IsrState]) =>
-    newGauge(s"${c.getName}PartitionCount", () => leaderPartitionsIterator.count(_.isrStateClass.equals(c)))
+    newGauge(s"${c.getSimpleName}PartitionCount", () => leaderPartitionsIterator.count(_.isrStateClass.equals(c)))
   )
 
   def reassigningPartitionsCount: Int = leaderPartitionsIterator.count(_.isReassigning)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.concurrent.locks.Lock
 import com.yammer.metrics.core.Meter
 import kafka.api._
-import kafka.cluster.{BrokerEndPoint, CommittedIsr, IsrState, Partition, PendingExpandIsr, PendingShrinkIsr}
+import kafka.cluster.{BrokerEndPoint, Partition}
 import kafka.common.RecordValidationException
 import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log._
@@ -283,11 +283,7 @@ class ReplicaManager(val config: KafkaConfig,
   newGauge("AtMinIsrPartitionCount", () => leaderPartitionsIterator.count(_.isAtMinIsr))
   newGauge("OneAboveMinIsrPartitionCount", () => leaderPartitionsIterator.count(_.isOneAboveMinIsr))
   newGauge("ReassigningPartitions", () => reassigningPartitionsCount)
-  Seq(
-    classOf[PendingExpandIsr],
-    classOf[PendingShrinkIsr],
-    classOf[CommittedIsr],
-  ).foreach((c: Class[_ <: IsrState]) =>
+  Partition.ISR_STATES_TO_CREATE_METRICS.foreach(c =>
     newGauge(s"${c.getSimpleName}PartitionCount", () => leaderPartitionsIterator.count(_.isrStateClass.equals(c)))
   )
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -61,7 +61,6 @@ import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.image.{LocalReplicaChanges, MetadataImage, TopicsDelta}
 
-import scala.collection.generic.Shrinkable
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.compat.java8.OptionConverters._

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.concurrent.locks.Lock
 import com.yammer.metrics.core.Meter
 import kafka.api._
-import kafka.cluster.{BrokerEndPoint, Partition}
+import kafka.cluster.{BrokerEndPoint, CommittedIsr, IsrState, Partition, PendingExpandIsr, PendingShrinkIsr}
 import kafka.common.RecordValidationException
 import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log._
@@ -61,6 +61,7 @@ import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.image.{LocalReplicaChanges, MetadataImage, TopicsDelta}
 
+import scala.collection.generic.Shrinkable
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.compat.java8.OptionConverters._
@@ -283,6 +284,13 @@ class ReplicaManager(val config: KafkaConfig,
   newGauge("AtMinIsrPartitionCount", () => leaderPartitionsIterator.count(_.isAtMinIsr))
   newGauge("OneAboveMinIsrPartitionCount", () => leaderPartitionsIterator.count(_.isOneAboveMinIsr))
   newGauge("ReassigningPartitions", () => reassigningPartitionsCount)
+  Seq(
+    classOf[PendingExpandIsr],
+    classOf[PendingShrinkIsr],
+    classOf[CommittedIsr],
+  ).foreach((c: Class[_ <: IsrState]) =>
+    newGauge(s"${c.getName}PartitionCount", () => leaderPartitionsIterator.count(_.isrStateClass.equals(c)))
+  )
 
   def reassigningPartitionsCount: Int = leaderPartitionsIterator.count(_.isReassigning)
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1778,7 +1778,11 @@ class PartitionTest extends AbstractPartitionTest {
       "InSyncReplicasCount",
       "ReplicasCount",
       "LastStableOffsetLag",
-      "AtMinIsr")
+      "AtMinIsr",
+      "CommittedIsr",
+      "PendingExpandIsr",
+      "PendingShrinkIsr",
+    )
 
     def getMetric(metric: String): Option[Metric] = {
       KafkaYammerMetrics.defaultRegistry().allMetrics().asScala.filter { case (metricName, _) =>

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -59,7 +59,7 @@ class AlterIsrManagerTest {
     // The metrics created in previous tests (via newGauge(), etc.) would be created and cached, gauging the DefaultAlterIsrManager
     // in the previous test case.  So need to clear everything after each round.
     KafkaYammerMetrics.defaultRegistry().allMetrics().forEach((name, _) => {
-     KafkaYammerMetrics.defaultRegistry().removeMetric(name)
+      KafkaYammerMetrics.defaultRegistry().removeMetric(name)
     })
   }
 

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -20,7 +20,6 @@ package kafka.server
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 import kafka.api.LeaderAndIsr
-import kafka.metrics.KafkaYammerMetrics
 import kafka.utils.{MockScheduler, MockTime}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.ClientResponse
@@ -32,11 +31,10 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AlterIsrRequest, AlterIsrResponse}
 import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{Assertions, BeforeEach, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.{ArgumentMatchers, Mockito}
 
-import scala.concurrent.duration.Duration
 
 class AlterIsrManagerTest {
 

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
+
 import kafka.api.LeaderAndIsr
 import kafka.utils.{MockScheduler, MockTime}
 import kafka.zk.KafkaZkClient
@@ -34,7 +35,6 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.{ArgumentMatchers, Mockito}
-
 
 class AlterIsrManagerTest {
 

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -19,8 +19,8 @@ package kafka.server
 
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
-
 import kafka.api.LeaderAndIsr
+import kafka.metrics.KafkaYammerMetrics
 import kafka.utils.{MockScheduler, MockTime}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.ClientResponse
@@ -32,9 +32,11 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AlterIsrRequest, AlterIsrResponse}
 import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.{Assertions, BeforeEach, Test}
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.{ArgumentMatchers, Mockito}
+
+import scala.concurrent.duration.Duration
 
 class AlterIsrManagerTest {
 
@@ -65,6 +67,50 @@ class AlterIsrManagerTest {
     alterIsrManager.start()
     alterIsrManager.submit(AlterIsrItem(tp0, new LeaderAndIsr(1, 1, List(1,2,3), 10), _ => {}, 0))
     EasyMock.verify(brokerToController)
+  }
+
+  @Test
+  def testMetrics(): Unit = {
+    val capture = EasyMock.newCapture[AbstractRequest.Builder[AlterIsrRequest]]()
+    val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
+
+    EasyMock.expect(brokerToController.start())
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.capture(callbackCapture))).times(2)
+    EasyMock.replay(brokerToController)
+
+    val scheduler = new MockScheduler(time)
+    val alterIsrManager = new DefaultAlterIsrManager(brokerToController, scheduler, time, brokerId, () => 2)
+    alterIsrManager.start()
+    assertEquals(0, alterIsrManager.unsentItemQueueSizeGauge.value())
+    assertEquals(0, alterIsrManager.inflightRequestGauge.value())
+    assertEquals(0, alterIsrManager.currentInflightRequestElapsedTimeGauge.value())
+
+    alterIsrManager.submit(AlterIsrItem(tp0, new LeaderAndIsr(1, 1, List(1,2,3), 10), _ => {}, 0))
+    alterIsrManager.submit(AlterIsrItem(tp0, new LeaderAndIsr(1, 1, List(1,2), 10), _ => {}, 0))
+    val delay = 2000
+    time.sleep(delay)
+    assertEquals(1, alterIsrManager.unsentItemQueueSizeGauge.value())
+    assertEquals(1, alterIsrManager.inflightRequestGauge.value())
+    assertTrue(alterIsrManager.currentInflightRequestElapsedTimeGauge.value() == delay)
+
+    // Simulate response
+    val alterIsrResp = partitionResponse(tp0, Errors.NONE)
+    val resp = new ClientResponse(null, null, "", 0L, 0L,
+      false, null, null, alterIsrResp)
+    callbackCapture.getValue.onComplete(resp)
+
+    // 2nd request, unsent == empty
+    time.sleep(delay * 2)
+    assertEquals(0, alterIsrManager.unsentItemQueueSizeGauge.value())
+    assertEquals(1, alterIsrManager.inflightRequestGauge.value())
+    assertTrue(alterIsrManager.currentInflightRequestElapsedTimeGauge.value() == delay * 2)
+
+    // Cleared all
+    time.sleep(delay * 2)
+    callbackCapture.getValue.onComplete(resp)
+    assertEquals(0, alterIsrManager.unsentItemQueueSizeGauge.value())
+    assertEquals(0, alterIsrManager.inflightRequestGauge.value())
+    assertTrue(alterIsrManager.currentInflightRequestElapsedTimeGauge.value() == 0)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -19,8 +19,8 @@ package kafka.server
 
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
-
 import kafka.api.LeaderAndIsr
+import kafka.metrics.KafkaYammerMetrics
 import kafka.utils.{MockScheduler, MockTime}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.ClientResponse
@@ -32,7 +32,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AlterIsrRequest, AlterIsrResponse}
 import org.easymock.EasyMock
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.{ArgumentMatchers, Mockito}
 
@@ -52,6 +52,15 @@ class AlterIsrManagerTest {
   @BeforeEach
   def setup(): Unit = {
     brokerToController = EasyMock.createMock(classOf[BrokerToControllerChannelManager])
+  }
+
+  @AfterEach
+  def tearDown(): Unit = {
+    // The metrics created in previous tests (via newGauge(), etc.) would be created and cached, gauging the DefaultAlterIsrManager
+    // in the previous test case.  So need to clear everything after each round.
+    KafkaYammerMetrics.defaultRegistry().allMetrics().forEach((name, _) => {
+     KafkaYammerMetrics.defaultRegistry().removeMetric(name)
+    })
   }
 
   @Test


### PR DESCRIPTION
TICKET = LIKAFKA-52218
EXIT_CRITERIA = When upstream provides similar observability or when the `DefaultAlterIsrManager` mechanism is significantly changed

We learned that the observability of the channel from the broker to the controller is critical in a recent incident. In the recent incident, we encountered that the request queue of `DefaultAlterIsrManager` is stuck, causing the partitions on lead by the stuck broker to be unable to expand or shrink the ISR.

In this patch, we introduced the metrics to inspect
1. the request queue size
2. `inflightRequest` flag
3. how long has the latest request been pending

Also, this introduced per-partition metric to the inspect ISR state (committed/pending expand/pending shrink),
which is more likely to be looked at with the JMX console when debugging is needed than as inGraph metrics (because the per-partition cardinality would impose too much load on the monitoring infra).


*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
