### PR TITLE
[LI-FIXUP] Enhance metrics tag for `BrokerToControllerRequestManager`s 

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -65,7 +65,7 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: BrokerToControll
   private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
 
   // Additional observability into the internal states
-  private val baseMetricTags = Map("class" -> getClass.getName)
+  private val baseMetricTags = Map("requestManagerCategory" -> BrokerToControllerRequestManager.getClass.getSimpleName)
   @volatile private var lastInflightRequestLockTimeMs = time.milliseconds()
   @VisibleForTesting private[server] val unsentItemQueueSizeGauge = newGauge("unsentItemQueueSize", () => unsentItemQueue.size, baseMetricTags)
   @VisibleForTesting private[server] val inflightRequestGauge = newGauge("inflightRequest", () => if (inflightRequest.get()) 1 else 0, baseMetricTags)

--- a/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerRequestManager.scala
@@ -65,7 +65,7 @@ abstract class AbstractBrokerToControllerRequestManager[Item <: BrokerToControll
   private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
 
   // Additional observability into the internal states
-  private val baseMetricTags = Map("requestManagerCategory" -> BrokerToControllerRequestManager.getClass.getSimpleName)
+  private val baseMetricTags = Map("requestManagerCategory" -> BrokerToControllerRequestManager.getClass.getSimpleName.replaceAll("\\$$", ""))
   @volatile private var lastInflightRequestLockTimeMs = time.milliseconds()
   @VisibleForTesting private[server] val unsentItemQueueSizeGauge = newGauge("unsentItemQueueSize", () => unsentItemQueue.size, baseMetricTags)
   @VisibleForTesting private[server] val inflightRequestGauge = newGauge("inflightRequest", () => if (inflightRequest.get()) 1 else 0, baseMetricTags)


### PR DESCRIPTION
This should be a direct fix-up to the commit
- e37eaa0 [LI-HOTFIX] Add observability into AlterIsrManager (#453)

EXIT_CRITERIA = When the corresponding commit is dropped

Using this tag, the `kafka-server` can generate inGraph metrics for both `DefaultAlterIsrManager` and `TransferLeaderManager` (or even future broker-to-controller channel) together with one regex query
```
"kafka.server:type=*,name=*,requestManagerCategory=BrokerToControllerRequestManager"
```


*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
