### PR TITLE
[LI-FIXUP] CI: Add back missing build for PR against 3.0-li main branch

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,6 +22,7 @@ on:
   pull_request:
     # Using wildcard (e.g. '**') to build on all branches will cause PRs to run duplicate checks like `test (pull_request)` with `test (push)`.
     branches:
+      - 3.0-li
       - 3.0-li-**
 
 jobs:


### PR DESCRIPTION
Should be a direct fix up to commit
- `bb2930a` [LI-HOTFIX] CI: Run test on PRs against all 3.0-li-** branches (#462)

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
