### PR TITLE
Add new RecommendedLeaderElectionCommand to support recommended-leader elections from the command line

### DIFF
--- a/bin/kafka-recommended-leader-election.sh
+++ b/bin/kafka-recommended-leader-election.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.RecommendedLeaderElectionCommand "$@"

--- a/core/src/main/scala/kafka/admin/LeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/LeaderElectionCommand.scala
@@ -46,7 +46,7 @@ object LeaderElectionCommand extends Logging {
     val commandOptions = new LeaderElectionCommandOptions(args)
     CommandLineUtils.printHelpAndExitIfNeeded(
       commandOptions,
-      "This tool attempts to elect a new leader for a set of topic partitions. The type of elections supported are preferred replicas and unclean replicas."
+      "This tool attempts to elect a new leader for a set of topic partitions. The type of elections supported are preferred replicas and unclean replicas. For recommended-leader elections, use RecommendedLeaderElectionCommand instead."
     )
 
     validate(commandOptions)
@@ -65,9 +65,9 @@ object LeaderElectionCommand extends Logging {
       case _ => None
     }
 
-    /* Note: No need to look at --all-topic-partitions as we want this to be None if it is use.
-     * The validate function should be checking that this option is required if the --topic and --path-to-json-file
-     * are not specified.
+    /* Note: No need to look at --all-topic-partitions as we want this value to be None if it is used.
+     * The validate function should be checking that the --all-topic-partitions option is required if
+     * neither --topic nor --path-to-json-file is specified.
      */
     val topicPartitions = jsonFileTopicPartitions.orElse(singleTopicPartition)
 
@@ -249,7 +249,7 @@ private final class LeaderElectionCommandOptions(args: Array[String]) extends Co
   val pathToJsonFile = parser
     .accepts(
       "path-to-json-file",
-      "The JSON file with the list  of partition for which leader elections should be performed. This is an example format. \n{\"partitions\":\n\t[{\"topic\": \"foo\", \"partition\": 1},\n\t {\"topic\": \"foobar\", \"partition\": 2}]\n}\nNot allowed if --all-topic-partitions or --topic flags are specified.")
+      "The JSON file with the list  of partitions for which leader elections should be performed. This is an example format: \n{\"partitions\":\n\t[{\"topic\": \"foo\", \"partition\": 1},\n\t {\"topic\": \"foobar\", \"partition\": 2}]\n}\nNot allowed if either the --all-topic-partitions flag or --topic flag is specified.")
     .withRequiredArg
     .describedAs("Path to JSON file")
     .ofType(classOf[String])
@@ -257,7 +257,7 @@ private final class LeaderElectionCommandOptions(args: Array[String]) extends Co
   val topic = parser
     .accepts(
       "topic",
-      "Name of topic for which to perform an election. Not allowed if --path-to-json-file or --all-topic-partitions is specified.")
+      "Name of the topic for which to perform an election. Not allowed if --path-to-json-file or --all-topic-partitions is specified.")
     .withRequiredArg
     .describedAs("topic name")
     .ofType(classOf[String])
@@ -278,7 +278,7 @@ private final class LeaderElectionCommandOptions(args: Array[String]) extends Co
   val electionType = parser
     .accepts(
       "election-type",
-      "Type of election to attempt. Possible values are \"preferred\" for preferred leader election or \"unclean\" for unclean leader election. If preferred election is selection, the election is only performed if the current leader is not the preferred leader for the topic partition. If unclean election is selected, the election is only performed if there are no leader for the topic partition. REQUIRED.")
+      "Type of election to attempt. Possible values are \"preferred\" for preferred leader election or \"unclean\" for unclean leader election. (For \"recommended\" leader elections, please use RecommendedLeaderElectionCommand instead.) If preferred election is selected, the election is performed only if the current leader is not the preferred leader for the topic partition. If unclean election is selected, the election is performed only if there are no leaders for the topic partition. REQUIRED.")
     .withRequiredArg
     .describedAs("election type")
     .withValuesConvertedBy(ElectionTypeConverter)

--- a/core/src/main/scala/kafka/admin/RecommendedLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/RecommendedLeaderElectionCommand.scala
@@ -18,7 +18,6 @@ package kafka.admin
 
 import java.util.{Optional, Properties}
 import java.util.concurrent.ExecutionException
-import joptsimple.util.EnumConverter
 import kafka.common.AdminCommandFailedException
 import kafka.utils.CommandDefaultOptions
 import kafka.utils.CommandLineUtils
@@ -27,7 +26,6 @@ import kafka.utils.Implicits._
 import kafka.utils.Json
 import kafka.utils.Logging
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
-import org.apache.kafka.common.ElectionType
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ClusterAuthorizationException
 import org.apache.kafka.common.errors.ElectionNotNeededException
@@ -40,10 +38,6 @@ import scala.concurrent.duration._
 
 object RecommendedLeaderElectionCommand extends Logging {
   val PREFERRED_BROKER_ENV = "PREFERRED_BROKERS"
-  val BACK_OFF_DURATION: Duration =  // FIXME? should this be a command-line option instead?
-    sys.env.get("BACK_OFF_DURATION")
-      .map(s => Duration(s.toInt, SECONDS))
-      .getOrElse(Duration(60, SECONDS))
 
   var preferredBrokers: Set[Int] = _
 
@@ -61,11 +55,28 @@ object RecommendedLeaderElectionCommand extends Logging {
 
     validate(commandOptions)
 
-    // This defines the healthy leaders from which to choose; it must exist. Comma-separated list of broker IDs.
-    preferredBrokers = sys.env.get(PREFERRED_BROKER_ENV)
+    // This (comma-separated) list of broker IDs defines the healthy leaders from which to choose. It is required.
+    val preferredBrokersOpt = 
+      if (commandOptions.options.has(commandOptions.preferredBrokers))
+        Option(commandOptions.options.valueOf(commandOptions.preferredBrokers))
+      else
+        sys.env.get(PREFERRED_BROKER_ENV)  // fall back to environment variable if flag is not defined
+
+    preferredBrokers = preferredBrokersOpt
       .map(_.split(",").toList.map(_.trim.toInt))
       .map(_.toSet)
-      .getOrElse(throw new IllegalArgumentException(s"Cannot parse env ${PREFERRED_BROKER_ENV}"))
+      .getOrElse(throw new IllegalArgumentException(
+        if (commandOptions.options.has(commandOptions.preferredBrokers))
+          s"Cannot parse option ${commandOptions.preferredBrokers.options().get(0)}"
+        else
+          s"Option ${commandOptions.preferredBrokers.options().get(0)} was not specified, and cannot parse env ${PREFERRED_BROKER_ENV}"
+      ))
+
+    val backoffDuration =
+      if (commandOptions.options.has(commandOptions.backoffSeconds))
+        Duration(commandOptions.options.valueOf(commandOptions.backoffSeconds), SECONDS)
+      else
+        Duration(60, SECONDS)
 
     val jsonFileTopicPartitions: Option[Map[TopicPartition, Integer]] =
       Option(commandOptions.options.valueOf(commandOptions.pathToJsonFile)).map { path  =>
@@ -104,14 +115,14 @@ object RecommendedLeaderElectionCommand extends Logging {
           val total = topicPartitions.size
           var processed = 0
           topicPartitions.grouped(100).foreach(partitionSubset => {
-            print(partitionSubset)
+            println(s"Processing ${partitionSubset} ...")
             electRecommendedLeaders(adminClient, partitionSubset)
             processed += partitionSubset.size
             if (processed == total) {
-              info(s"Finished processing $processed partitions.")
+              println(s"Finished processing $processed partitions.")
             } else {
-              info(s"Processed $processed/$total partitions. Sleeping ${BACK_OFF_DURATION.toSeconds} secs to avoid flooding...\n")
-              Thread.sleep(BACK_OFF_DURATION.toMillis)
+              print(s"Processed $processed/$total partitions. Sleeping ${backoffDuration.toSeconds} secs to avoid flooding...")
+              Thread.sleep(backoffDuration.toMillis)
               println(" done")
             }
           })
@@ -129,15 +140,16 @@ object RecommendedLeaderElectionCommand extends Logging {
   private[this] def parseReplicaElectionData(jsonString: String): Map[TopicPartition, Integer] = {
     Json.parseFull(jsonString) match {
       case Some(js) =>
-        js.asJsonObject.get("KafkaPartitionState").get.asJsonObject.get("urp") match {
+        //js.asJsonObject.get("KafkaPartitionState").get.asJsonObject.get("urp") match {
+        js.asJsonObject.get("partitions") match {
           case Some(partitionsList) =>
             val partitionsRaw = partitionsList.asJsonArray.iterator.map(_.asJsonObject)
             val partitionsWithNewLeader =
               partitionsRaw
                 .map { p =>
-                  // The logic here is predicated on the fact that the JSON's description of current leadership
-                  // and current ISR matches the controller's view, even if the controller's view is nominally
-                  // "wrong" (as in the "stuck AlterIsr" case of April 2023). Regardless of what the ISR _should_
+                  // The logic here is predicated on the assumption that the JSON's description of current leadership
+                  // and current ISR matches the controller's view, even if the controller's view is nominally "wrong"
+                  // (as was true in the "stuck AlterIsr" case of April 2023). Regardless of what the ISR _should_
                   // be, the controller is the one that "approves" the recommended leadership election, so "fixing"
                   // the ISR in the JSON view doesn't help: the controller won't switch leadership to a replica
                   // that's not in the controller's understanding of the ISR.
@@ -146,13 +158,13 @@ object RecommendedLeaderElectionCommand extends Logging {
                   val leader = p("leader").to[Int]
                   val inSync = p("in-sync").asJsonArray.iterator.map(_.to[Int]).toSet
                   if (inSync.size < 2) {
-                    warn(s"partition $topic-$partition has no other leader to choose. Skipping.")
+                    println(s"partition $topic-$partition has no other leader to choose. Skipping.")
                     None
                   } else if (inSync.intersect(preferredBrokers).isEmpty) {
-                    warn(s"partition $topic-$partition has no healthy leader to choose. Skipping.")
+                    println(s"partition $topic-$partition has no healthy leader to choose. Skipping.")
                     None
                   } else if (preferredBrokers.contains(leader)) {
-                    info(s"Skipping $topic-$partition as the current leader ${leader} is in the preferred/healthy set.")
+                    println(s"Skipping $topic-$partition as the current leader ${leader} is in the preferred/healthy set.")
                     None
                   } else{
                     val newLeader = new Integer((inSync - leader).intersect(preferredBrokers).head)
@@ -328,6 +340,23 @@ private final class RecommendedLeaderElectionCommandOptions(args: Array[String])
     .withRequiredArg
     .describedAs("the new leader")
     .ofType(classOf[Integer])
+
+  // a.k.a. healthyBrokers:
+  val preferredBrokers = parser
+    .accepts(
+      "preferred-brokers",
+      s"Comma-separated list of brokers considered healthy enough to be targets for leadership elections. REQUIRED if the ${RecommendedLeaderElectionCommand.PREFERRED_BROKER_ENV} environment variable is not set.")
+    .withRequiredArg
+    .describedAs("list of healthy broker IDs")
+    .ofType(classOf[String])
+
+  val backoffSeconds = parser
+    .accepts(
+      "backoff-seconds",
+      "Number of seconds to pause between each batch of 100 topic-partition leadership elections. Default: 60 sec.")
+    .withRequiredArg
+    .describedAs("seconds to pause")
+    .ofType(classOf[Long])
 
   options = parser.parse(args: _*)
 }

--- a/core/src/main/scala/kafka/admin/RecommendedLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/RecommendedLeaderElectionCommand.scala
@@ -1,0 +1,333 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.admin
+
+import java.util.{Optional, Properties}
+import java.util.concurrent.ExecutionException
+import joptsimple.util.EnumConverter
+import kafka.common.AdminCommandFailedException
+import kafka.utils.CommandDefaultOptions
+import kafka.utils.CommandLineUtils
+import kafka.utils.CoreUtils
+import kafka.utils.Implicits._
+import kafka.utils.Json
+import kafka.utils.Logging
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
+import org.apache.kafka.common.ElectionType
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.ClusterAuthorizationException
+import org.apache.kafka.common.errors.ElectionNotNeededException
+import org.apache.kafka.common.errors.TimeoutException
+import org.apache.kafka.common.utils.Utils
+
+import scala.jdk.CollectionConverters._
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+object RecommendedLeaderElectionCommand extends Logging {
+  val PREFERRED_BROKER_ENV = "PREFERRED_BROKERS"
+  val BACK_OFF_DURATION: Duration =  // FIXME? should this be a command-line option instead?
+    sys.env.get("BACK_OFF_DURATION")
+      .map(s => Duration(s.toInt, SECONDS))
+      .getOrElse(Duration(60, SECONDS))
+
+  var preferredBrokers: Set[Int] = _
+
+
+  def main(args: Array[String]): Unit = {
+    run(args, 30.second)
+  }
+
+  def run(args: Array[String], timeout: Duration): Unit = {
+    val commandOptions = new RecommendedLeaderElectionCommandOptions(args)
+    CommandLineUtils.printHelpAndExitIfNeeded(
+      commandOptions,
+      "This tool attempts to elect a new (recommended) leader for a set of topic partitions. To perform a preferred or unclean leader election, please use LeaderElectionCommand instead."
+    )
+
+    validate(commandOptions)
+
+    // This defines the healthy leaders from which to choose; it must exist. Comma-separated list of broker IDs.
+    preferredBrokers = sys.env.get(PREFERRED_BROKER_ENV)
+      .map(_.split(",").toList.map(_.trim.toInt))
+      .map(_.toSet)
+      .getOrElse(throw new IllegalArgumentException(s"Cannot parse env ${PREFERRED_BROKER_ENV}"))
+
+    val jsonFileTopicPartitions: Option[Map[TopicPartition, Integer]] =
+      Option(commandOptions.options.valueOf(commandOptions.pathToJsonFile)).map { path  =>
+        parseReplicaElectionData(Utils.readFileAsString(path))
+      }
+
+    val singleTopicPartition = (
+      Option(commandOptions.options.valueOf(commandOptions.topic)),
+      Option(commandOptions.options.valueOf(commandOptions.partition)),
+      Option(commandOptions.options.valueOf(commandOptions.newLeader)),
+    ) match {
+      case (Some(topic), Some(partition), Some(newLeader)) => Some(Map(new TopicPartition(topic, partition) -> newLeader))
+      case _ => None
+    }
+
+    val topicPartitionsOpt = jsonFileTopicPartitions.orElse(singleTopicPartition)
+
+    val adminClient = {
+      val props = Option(commandOptions.options.valueOf(commandOptions.adminClientConfig)).map { config =>
+        Utils.loadProps(config)
+      }.getOrElse(new Properties())
+
+      props.setProperty(
+        AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
+        commandOptions.options.valueOf(commandOptions.bootstrapServer)
+      )
+      props.setProperty(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, timeout.toMillis.toString)
+      props.setProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, (timeout.toMillis / 2).toString)
+
+      Admin.create(props)
+    }
+
+    try {
+      topicPartitionsOpt match {
+        case Some(topicPartitions) =>
+          val total = topicPartitions.size
+          var processed = 0
+          topicPartitions.grouped(100).foreach(partitionSubset => {
+            print(partitionSubset)
+            electRecommendedLeaders(adminClient, partitionSubset)
+            processed += partitionSubset.size
+            if (processed == total) {
+              info(s"Finished processing $processed partitions.")
+            } else {
+              info(s"Processed $processed/$total partitions. Sleeping ${BACK_OFF_DURATION.toSeconds} secs to avoid flooding...\n")
+              Thread.sleep(BACK_OFF_DURATION.toMillis)
+              println(" done")
+            }
+          })
+        case None =>
+          val message = "Topic-partitions must be explicitly specified but none were provided: nothing to do!"
+          println(message)
+          throw new AdminCommandFailedException(message)
+      }
+    } finally {
+      adminClient.close()
+    }
+  }
+
+  // Parse the provided JSON string and return the topic-partitions and their corresponding new leaders.
+  private[this] def parseReplicaElectionData(jsonString: String): Map[TopicPartition, Integer] = {
+    Json.parseFull(jsonString) match {
+      case Some(js) =>
+        js.asJsonObject.get("KafkaPartitionState").get.asJsonObject.get("urp") match {
+          case Some(partitionsList) =>
+            val partitionsRaw = partitionsList.asJsonArray.iterator.map(_.asJsonObject)
+            val partitionsWithNewLeader =
+              partitionsRaw
+                .map { p =>
+                  // The logic here is predicated on the fact that the JSON's description of current leadership
+                  // and current ISR matches the controller's view, even if the controller's view is nominally
+                  // "wrong" (as in the "stuck AlterIsr" case of April 2023). Regardless of what the ISR _should_
+                  // be, the controller is the one that "approves" the recommended leadership election, so "fixing"
+                  // the ISR in the JSON view doesn't help: the controller won't switch leadership to a replica
+                  // that's not in the controller's understanding of the ISR.
+                  val topic = p("topic").to[String]
+                  val partition = p("partition").to[Int]
+                  val leader = p("leader").to[Int]
+                  val inSync = p("in-sync").asJsonArray.iterator.map(_.to[Int]).toSet
+                  if (inSync.size < 2) {
+                    warn(s"partition $topic-$partition has no other leader to choose. Skipping.")
+                    None
+                  } else if (inSync.intersect(preferredBrokers).isEmpty) {
+                    warn(s"partition $topic-$partition has no healthy leader to choose. Skipping.")
+                    None
+                  } else if (preferredBrokers.contains(leader)) {
+                    info(s"Skipping $topic-$partition as the current leader ${leader} is in the preferred/healthy set.")
+                    None
+                  } else{
+                    val newLeader = new Integer((inSync - leader).intersect(preferredBrokers).head)
+                    Some((new TopicPartition(topic, partition), newLeader))
+                  }
+                }
+                // .collect {case Some((tp: TopicPartition, newLeader: Integer)) => (tp, newLeader)}
+                // somehow triggered a weird spotbugs failure:
+                // ```
+                // "Bug type UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"
+                // In method kafka.admin.RecommendedLeaderElectionCommand$$anonfun$1.applyOrElse(Option, Function1)
+                // superclass is scala.runtime.AbstractPartialFunction
+                // Did you intend to override scala.runtime.AbstractPartialFunction.applyOrElse(Object, Function1)
+                // ```
+                // => ended up using an equivalent but non-idiomatic or-else-null-then-filter-out pattern:
+                .map(_.orNull).filter(_ != null)
+                .toMap
+            val duplicatePartitions = CoreUtils.duplicates(partitionsWithNewLeader)
+            if (duplicatePartitions.nonEmpty) {
+              throw new AdminOperationException(
+                s"Replica election data contains duplicate partitions: ${duplicatePartitions.mkString(",")}"
+              )
+            }
+            partitionsWithNewLeader
+          case None => throw new AdminOperationException("Replica election data is missing \"partitions\" field")
+        }
+      case None => throw new AdminOperationException("Replica election data is empty")
+    }
+  }
+
+  private[this] def electRecommendedLeaders(
+    client: Admin,
+    topicPartitionsWithNewLeaders: Map[TopicPartition, Integer]
+  ): Unit = {
+    val electionResults: mutable.Map[TopicPartition, Optional[Throwable]] = try {
+      if (topicPartitionsWithNewLeaders != null) {
+        debug(s"Calling AdminClient.electRecommendedLeaders($topicPartitionsWithNewLeaders)")
+        client.electRecommendedLeaders(topicPartitionsWithNewLeaders.asJava).partitions.get.asScala
+      } else {
+        debug(s"electRecommendedLeaders() called with no partitions: nothing to do!")
+        mutable.Map.empty[TopicPartition, Optional[Throwable]]
+      }
+    } catch {
+      case e: ExecutionException =>
+        e.getCause match {
+          case cause: TimeoutException =>
+            val message = "Timeout waiting for election results"
+            println(message)
+            throw new AdminCommandFailedException(message, cause)
+          case cause: ClusterAuthorizationException =>
+            val message = "Not authorized to perform leader election"
+            println(message)
+            throw new AdminCommandFailedException(message, cause)
+          case _ =>
+            throw e
+        }
+      case e: Throwable =>
+        println("Error while making request")
+        throw e
+    }
+
+    val succeeded = mutable.Set.empty[TopicPartition]
+    val noop = mutable.Set.empty[TopicPartition]
+    val failed = mutable.Map.empty[TopicPartition, Throwable]
+
+    electionResults.foreach[Unit] { case (topicPartition, error) =>
+      if (error.isPresent) {
+        error.get match {
+          case _: ElectionNotNeededException => noop += topicPartition
+          case _ => failed += topicPartition -> error.get
+        }
+      } else {
+        succeeded += topicPartition
+      }
+    }
+
+    if (succeeded.nonEmpty) {
+      val partitions = succeeded.mkString(", ")
+      println(s"Successfully completed recommended leader election for partitions $partitions")
+    }
+
+    if (noop.nonEmpty) {
+      val partitions = noop.mkString(", ")
+      println(s"Valid replica already elected for partitions $partitions")
+    }
+
+    if (failed.nonEmpty) {
+      val rootException = new AdminCommandFailedException(s"${failed.size} replica(s) could not be elected")
+      failed.forKeyValue { (topicPartition, exception) =>
+        println(s"Error completing recommended leader election for partition: $topicPartition: $exception")
+        rootException.addSuppressed(exception)
+      }
+      throw rootException
+    }
+  }
+
+  private[this] def validate(commandOptions: RecommendedLeaderElectionCommandOptions): Unit = {
+    // required options: --bootstrap-server
+    var missingOptions = List.empty[String]
+    if (!commandOptions.options.has(commandOptions.bootstrapServer)) {
+      missingOptions = commandOptions.bootstrapServer.options().get(0) :: missingOptions
+    }
+
+    if (missingOptions.nonEmpty) {
+      throw new AdminCommandFailedException(s"Missing required option(s): ${missingOptions.mkString(", ")}")
+    }
+
+    // Two configurations are allowed:  (--topic AND --partition AND --leader) OR --path-to-json-file
+    (
+      commandOptions.options.has(commandOptions.topic),
+      commandOptions.options.has(commandOptions.partition),
+      commandOptions.options.has(commandOptions.newLeader),
+      commandOptions.options.has(commandOptions.pathToJsonFile)
+    ) match {
+      case (true, true, true, false) =>    // valid, don't throw
+      case (false, false, false, true) =>  // valid, don't throw
+      case _ =>
+        throw new AdminCommandFailedException(
+          "Exactly one of the following combinations is required: (1) " +
+          s"${commandOptions.pathToJsonFile.options().get(0)} OR (2) " +
+          s"${commandOptions.topic.options().get(0)}, ${commandOptions.partition.options().get(0)}, and " +
+          s"${commandOptions.newLeader.options().get(0)}. Mixtures of the two are not allowed."
+        )
+    }
+  }
+}
+
+private final class RecommendedLeaderElectionCommandOptions(args: Array[String]) extends CommandDefaultOptions(args) {
+  val bootstrapServer = parser
+    .accepts(
+      "bootstrap-server",
+      "A hostname and port for the broker to connect to, in the form host:port. Multiple comma-separated URLs can be given. REQUIRED.")
+    .withRequiredArg
+    .describedAs("host:port")
+    .ofType(classOf[String])
+
+  val adminClientConfig = parser
+    .accepts(
+      "admin.config",
+      "Configuration properties file to pass to the admin client.")
+    .withRequiredArg
+    .describedAs("config file")
+    .ofType(classOf[String])
+
+  val pathToJsonFile = parser
+    .accepts(
+      "path-to-json-file",
+      "The JSON file with the list  of partition for which leader elections should be performed. This is an example format. \n{\"partitions\":\n\t[{\"topic\": \"foo\", \"partition\": 1, \"leader\": 8001, \"in-sync\": [6221, 1309, 8001]},\n\t {\"topic\": \"foobar\", \"partition\": 2, \"leader\": 7911, \"in-sync\": [5577, 7911, 7174]}]\n}\nNot allowed if --topic/--partition/--leader are specified, but REQUIRED if they aren't.")
+    .withRequiredArg
+    .describedAs("Path to JSON file specifying topic-partitions and their corresponding _current_ in-sync replica sets and leaders (i.e., controller's and CC's view). New leaders for each partition will be selected from one of its healthy (listed in the PREFERRED_BROKERS env var), in-sync followers.")
+    .ofType(classOf[String])
+
+  val topic = parser
+    .accepts(
+      "topic",
+      "Name of the topic for which to perform an election. REQUIRED if --partition and --leader are specified. Not allowed if --path-to-json-file is specified.")
+    .withRequiredArg
+    .describedAs("topic name")
+    .ofType(classOf[String])
+
+  val partition = parser
+    .accepts(
+      "partition",
+      "Partition id for which to perform an election. REQUIRED if --topic and --leader are specified. Not allowed if --path-to-json-file is specified.")
+    .withRequiredArg
+    .describedAs("partition id")
+    .ofType(classOf[Integer])
+
+  val newLeader = parser
+    .accepts(
+      "leader",
+      "The new leader for the recommended election. REQUIRED if --topic and --partition are specified. Not allowed if --path-to-json-file is specified. May be ignored if the controller doesn't believe it's in the partition's current ISR.")
+    .withRequiredArg
+    .describedAs("the new leader")
+    .ofType(classOf[Integer])
+
+  options = parser.parse(args: _*)
+}

--- a/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
@@ -24,7 +24,7 @@ import java.nio.file.Path
 import kafka.common.AdminCommandFailedException
 import kafka.server.KafkaConfig
 import kafka.server.KafkaServer
-import kafka.utils.TestUtils
+import kafka.utils.{Json, TestUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.TopicPartition
@@ -44,9 +44,9 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
   import LeaderElectionCommandTest._
 
   var servers = Seq.empty[KafkaServer]
-  val broker1 = 0
-  val broker2 = 1
-  val broker3 = 2
+  //val broker0 = 0
+  val broker1 = 1
+  val broker2 = 2
 
   @BeforeEach
   override def setUp(): Unit = {
@@ -74,19 +74,19 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
     TestUtils.resource(Admin.create(createConfig(servers).asJava)) { client =>
       val topic = "unclean-topic"
       val partition = 0
-      val assignment = Seq(broker2, broker3)
+      val assignment = Seq(broker1, broker2)
 
       TestUtils.createTopic(zkClient, topic, Map(partition -> assignment), servers)
 
       val topicPartition = new TopicPartition(topic, partition)
 
-      TestUtils.assertLeader(client, topicPartition, broker2)
+      TestUtils.assertLeader(client, topicPartition, broker1)
 
-      servers(broker3).shutdown()
-      TestUtils.waitForBrokersOutOfIsr(client, Set(topicPartition), Set(broker3))
       servers(broker2).shutdown()
+      TestUtils.waitForBrokersOutOfIsr(client, Set(topicPartition), Set(broker2))
+      servers(broker1).shutdown()
       TestUtils.assertNoLeader(client, topicPartition)
-      servers(broker3).startup()
+      servers(broker2).startup()
 
       LeaderElectionCommand.main(
         Array(
@@ -96,7 +96,7 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
         )
       )
 
-      TestUtils.assertLeader(client, topicPartition, broker3)
+      TestUtils.assertLeader(client, topicPartition, broker2)
     }
   }
 
@@ -105,19 +105,19 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
     TestUtils.resource(Admin.create(createConfig(servers).asJava)) { client =>
       val topic = "unclean-topic"
       val partition = 0
-      val assignment = Seq(broker2, broker3)
+      val assignment = Seq(broker1, broker2)
 
       TestUtils.createTopic(zkClient, topic, Map(partition -> assignment), servers)
 
       val topicPartition = new TopicPartition(topic, partition)
 
-      TestUtils.assertLeader(client, topicPartition, broker2)
+      TestUtils.assertLeader(client, topicPartition, broker1)
 
-      servers(broker3).shutdown()
-      TestUtils.waitForBrokersOutOfIsr(client, Set(topicPartition), Set(broker3))
       servers(broker2).shutdown()
+      TestUtils.waitForBrokersOutOfIsr(client, Set(topicPartition), Set(broker2))
+      servers(broker1).shutdown()
       TestUtils.assertNoLeader(client, topicPartition)
-      servers(broker3).startup()
+      servers(broker2).startup()
 
       LeaderElectionCommand.main(
         Array(
@@ -128,7 +128,7 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
         )
       )
 
-      TestUtils.assertLeader(client, topicPartition, broker3)
+      TestUtils.assertLeader(client, topicPartition, broker2)
     }
   }
 
@@ -137,19 +137,19 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
     TestUtils.resource(Admin.create(createConfig(servers).asJava)) { client =>
       val topic = "unclean-topic"
       val partition = 0
-      val assignment = Seq(broker2, broker3)
+      val assignment = Seq(broker1, broker2)
 
       TestUtils.createTopic(zkClient, topic, Map(partition -> assignment), servers)
 
       val topicPartition = new TopicPartition(topic, partition)
 
-      TestUtils.assertLeader(client, topicPartition, broker2)
+      TestUtils.assertLeader(client, topicPartition, broker1)
 
-      servers(broker3).shutdown()
-      TestUtils.waitForBrokersOutOfIsr(client, Set(topicPartition), Set(broker3))
       servers(broker2).shutdown()
+      TestUtils.waitForBrokersOutOfIsr(client, Set(topicPartition), Set(broker2))
+      servers(broker1).shutdown()
       TestUtils.assertNoLeader(client, topicPartition)
-      servers(broker3).startup()
+      servers(broker2).startup()
 
       val topicPartitionPath = tempTopicPartitionFile(Set(topicPartition))
 
@@ -161,7 +161,7 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
         )
       )
 
-      TestUtils.assertLeader(client, topicPartition, broker3)
+      TestUtils.assertLeader(client, topicPartition, broker2)
     }
   }
 
@@ -170,18 +170,18 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
     TestUtils.resource(Admin.create(createConfig(servers).asJava)) { client =>
       val topic = "unclean-topic"
       val partition = 0
-      val assignment = Seq(broker2, broker3)
+      val assignment = Seq(broker1, broker2)
 
       TestUtils.createTopic(zkClient, topic, Map(partition -> assignment), servers)
 
       val topicPartition = new TopicPartition(topic, partition)
 
-      TestUtils.assertLeader(client, topicPartition, broker2)
+      TestUtils.assertLeader(client, topicPartition, broker1)
 
-      servers(broker2).shutdown()
-      TestUtils.assertLeader(client, topicPartition, broker3)
-      servers(broker2).startup()
-      TestUtils.waitForBrokersInIsr(client, topicPartition, Set(broker2))
+      servers(broker1).shutdown()
+      TestUtils.assertLeader(client, topicPartition, broker2)
+      servers(broker1).startup()
+      TestUtils.waitForBrokersInIsr(client, topicPartition, Set(broker1))
 
       LeaderElectionCommand.main(
         Array(
@@ -191,7 +191,7 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
         )
       )
 
-      TestUtils.assertLeader(client, topicPartition, broker2)
+      TestUtils.assertLeader(client, topicPartition, broker1)
     }
   }
 
@@ -273,7 +273,6 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
 
   @Test
   def testRecommendedElectionBothJsonAndTopic(): Unit = {
-    //val fakeJsonString = "{\"partitions\":[{\"topic\": \"foo\", \"partition\": 1, \"leader\": 8001, \"in-sync\": [6221, 1309, 8001]}, {\"topic\": \"foobar\", \"partition\": 2, \"leader\": 7911, \"in-sync\": [5577, 7911, 7174]}]}"
     val fakeJsonFile = "/tmp/fakeTopicPartitions.json"
     val e = assertThrows(classOf[Throwable], () => RecommendedLeaderElectionCommand.main(
       Array(
@@ -283,6 +282,63 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
       )
     ))
     assertTrue(e.getMessage.startsWith("Exactly one of the following combinations is required"))
+  }
+
+  @Test
+  def testRecommendedElectionHappyPathTopicPartitionLeader(): Unit = {
+    TestUtils.resource(Admin.create(createConfig(servers).asJava)) { client =>
+      val topic = "random-topic"
+      val partition = 0
+      val recommendedLeader = broker2
+      val assignment = Seq(broker1, broker2)
+
+      TestUtils.createTopic(zkClient, topic, Map(partition -> assignment), servers)
+
+      val topicPartition = new TopicPartition(topic, partition)
+
+      TestUtils.assertLeader(client, topicPartition, broker1)
+
+      RecommendedLeaderElectionCommand.main(
+        Array(
+          "--bootstrap-server", bootstrapServers(servers),
+          "--topic", topic,
+          "--partition", partition.toString,
+          "--leader", recommendedLeader.toString,
+          "--preferred-brokers", "0,2" // broker0 and broker2 "healthy"; broker1 not
+        )
+      )
+
+      TestUtils.assertLeader(client, topicPartition, broker2)
+    }
+  }
+
+  @Test
+  def testRecommendedElectionHappyPathJson(): Unit = {
+    TestUtils.resource(Admin.create(createConfig(servers).asJava)) { client =>
+      val topic = "random-topic"
+      val partition = 0
+      val assignment = Seq(broker1, broker2)
+
+      TestUtils.createTopic(zkClient, topic, Map(partition -> assignment), servers)
+
+      val topicPartition = new TopicPartition(topic, partition)
+
+      TestUtils.assertLeader(client, topicPartition, broker1)
+
+      val jsonPath = tempTopicPartitionLeaderIsrFile(topicPartition, broker1, assignment)
+
+      RecommendedLeaderElectionCommand.main(
+        Array(
+          "--bootstrap-server", bootstrapServers(servers),
+          "--path-to-json-file", jsonPath.toString,
+          "--preferred-brokers", "0,2" // broker0 and broker2 "healthy"; broker1 not
+        )
+      )
+
+      // broker2 is the only healthy (preferred) broker that's also in the ISR (= assignment), so the
+      // controller should pick it:
+      TestUtils.assertLeader(client, topicPartition, broker2)
+    }
   }
 
   @Test
@@ -318,22 +374,22 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
       val topic = "non-preferred-topic"
       val partition0 = 0
       val partition1 = 1
-      val assignment0 = Seq(broker2, broker3)
-      val assignment1 = Seq(broker3, broker2)
+      val assignment0 = Seq(broker1, broker2)
+      val assignment1 = Seq(broker2, broker1)
 
       TestUtils.createTopic(zkClient, topic, Map(partition0 -> assignment0, partition1 -> assignment1), servers)
 
       val topicPartition0 = new TopicPartition(topic, partition0)
       val topicPartition1 = new TopicPartition(topic, partition1)
 
-      TestUtils.assertLeader(client, topicPartition0, broker2)
-      TestUtils.assertLeader(client, topicPartition1, broker3)
+      TestUtils.assertLeader(client, topicPartition0, broker1)
+      TestUtils.assertLeader(client, topicPartition1, broker2)
 
-      servers(broker2).shutdown()
-      TestUtils.assertLeader(client, topicPartition0, broker3)
-      servers(broker2).startup()
-      TestUtils.waitForBrokersInIsr(client, topicPartition0, Set(broker2))
-      TestUtils.waitForBrokersInIsr(client, topicPartition1, Set(broker2))
+      servers(broker1).shutdown()
+      TestUtils.assertLeader(client, topicPartition0, broker2)
+      servers(broker1).startup()
+      TestUtils.waitForBrokersInIsr(client, topicPartition0, Set(broker1))
+      TestUtils.waitForBrokersInIsr(client, topicPartition1, Set(broker1))
 
       val topicPartitionPath = tempTopicPartitionFile(Set(topicPartition0, topicPartition1))
       val output = TestUtils.grabConsoleOutput(
@@ -373,6 +429,47 @@ object LeaderElectionCommandTest {
     file.deleteOnExit()
 
     val jsonString = TestUtils.stringifyTopicPartitions(partitions)
+
+    Files.write(file.toPath, jsonString.getBytes(StandardCharsets.UTF_8))
+
+    file.toPath
+  }
+
+  def tempTopicPartitionLeaderIsrFile(tp: TopicPartition, currentLeader: Int, currentIsr: Seq[Int]): Path = {
+    val file = File.createTempFile("leader-election-command", ".json")
+    file.deleteOnExit()
+
+    // This is more or less our target syntax, in pretty-print form (except this method supports only one element):
+    //
+    // val fakeJsonString = "{
+    //   \"partitions\":[
+    //     {
+    //       \"topic\": \"foo\",
+    //       \"partition\": 1,
+    //       \"leader\": 8001,
+    //       \"in-sync\": [6221, 1309, 8001]
+    //     },
+    //     {
+    //       \"topic\": \"foobar\",
+    //       \"partition\": 2,
+    //       \"leader\": 7911,
+    //       \"in-sync\": [5577, 7911, 7174]
+    //     }
+    //   ]
+    // }"
+    val jsonString = Json.encodeAsString(
+      Map(
+        "partitions" -> Seq(
+          Map(
+            "topic" -> tp.topic,
+            "partition" -> tp.partition,
+            "leader" -> currentLeader,
+            "in-sync" -> currentIsr.asJava
+          ).asJava
+        ).asJava
+      ).asJava
+    )
+    //println(s"\n\nDEBUG:  jsonString = ${jsonString}\n\n")
 
     Files.write(file.toPath, jsonString.getBytes(StandardCharsets.UTF_8))
 

--- a/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
@@ -248,6 +248,44 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
   }
 
   @Test
+  def testRecommendedElectionTopicAndPartitionWithoutLeader(): Unit = {
+    val e = assertThrows(classOf[Throwable], () => RecommendedLeaderElectionCommand.main(
+      Array(
+        "--bootstrap-server", bootstrapServers(servers),
+        "--topic", "some-topic",
+        "--partition", "0"
+      )
+    ))
+    assertTrue(e.getMessage.startsWith("Exactly one of the following combinations is required"))
+  }
+
+  @Test
+  def testRecommendedElectionTopicAndLeaderWithoutPartition(): Unit = {
+    val e = assertThrows(classOf[Throwable], () => RecommendedLeaderElectionCommand.main(
+      Array(
+        "--bootstrap-server", bootstrapServers(servers),
+        "--topic", "some-topic",
+        "--leader", "2"
+      )
+    ))
+    assertTrue(e.getMessage.startsWith("Exactly one of the following combinations is required"))
+  }
+
+  @Test
+  def testRecommendedElectionBothJsonAndTopic(): Unit = {
+    //val fakeJsonString = "{\"partitions\":[{\"topic\": \"foo\", \"partition\": 1, \"leader\": 8001, \"in-sync\": [6221, 1309, 8001]}, {\"topic\": \"foobar\", \"partition\": 2, \"leader\": 7911, \"in-sync\": [5577, 7911, 7174]}]}"
+    val fakeJsonFile = "/tmp/fakeTopicPartitions.json"
+    val e = assertThrows(classOf[Throwable], () => RecommendedLeaderElectionCommand.main(
+      Array(
+        "--bootstrap-server", bootstrapServers(servers),
+        "--path-to-json-file", fakeJsonFile,
+        "--topic", "some-topic"
+      )
+    ))
+    assertTrue(e.getMessage.startsWith("Exactly one of the following combinations is required"))
+  }
+
+  @Test
   def testMissingTopicPartitionSelection(): Unit = {
     val e = assertThrows(classOf[Throwable], () => LeaderElectionCommand.main(
       Array(


### PR DESCRIPTION
TICKET = LIKAFKA-52212

LI_DESCRIPTION =
RecommendedLeaderElectionCommand is a sibling command to LeaderElectionCommand. Where the latter supports preferred and unclean leader-election types, the new command supports (only) recommended leader elections. In other respects it's very similar, but the JSON input format it supports requires four fields, not two:  topic, partition, leader, and in-sync. The leader and in-sync fields represent the _current_ state of the partition's ISR as seen by the controller (and Cruise Control). The controller will select a new leader for each such partition by selecting one of the followers from the in-sync list.

EXIT_CRITERIA = If/when recommended leader election support and this command are accepted upstream.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
