### PR TITLE
[LI-CHERRY-PICK] MINOR: Update library dependencies (Q1 2022) (#11306)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,16 +34,16 @@ buildscript {
 
 plugins {
   id 'com.diffplug.spotless' version '5.12.5'
-  id 'com.github.ben-manes.versions' version '0.38.0'
+  id 'com.github.ben-manes.versions' version '0.42.0'
   id 'idea'
   id 'java-library'
-  id 'org.owasp.dependencycheck' version '6.1.6'
+  id 'org.owasp.dependencycheck' version '6.5.3'
   id 'org.nosphere.apache.rat' version "0.7.0"
 
-  id "com.github.spotbugs" version '4.7.1' apply false
+  id "com.github.spotbugs" version '5.0.5' apply false
   id 'org.gradle.test-retry' version '1.3.1' apply false
-  id 'org.scoverage' version '5.0.0' apply false
-  id 'com.github.johnrengelman.shadow' version '7.0.0' apply false
+  id 'org.scoverage' version '7.0.0' apply false
+  id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
 }
 
 spotless {

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -353,7 +353,7 @@ public class TestSslUtils {
                 pemWriter.writeObject(new JcaPKCS8Generator(privateKey, null));
             } else {
                 JceOpenSSLPKCS8EncryptorBuilder encryptorBuilder = new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.PBE_SHA1_3DES);
-                encryptorBuilder.setPasssword(password.value().toCharArray());
+                encryptorBuilder.setPassword(password.value().toCharArray());
                 try {
                     pemWriter.writeObject(new JcaPKCS8Generator(privateKey, encryptorBuilder.build()));
                 } catch (Exception e) {

--- a/core/src/main/scala/kafka/log/LazyIndex.scala
+++ b/core/src/main/scala/kafka/log/LazyIndex.scala
@@ -54,11 +54,11 @@ class LazyIndex[T <: AbstractIndex] private (@volatile private var indexWrapper:
 
   def get: T = {
     indexWrapper match {
-      case indexValue: IndexValue[T] => indexValue.index
+      case indexValue: IndexValue[_] => indexValue.index.asInstanceOf[T]
       case _: IndexFile =>
         inLock(lock) {
           indexWrapper match {
-            case indexValue: IndexValue[T] => indexValue.index
+            case indexValue: IndexValue[_] => indexValue.index.asInstanceOf[T]
             case indexFile: IndexFile =>
               val indexValue = new IndexValue(loadIndex(indexFile.file))
               indexWrapper = indexValue

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,8 +27,8 @@ ext {
 }
 
 // Add Scala version
-def defaultScala212Version = '2.12.14'
-def defaultScala213Version = '2.13.6'
+def defaultScala212Version = '2.12.15'
+def defaultScala213Version = '2.13.8'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {
     versions["scala"] = defaultScala212Version
@@ -58,7 +58,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.66",
+  bcpkix: "1.70",
   checkstyle: "8.36.2",
   commonsCli: "1.4",
   conscrypt: "2.1.0",
@@ -74,17 +74,18 @@ versions += [
   javassist: "3.27.0-GA",
   jetty: "9.4.43.v20210629",
   jersey: "2.34",
-  jline: "3.12.1",
-  jmh: "1.32",
+  jline: "3.21.0",
+  jmh: "1.34",
   hamcrest: "2.2",
   log4j: "1.2.17",
-  scalaLogging: "3.9.3",
+  scalaLogging: "3.9.4",
   jaxb: "2.3.0",
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
-  junit: "5.7.1",
-  jqwik: "1.5.0",
+  jose4j: "0.7.9",
+  junit: "5.8.2",
+  jqwik: "1.6.3",
   kafka_0100: "0.10.0.1",
   kafka_0101: "0.10.1.1",
   kafka_0102: "0.10.2.2",
@@ -102,23 +103,23 @@ versions += [
   kafka_28: "2.8.0",
   ktls: "0.0.3",
   lz4: "1.8.0",
-  mavenArtifact: "3.8.1",
+  mavenArtifact: "3.8.4",
   metrics: "2.2.0",
   mockito: "4.4.0",
   netty: "4.1.78.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
   rocksDB: "6.29.4.1",
-  scalaCollectionCompat: "2.4.4",
-  scalafmt: "1.5.1",
-  scalaJava8Compat : "1.0.0",
-  scoverage: "1.4.1",
-  slf4j: "1.7.30",
+  scalaCollectionCompat: "2.6.0",
+  scalafmt: "2.7.5",
+  scalaJava8Compat : "1.0.2",
+  scoverage: "1.4.11",
+  slf4j: "1.7.32",
   snappy: "1.1.8.4",
   spotbugs: "4.2.2",
   zinc: "1.3.5",
   zookeeper: "3.6.3-23",
-  zstd: "1.5.0-4"
+  zstd: "1.5.2-1"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
@@ -80,7 +80,7 @@ class TopologyTest {
     def getTopologyJava: TopologyDescription = {
       val streamBuilder = new StreamsBuilderJ
       val textLines = streamBuilder.stream[String, String](inputTopic)
-      val _: KStreamJ[String, String] = textLines.flatMapValues(s => pattern.split(s.toLowerCase).toIterable.asJava)
+      val _: KStreamJ[String, String] = textLines.flatMapValues(s => pattern.split(s.toLowerCase).toBuffer.asJava)
       streamBuilder.build().describe()
     }
 
@@ -114,7 +114,7 @@ class TopologyTest {
       val textLines: KStreamJ[String, String] = streamBuilder.stream[String, String](inputTopic)
 
       val splits: KStreamJ[String, String] =
-        textLines.flatMapValues(s => pattern.split(s.toLowerCase).toIterable.asJava)
+        textLines.flatMapValues(s => pattern.split(s.toLowerCase).toBuffer.asJava)
 
       val grouped: KGroupedStreamJ[String, String] = splits.groupBy((_, v) => v)
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
@@ -154,7 +154,7 @@ class WordCountTest extends WordCountTestData {
     val pattern = Pattern.compile("\\W+", Pattern.UNICODE_CHARACTER_CLASS)
 
     val splits: KStreamJ[String, String] = textLines.flatMapValues { line =>
-      pattern.split(line.toLowerCase).toIterable.asJava
+      pattern.split(line.toLowerCase).toBuffer.asJava
     }
 
     val grouped: KGroupedStreamJ[String, String] = splits.groupBy { (_, v) =>


### PR DESCRIPTION
This partitially resolves the error for scoverage (for scala test coverage generation) not being compatible with our Scala set up.

- scala 2.13: 2.13.6 -> 2.13.8
  * Support Java 18 and improve Android compatibility
  * https://www.scala-lang.org/news/2.13.7
  * https://www.scala-lang.org/news/2.13.8
- scala 2.12: 2.12.14 -> 2.12.15.
  * The `-release` flag now works with Scala 2.12, backend parallelism can be enabled via `-Ybackend-parallelism N` and string interpolation is more efficient.
  * https://www.scala-lang.org/news/2.12.5
- gradle versions plugin: 0.38.0 -> 0.42.0
  * Minor fixes
  * https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.40.0
  * https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.41.0
  * https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.42.0
- gradle dependency check plugin: 6.1.6 -> 6.5.3
  * Minor fixes
- gradle spotbugs plugin: 4.7.1 -> 5.0.5
  * Fixes and minor improvements
  * There were too many releases to include all the links, include the major version bump
  * https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/5.0.0
- gradle scoverage plugin: 5.0.0 -> 7.0.0
  * Support newer Gradle versions and other improvements
  * https://github.com/scoverage/gradle-scoverage/releases/tag/6.0.0
  * https://github.com/scoverage/gradle-scoverage/releases/tag/6.1.0
  * https://github.com/scoverage/gradle-scoverage/releases/tag/7.0.0
- gradle shadow plugin: 7.0.0 -> 7.1.2
  * Support gradle toolchains and security fixes
  * https://github.com/johnrengelman/shadow/releases/tag/7.1.0
  * https://github.com/johnrengelman/shadow/releases/tag/7.1.1
  * https://github.com/johnrengelman/shadow/releases/tag/7.1.2
- bcpkix: 1.66 -> 1.70
  * Several improvements and fixes
  * https://www.bouncycastle.org/releasenotes.html
- jline: 3.12.1 -> 3.21.0
  * Various fixes and improvements
- jmh: 1.32 -> 1.34
  * Compiler blackhole enabled by default when using Java 17 and improved gradle incremental compilation
  * https://mail.openjdk.java.net/pipermail/jmh-dev/2021-August/003355.html
  * https://mail.openjdk.java.net/pipermail/jmh-dev/2021-December/003406.html
- scalaLogging: 3.9.3 -> 3.9.4
  * Support for Scala 3.0
- jose4j: 0.7.8 -> 0.7.9
  * Minor fixes
- junit: 5.7.1 -> 5.8.2
  * Minor improvements and fixes
  * https://junit.org/junit5/docs/current/release-notes/index.html#release-notes-5.8.0
  * https://junit.org/junit5/docs/current/release-notes/index.html#release-notes-5.8.1
  * https://junit.org/junit5/docs/current/release-notes/index.html#release-notes-5.8.2
- jqwik: 1.5.0 -> 1.6.3
  * Numerous improvements
  * https://github.com/jlink/jqwik/releases/tag/1.6.0
- mavenArtifact: 3.8.1 -> 3.8.4
- mockito: 3.12.4 -> 4.3.1
  * Removed deprecated methods, `DoNotMock` annotation and minor fixes/improvements
  * https://github.com/mockito/mockito/releases/tag/v4.0.0
  * https://github.com/mockito/mockito/releases/tag/v4.1.0
  * https://github.com/mockito/mockito/releases/tag/v4.2.0
  * https://github.com/mockito/mockito/releases/tag/v4.3.0
- scalaCollectionCompat: 2.4.4 -> 2.6.0
  * Minor fixes
  * https://github.com/scala/scala-collection-compat/releases/tag/v2.5.0
  * https://github.com/scala/scala-collection-compat/releases/tag/v2.6.0
- scalaJava8Compat: 1.0.0 -> 1.0.2
  * Minor changes
- scoverage: 1.4.1 -> 1.4.11
  * Support for newer Scala versions
- slf4j: 1.7.30 -> 1.7.32
  * Minor fixes, 1.7.35 automatically uses reload4j and 1.7.33/1.7.34 cause build failures, so we stick with 1.7.32 for now.
- zstd: 1.5.0-4 -> 1.5.2-1
  * zstd 1.5.2
  * Small refinements and performance improvements
  * https://github.com/facebook/zstd/releases/tag/v1.5.1
  * https://github.com/facebook/zstd/releases/tag/v1.5.2

Checkstyle, spotBugs and spotless will be upgraded separately as they either require non trivial code changes or they have regressions that affect us.

Reviewers: Manikumar Reddy <manikumar.reddy@gmail.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
