### PR TITLE
[LI-CHERRY-PICK] KAFKA-13865: Fix ResponseSendTimeMs metric in RequestChannel is removed twice (#12111)

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -858,7 +858,6 @@ class RequestMetrics(name: String, config: KafkaConfig) extends KafkaMetricsGrou
     removeMetric(ResponseSendTimeNs, tags)
     removeMetric(RequestBytes, tags)
     removeMetric(ResponseBytes, tags)
-    removeMetric(ResponseSendTimeMs, tags)
     if (name == ApiKeys.FETCH.name || name == ApiKeys.PRODUCE.name) {
       removeMetric(MessageConversionsTimeMs, tags)
       removeMetric(TemporaryMemoryBytes, tags)


### PR DESCRIPTION
Fix ResponseSendTimeMs metric in RequestChannel is removed twice

Reviewers: Luke Chen <showuon@gmail.com>