### PR TITLE
Trigger maybeIncrementLeaderHW in the alterISR request callback

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1445,7 +1445,7 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  private[cluster] def shrinkIsr(outOfSyncReplicas: Set[Int], isrUpdateCompleteFuture: CompletableFuture[Boolean] = new CompletableFuture[Boolean]): Unit = {
+  private[cluster] def shrinkIsr(outOfSyncReplicas: Set[Int], isrUpdateCompleteFuture: CompletableFuture[Boolean]): Unit = {
     // This is called from maybeShrinkIsr which holds the ISR write lock
     if (!isrState.isInflight) {
       // When shrinking the ISR, we cannot assume that the update will succeed as this could erroneously advance the HW
@@ -1454,6 +1454,7 @@ class Partition(val topicPartition: TopicPartition,
       sendAlterIsrRequest(PendingShrinkIsr(isrState.isr, outOfSyncReplicas), isrUpdateCompleteFuture)
     } else {
       trace(s"ISR update in-flight, not removing out-of-sync replicas $outOfSyncReplicas")
+      isrUpdateCompleteFuture.complete(false)
     }
   }
 
@@ -1480,7 +1481,18 @@ class Partition(val topicPartition: TopicPartition,
     }
 
     val newLeaderAndIsr = new LeaderAndIsr(localBrokerId, leaderEpoch, isrToSend.toList, zkVersion)
-    val alterIsrItem = AlterIsrItem(topicPartition, newLeaderAndIsr, handleAlterIsrResponse(proposedIsrState, isrUpdateCompleteFuture), controllerEpoch)
+    val alterIsrItem = AlterIsrItem(
+      topicPartition,
+      newLeaderAndIsr,
+      result => {
+        try {
+          isrUpdateCompleteFuture.complete(handleAlterIsrResponse(proposedIsrState)(result))
+        } finally {
+          case e: Exception => isrUpdateCompleteFuture.completeExceptionally(e)
+        }
+      },
+      controllerEpoch
+    )
 
     val oldState = isrState
     isrState = proposedIsrState
@@ -1502,15 +1514,17 @@ class Partition(val topicPartition: TopicPartition,
    * give up. This leaves [[Partition.isrState]] in an in-flight state (either pending shrink or pending expand).
    * Since our error was non-retryable we are okay staying in this state until we see new metadata from UpdateMetadata
    * or LeaderAndIsr
+   *
+   * @return true if the HW incremented after handleAlterIsrResponse
    */
-  private def handleAlterIsrResponse(proposedIsrState: IsrState, isrUpdateCompleteFuture: CompletableFuture[Boolean])(result: Either[Errors, LeaderAndIsr]): Unit = {
+  private def handleAlterIsrResponse(proposedIsrState: IsrState)(result: Either[Errors, LeaderAndIsr]): Boolean = {
     inWriteLock(leaderIsrUpdateLock) {
       if (isrState != proposedIsrState) {
         // This means isrState was updated through leader election or some other mechanism before we got the AlterIsr
         // response. We don't know what happened on the controller exactly, but we do know this response is out of date
         // so we ignore it.
         warn(s"Ignoring failed ISR update to $proposedIsrState since we have already updated state to $isrState")
-        return
+        return false
       }
 
       result match {
@@ -1552,17 +1566,14 @@ class Partition(val topicPartition: TopicPartition,
                   // Try to increment leader HWM if it tries to shrinkISR.
                   val leaderHWIncremented = maybeIncrementLeaderHW(leaderLog)
                   info(s"HW incremented: ${leaderHWIncremented}, for partition ${topicPartition} after shrinking ISR to ${isrState.isr.mkString(",")}")
-                  isrUpdateCompleteFuture.complete(leaderHWIncremented)
+                  return leaderHWIncremented
                 }
               case _ => // nothing to do, shouldn't get here
             }
           }
       }
     }
-
-    if (!isrUpdateCompleteFuture.isDone) {
-      isrUpdateCompleteFuture.complete(false)
-    }
+    false
   }
 
   override def equals(that: Any): Boolean = that match {

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -992,8 +992,7 @@ class Partition(val topicPartition: TopicPartition,
       val isrUpdateCompleteFuture: CompletableFuture[Boolean] = new CompletableFuture()
 
       inWriteLock(leaderIsrUpdateLock) {
-        info(s"Acquired leaderIsrUpdateLock for ${topicPartition}. Starting to update isr.")
-        leaderLogIfLocal.exists { leaderLog =>
+        leaderLogIfLocal.foreach { leaderLog =>
           val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
           if (outOfSyncReplicaIds.nonEmpty) {
             val outOfSyncReplicaLog = outOfSyncReplicaIds.map { replicaId =>
@@ -1012,14 +1011,13 @@ class Partition(val topicPartition: TopicPartition,
 
             shrinkIsr(outOfSyncReplicaIds, isrUpdateCompleteFuture)
           }
-          return
         }
       }
 
       try {
         // some delayed operations may be unblocked after HW changed
         if (isrUpdateCompleteFuture.get(isrUpdateTimeoutMs, TimeUnit.MILLISECONDS)) {
-          info(s"Completed isr shrink and incremented HWM for partition ${topicPartition}." +
+          info(s"Completed isr shrink and incremented HW for partition ${topicPartition}." +
             s" Current isr is ${isrState}. Trying to complete delayed request")
           tryCompleteDelayedRequests()
         }
@@ -1546,15 +1544,16 @@ class Partition(val topicPartition: TopicPartition,
             isrState = CommittedIsr(leaderAndIsr.isr.toSet)
             zkVersion = leaderAndIsr.zkVersion
             info(s"ISR updated to ${isrState.isr.mkString(",")} and version updated to [$zkVersion]")
-
-            // Try to increment leader HWM if it tries to shrinkISR.
-            if (proposedIsrState.isInstanceOf[PendingShrinkIsr]) {
-              leaderLogIfLocal.exists(leaderLog => isrUpdateCompleteFuture.complete(maybeIncrementLeaderHW(leaderLog)))
-            }
-
             proposedIsrState match {
               case PendingExpandIsr(_, _) => isrChangeListener.markExpand()
-              case PendingShrinkIsr(_, _) => isrChangeListener.markShrink()
+              case PendingShrinkIsr(_, _) =>
+                isrChangeListener.markShrink()
+                leaderLogIfLocal.foreach{leaderLog =>
+                  // Try to increment leader HWM if it tries to shrinkISR.
+                  val leaderHWIncremented = maybeIncrementLeaderHW(leaderLog)
+                  info(s"HW incremented: ${leaderHWIncremented}, for partition ${topicPartition} after shrinking ISR to ${isrState.isr.mkString(",")}")
+                  isrUpdateCompleteFuture.complete(leaderHWIncremented)
+                }
               case _ => // nothing to do, shouldn't get here
             }
           }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -42,6 +42,7 @@ import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.{IsolationLevel, TopicPartition, Uuid}
 
+import java.util.concurrent.{CompletableFuture, TimeUnit}
 import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
 
@@ -257,6 +258,9 @@ class Partition(val topicPartition: TopicPartition,
   // The bucket size is set to 1 minute, with max log number 300. The logs will hit max QPS at 5, which should be acceptable.
   val logSlowReplicationBucketLengthMs: Long = 60000
   val logSlowReplicationBucketMaxLogCount: Int = 300
+
+  // maybeShrinkISR will block returning by isr update completion, or this timeout
+  val isrUpdateTimeoutMs: Long = 5000
 
   // Logs belonging to this partition. Majority of time it will be only one log, but if log directory
   // is getting changed (as a result of ReplicaAlterLogDirs command), we may have two logs until copy
@@ -982,6 +986,7 @@ class Partition(val topicPartition: TopicPartition,
     val needsIsrUpdate = !isrState.isInflight && inReadLock(leaderIsrUpdateLock) {
       needsShrinkIsr()
     }
+    val isrUpdateCompleteFuture: CompletableFuture[Boolean] = new CompletableFuture()
     val leaderHWIncremented = needsIsrUpdate && inWriteLock(leaderIsrUpdateLock) {
       leaderLogIfLocal.exists { leaderLog =>
         val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
@@ -1000,7 +1005,7 @@ class Partition(val topicPartition: TopicPartition,
                s"endOffset: ${leaderLog.logEndOffset}). " +
                s"Out of sync replicas: $outOfSyncReplicaLog.")
 
-          shrinkIsr(outOfSyncReplicaIds)
+          shrinkIsr(outOfSyncReplicaIds, isrUpdateCompleteFuture)
 
           // we may need to increment high watermark since ISR could be down to 1
           maybeIncrementLeaderHW(leaderLog)
@@ -1010,9 +1015,17 @@ class Partition(val topicPartition: TopicPartition,
       }
     }
 
-    // some delayed operations may be unblocked after HW changed
-    if (leaderHWIncremented)
-      tryCompleteDelayedRequests()
+    try {
+      // some delayed operations may be unblocked after HW changed
+      if (isrUpdateCompleteFuture.get(isrUpdateTimeoutMs, TimeUnit.MILLISECONDS)) {
+        info(s"Completed shrinking isr and incrementing HWM for partition ${topicPartition}." +
+          s" Current isr is ${isrState}. Trying to complete delayed request")
+        tryCompleteDelayedRequests()
+      }
+    } catch {
+      case e: Exception =>
+        error("Failed to complete shrinking isr with exception.", e)
+    }
   }
 
   /**
@@ -1432,13 +1445,13 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  private[cluster] def shrinkIsr(outOfSyncReplicas: Set[Int]): Unit = {
+  private[cluster] def shrinkIsr(outOfSyncReplicas: Set[Int], isrUpdateCompleteFuture: CompletableFuture[Boolean] = new CompletableFuture[Boolean]): Unit = {
     // This is called from maybeShrinkIsr which holds the ISR write lock
     if (!isrState.isInflight) {
       // When shrinking the ISR, we cannot assume that the update will succeed as this could erroneously advance the HW
       // We update pendingInSyncReplicaIds here simply to prevent any further ISR updates from occurring until we get
       // the next LeaderAndIsr
-      sendAlterIsrRequest(PendingShrinkIsr(isrState.isr, outOfSyncReplicas))
+      sendAlterIsrRequest(PendingShrinkIsr(isrState.isr, outOfSyncReplicas), isrUpdateCompleteFuture)
     } else {
       trace(s"ISR update in-flight, not removing out-of-sync replicas $outOfSyncReplicas")
     }
@@ -1457,7 +1470,7 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  private def sendAlterIsrRequest(proposedIsrState: IsrState): Unit = {
+  private def sendAlterIsrRequest(proposedIsrState: IsrState, isrUpdateCompleteFuture: CompletableFuture[Boolean] = new CompletableFuture[Boolean]): Unit = {
     val isrToSend: Set[Int] = proposedIsrState match {
       case PendingExpandIsr(isr, newInSyncReplicaId) => isr + newInSyncReplicaId
       case PendingShrinkIsr(isr, outOfSyncReplicaIds) => isr -- outOfSyncReplicaIds
@@ -1467,7 +1480,7 @@ class Partition(val topicPartition: TopicPartition,
     }
 
     val newLeaderAndIsr = new LeaderAndIsr(localBrokerId, leaderEpoch, isrToSend.toList, zkVersion)
-    val alterIsrItem = AlterIsrItem(topicPartition, newLeaderAndIsr, handleAlterIsrResponse(proposedIsrState), controllerEpoch)
+    val alterIsrItem = AlterIsrItem(topicPartition, newLeaderAndIsr, handleAlterIsrResponse(proposedIsrState, isrUpdateCompleteFuture), controllerEpoch)
 
     val oldState = isrState
     isrState = proposedIsrState
@@ -1490,7 +1503,7 @@ class Partition(val topicPartition: TopicPartition,
    * Since our error was non-retryable we are okay staying in this state until we see new metadata from UpdateMetadata
    * or LeaderAndIsr
    */
-  private def handleAlterIsrResponse(proposedIsrState: IsrState)(result: Either[Errors, LeaderAndIsr]): Unit = {
+  private def handleAlterIsrResponse(proposedIsrState: IsrState, isrUpdateCompleteFuture: CompletableFuture[Boolean])(result: Either[Errors, LeaderAndIsr]): Unit = {
     inWriteLock(leaderIsrUpdateLock) {
       if (isrState != proposedIsrState) {
         // This means isrState was updated through leader election or some other mechanism before we got the AlterIsr
@@ -1531,7 +1544,11 @@ class Partition(val topicPartition: TopicPartition,
             isrState = CommittedIsr(leaderAndIsr.isr.toSet)
             zkVersion = leaderAndIsr.zkVersion
             info(s"ISR updated to ${isrState.isr.mkString(",")} and version updated to [$zkVersion]")
-            leaderLogIfLocal.exists(leaderLog => maybeIncrementLeaderHW(leaderLog))
+
+            // Try to increment leader HWM if it tries to shrinkISR.
+            if (proposedIsrState.isInstanceOf[PendingShrinkIsr]) {
+              leaderLogIfLocal.exists(leaderLog => isrUpdateCompleteFuture.complete(maybeIncrementLeaderHW(leaderLog)))
+            }
 
             proposedIsrState match {
               case PendingExpandIsr(_, _) => isrChangeListener.markExpand()
@@ -1540,6 +1557,10 @@ class Partition(val topicPartition: TopicPartition,
             }
           }
       }
+    }
+
+    if (!isrUpdateCompleteFuture.isDone) {
+      isrUpdateCompleteFuture.complete(false)
     }
   }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1487,7 +1487,7 @@ class Partition(val topicPartition: TopicPartition,
       result => {
         try {
           isrUpdateCompleteFuture.complete(handleAlterIsrResponse(proposedIsrState)(result))
-        } finally {
+        } catch {
           case e: Exception => isrUpdateCompleteFuture.completeExceptionally(e)
         }
       },

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -986,45 +986,47 @@ class Partition(val topicPartition: TopicPartition,
     val needsIsrUpdate = !isrState.isInflight && inReadLock(leaderIsrUpdateLock) {
       needsShrinkIsr()
     }
-    val isrUpdateCompleteFuture: CompletableFuture[Boolean] = new CompletableFuture()
-    val leaderHWIncremented = needsIsrUpdate && inWriteLock(leaderIsrUpdateLock) {
-      leaderLogIfLocal.exists { leaderLog =>
-        val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
-        if (outOfSyncReplicaIds.nonEmpty) {
-          val outOfSyncReplicaLog = outOfSyncReplicaIds.map { replicaId =>
-            val replica = getReplica(replicaId)
-            val logEndOffsetMessage = replica
-              .map(_.logEndOffset.toString)
-              .getOrElse("unknown")
-            val lastCaughtUpTimeMessage = replica.map(_.lastCaughtUpTimeMs.toString).getOrElse("unknown")
-            s"(brokerId: $replicaId, endOffset: $logEndOffsetMessage, lastCaughtUpTime: $lastCaughtUpTimeMessage)"
-          }.mkString(" ")
-          val newIsrLog = (isrState.isr -- outOfSyncReplicaIds).mkString(",")
-          info(s"Shrinking ISR from ${isrState.isr.mkString(",")} to $newIsrLog. " +
-               s"Leader: (highWatermark: ${leaderLog.highWatermark}, " +
-               s"endOffset: ${leaderLog.logEndOffset}). " +
-               s"Out of sync replicas: $outOfSyncReplicaLog.")
 
-          shrinkIsr(outOfSyncReplicaIds, isrUpdateCompleteFuture)
+    if (needsIsrUpdate) {
+      info(s"Needs shrink isr for ${topicPartition}")
+      val isrUpdateCompleteFuture: CompletableFuture[Boolean] = new CompletableFuture()
 
-          // we may need to increment high watermark since ISR could be down to 1
-          maybeIncrementLeaderHW(leaderLog)
-        } else {
-          false
+      inWriteLock(leaderIsrUpdateLock) {
+        info(s"Acquired leaderIsrUpdateLock for ${topicPartition}. Starting to update isr.")
+        leaderLogIfLocal.exists { leaderLog =>
+          val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
+          if (outOfSyncReplicaIds.nonEmpty) {
+            val outOfSyncReplicaLog = outOfSyncReplicaIds.map { replicaId =>
+              val replica = getReplica(replicaId)
+              val logEndOffsetMessage = replica
+                .map(_.logEndOffset.toString)
+                .getOrElse("unknown")
+              val lastCaughtUpTimeMessage = replica.map(_.lastCaughtUpTimeMs.toString).getOrElse("unknown")
+              s"(brokerId: $replicaId, endOffset: $logEndOffsetMessage, lastCaughtUpTime: $lastCaughtUpTimeMessage)"
+            }.mkString(" ")
+            val newIsrLog = (isrState.isr -- outOfSyncReplicaIds).mkString(",")
+            info(s"Shrinking ISR from ${isrState.isr.mkString(",")} to $newIsrLog. " +
+              s"Leader: (highWatermark: ${leaderLog.highWatermark}, " +
+              s"endOffset: ${leaderLog.logEndOffset}). " +
+              s"Out of sync replicas: $outOfSyncReplicaLog.")
+
+            shrinkIsr(outOfSyncReplicaIds, isrUpdateCompleteFuture)
+          }
+          return
         }
       }
-    }
 
-    try {
-      // some delayed operations may be unblocked after HW changed
-      if (isrUpdateCompleteFuture.get(isrUpdateTimeoutMs, TimeUnit.MILLISECONDS)) {
-        info(s"Completed shrinking isr and incrementing HWM for partition ${topicPartition}." +
-          s" Current isr is ${isrState}. Trying to complete delayed request")
-        tryCompleteDelayedRequests()
+      try {
+        // some delayed operations may be unblocked after HW changed
+        if (isrUpdateCompleteFuture.get(isrUpdateTimeoutMs, TimeUnit.MILLISECONDS)) {
+          info(s"Completed isr shrink and incremented HWM for partition ${topicPartition}." +
+            s" Current isr is ${isrState}. Trying to complete delayed request")
+          tryCompleteDelayedRequests()
+        }
+      } catch {
+        case e: Exception =>
+          error("Failed to complete shrinking isr with exception.", e)
       }
-    } catch {
-      case e: Exception =>
-        error("Failed to complete shrinking isr with exception.", e)
     }
   }
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1531,6 +1531,8 @@ class Partition(val topicPartition: TopicPartition,
             isrState = CommittedIsr(leaderAndIsr.isr.toSet)
             zkVersion = leaderAndIsr.zkVersion
             info(s"ISR updated to ${isrState.isr.mkString(",")} and version updated to [$zkVersion]")
+            leaderLogIfLocal.exists(leaderLog => maybeIncrementLeaderHW(leaderLog))
+
             proposedIsrState match {
               case PendingExpandIsr(_, _) => isrChangeListener.markExpand()
               case PendingShrinkIsr(_, _) => isrChangeListener.markShrink()

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1445,7 +1445,7 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  private[cluster] def shrinkIsr(outOfSyncReplicas: Set[Int], isrUpdateCompleteFuture: CompletableFuture[Boolean]): Unit = {
+  private[cluster] def shrinkIsr(outOfSyncReplicas: Set[Int], isrUpdateCompleteFuture: CompletableFuture[Boolean] = new CompletableFuture[Boolean]): Unit = {
     // This is called from maybeShrinkIsr which holds the ISR write lock
     if (!isrState.isInflight) {
       // When shrinking the ISR, we cannot assume that the update will succeed as this could erroneously advance the HW

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -273,7 +273,7 @@ class PartitionLockTest extends Logging {
       alterIsrManager,
       transferLeaderManager) {
 
-      override def shrinkIsr(newIsr: Set[Int]): Unit = {
+      override def shrinkIsr(newIsr: Set[Int], isrUpdateCompleteFuture: CompletableFuture[Boolean]): Unit = {
         shrinkIsrSemaphore.acquire()
         try {
           super.shrinkIsr(newIsr)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -276,7 +276,7 @@ class PartitionLockTest extends Logging {
       override def shrinkIsr(newIsr: Set[Int], isrUpdateCompleteFuture: CompletableFuture[Boolean]): Unit = {
         shrinkIsrSemaphore.acquire()
         try {
-          super.shrinkIsr(newIsr)
+          super.shrinkIsr(newIsr, isrUpdateCompleteFuture)
         } finally {
           shrinkIsrSemaphore.release()
         }


### PR DESCRIPTION
This PR should fix the super high Produce latency during uncontrolled broker death.

**Description**

Today, the maybeIncrementLeaderHW is called after shrinkISR() being called:
https://github.com/linkedin/kafka/blob/3475c3a1b998ec3416692f304b5c82b5f0781576/core/src/main/scala/kafka/cluster/Partition.scala#L1006

The problem is shrinkISR() internally sends the AlterISR request to controller in an async manner. By the time maybeIncrementLeaderHW is called, the ISR state on the current broker is likely not updated yet.

This PR invokes maybeIncrementLeaderHW in the callback of the AlterISR request, making sure the ISR state has been updated when trying to incrementLeaderHW. Meanwhile, it calls the tryCompleteDelayedRequests after the HW is incremented. To avoid deadlock, the tryCompleteDelayedRequests is called out of the leaderIsrUpdateLock, with the help of a completable future.

With this change, the Produce Delay should be capped at ShrinkISR duration (potentially plus controller queue length), comparing to the previously infinite wait time.

**Testing**
In cert-candidate cluster, before the change, lots of request are timeout on broker hard-kill
![Screenshot 2023-09-07 at 10 06 14 PM](https://github.com/linkedin/kafka/assets/38366317/e1911337-3bac-47dd-939c-9e73c54ed80a)




After the change, the produce delay is capped at replicaLagMaxMs * 1.5 = 15 seconds

![Screenshot 2023-09-07 at 7 51 59 PM](https://github.com/linkedin/kafka/assets/38366317/9154da71-e965-4fc6-b970-c7e10333f1f3)



