### PR TITLE
[LI-HOTFIX] Only enable Totaltime latency histogram metrics for configured request names

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -41,6 +41,7 @@ import org.apache.kafka.common.utils.{Sanitizer, Time}
 
 import java.util
 import scala.annotation.nowarn
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
@@ -749,10 +750,9 @@ class RequestMetrics(name: String, config: KafkaConfig) extends KafkaMetricsGrou
     else
       None
 
-  // metrics to count the number of requests in different total time buckets. Only populated for fetch and produce
-  // requests (including sub-categories, e.g., FetchConsumer, Produce0To1MbAck1)
+  // metrics to count the number of requests in different total time buckets. Only populated for configured requests
   val totalTimeBucketHist =
-    if (name.startsWith(ApiKeys.FETCH.name) || name.startsWith(ApiKeys.PRODUCE.name))
+    if (config.totalTimeHistogramEnabledMetrics.exists(metricName => metricName.equalsIgnoreCase(name)))
       Some(new Histogram("TotalTime", "Ms", config.requestMetricsTotalTimeBuckets))
     else
       None

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -268,6 +268,7 @@ object Defaults {
   val MetricReplaceOnDuplicate = false
   val RequestMetricsSizeBuckets = "0,1,10,50,100"
   val RequestMetricsTotalTimeBuckets = "0,5,10,20,30,40,50,100,200,300,500,1000,5000,15000"
+  val TotalTimeHistogramEnabledMetrics = util.Arrays.asList("Produce0To1MbAcks1", "Produce0To1MbAcksAll", "FetchConsumer0To1Mb")
 
 
   /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
@@ -633,6 +634,7 @@ object KafkaConfig {
   val MetricReplaceOnDuplicateProp: String = CommonClientConfigs.METRICS_REPLACE_ON_DUPLICATE_CONFIG
   val RequestMetricsSizeBucketsProp: String = "request.metrics.size.buckets"
   val RequestMetricsTotalTimeBucketsProp: String = "request.metrics.total.time.buckets"
+  val TotalTimeHistogramEnabledMetricsProp: String = "total.time.histogram.enabled.metrics"
 
   /** ********* Kafka Yammer Metrics Reporters Configuration ***********/
   val KafkaMetricsReporterClassesProp = "kafka.metrics.reporters"
@@ -1088,6 +1090,7 @@ object KafkaConfig {
   val MetricReplaceOnDuplicateDoc = CommonClientConfigs.METRICS_REPLACE_ON_DUPLICATE_DOC
   val RequestMetricsSizeBucketsDoc = "The size buckets used to group requests to provide RequestMetrics for each group"
   val RequestMetricsTotalTimeBucketsDoc = "The bin boundaries used to get the latency histogram. The number of requests with TotalTime latency within these bin boundaries is counted."
+  val TotalTimeHistogramEnabledMetricsDoc = "The list of RequestMetrics names that would have TotalTime latency histogram enabled."
 
 
   /** ********* Kafka Yammer Metrics Reporter Configuration ***********/
@@ -1419,6 +1422,7 @@ object KafkaConfig {
       .define(MetricReplaceOnDuplicateProp, BOOLEAN, Defaults.MetricReplaceOnDuplicate, LOW, MetricReplaceOnDuplicateDoc)
       .define(RequestMetricsSizeBucketsProp, STRING, Defaults.RequestMetricsSizeBuckets, RequestMetricsBucketsValidator, LOW, RequestMetricsSizeBucketsDoc)
       .define(RequestMetricsTotalTimeBucketsProp, STRING, Defaults.RequestMetricsTotalTimeBuckets, RequestMetricsBucketsValidator, LOW, RequestMetricsTotalTimeBucketsDoc)
+      .define(TotalTimeHistogramEnabledMetricsProp, LIST, Defaults.TotalTimeHistogramEnabledMetrics, LOW, TotalTimeHistogramEnabledMetricsDoc)
 
       /** ********* Kafka Yammer Metrics Reporter Configuration for docs ***********/
       .define(KafkaMetricsReporterClassesProp, LIST, Defaults.KafkaMetricReporterClasses, LOW, KafkaMetricsReporterClassesDoc)
@@ -1979,6 +1983,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val metricReplaceOnDuplicate = getBoolean(KafkaConfig.MetricReplaceOnDuplicateProp)
   def requestMetricsSizeBuckets = getRequestMetricsSizeBuckets()
   def requestMetricsTotalTimeBuckets = getRequestMetricsTotalTimeBuckets()
+  def totalTimeHistogramEnabledMetrics = getList(KafkaConfig.TotalTimeHistogramEnabledMetricsProp)
 
   /** ********* SSL/SASL Configuration **************/
   // Security configs may be overridden for listeners, so it is not safe to use the base values

--- a/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
@@ -362,11 +362,13 @@ class RequestChannelTest {
     val props = new Properties()
     props.put(KafkaConfig.ZkConnectProp, "127.0.0.1:2181")
     props.put(KafkaConfig.RequestMetricsTotalTimeBucketsProp, "0, 10, 30, 300")
+    props.put(KafkaConfig.TotalTimeHistogramEnabledMetricsProp, util.Arrays.asList("Produce0To1MbAcks1", "Produce0To1MbAcksAll", "FetchConsumer0To1Mb"))
+
     val config = KafkaConfig.fromProps(props)
-    // totalTimeBucketHist is only enabled for Produce/Fetch related requests.
+    // totalTimeBucketHist is only enabled for RequestMetrics with name defined in TotalTimeHistogramEnabledMetricsProp.
     val requestMetricsNoTotalTimeBucketHist = new RequestMetrics("RequestMetrics", config)
     assertTrue(requestMetricsNoTotalTimeBucketHist.totalTimeBucketHist.isEmpty)
-    val requestMetrics = new RequestMetrics("FetchConsumer", config)
+    val requestMetrics = new RequestMetrics("FetchConsumer0To1Mb", config)
     assertTrue(requestMetrics.totalTimeBucketHist.isDefined)
     val boundaries = Array(0, 10, 30, 300)
     val histogram = new requestMetrics.Histogram("TotalTime", "Ms", boundaries)

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1094,6 +1094,7 @@ class SocketServerTest {
 
   private def checkClientDisconnectionUpdatesRequestMetrics(responseBufferSize: Int): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 0)
+    props.put("total.time.histogram.enabled.metrics", util.Arrays.asList("Produce"))
     val serverMetrics = new Metrics
     var conn: Socket = null
     val overrideServer = new SocketServer(

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -811,6 +811,7 @@ class KafkaConfigTest {
         case KafkaConfig.KafkaMetricsReporterClassesProp => // ignore
         case KafkaConfig.KafkaMetricsPollingIntervalSecondsProp => //ignore
         case KafkaConfig.RequestMetricsSizeBucketsProp =>  assertPropertyInvalid(baseProperties, name, "", "1", "1, 2, 5, not_a_number, 9")
+        case KafkaConfig.TotalTimeHistogramEnabledMetricsProp => // ignore
 
         // Broker-side observer configs
         case KafkaConfig.ObserverClassNameProp => // ignore since even if the class name is invalid, a NoOpObserver class is used instead


### PR DESCRIPTION
LI_DESCRIPTION =
This PR is to enable totalTimeBucketHist ONLY for requestMetrics with name configured in TotalTimeHistogramEnabledMetricsProp. totalTimeBucketHist is used for latency SLOs evaluation. With the current definition of latency SLOs, we only need these metrics for "Produce0To1MbAcks1", "Produce0To1MbAcksAll", and "FetchConsumer0To1Mb". Make this configurable to accomondate possible future changes.

EXIT_CRITERIA = N/A
