### PR TITLE
[LI-HOTFIX] Update ktls-jni version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -100,7 +100,7 @@ versions += [
   kafka_26: "2.6.2",
   kafka_27: "2.7.1",
   kafka_28: "2.8.0",
-  ktls: "0.0.2",
+  ktls: "0.0.3",
   lz4: "1.8.0",
   mavenArtifact: "3.8.1",
   metrics: "2.2.0",


### PR DESCRIPTION
Update ktls-jni version after close notify exceptions fix in the library.

EXIT_CRITERIA = When KTLS feature is no longer valid or upstream supports it

JIRA Ticket=[LIKAFKA-53806](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-53806)

Testing:

./gradlew build is passing in local

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
