### PR TITLE
[LI-HOTFIX] Add federated topic znode delete rpc 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -199,6 +199,13 @@ public interface Admin extends AutoCloseable {
      */
     CreateTopicsResult createTopics(Collection<NewTopic> newTopics, CreateTopicsOptions options);
 
+    /**
+     * Create federated topic znodes, with znode name as the topic name and data as namespace name.
+     * This operation is decoupled from createTopics and will eventually only change
+     * the ACL validation behavior within kafka-server level
+     * @param federatedTopics map of topic name to namespace name for federated topics
+     * @return The CreateOrDeleteFederatedTopicZnodesResult
+     */
     default CreateOrDeleteFederatedTopicZnodesResult createFederatedTopicZnodes(Map<String, String> federatedTopics) {
         return createFederatedTopicZnodes(federatedTopics, new CreateFederatedTopicZnodesOptions());
     }
@@ -270,11 +277,17 @@ public interface Admin extends AutoCloseable {
      */
     DeleteTopicsResult deleteTopics(TopicCollection topics, DeleteTopicsOptions options);
 
-    default CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics) {
-        return deleteFederatedTopicZnodes(xinfraTopics, new DeleteFederatedTopicZnodesOptions());
+    /**
+     * Delete federated topic znodes. This operation is decoupled from deleteTopics and will eventually only change
+     * the ACL validation behavior within kafka-server level
+     * @param federatedTopics map of topic name to namespace name for federated topics
+     * @return The CreateOrDeleteFederatedTopicZnodesResult
+     */
+    default CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> federatedTopics) {
+        return deleteFederatedTopicZnodes(federatedTopics, new DeleteFederatedTopicZnodesOptions());
     }
 
-    CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics, DeleteFederatedTopicZnodesOptions options);
+    CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> federatedTopics, DeleteFederatedTopicZnodesOptions options);
 
     /**
      * List the topics available in the cluster with the default options.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -270,6 +270,12 @@ public interface Admin extends AutoCloseable {
      */
     DeleteTopicsResult deleteTopics(TopicCollection topics, DeleteTopicsOptions options);
 
+    default CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics) {
+        return deleteFederatedTopicZnodes(xinfraTopics, new DeleteFederatedTopicZnodesOptions());
+    }
+
+    CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics, DeleteFederatedTopicZnodesOptions options);
+
     /**
      * List the topics available in the cluster with the default options.
      * <p>

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateOrDeleteFederatedTopicZnodesResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateOrDeleteFederatedTopicZnodesResult.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 /**
- * The result of {@link Admin#CreateFederatedTopicZnode()} or {@link Admin#DeleteFederatedTopicZnode()}.
+ * The result of {@link Admin#CreateFederatedTopicZnodes()} or {@link Admin#DeleteFederatedTopicZnodes()}.
  *
  * The API of this class is evolving, see {@link Admin} for details.
  */

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteFederatedTopicZnodesOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteFederatedTopicZnodesOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * Options for {@link Admin#deleteFederatedTopicZnodes(Map, DeleteFederatedTopicZnodesOptions)} (Collection)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DeleteFederatedTopicZnodesOptions extends AbstractOptions<DeleteFederatedTopicZnodesOptions> {
+    private boolean retryOnQuotaViolation = true;
+
+    /**
+     * Set the timeout in milliseconds for this operation or {@code null} if the default api timeout for the
+     * AdminClient should be used.
+     *
+     */
+    // This method is retained to keep binary compatibility with 0.11
+    public DeleteFederatedTopicZnodesOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * Set to true if quota violation should be automatically retried.
+     */
+    public DeleteFederatedTopicZnodesOptions retryOnQuotaViolation(boolean retryOnQuotaViolation) {
+        this.retryOnQuotaViolation = retryOnQuotaViolation;
+        return this;
+    }
+
+    /**
+     * Returns true if quota violation should be automatically retried.
+     */
+    public boolean shouldRetryOnQuotaViolation() {
+        return retryOnQuotaViolation;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -142,6 +142,7 @@ import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData;
 import org.apache.kafka.common.message.LiCreateFederatedTopicZnodesRequestData;
+import org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesRequestData;
 import org.apache.kafka.common.message.LiMoveControllerRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
@@ -224,6 +225,8 @@ import org.apache.kafka.common.requests.LiMoveControllerRequest;
 import org.apache.kafka.common.requests.LiMoveControllerResponse;
 import org.apache.kafka.common.requests.LiCreateFederatedTopicZnodesRequest;
 import org.apache.kafka.common.requests.LiCreateFederatedTopicZnodesResponse;
+import org.apache.kafka.common.requests.LiDeleteFederatedTopicZnodesRequest;
+import org.apache.kafka.common.requests.LiDeleteFederatedTopicZnodesResponse;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
@@ -1748,6 +1751,45 @@ public class KafkaAdminClient extends AdminClient {
             return DeleteTopicsResult.ofTopicNames(handleDeleteTopicsUsingNames(((TopicNameCollection) topics).topicNames(), options));
         else
             throw new IllegalArgumentException("The TopicCollection: " + topics + " provided did not match any supported classes for deleteTopics.");
+    }
+
+    @Override
+    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics,
+                                                                         DeleteFederatedTopicZnodesOptions options) {
+        final Map<String, KafkaFutureImpl<Void>> topicFutures = new HashMap<>(xinfraTopics.size());
+        final long now = time.milliseconds();
+        List<LiDeleteFederatedTopicZnodesRequestData.FederatedTopics> topics = new ArrayList<>();
+        xinfraTopics.forEach((topic, namespace) -> {
+            topics.add(new LiDeleteFederatedTopicZnodesRequestData.FederatedTopics().setName(topic).setNamespace(namespace));
+            topicFutures.put(topic, new KafkaFutureImpl<>());
+        });
+        runnable.call(new Call("deleteXinfraTopicsZnode", calcDeadlineMs(now, options.timeoutMs()),
+            new ControllerNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new LiDeleteFederatedTopicZnodesRequest.Builder(new LiDeleteFederatedTopicZnodesRequestData()
+                    .setTopics(topics)
+                    .setTimeoutMs(timeoutMs),  (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                LiDeleteFederatedTopicZnodesResponse response = (LiDeleteFederatedTopicZnodesResponse) abstractResponse;
+                Errors errors = Errors.forCode(response.data().errorCode());
+                if (errors != Errors.NONE) {
+                    completeAllExceptionally(topicFutures.values(), errors.exception());
+                    return;
+                }
+                topicFutures.values().forEach(f -> f.complete(null));
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                // Fail all the other remaining futures
+                completeAllExceptionally(topicFutures.values(), throwable);
+            }
+        }, now);
+        return new CreateOrDeleteFederatedTopicZnodesResult(new HashMap<>(topicFutures));
     }
 
     private Map<String, KafkaFuture<Void>> handleDeleteTopicsUsingNames(final Collection<String> topicNames,

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1754,16 +1754,16 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics,
-                                                                         DeleteFederatedTopicZnodesOptions options) {
-        final Map<String, KafkaFutureImpl<Void>> topicFutures = new HashMap<>(xinfraTopics.size());
+    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> federatedTopics,
+                                                                               DeleteFederatedTopicZnodesOptions options) {
+        final Map<String, KafkaFutureImpl<Void>> topicFutures = new HashMap<>(federatedTopics.size());
         final long now = time.milliseconds();
         List<LiDeleteFederatedTopicZnodesRequestData.FederatedTopics> topics = new ArrayList<>();
-        xinfraTopics.forEach((topic, namespace) -> {
+        federatedTopics.forEach((topic, namespace) -> {
             topics.add(new LiDeleteFederatedTopicZnodesRequestData.FederatedTopics().setName(topic).setNamespace(namespace));
             topicFutures.put(topic, new KafkaFutureImpl<>());
         });
-        runnable.call(new Call("deleteXinfraTopicsZnode", calcDeadlineMs(now, options.timeoutMs()),
+        runnable.call(new Call("deleteFederatedTopicsZnode", calcDeadlineMs(now, options.timeoutMs()),
             new ControllerNodeProvider()) {
             @Override
             AbstractRequest.Builder<?> createRequest(int timeoutMs) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
@@ -58,7 +58,7 @@ public class NoOpAdminClient extends AdminClient {
     }
 
     @Override
-    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics,
+    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> federatedTopics,
         DeleteFederatedTopicZnodesOptions options) {
         return null;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NoOpAdminClient.java
@@ -58,6 +58,12 @@ public class NoOpAdminClient extends AdminClient {
     }
 
     @Override
+    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics,
+        DeleteFederatedTopicZnodesOptions options) {
+        return null;
+    }
+
+    @Override
     public ListTopicsResult listTopics(ListTopicsOptions options) {
         return null;
     }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -115,7 +115,8 @@ public enum ApiKeys {
     LI_COMBINED_CONTROL(ApiMessageType.LI_COMBINED_CONTROL, true),
     LI_MOVE_CONTROLLER(ApiMessageType.LI_MOVE_CONTROLLER, true),
 
-    LI_CREATE_FEDERATED_TOPIC_ZNODES(ApiMessageType.LI_CREATE_FEDERATED_TOPIC_ZNODES, false, true);
+    LI_CREATE_FEDERATED_TOPIC_ZNODES(ApiMessageType.LI_CREATE_FEDERATED_TOPIC_ZNODES, false, true),
+    LI_DELETE_FEDERATED_TOPIC_ZNODES(ApiMessageType.LI_DELETE_FEDERATED_TOPIC_ZNODES, false, true);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -311,6 +311,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return LiMoveControllerRequest.parse(buffer, apiVersion);
             case LI_CREATE_FEDERATED_TOPIC_ZNODES:
                 return LiCreateFederatedTopicZnodesRequest.parse(buffer, apiVersion);
+            case LI_DELETE_FEDERATED_TOPIC_ZNODES:
+                return LiDeleteFederatedTopicZnodesRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -255,6 +255,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return LiMoveControllerResponse.parse(responseBuffer, version);
             case LI_CREATE_FEDERATED_TOPIC_ZNODES:
                 return LiCreateFederatedTopicZnodesResponse.parse(responseBuffer, version);
+            case LI_DELETE_FEDERATED_TOPIC_ZNODES:
+                return LiDeleteFederatedTopicZnodesResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiDeleteFederatedTopicZnodesRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiDeleteFederatedTopicZnodesRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesRequestData;
+import org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiDeleteFederatedTopicZnodesRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiDeleteFederatedTopicZnodesRequest> {
+        private final LiDeleteFederatedTopicZnodesRequestData data;
+
+        public Builder(LiDeleteFederatedTopicZnodesRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiDeleteFederatedTopicZnodesRequest build(short version) {
+            return new LiDeleteFederatedTopicZnodesRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiDeleteFederatedTopicZnodesRequestData data;
+
+    LiDeleteFederatedTopicZnodesRequest(LiDeleteFederatedTopicZnodesRequestData data, short version) {
+        super(ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES, version);
+        this.data = data;
+    }
+
+    public static LiDeleteFederatedTopicZnodesRequest parse(ByteBuffer buffer, short version) {
+        return new LiDeleteFederatedTopicZnodesRequest(new LiDeleteFederatedTopicZnodesRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiDeleteFederatedTopicZnodesResponseData data = new LiDeleteFederatedTopicZnodesResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiDeleteFederatedTopicZnodesResponse(data, version());
+    }
+
+    @Override
+    public LiDeleteFederatedTopicZnodesRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiDeleteFederatedTopicZnodesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiDeleteFederatedTopicZnodesResponse.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiDeleteFederatedTopicZnodesResponse extends AbstractResponse {
+    private final LiDeleteFederatedTopicZnodesResponseData data;
+    private final short version;
+
+    public LiDeleteFederatedTopicZnodesResponse(LiDeleteFederatedTopicZnodesResponseData data, short version) {
+        super(ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES);
+        this.data = data;
+        this.version = version;
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    public LiDeleteFederatedTopicZnodesResponseData data() {
+        return data;
+    }
+
+    public static LiDeleteFederatedTopicZnodesResponse prepareResponse(Errors error, int throttleTimeMs, short version) {
+        LiDeleteFederatedTopicZnodesResponseData data = new LiDeleteFederatedTopicZnodesResponseData();
+        data.setErrorCode(error.code());
+        data.setThrottleTimeMs(throttleTimeMs);
+        return new LiDeleteFederatedTopicZnodesResponse(data, version);
+    }
+
+    public static LiDeleteFederatedTopicZnodesResponse parse(ByteBuffer buffer, short version) {
+        return new LiDeleteFederatedTopicZnodesResponse(new LiDeleteFederatedTopicZnodesResponseData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/resources/common/message/LiDeleteFederatedTopicZnodesRequest.json
+++ b/clients/src/main/resources/common/message/LiDeleteFederatedTopicZnodesRequest.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1004,
+  "type": "request",
+  "listeners": ["zkBroker", "broker", "controller"],
+  "name": "LiDeleteFederatedTopicZnodesRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]FederatedTopics", "versions": "0+", "about": "The name and namespace of the federated topic",
+      "fields": [
+        {"name": "Name", "type": "string", "versions": "0+", "about": "The topic name"},
+        {"name": "Namespace", "type": "string", "versions": "0+", "about": "The namespace of the topic"}
+      ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The length of time in milliseconds to wait for the deletions to complete." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiDeleteFederatedTopicZnodesResponse.json
+++ b/clients/src/main/resources/common/message/LiDeleteFederatedTopicZnodesResponse.json
@@ -1,0 +1,27 @@
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1004,
+  "type": "response",
+  "name": "LiDeleteFederatedTopicZnodesResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." },
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -413,6 +413,11 @@ public class MockAdminClient extends AdminClient {
         return result;
     }
 
+    @Override
+    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics, DeleteFederatedTopicZnodesOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
     private Map<String, KafkaFuture<Void>> handleDeleteTopicsUsingNames(Collection<String> topicNameCollection, DeleteTopicsOptions options) {
         Map<String, KafkaFuture<Void>> deleteTopicsResult = new HashMap<>();
         Collection<String> topicNames = new ArrayList<>(topicNameCollection);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -414,7 +414,7 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
-    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> xinfraTopics, DeleteFederatedTopicZnodesOptions options) {
+    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(Map<String, String> federatedTopics, DeleteFederatedTopicZnodesOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -99,6 +99,7 @@ object RequestConvertToJson {
       case req: LiCombinedControlRequest => LiCombinedControlRequestDataJsonConverter.write(req.data, request.version())
       case req: LiMoveControllerRequest => LiMoveControllerRequestDataJsonConverter.write(req.data, request.version())
       case req: LiCreateFederatedTopicZnodesRequest => LiCreateFederatedTopicZnodesRequestDataJsonConverter.write(req.data, request.version())
+      case req: LiDeleteFederatedTopicZnodesRequest => LiDeleteFederatedTopicZnodesRequestDataJsonConverter.write(req.data, request.version())
       case _ => throw new IllegalStateException(s"ApiKey ${request.apiKey} is not currently handled in `request`, the " +
         "code should be updated to do so.");
     }
@@ -178,6 +179,7 @@ object RequestConvertToJson {
       case res: LiCombinedControlResponse => LiCombinedControlResponseDataJsonConverter.write(res.data, version)
       case res: LiMoveControllerResponse => LiMoveControllerResponseDataJsonConverter.write(res.data, version)
       case res: LiCreateFederatedTopicZnodesResponse => LiCreateFederatedTopicZnodesResponseDataJsonConverter.write(res.data, version)
+      case res: LiDeleteFederatedTopicZnodesResponse => LiDeleteFederatedTopicZnodesResponseDataJsonConverter.write(res.data, version)
       case _ => throw new IllegalStateException(s"ApiKey ${response.apiKey} is not currently handled in `response`, the " +
         "code should be updated to do so.");
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -257,6 +257,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.LI_COMBINED_CONTROL => handleLiCombinedControlRequest(request, requestLocal)
         case ApiKeys.LI_MOVE_CONTROLLER => handleMoveControllerRequest(request)
         case ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES => maybeForwardToController(request, handleMarkFederatedTopicRequest)
+        case ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES => maybeForwardToController(request, handleDeleteFederatedTopicZnodesRequest)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {
@@ -3732,7 +3733,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
 
       try {
-        toCreate.foreach( entry => {
+        toCreate.foreach(entry => {
           zkSupport.zkClient.createFederatedTopicZNode(entry._1, entry._2)
         })
         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
@@ -3741,6 +3742,70 @@ class KafkaApis(val requestChannel: RequestChannel,
       } catch {
         case throwable: Throwable =>
           requestHelper.sendResponseExemptThrottle(request, markFederatedTopicRequest.getErrorResponse(throwable))
+      }
+    }
+  }
+
+
+  def handleDeleteFederatedTopicZnodesRequest(request: RequestChannel.Request): Unit = {
+    val federatedTopicZnodesDeleteRequest = request.body[LiDeleteFederatedTopicZnodesRequest]
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+
+    if (!zkSupport.controller.isActive) {
+      requestHelper.sendResponseExemptThrottle(request,
+        LiDeleteFederatedTopicZnodesResponse.prepareResponse(Errors.NOT_CONTROLLER, 0, federatedTopicZnodesDeleteRequest.version())
+      )
+    } else if (!zkSupport.controller.topicDeletionManager.isDeleteTopicEnabled) {
+      val error = if (request.context.apiVersion < 3) Errors.INVALID_REQUEST else Errors.TOPIC_DELETION_DISABLED
+      requestHelper.sendResponseExemptThrottle(request,
+        LiDeleteFederatedTopicZnodesResponse.prepareResponse(error, 0, federatedTopicZnodesDeleteRequest.version())
+      )
+    } else {
+      val allTopics = mutable.Set[String]()
+      federatedTopicZnodesDeleteRequest.data().topics().forEach(federatedTopic => {
+        allTopics += federatedTopic.name()
+      })
+      val results = new DeletableTopicResultCollection(allTopics.size)
+      val toDelete = mutable.Set[String]()
+
+      allTopics.foreach(topic => {
+        results.add(new DeletableTopicResult().setName(topic))
+      })
+
+      val authorizedDescribeTopics = authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC,
+        results.asScala.filter(result => result.name() != null))(_.name)
+      val authorizedDeleteTopics = authHelper.filterByAuthorized(request.context, DELETE, TOPIC,
+        results.asScala.filter(result => result.name() != null))(_.name)
+      results.forEach { topic =>
+        val unresolvedTopicId = topic.topicId() != Uuid.ZERO_UUID && topic.name() == null
+        if (unresolvedTopicId) {
+          topic.setErrorCode(Errors.UNKNOWN_TOPIC_ID.code)
+        } else if (!authorizedDescribeTopics.contains(topic.name)) {
+
+          // Because the client does not have Describe permission, the name should
+          // not be returned in the response. Note, however, that we do not consider
+          // the topicId itself to be sensitive, so there is no reason to obscure
+          // this case with `UNKNOWN_TOPIC_ID`.
+          topic.setName(null)
+          topic.setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
+        } else if (!authorizedDeleteTopics.contains(topic.name)) {
+          topic.setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code)
+        } else {
+          toDelete += topic.name
+        }
+      }
+
+      try {
+        toDelete.foreach(federatedTopic => {
+          zkSupport.zkClient.deleteFederatedTopicZNode(federatedTopic)
+        })
+        requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+          LiDeleteFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, requestThrottleMs,
+            federatedTopicZnodesDeleteRequest.version())
+        )
+      } catch {
+        case throwable: Throwable =>
+          requestHelper.sendResponseExemptThrottle(request, federatedTopicZnodesDeleteRequest.getErrorResponse(throwable))
       }
     }
   }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -256,7 +256,11 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => handleLiControlledShutdownSkipSafetyCheck(request)
         case ApiKeys.LI_COMBINED_CONTROL => handleLiCombinedControlRequest(request, requestLocal)
         case ApiKeys.LI_MOVE_CONTROLLER => handleMoveControllerRequest(request)
+        // LI_CREATE_FEDERATED_TOPIC_ZNODES is decoupled from CREATE_TOPICS and only changes the ACL validation behavior
+        // within kafka-server level
         case ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES => maybeForwardToController(request, handleMarkFederatedTopicRequest)
+        // LI_DELETE_FEDERATED_TOPIC_ZNODES is decoupled from DELETE_TOPICS and only changes the ACL validation behavior
+        // within kafka-server level
         case ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES => maybeForwardToController(request, handleDeleteFederatedTopicZnodesRequest)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -23,6 +23,7 @@ import kafka.security.authorizer.AclEntry
 import kafka.server.KafkaConfig
 import kafka.utils.Logging
 import kafka.utils.TestUtils._
+import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateTopicsOptions, CreateTopicsResult, DescribeClusterOptions, DescribeTopicsOptions, NewTopic, TopicDescription}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.acl.AclOperation
@@ -220,6 +221,14 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
       expectedPresent.forall(topicName => topics.contains(topicName)) &&
         expectedMissing.forall(topicName => !topics.contains(topicName))
     }, "timed out waiting for topics")
+  }
+
+  def waitForFederatedTopicZnodes(client: KafkaZkClient, expectedPresent: Seq[String], expectedMissing: Seq[String]): Unit = {
+    waitUntilTrue(() => {
+      val topics = client.getAllFederatedTopics
+      expectedPresent.forall(topicName => topics.contains(topicName)) &&
+        expectedMissing.forall(topicName => !topics.contains(topicName))
+    }, "timed out waiting for federated topics")
   }
 
   def getTopicMetadata(client: Admin,

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -136,9 +136,24 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
   def testFederatedTopicCreateDeleteAndGet(): Unit = {
     client = Admin.create(createConfig)
     val federatedTopic = Map("federated-test-topic" -> "tracking").asJava
-
-    // create the federated topic znode
+    val expectedFedTopic = Seq("/tracking/federated-test-topic")
+    // create one federated topic
     client.createFederatedTopicZnodes(federatedTopic)
+    // since creation is async, wait for federated topic znodes to be created
+    waitForFederatedTopicZnodes(zkClient, expectedFedTopic, List())
+
+    // check federated topic is created
+    val federatedTopics = zkClient.getAllFederatedTopics
+    assertEquals(1, federatedTopics.size)
+
+    // delete federated topic znode
+    client.deleteFederatedTopicZnodes(federatedTopic)
+
+    waitForFederatedTopicZnodes(zkClient, List(), expectedFedTopic)
+
+    // after deletion, federated topic znodes should be empty
+    val result1 = zkClient.getAllFederatedTopics
+    assertEquals(0, result1.size)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -664,6 +664,9 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES =>
           new LiCreateFederatedTopicZnodesRequest.Builder(new LiCreateFederatedTopicZnodesRequestData(), ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES.latestVersion)
 
+        case ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES =>
+          new LiDeleteFederatedTopicZnodesRequest.Builder(new LiDeleteFederatedTopicZnodesRequestData(), ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES.latestVersion)
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }


### PR DESCRIPTION
This PR adds 
1. delete federated topic rpc that deletes the znode entry under /federatedTopics/topicName (value = namespace name)
2. zk function to get all federated topics as a set of string, in the format of /namespaceName/topicName for easier usage and avoid duplicate code in kafka-server

LI_DESCRIPTION =
In order to make kafka broker understand new acl, it will need to understand the topic name and its corresponding namespace. So when a new kafka topic is deleted by xmd-service, the corresponding znode will also be deleted in the above new znode directory.

Added integ-test to verify create and delete logic

EXIT_CRITERIA = We can deprecate this pr when all kafka clients have been migrated to xinfra clients and all topic CUDs go through xmd, then we don't need kafka broker to understand both old and new topic acl, it will only need to understand the new acl.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
