### PR TITLE
add rpc for xinfra topic creation and deletion

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -162,6 +162,9 @@
     <suppress checks="MethodLength"
               files="KTableImpl.java"/>
 
+    <suppress checks="MethodLength"
+              files="(AbstractRequest|AbstractResponse).java"/>
+
     <suppress checks="ParameterNumber"
               files="StreamThread.java"/>
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -199,6 +199,13 @@ public interface Admin extends AutoCloseable {
      */
     CreateTopicsResult createTopics(Collection<NewTopic> newTopics, CreateTopicsOptions options);
 
+    default CreateOrDeleteXinfraTopicsZnodeResult createXinfraTopicsZnode(Map<String, String> xinfraTopics) {
+        return createXinfraTopicsZnode(xinfraTopics, new CreateXinfraTopicsZnodeOptions());
+    }
+
+    CreateOrDeleteXinfraTopicsZnodeResult createXinfraTopicsZnode(Map<String, String> xinfraTopics,
+        CreateXinfraTopicsZnodeOptions options);
+
     /**
      * This is a convenience method for {@link #deleteTopics(TopicCollection, DeleteTopicsOptions)}
      * with default options. See the overload for more details.
@@ -263,6 +270,12 @@ public interface Admin extends AutoCloseable {
      */
     DeleteTopicsResult deleteTopics(TopicCollection topics, DeleteTopicsOptions options);
 
+    default CreateOrDeleteXinfraTopicsZnodeResult deleteXinfraTopicsZnode(Map<String, String> xinfraTopics) {
+        return deleteXinfraTopicsZnode(xinfraTopics, new DeleteXinfraTopicsZnodeOptions());
+    }
+
+    CreateOrDeleteXinfraTopicsZnodeResult deleteXinfraTopicsZnode(Map<String, String> xinfraTopics, DeleteXinfraTopicsZnodeOptions options);
+
     /**
      * List the topics available in the cluster with the default options.
      * <p>
@@ -282,6 +295,12 @@ public interface Admin extends AutoCloseable {
      * @return The ListTopicsResult.
      */
     ListTopicsResult listTopics(ListTopicsOptions options);
+
+    default ListXinfraTopicsResult listXinfraTopics() {
+        return listXinfraTopics(new ListXinfraTopicsOptions());
+    }
+
+    ListXinfraTopicsResult listXinfraTopics(ListXinfraTopicsOptions options);
 
     /**
      * Describe some topics in the cluster, with the default options.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateOrDeleteXinfraTopicsZnodeResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateOrDeleteXinfraTopicsZnodeResult.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link Admin#CreateXinfraTopicZnode()} or {@link Admin#DeleteXinfraTopicZnode()}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class CreateOrDeleteXinfraTopicsZnodeResult {
+    private final Map<String, KafkaFuture<Void>> future;
+
+    CreateOrDeleteXinfraTopicsZnodeResult(Map<String, KafkaFuture<Void>> future) {
+        this.future = future;
+    }
+
+    public Map<String, KafkaFuture<Void>> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateXinfraTopicsZnodeOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateXinfraTopicsZnodeOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * Options for {@link Admin#createXinfraTopicsZnode(Map, CreateXinfraTopicsZnodeOptions)} (Collection)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class CreateXinfraTopicsZnodeOptions extends AbstractOptions<CreateXinfraTopicsZnodeOptions> {
+    private boolean retryOnQuotaViolation = true;
+
+    /**
+     * Set the timeout in milliseconds for this operation or {@code null} if the default api timeout for the
+     * AdminClient should be used.
+     *
+     */
+    // This method is retained to keep binary compatibility with 0.11
+    public CreateXinfraTopicsZnodeOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * Set to true if quota violation should be automatically retried.
+     */
+    public CreateXinfraTopicsZnodeOptions retryOnQuotaViolation(boolean retryOnQuotaViolation) {
+        this.retryOnQuotaViolation = retryOnQuotaViolation;
+        return this;
+    }
+
+    /**
+     * Returns true if quota violation should be automatically retried.
+     */
+    public boolean shouldRetryOnQuotaViolation() {
+        return retryOnQuotaViolation;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteXinfraTopicsZnodeOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteXinfraTopicsZnodeOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * Options for {@link Admin#deleteXinfraTopicsZnode(Map, DeleteXinfraTopicsZnodeOptions)} (Collection)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DeleteXinfraTopicsZnodeOptions extends AbstractOptions<DeleteXinfraTopicsZnodeOptions> {
+    private boolean retryOnQuotaViolation = true;
+
+    /**
+     * Set the timeout in milliseconds for this operation or {@code null} if the default api timeout for the
+     * AdminClient should be used.
+     *
+     */
+    // This method is retained to keep binary compatibility with 0.11
+    public DeleteXinfraTopicsZnodeOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * Set to true if quota violation should be automatically retried.
+     */
+    public DeleteXinfraTopicsZnodeOptions retryOnQuotaViolation(boolean retryOnQuotaViolation) {
+        this.retryOnQuotaViolation = retryOnQuotaViolation;
+        return this;
+    }
+
+    /**
+     * Returns true if quota violation should be automatically retried.
+     */
+    public boolean shouldRetryOnQuotaViolation() {
+        return retryOnQuotaViolation;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -142,6 +142,8 @@ import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData;
 import org.apache.kafka.common.message.LiMoveControllerRequestData;
+import org.apache.kafka.common.message.LiXinfraTopicCreateRequestData;
+import org.apache.kafka.common.message.LiXinfraTopicDeleteRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition;
@@ -149,6 +151,7 @@ import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsTopic;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicResponse;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
+import org.apache.kafka.common.message.ListXinfraTopicsRequestData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.UnregisterBrokerRequestData;
@@ -221,12 +224,18 @@ import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckReque
 import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckResponse;
 import org.apache.kafka.common.requests.LiMoveControllerRequest;
 import org.apache.kafka.common.requests.LiMoveControllerResponse;
+import org.apache.kafka.common.requests.LiXinfraTopicCreateRequest;
+import org.apache.kafka.common.requests.LiXinfraTopicCreateResponse;
+import org.apache.kafka.common.requests.LiXinfraTopicDeleteRequest;
+import org.apache.kafka.common.requests.LiXinfraTopicDeleteResponse;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.apache.kafka.common.requests.ListOffsetsResponse;
 import org.apache.kafka.common.requests.ListPartitionReassignmentsRequest;
 import org.apache.kafka.common.requests.ListPartitionReassignmentsResponse;
+import org.apache.kafka.common.requests.ListXinfraTopicsRequest;
+import org.apache.kafka.common.requests.ListXinfraTopicsResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RenewDelegationTokenRequest;
@@ -1596,6 +1605,45 @@ public class KafkaAdminClient extends AdminClient {
         return new CreateTopicsResult(new HashMap<>(topicFutures));
     }
 
+    @Override
+    public CreateOrDeleteXinfraTopicsZnodeResult createXinfraTopicsZnode(final Map<String, String> xinfraTopics,
+                                                                         final CreateXinfraTopicsZnodeOptions options) {
+        final Map<String, KafkaFutureImpl<Void>> topicFutures = new HashMap<>(xinfraTopics.size());
+        final long now = time.milliseconds();
+        List<LiXinfraTopicCreateRequestData.XinfraTopics> topics = new ArrayList<>();
+        xinfraTopics.forEach((topic, namespace) -> {
+            topics.add(new LiXinfraTopicCreateRequestData.XinfraTopics().setName(topic).setNamespace(namespace));
+            topicFutures.put(topic, new KafkaFutureImpl<>());
+        });
+        runnable.call(new Call("createXinfraTopicsZnode", calcDeadlineMs(now, options.timeoutMs()),
+            new ControllerNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new LiXinfraTopicCreateRequest.Builder(new LiXinfraTopicCreateRequestData()
+                    .setTopics(topics)
+                    .setTimeoutMs(timeoutMs),  (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                LiXinfraTopicCreateResponse response = (LiXinfraTopicCreateResponse) abstractResponse;
+                Errors errors = Errors.forCode(response.data().errorCode());
+                if (errors != Errors.NONE) {
+                    completeAllExceptionally(topicFutures.values(), errors.exception());
+                    return;
+                }
+                topicFutures.values().forEach(f -> f.complete(null));
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                // Fail all the other remaining futures
+                completeAllExceptionally(topicFutures.values(), throwable);
+            }
+        }, now);
+        return new CreateOrDeleteXinfraTopicsZnodeResult(new HashMap<>(topicFutures));
+    }
+
     private Call getCreateTopicsCall(final CreateTopicsOptions options,
                                      final Map<String, KafkaFutureImpl<TopicMetadataAndConfig>> futures,
                                      final CreatableTopicCollection topics,
@@ -1706,6 +1754,45 @@ public class KafkaAdminClient extends AdminClient {
             return DeleteTopicsResult.ofTopicNames(handleDeleteTopicsUsingNames(((TopicNameCollection) topics).topicNames(), options));
         else
             throw new IllegalArgumentException("The TopicCollection: " + topics + " provided did not match any supported classes for deleteTopics.");
+    }
+
+    @Override
+    public CreateOrDeleteXinfraTopicsZnodeResult deleteXinfraTopicsZnode(Map<String, String> xinfraTopics,
+                                                                         DeleteXinfraTopicsZnodeOptions options) {
+        final Map<String, KafkaFutureImpl<Void>> topicFutures = new HashMap<>(xinfraTopics.size());
+        final long now = time.milliseconds();
+        List<LiXinfraTopicDeleteRequestData.XinfraTopics> topics = new ArrayList<>();
+        xinfraTopics.forEach((topic, namespace) -> {
+            topics.add(new LiXinfraTopicDeleteRequestData.XinfraTopics().setName(topic).setNamespace(namespace));
+            topicFutures.put(topic, new KafkaFutureImpl<>());
+        });
+        runnable.call(new Call("deleteXinfraTopicsZnode", calcDeadlineMs(now, options.timeoutMs()),
+            new ControllerNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new LiXinfraTopicDeleteRequest.Builder(new LiXinfraTopicDeleteRequestData()
+                    .setTopics(topics)
+                    .setTimeoutMs(timeoutMs),  (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                LiXinfraTopicDeleteResponse response = (LiXinfraTopicDeleteResponse) abstractResponse;
+                Errors errors = Errors.forCode(response.data().errorCode());
+                if (errors != Errors.NONE) {
+                    completeAllExceptionally(topicFutures.values(), errors.exception());
+                    return;
+                }
+                topicFutures.values().forEach(f -> f.complete(null));
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                // Fail all the other remaining futures
+                completeAllExceptionally(topicFutures.values(), throwable);
+            }
+        }, now);
+        return new CreateOrDeleteXinfraTopicsZnodeResult(new HashMap<>(topicFutures));
     }
 
     private Map<String, KafkaFuture<Void>> handleDeleteTopicsUsingNames(final Collection<String> topicNames,
@@ -1943,6 +2030,39 @@ public class KafkaAdminClient extends AdminClient {
             }
         }, now);
         return new ListTopicsResult(topicListingFuture);
+    }
+
+    @Override
+    public ListXinfraTopicsResult listXinfraTopics(ListXinfraTopicsOptions options) {
+        final KafkaFutureImpl<List<String>> xinfraTopicListingFuture = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        runnable.call(new Call("listXinfraTopics", calcDeadlineMs(now, options.timeoutMs()),
+            new LeastLoadedNodeProvider()) {
+
+            @Override
+            AbstractRequest.Builder createRequest(int timeoutMs) {
+                return new ListXinfraTopicsRequest.Builder(new ListXinfraTopicsRequestData(), (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                ListXinfraTopicsResponse response = (ListXinfraTopicsResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                if (error != Errors.NONE) {
+                    xinfraTopicListingFuture.completeExceptionally(error.exception());
+                    return;
+                }
+
+                List<String> allXinfraTopics = new ArrayList<>(response.data().topics());
+                xinfraTopicListingFuture.complete(allXinfraTopics);
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                xinfraTopicListingFuture.completeExceptionally(throwable);
+            }
+        }, now);
+        return new ListXinfraTopicsResult(xinfraTopicListingFuture);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListXinfraTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListXinfraTopicsOptions.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Objects;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * Options for {@link Admin#listXinfraTopics()}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class ListXinfraTopicsOptions extends AbstractOptions<ListXinfraTopicsOptions> {
+    private boolean listInternal = false;
+
+    /**
+     * Set the timeout in milliseconds for this operation or {@code null} if the default api timeout for the
+     * AdminClient should be used.
+     *
+     */
+    // This method is retained to keep binary compatibility with 0.11
+    public ListXinfraTopicsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * Set whether we should list internal topics.
+     *
+     * @param listInternal  Whether we should list internal topics.  null means to use
+     *                      the default.
+     * @return              This ListTopicsOptions object.
+     */
+    public ListXinfraTopicsOptions listInternal(boolean listInternal) {
+        this.listInternal = listInternal;
+        return this;
+    }
+
+    /**
+     * Return true if we should list internal topics.
+     */
+    public boolean shouldListInternal() {
+        return listInternal;
+    }
+
+    @Override
+    public String toString() {
+        return "ListXinfraTopicsOptions(" +
+            "listInternal=" + listInternal +
+            ')';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListXinfraTopicsOptions that = (ListXinfraTopicsOptions) o;
+        return listInternal == that.listInternal;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(listInternal);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListXinfraTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListXinfraTopicsResult.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * The result of the {@link Admin#listXinfraTopics()} call.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class ListXinfraTopicsResult {
+    final KafkaFuture<List<String>> future;
+
+    ListXinfraTopicsResult(KafkaFuture<List<String>> future) {
+        this.future = future;
+    }
+
+    /**
+     * Return a future which yields a map of topic names to namespaces.
+     */
+    public KafkaFuture<List<String>> namesAndNamespaces() {
+        return future;
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
@@ -47,12 +47,29 @@ public class NoOpAdminClient extends AdminClient {
     }
 
     @Override
+    public CreateOrDeleteXinfraTopicsZnodeResult createXinfraTopicsZnode(Map<String, String> xinfraTopics,
+        CreateXinfraTopicsZnodeOptions options) {
+        return null;
+    }
+
+    @Override
     public DeleteTopicsResult deleteTopics(TopicCollection topics, DeleteTopicsOptions options) {
         return null;
     }
 
     @Override
+    public CreateOrDeleteXinfraTopicsZnodeResult deleteXinfraTopicsZnode(Map<String, String> xinfraTopics,
+        DeleteXinfraTopicsZnodeOptions options) {
+        return null;
+    }
+
+    @Override
     public ListTopicsResult listTopics(ListTopicsOptions options) {
+        return null;
+    }
+
+    @Override
+    public ListXinfraTopicsResult listXinfraTopics(ListXinfraTopicsOptions options) {
         return null;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -113,7 +113,11 @@ public enum ApiKeys {
     // LinkedIn API keys for APIs not yet upstreamed.
     LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK(ApiMessageType.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, true, true),
     LI_COMBINED_CONTROL(ApiMessageType.LI_COMBINED_CONTROL, true),
-    LI_MOVE_CONTROLLER(ApiMessageType.LI_MOVE_CONTROLLER, true);
+    LI_MOVE_CONTROLLER(ApiMessageType.LI_MOVE_CONTROLLER, true),
+
+    LI_XINFRA_TOPIC_CREATE(ApiMessageType.LI_XINFRA_TOPIC_CREATE, false, true),
+    LI_XINFRA_TOPIC_DELETE(ApiMessageType.LI_XINFRA_TOPIC_DELETE, false, true),
+    LIST_XINFRA_TOPICS(ApiMessageType.LIST_XINFRA_TOPICS);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -309,6 +309,12 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return LiCombinedControlRequest.parse(buffer, apiVersion);
             case LI_MOVE_CONTROLLER:
                 return LiMoveControllerRequest.parse(buffer, apiVersion);
+            case LI_XINFRA_TOPIC_CREATE:
+                return LiXinfraTopicCreateRequest.parse(buffer, apiVersion);
+            case LI_XINFRA_TOPIC_DELETE:
+                return LiXinfraTopicDeleteRequest.parse(buffer, apiVersion);
+            case LIST_XINFRA_TOPICS:
+                return ListXinfraTopicsRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -253,6 +253,12 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return LiCombinedControlResponse.parse(responseBuffer, version);
             case LI_MOVE_CONTROLLER:
                 return LiMoveControllerResponse.parse(responseBuffer, version);
+            case LI_XINFRA_TOPIC_CREATE:
+                return LiXinfraTopicCreateResponse.parse(responseBuffer, version);
+            case LI_XINFRA_TOPIC_DELETE:
+                return LiXinfraTopicDeleteResponse.parse(responseBuffer, version);
+            case LIST_XINFRA_TOPICS:
+                return ListXinfraTopicsResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiXinfraTopicCreateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiXinfraTopicCreateRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiXinfraTopicCreateRequestData;
+import org.apache.kafka.common.message.LiXinfraTopicCreateResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiXinfraTopicCreateRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiXinfraTopicCreateRequest> {
+        private final LiXinfraTopicCreateRequestData data;
+
+        public Builder(LiXinfraTopicCreateRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_XINFRA_TOPIC_CREATE, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiXinfraTopicCreateRequest build(short version) {
+            return new LiXinfraTopicCreateRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiXinfraTopicCreateRequestData data;
+
+    LiXinfraTopicCreateRequest(LiXinfraTopicCreateRequestData data, short version) {
+        super(ApiKeys.LI_XINFRA_TOPIC_CREATE, version);
+        this.data = data;
+    }
+
+    public static LiXinfraTopicCreateRequest parse(ByteBuffer buffer, short version) {
+        return new LiXinfraTopicCreateRequest(new LiXinfraTopicCreateRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiXinfraTopicCreateResponseData data = new LiXinfraTopicCreateResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiXinfraTopicCreateResponse(data, version());
+    }
+
+    @Override
+    public LiXinfraTopicCreateRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiXinfraTopicCreateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiXinfraTopicCreateResponse.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.message.LiXinfraTopicCreateResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiXinfraTopicCreateResponse extends AbstractResponse {
+    private final LiXinfraTopicCreateResponseData data;
+    private final short version;
+
+    public LiXinfraTopicCreateResponse(LiXinfraTopicCreateResponseData data, short version) {
+        super(ApiKeys.LI_XINFRA_TOPIC_CREATE);
+        this.data = data;
+        this.version = version;
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    public LiXinfraTopicCreateResponseData data() {
+        return data;
+    }
+
+    public static LiXinfraTopicCreateResponse prepareResponse(Errors error, short version) {
+        LiXinfraTopicCreateResponseData data = new LiXinfraTopicCreateResponseData();
+        data.setErrorCode(error.code());
+        return new LiXinfraTopicCreateResponse(data, version);
+    }
+
+    public static LiXinfraTopicCreateResponse parse(ByteBuffer buffer, short version) {
+        return new LiXinfraTopicCreateResponse(new LiXinfraTopicCreateResponseData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return 0;
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiXinfraTopicDeleteRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiXinfraTopicDeleteRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiXinfraTopicDeleteRequestData;
+import org.apache.kafka.common.message.LiXinfraTopicDeleteResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiXinfraTopicDeleteRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiXinfraTopicDeleteRequest> {
+        private final LiXinfraTopicDeleteRequestData data;
+
+        public Builder(LiXinfraTopicDeleteRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_XINFRA_TOPIC_DELETE, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiXinfraTopicDeleteRequest build(short version) {
+            return new LiXinfraTopicDeleteRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiXinfraTopicDeleteRequestData data;
+
+    LiXinfraTopicDeleteRequest(LiXinfraTopicDeleteRequestData data, short version) {
+        super(ApiKeys.LI_XINFRA_TOPIC_DELETE, version);
+        this.data = data;
+    }
+
+    public static LiXinfraTopicDeleteRequest parse(ByteBuffer buffer, short version) {
+        return new LiXinfraTopicDeleteRequest(new LiXinfraTopicDeleteRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiXinfraTopicDeleteResponseData data = new LiXinfraTopicDeleteResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiXinfraTopicDeleteResponse(data, version());
+    }
+
+    @Override
+    public LiXinfraTopicDeleteRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiXinfraTopicDeleteResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiXinfraTopicDeleteResponse.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.message.LiXinfraTopicDeleteResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiXinfraTopicDeleteResponse extends AbstractResponse {
+    private final LiXinfraTopicDeleteResponseData data;
+    private final short version;
+
+    public LiXinfraTopicDeleteResponse(LiXinfraTopicDeleteResponseData data, short version) {
+        super(ApiKeys.LI_XINFRA_TOPIC_DELETE);
+        this.data = data;
+        this.version = version;
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    public LiXinfraTopicDeleteResponseData data() {
+        return data;
+    }
+
+    public static LiXinfraTopicDeleteResponse prepareResponse(Errors error, short version) {
+        LiXinfraTopicDeleteResponseData data = new LiXinfraTopicDeleteResponseData();
+        data.setErrorCode(error.code());
+        return new LiXinfraTopicDeleteResponse(data, version);
+    }
+
+    public static LiXinfraTopicDeleteResponse parse(ByteBuffer buffer, short version) {
+        return new LiXinfraTopicDeleteResponse(new LiXinfraTopicDeleteResponseData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return 0;
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListXinfraTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListXinfraTopicsRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.apache.kafka.common.message.ListXinfraTopicsRequestData;
+import org.apache.kafka.common.message.ListXinfraTopicsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class ListXinfraTopicsRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<ListXinfraTopicsRequest> {
+
+        private final ListXinfraTopicsRequestData data;
+
+        public Builder(ListXinfraTopicsRequestData data, short allowedVersion) {
+            super(ApiKeys.LIST_XINFRA_TOPICS, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public ListXinfraTopicsRequest build(short version) {
+            return new ListXinfraTopicsRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final ListXinfraTopicsRequestData data;
+
+    public ListXinfraTopicsRequest(ListXinfraTopicsRequestData data, short version) {
+        super(ApiKeys.LIST_XINFRA_TOPICS, version);
+        this.data = data;
+    }
+
+    @Override
+    public ListXinfraTopicsResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        ListXinfraTopicsResponseData data = new ListXinfraTopicsResponseData().
+            setTopics(Collections.emptyList()).
+            setErrorCode(Errors.forException(e).code());
+        return new ListXinfraTopicsResponse(data, version());
+    }
+
+    public static ListXinfraTopicsRequest parse(ByteBuffer buffer, short version) {
+        return new ListXinfraTopicsRequest(new ListXinfraTopicsRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public ListXinfraTopicsRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListXinfraTopicsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListXinfraTopicsResponse.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.message.ListXinfraTopicsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class ListXinfraTopicsResponse extends AbstractResponse {
+    private final ListXinfraTopicsResponseData data;
+    private final short version;
+
+    public ListXinfraTopicsResponse(ListXinfraTopicsResponseData data, short version) {
+        super(ApiKeys.LIST_XINFRA_TOPICS);
+        this.data = data;
+        this.version = version;
+    }
+
+    @Override
+    public ListXinfraTopicsResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return 0;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return errorCounts(Errors.forCode(data.errorCode()));
+    }
+
+    public static ListXinfraTopicsResponse parse(ByteBuffer buffer, short version) {
+        return new ListXinfraTopicsResponse(
+            new ListXinfraTopicsResponseData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    public static ListXinfraTopicsResponse prepareResponse(Errors error, short version) {
+        ListXinfraTopicsResponseData data = new ListXinfraTopicsResponseData();
+        data.setErrorCode(error.code());
+        return new ListXinfraTopicsResponse(data, version);
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/resources/common/message/LiXinfraTopicCreateRequest.json
+++ b/clients/src/main/resources/common/message/LiXinfraTopicCreateRequest.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1003,
+  "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
+  "name": "LiXinfraTopicCreateRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]XinfraTopics", "versions": "0+", "about": "The name and namespace of the xinfra topic",
+      "fields": [
+        {"name": "Name", "type": "string", "versions": "0+", "about": "The topic name"},
+        {"name": "Namespace", "type": "string", "versions": "0+", "about": "The namespace of the topic"}
+      ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The length of time in milliseconds to wait for the creations to complete." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiXinfraTopicCreateResponse.json
+++ b/clients/src/main/resources/common/message/LiXinfraTopicCreateResponse.json
@@ -1,0 +1,25 @@
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1003,
+  "type": "response",
+  "name": "LiXinfraTopicCreateResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiXinfraTopicDeleteRequest.json
+++ b/clients/src/main/resources/common/message/LiXinfraTopicDeleteRequest.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1004,
+  "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
+  "name": "LiXinfraTopicDeleteRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]XinfraTopics", "versions": "0+", "about": "The name and namespace of the xinfra topic",
+      "fields": [
+        {"name": "Name", "type": "string", "versions": "0+", "about": "The topic name"},
+        {"name": "Namespace", "type": "string", "versions": "0+", "about": "The namespace of the topic"}
+      ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The length of time in milliseconds to wait for the deletions to complete." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiXinfraTopicDeleteResponse.json
+++ b/clients/src/main/resources/common/message/LiXinfraTopicDeleteResponse.json
@@ -1,0 +1,25 @@
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1004,
+  "type": "response",
+  "name": "LiXinfraTopicDeleteResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." }
+  ]
+}

--- a/clients/src/main/resources/common/message/ListXinfraTopicsRequest.json
+++ b/clients/src/main/resources/common/message/ListXinfraTopicsRequest.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1005,
+  "type": "request",
+  "listeners": ["zkBroker"],
+  "name": "ListXinfraTopicsRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+  ]
+}

--- a/clients/src/main/resources/common/message/ListXinfraTopicsResponse.json
+++ b/clients/src/main/resources/common/message/ListXinfraTopicsResponse.json
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1005,
+  "type": "response",
+  "name": "ListXinfraTopicsResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]string", "versions": "0+", "about": "The name and namespace of the xinfra topic"},
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -329,6 +329,12 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public CreateOrDeleteXinfraTopicsZnodeResult createXinfraTopicsZnode(Map<String, String> xinfraTopics,
+        CreateXinfraTopicsZnodeOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     synchronized public ListTopicsResult listTopics(ListTopicsOptions options) {
         Map<String, TopicListing> topicListings = new HashMap<>();
 
@@ -352,6 +358,11 @@ public class MockAdminClient extends AdminClient {
         KafkaFutureImpl<Map<String, TopicListing>> future = new KafkaFutureImpl<>();
         future.complete(topicListings);
         return new ListTopicsResult(future);
+    }
+
+    @Override
+    public ListXinfraTopicsResult listXinfraTopics(ListXinfraTopicsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override
@@ -405,6 +416,11 @@ public class MockAdminClient extends AdminClient {
         else
             throw new IllegalArgumentException("The TopicCollection provided did not match any supported classes for deleteTopics.");
         return result;
+    }
+
+    @Override
+    public CreateOrDeleteXinfraTopicsZnodeResult deleteXinfraTopicsZnode(Map<String, String> xinfraTopics, DeleteXinfraTopicsZnodeOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     private Map<String, KafkaFuture<Void>> handleDeleteTopicsUsingNames(Collection<String> topicNameCollection, DeleteTopicsOptions options) {

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -98,6 +98,9 @@ object RequestConvertToJson {
       case req: LiControlledShutdownSkipSafetyCheckRequest => LiControlledShutdownSkipSafetyCheckRequestDataJsonConverter.write(req.data, request.version)
       case req: LiCombinedControlRequest => LiCombinedControlRequestDataJsonConverter.write(req.data, request.version())
       case req: LiMoveControllerRequest => LiMoveControllerRequestDataJsonConverter.write(req.data, request.version())
+      case req: LiXinfraTopicCreateRequest => LiXinfraTopicCreateRequestDataJsonConverter.write(req.data, request.version())
+      case req: LiXinfraTopicDeleteRequest => LiXinfraTopicDeleteRequestDataJsonConverter.write(req.data, request.version())
+      case req: ListXinfraTopicsRequest => ListXinfraTopicsRequestDataJsonConverter.write(req.data, request.version())
       case _ => throw new IllegalStateException(s"ApiKey ${request.apiKey} is not currently handled in `request`, the " +
         "code should be updated to do so.");
     }
@@ -176,6 +179,9 @@ object RequestConvertToJson {
       case res: LiControlledShutdownSkipSafetyCheckResponse => LiControlledShutdownSkipSafetyCheckResponseDataJsonConverter.write(res.data, version)
       case res: LiCombinedControlResponse => LiCombinedControlResponseDataJsonConverter.write(res.data, version)
       case res: LiMoveControllerResponse => LiMoveControllerResponseDataJsonConverter.write(res.data, version)
+      case res: LiXinfraTopicCreateResponse => LiXinfraTopicCreateResponseDataJsonConverter.write(res.data, version)
+      case res: LiXinfraTopicDeleteResponse => LiXinfraTopicDeleteResponseDataJsonConverter.write(res.data, version)
+      case res: ListXinfraTopicsResponse => ListXinfraTopicsResponseDataJsonConverter.write(res.data, version)
       case _ => throw new IllegalStateException(s"ApiKey ${response.apiKey} is not currently handled in `response`, the " +
         "code should be updated to do so.");
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -256,6 +256,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => handleLiControlledShutdownSkipSafetyCheck(request)
         case ApiKeys.LI_COMBINED_CONTROL => handleLiCombinedControlRequest(request, requestLocal)
         case ApiKeys.LI_MOVE_CONTROLLER => handleMoveControllerRequest(request)
+        case ApiKeys.LI_XINFRA_TOPIC_CREATE => maybeForwardToController(request, handleXinfraTopicCreateRequest)
+        case ApiKeys.LI_XINFRA_TOPIC_DELETE => maybeForwardToController(request, handleXinfraTopicDeleteRequest)
+        case ApiKeys.LIST_XINFRA_TOPICS => handleListXinfraTopicsRequest(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -1666,6 +1669,25 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     sendResponseCallback(describeGroupsResponseData)
+  }
+
+  def handleListXinfraTopicsRequest(request: RequestChannel.Request): Unit = {
+    val listXinfraTopicsRequest = request.body[ListXinfraTopicsRequest]
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+
+    val listXinfraTopicsResponse = try {
+      val allXinfraTopics = zkSupport.zkClient.getAllXinfraTopics
+      val topicsList = allXinfraTopics.map {
+        case (topic, namespace) => (topic + " " + namespace)
+      }.toList.asJava
+
+      new ListXinfraTopicsResponse(
+        new ListXinfraTopicsResponseData().setTopics(topicsList), listXinfraTopicsRequest.version())
+    } catch {
+      case throwable: Throwable =>
+        listXinfraTopicsRequest.getErrorResponse(throwable)
+    }
+    requestHelper.sendResponseExemptThrottle(request, listXinfraTopicsResponse)
   }
 
   def handleListGroupsRequest(request: RequestChannel.Request): Unit = {
@@ -3684,6 +3706,40 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     requestHelper.sendResponseExemptThrottle(request, moveControllerResponse)
+  }
+
+  def handleXinfraTopicCreateRequest(request: RequestChannel.Request): Unit = {
+    val xinfraTopicCreateRequest = request.body[LiXinfraTopicCreateRequest]
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+
+    val xinfraTopicCreateResponse = try {
+      xinfraTopicCreateRequest.data().topics().forEach(xinfraTopic => {
+        zkSupport.zkClient.createXinfraTopicZNode(xinfraTopic.name(), xinfraTopic.namespace())
+      })
+      LiXinfraTopicCreateResponse.prepareResponse(Errors.NONE, xinfraTopicCreateRequest.version())
+    } catch {
+      case throwable: Throwable =>
+        xinfraTopicCreateRequest.getErrorResponse(throwable)
+    }
+
+    requestHelper.sendResponseExemptThrottle(request, xinfraTopicCreateResponse)
+  }
+
+  def handleXinfraTopicDeleteRequest(request: RequestChannel.Request): Unit = {
+    val xinfraTopicDeleteRequest = request.body[LiXinfraTopicDeleteRequest]
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+
+    val xinfraTopicDeleteResponse = try {
+      xinfraTopicDeleteRequest.data().topics().forEach(xinfraTopic => {
+        zkSupport.zkClient.deleteXinfraTopicZNode(xinfraTopic.name())
+      })
+      LiXinfraTopicDeleteResponse.prepareResponse(Errors.NONE, xinfraTopicDeleteRequest.version())
+    } catch {
+      case throwable: Throwable =>
+        xinfraTopicDeleteRequest.getErrorResponse(throwable)
+    }
+
+    requestHelper.sendResponseExemptThrottle(request, xinfraTopicDeleteResponse)
   }
 }
 

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -145,6 +145,25 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
     }.toMap
   }
 
+  def getAllXinfraTopics: Map[String, String] = {
+    val topics = getChildren(XinfraTopicsZNode.path)
+
+    val getDataRequests = topics.map(topic => GetDataRequest(
+      XinfraTopicZnode.path(topic),
+      ctx = Some(topic)))
+
+    val getDataResponses = retryRequestsUntilConnected(getDataRequests)
+    getDataResponses.flatMap { getDataResponse =>
+      val topic = getDataResponse.ctx.get.asInstanceOf[String]
+      getDataResponse.resultCode match {
+        case Code.OK =>
+          Some(topic, XinfraTopicZnode.decode(getDataResponse.data))
+        case Code.NONODE => None
+        case _ => throw getDataResponse.resultException.get
+      }
+    }.toMap
+  }
+
   /**
    * Registers a given broker in zookeeper as the controller and increments controller epoch.
    * @param controllerId the id of the broker that is to be registered as the controller.
@@ -1860,6 +1879,15 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
 
   def deleteFeatureZNode(): Unit = {
     deletePath(FeatureZNode.path, ZkVersion.MatchAnyVersion, false)
+  }
+
+  def createXinfraTopicZNode(topic: String, namespace: String): Unit = {
+    val path = XinfraTopicZnode.path(topic)
+    createRecursive(path, XinfraTopicZnode.encode(namespace))
+  }
+
+  def deleteXinfraTopicZNode(topic: String): Unit = {
+    deletePath(XinfraTopicZnode.path(topic), ZkVersion.MatchAnyVersion, false)
   }
 
   private def setConsumerOffset(group: String, topicPartition: TopicPartition, offset: Long): SetDataResponse = {

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -75,6 +75,10 @@ object BrokersZNode {
   def path = "/brokers"
 }
 
+object XinfraTopicsZNode {
+  def path = "/xinfraTopics"
+}
+
 object PreferredControllersZNode {
   def path = s"${BrokersZNode.path}/preferred_controllers"
   def encode: Array[Byte] = null
@@ -333,6 +337,12 @@ object BrokerIdZNode {
           s"${new String(jsonBytes, UTF_8)}", e)
     }
   }
+}
+
+object XinfraTopicZnode {
+  def path(topic: String) = s"${XinfraTopicsZNode.path}/$topic"
+  def encode(namespace: String): Array[Byte] = namespace.getBytes(UTF_8)
+  def decode(bytes: Array[Byte]): String = if (bytes != null) new String(bytes, UTF_8) else ""
 }
 
 object TopicsZNode {

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -133,6 +133,27 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
   }
 
   @Test
+  def testXinfraTopicCreateDeleteAndGet(): Unit = {
+    client = Admin.create(createConfig)
+    val xinfraTopic = Map("xinfra-test-topic" -> "tracking").asJava
+
+    // create the xinfra topic znode
+    client.createXinfraTopicsZnode(xinfraTopic)
+
+    // list xinfra topic should return exactly one entry
+    val result = client.listXinfraTopics()
+    assertEquals(1, result.namesAndNamespaces().get().size())
+    assertEquals("xinfra-test-topic tracking", result.namesAndNamespaces().get().get(0))
+
+    // delete xinfra topic znode
+    client.deleteXinfraTopicsZnode(xinfraTopic)
+
+    // after deletion, list xinfra topic should return 0 entry
+    val result1 = client.listXinfraTopics()
+    assertEquals(0, result1.namesAndNamespaces().get().size())
+  }
+
+  @Test
   def testDeleteTopicsWithIds(): Unit = {
     client = Admin.create(createConfig)
     val topics = Seq("mytopic", "mytopic2", "mytopic3")

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -661,6 +661,15 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.LI_MOVE_CONTROLLER =>
           new LiMoveControllerRequest.Builder(new LiMoveControllerRequestData(), ApiKeys.LI_MOVE_CONTROLLER.latestVersion)
 
+        case ApiKeys.LI_XINFRA_TOPIC_CREATE =>
+          new LiXinfraTopicCreateRequest.Builder(new LiXinfraTopicCreateRequestData(), ApiKeys.LI_XINFRA_TOPIC_CREATE.latestVersion)
+
+        case ApiKeys.LI_XINFRA_TOPIC_DELETE =>
+          new LiXinfraTopicDeleteRequest.Builder(new LiXinfraTopicDeleteRequestData(), ApiKeys.LI_XINFRA_TOPIC_DELETE.latestVersion)
+
+        case ApiKeys.LIST_XINFRA_TOPICS =>
+          new ListXinfraTopicsRequest.Builder(new ListXinfraTopicsRequestData(), ApiKeys.LIST_XINFRA_TOPICS.latestVersion)
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }


### PR DESCRIPTION
This pr adds three RPCs for xinfra topic operations:
1. xinfra topic create: adds a new znode to /xinfraTopics/topicName(value = namespace name)
2. xinfra topic delete: deletes the znode under /xinfraTopics/topicName
3. list all xinfra topics: list all znodes under /xinfraTopics, returning a list of strings, where each string is a concatenation of topic name and namespace name, separated by space, helping reuse the TopicChangeListener in kafka server.

Added integ-test for the three RPCs.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
