### PR TITLE
[LI-HOTFIX] Modify ktls log level to debug

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -115,7 +115,7 @@ public class SslTransportLayer implements TransportLayer {
         final LogContext logContext = new LogContext(String.format("[SslTransportLayer channelId=%s key=%s] ", channelId, key));
         this.log = logContext.logger(getClass());
 
-        log.info(String.format(
+        log.debug(String.format(
             "New SSL channel created with kernel offload turned %s", shouldAttemptKtls ? "on" : "off"));
     }
 


### PR DESCRIPTION
EXIT-CRITERIA = When KTLS feature is no longer valid or upstream supports it

LI_DESCRIPTION : https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-53209

Modifying the log level of a ktls log from INFO to DEBUG

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
