### PR TITLE
Add log if process fetch takes more than replicaLagTimeMaxMs

### DIFF
--- a/core/src/main/scala/kafka/server/AsyncReplicaFetcher.scala
+++ b/core/src/main/scala/kafka/server/AsyncReplicaFetcher.scala
@@ -66,7 +66,8 @@ class AsyncReplicaFetcher(name: String,
                                 failedPartitions,
                                 fetchBackOffMs = brokerConfig.replicaFetchBackoffMs,
                                 replicaMgr.brokerTopicStats,
-                                fetcherEventBus = fetcherEventBus) {
+                                fetcherEventBus = fetcherEventBus,
+                                replicaMaxLagMs = brokerConfig.replicaLagTimeMaxMs) {
 
   private val replicaId = brokerConfig.brokerId
   private val logContext = new LogContext(s"[ReplicaFetcher replicaId=$replicaId, leaderId=${sourceBroker.id}, " +


### PR DESCRIPTION
LI_DESCRIPTION = LIKAFKA-54083
EXIT_CRITERIA = N/A

**Description**

In the recent investigation of produce latency, we found there are strong relationship between produce latency and truncateAndFetch latency. However, it's hard to find why the truncateAndFetch can reach that high, and which partitions are causing the high truncateAndFetch latency. 

![Screenshot 2023-08-10 at 3 05 45 PM](https://github.com/linkedin/kafka/assets/38366317/bc4cce94-2aad-49dd-b8fa-9e8a85584998)

In this PR, we passed through the replicaMaxLagMs config all the way to Fetcher thread, and log the fetch request if it takes longer than it. This could be very helpful for the produce latency investigation.