### PR TITLE
[LI-FIXUP] Build with published ktls-jni component

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,9 @@ allprojects {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven {
-      url  "https://linkedin.jfrog.io/artifactory/zookeeper"
-    }
+    maven { url  "https://linkedin.jfrog.io/artifactory/zookeeper" }
+    maven { url  "https://linkedin.jfrog.io/artifactory/ktls-jni" }
+
   }
 
   dependencyUpdates {

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -58,6 +58,7 @@
     <allow pkg="org.apache.kafka.common.internals" exact-match="true" />
     <allow pkg="org.apache.kafka.test" />
     <allow pkg="org.conscrypt" />
+    <allow pkg="com.linkedin.ktls"/>
 
     <subpackage name="acl">
       <allow pkg="org.apache.kafka.common.annotation" />

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -773,6 +773,7 @@ public class SslTransportLayer implements TransportLayer {
             attemptToEnableKernelTls();
         }
         if (ktlsEnabled) {
+            log.debug("Writing with Kernel TLS enabled");
             return writeKernelTLS(srcs, offset, length);
         }
         if ((offset < 0) || (length < 0) || (offset > srcs.length - length))

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -118,6 +118,8 @@ public class SslSelectorTest extends SelectorTest {
         );
         sslServerConfigs.put(SecurityConfig.SECURITY_PROVIDERS_CONFIG, testProviderCreator.getClass().getName());
         sslServerConfigs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, SslConfigs.DEFAULT_SSL_CONTEXT_PROVIDER_CLASS);
+        sslServerConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
+        sslServerConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_DOC, false);
         EchoServer server = new EchoServer(SecurityProtocol.SSL, sslServerConfigs);
         server.start();
         Time time = new MockTime();

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -99,6 +99,7 @@ public class SslTransportLayerTest {
             sslConfigOverrides.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol);
             sslConfigOverrides.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Collections.singletonList(tlsProtocol));
             sslConfigOverrides.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, SslConfigs.DEFAULT_SSL_CONTEXT_PROVIDER_CLASS);
+            sslConfigOverrides.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
             init();
         }
 
@@ -114,6 +115,8 @@ public class SslTransportLayerTest {
             clientCertStores = certBuilder(false, "client", useInlinePem, provider).addHostName("localhost").build();
             sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
             sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
+            sslClientConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
+            sslServerConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
             sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, DefaultSslEngineFactory.class);
             sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, DefaultSslEngineFactory.class);
         }
@@ -349,11 +352,11 @@ public class SslTransportLayerTest {
         ListenerName clientListenerName = new ListenerName("client");
         args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
         args.sslServerConfigs.put(clientListenerName.configPrefix() + BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
-
+        args.sslServerConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
         // `client` listener is not configured at this point, so client auth should be required
         server = createEchoServer(args, SecurityProtocol.SSL);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
-
+        args.sslClientConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
         // Connect with client auth should work fine
         createSelector(args.sslClientConfigs);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
@@ -1067,6 +1070,7 @@ public class SslTransportLayerTest {
         ListenerReconfigurable reconfigurableBuilder = (ListenerReconfigurable) serverChannelBuilder;
         assertEquals(listenerName, reconfigurableBuilder.listenerName());
         reconfigurableBuilder.validateReconfiguration(newKeystoreConfigs);
+        newKeystoreConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
         reconfigurableBuilder.reconfigure(newKeystoreConfigs);
 
         // Verify that new client with old truststore fails
@@ -1091,6 +1095,7 @@ public class SslTransportLayerTest {
         missingStoreConfigs.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "some.keystore.path");
         missingStoreConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, new Password("some.keystore.password"));
         missingStoreConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, new Password("some.key.password"));
+        missingStoreConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
         verifyInvalidReconfigure(reconfigurableBuilder, missingStoreConfigs, "keystore not found");
 
         // Verify that new connections continue to work with the server with previously configured keystore after failed reconfiguration
@@ -1135,6 +1140,7 @@ public class SslTransportLayerTest {
         }
         ListenerReconfigurable reconfigurableBuilder = (ListenerReconfigurable) serverChannelBuilder;
         reconfigurableBuilder.validateReconfiguration(newKeystoreConfigs);
+        newKeystoreConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
         reconfigurableBuilder.reconfigure(newKeystoreConfigs);
 
         for (String propName : CertStores.TRUSTSTORE_PROPS) {
@@ -1153,6 +1159,7 @@ public class SslTransportLayerTest {
         for (String propName : CertStores.KEYSTORE_PROPS) {
             invalidKeystoreConfigs.put(propName, invalidConfig.get(propName));
         }
+        invalidKeystoreConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
         verifyInvalidReconfigure(reconfigurableBuilder, invalidKeystoreConfigs, "keystore without existing SubjectAltName");
         String node3 = "3";
         selector.connect(node3, addr, BUFFER_SIZE, BUFFER_SIZE);
@@ -1191,6 +1198,7 @@ public class SslTransportLayerTest {
         ListenerReconfigurable reconfigurableBuilder = (ListenerReconfigurable) serverChannelBuilder;
         assertEquals(listenerName, reconfigurableBuilder.listenerName());
         reconfigurableBuilder.validateReconfiguration(newTruststoreConfigs);
+        newTruststoreConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
         reconfigurableBuilder.reconfigure(newTruststoreConfigs);
 
         // Verify that new client with old truststore fails
@@ -1213,6 +1221,7 @@ public class SslTransportLayerTest {
         missingStoreConfigs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
         missingStoreConfigs.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "some.truststore.path");
         missingStoreConfigs.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, new Password("some.truststore.password"));
+        missingStoreConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
         verifyInvalidReconfigure(reconfigurableBuilder, missingStoreConfigs, "truststore not found");
 
         // Verify that new connections continue to work with the server with previously configured keystore after failed reconfiguration

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
@@ -204,6 +204,7 @@ public class DefaultSslEngineFactoryTest {
         factory = new DefaultSslEngineFactory();
         configs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
         configs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, SslConfigs.DEFAULT_SSL_CONTEXT_PROVIDER_CLASS);
+        configs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -184,6 +184,8 @@ public class TestSslUtils {
         enabledProtocols.add(tlsProtocol);
         sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
         sslConfigs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, SslConfigs.DEFAULT_SSL_CONTEXT_PROVIDER_CLASS);
+        sslConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
+        sslConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_DOC, false);
         return sslConfigs;
     }
 
@@ -564,6 +566,8 @@ public class TestSslUtils {
             } else {
                 sslConfigs.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, SimpleSslContextProvider.class.getName());
             }
+            sslConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
+            sslConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_DOC, false);
             return sslConfigs;
         }
 
@@ -589,6 +593,8 @@ public class TestSslUtils {
                 sslConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keyPassword);
                 sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, certPem);
             }
+            sslConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_CONFIG, false);
+            sslConfigs.put(SslConfigs.SSL_KERNEL_OFFLOAD_ENABLE_DOC, false);
             return sslConfigs;
         }
     }

--- a/core/src/main/scala/kafka/tools/KernelTLSBenchmark.scala
+++ b/core/src/main/scala/kafka/tools/KernelTLSBenchmark.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package kafka.tools
 
 import com.typesafe.scalalogging.LazyLogging

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -100,7 +100,7 @@ versions += [
   kafka_26: "2.6.2",
   kafka_27: "2.7.1",
   kafka_28: "2.8.0",
-  ktls: "1.0.0-SNAPSHOT",
+  ktls: "0.0.2",
   lz4: "1.8.0",
   mavenArtifact: "3.8.1",
   metrics: "2.2.0",


### PR DESCRIPTION
Add logs for kernel tls and change the version of ktls library and add maven url for ktls library

EXIT_CRITERIA = When KTLS feature is no longer valid or upstream supports it

JIRA Ticket = https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-53140

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
