### PR TITLE
[LI-HOTFIX] Prevent preferred controller set to over-shrink in controlled shutdown process

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/NotEnoughPreferredControllersException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/NotEnoughPreferredControllersException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+/**
+ * No enough stand by preferred controllers
+ */
+public class NotEnoughPreferredControllersException extends RetriableException {
+    private static final long serialVersionUID = 1L;
+
+    public NotEnoughPreferredControllersException() {
+        super();
+    }
+
+    public NotEnoughPreferredControllersException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotEnoughPreferredControllersException(String message) {
+        super(message);
+    }
+
+    public NotEnoughPreferredControllersException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -79,6 +79,7 @@ import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.errors.NoReassignmentInProgressException;
 import org.apache.kafka.common.errors.NotControllerException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
+import org.apache.kafka.common.errors.NotEnoughPreferredControllersException;
 import org.apache.kafka.common.errors.NotEnoughReplicasAfterAppendException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
@@ -371,7 +372,8 @@ public enum Errors {
     LI_OFFSET_MOVED_TO_TIERED_STORAGE and OFFSET_MOVED_TO_TIERED_STORAGE in the same way for a while, and then remove
     LI_OFFSET_MOVED_TO_TIERED_STORAGE and fully move to using OFFSET_MOVED_TO_TIERED_STORAGE.
      */
-    LI_OFFSET_MOVED_TO_TIERED_STORAGE(1107, "The requested offset is moved to tiered storage.", OffsetMovedToTieredStorageException::new);
+    LI_OFFSET_MOVED_TO_TIERED_STORAGE(1107, "The requested offset is moved to tiered storage.", OffsetMovedToTieredStorageException::new),
+    LI_NOT_ENOUGH_PREFERRED_CONTROLLERS(2000, "Not enough live preferred controllers", NotEnoughPreferredControllersException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -373,7 +373,7 @@ public enum Errors {
     LI_OFFSET_MOVED_TO_TIERED_STORAGE and fully move to using OFFSET_MOVED_TO_TIERED_STORAGE.
      */
     LI_OFFSET_MOVED_TO_TIERED_STORAGE(1107, "The requested offset is moved to tiered storage.", OffsetMovedToTieredStorageException::new),
-    LI_NOT_ENOUGH_PREFERRED_CONTROLLERS(2000, "Not enough live preferred controllers", NotEnoughPreferredControllersException::new);
+    NOT_ENOUGH_PREFERRED_CONTROLLERS(2000, "Not enough live preferred controllers", NotEnoughPreferredControllersException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiErrorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiErrorTest.java
@@ -58,7 +58,7 @@ public class ApiErrorTest {
             new NotEnoughReplicasException(), Errors.NOT_ENOUGH_REPLICAS, null));
 
         arguments.add(Arguments.of(
-            new NotEnoughPreferredControllersException(), Errors.LI_NOT_ENOUGH_PREFERRED_CONTROLLERS, null));
+            new NotEnoughPreferredControllersException(), Errors.NOT_ENOUGH_PREFERRED_CONTROLLERS, null));
 
         // avoid populating the error message if it's a generic one
         arguments.add(Arguments.of(

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiErrorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiErrorTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.NotControllerException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
+import org.apache.kafka.common.errors.NotEnoughPreferredControllersException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownServerException;
@@ -55,6 +56,9 @@ public class ApiErrorTest {
 
         arguments.add(Arguments.of(
             new NotEnoughReplicasException(), Errors.NOT_ENOUGH_REPLICAS, null));
+
+        arguments.add(Arguments.of(
+            new NotEnoughPreferredControllersException(), Errors.LI_NOT_ENOUGH_PREFERRED_CONTROLLERS, null));
 
         // avoid populating the error message if it's a generic one
         arguments.add(Arguments.of(

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -35,7 +35,7 @@ import kafka.zookeeper.{StateChangeHandler, ZNodeChangeHandler, ZNodeChildChange
 import org.apache.kafka.common.ElectionType
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException, NotEnoughReplicasException, PolicyViolationException, StaleBrokerEpochException}
+import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException, NotEnoughPreferredControllersException, NotEnoughReplicasException, PolicyViolationException, StaleBrokerEpochException}
 import org.apache.kafka.common.message.{AllocateProducerIdsRequestData, AllocateProducerIdsResponseData, AlterIsrRequestData, AlterIsrResponseData, UpdateFeaturesRequestData}
 import org.apache.kafka.common.feature.{Features, FinalizedVersionRange}
 import org.apache.kafka.common.metrics.Metrics
@@ -1733,14 +1733,30 @@ class KafkaController(val config: KafkaConfig,
       else brokerEpoch
 
     val shouldSkipShutdownSafetyCheck = controllerContext.skipShutdownSafetyCheck.getOrElse(id, -1L) >= actualBrokerEpoch
-    if (config.controlledShutdownSafetyCheckEnable && !safeToShutdown(id, actualBrokerEpoch)) {
-      if (shouldSkipShutdownSafetyCheck) {
-        info(s"Controlled shutdown safety check has been skipped for broker $id (broker epoch $actualBrokerEpoch). Allowing shutdown even though it is not safe to do so.")
-      } else {
-        info(s"Controlled shutdown safety has prevented broker $id (broker epoch $actualBrokerEpoch) from shutting down.")
-        throw new NotEnoughReplicasException(
-          s"Broker id $id cannot initiate shutdown without an impact on topic availability.")
+    var passedAllShutdown: Boolean = true // For logging purpose
+    // TODO: live controller itself?
+    if (controllerContext.getLivePreferredControllerIds.size <= config.liMinPreferredControllerCount
+        // Only check if this broker affects live preferred controller set so that for non-preferred-controller clusters it doesn't get blocked
+        && controllerContext.getLivePreferredControllerIds.contains(id)) {
+      passedAllShutdown &= false
+      if (!shouldSkipShutdownSafetyCheck) {
+        info(s"Live preferred controller check has prevented broker $id (broker epoch $actualBrokerEpoch) from shutting down.")
+        throw new NotEnoughPreferredControllersException(s"Broker id $id cannot initiate shutdown without an impact on preferred controller availability.")
       }
+    }
+
+    // This is not an else if, in case in some sense that preferred controller still got scheduled with replicas.
+    // While it should be guaranteed on external component like cruise-control, Kafka itself should be defensive on this
+    if (config.controlledShutdownSafetyCheckEnable && !safeToShutdown(id, actualBrokerEpoch)) {
+      passedAllShutdown &= false
+      if (!shouldSkipShutdownSafetyCheck) {
+        info(s"Controlled shutdown safety has prevented broker $id (broker epoch $actualBrokerEpoch) from shutting down.")
+        throw new NotEnoughReplicasException(s"Broker id $id cannot initiate shutdown without an impact on topic availability.")
+      }
+    }
+
+    if (!passedAllShutdown && shouldSkipShutdownSafetyCheck) {
+      info(s"Controlled shutdown safety check has been skipped for broker $id (broker epoch $actualBrokerEpoch). Allowing shutdown even though it is not safe to do so.")
     }
 
     zkClient.recordBrokerShutdown(id, brokerEpoch, controllerContext.epochZkVersion)

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1737,7 +1737,7 @@ class KafkaController(val config: KafkaConfig,
     if (controllerContext.getLivePreferredControllerIds.size <= config.liMinPreferredControllerCount
         // Only check if this broker affects live preferred controller set so that for non-preferred-controller clusters it doesn't get blocked
         && controllerContext.getLivePreferredControllerIds.contains(id)) {
-      passedAllShutdown &= false
+      passedAllShutdown = false
       if (!shouldSkipShutdownSafetyCheck) {
         info(s"Live preferred controller check has prevented broker $id (broker epoch $actualBrokerEpoch) from shutting down.")
         throw new NotEnoughPreferredControllersException(s"Broker id $id cannot initiate shutdown without an impact on preferred controller availability.")
@@ -1747,7 +1747,7 @@ class KafkaController(val config: KafkaConfig,
     // This is not an else if, in case in some sense that preferred controller still got scheduled with replicas.
     // While it should be guaranteed on external component like cruise-control, Kafka itself should be defensive on this.
     if (config.controlledShutdownSafetyCheckEnable && !safeToShutdown(id, actualBrokerEpoch)) {
-      passedAllShutdown &= false
+      passedAllShutdown = false
       if (!shouldSkipShutdownSafetyCheck) {
         info(s"Controlled shutdown safety has prevented broker $id (broker epoch $actualBrokerEpoch) from shutting down.")
         throw new NotEnoughReplicasException(s"Broker id $id cannot initiate shutdown without an impact on topic availability.")

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1734,7 +1734,6 @@ class KafkaController(val config: KafkaConfig,
 
     val shouldSkipShutdownSafetyCheck = controllerContext.skipShutdownSafetyCheck.getOrElse(id, -1L) >= actualBrokerEpoch
     var passedAllShutdown: Boolean = true // For logging purpose
-    // TODO: live controller itself?
     if (controllerContext.getLivePreferredControllerIds.size <= config.liMinPreferredControllerCount
         // Only check if this broker affects live preferred controller set so that for non-preferred-controller clusters it doesn't get blocked
         && controllerContext.getLivePreferredControllerIds.contains(id)) {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1745,7 +1745,7 @@ class KafkaController(val config: KafkaConfig,
     }
 
     // This is not an else if, in case in some sense that preferred controller still got scheduled with replicas.
-    // While it should be guaranteed on external component like cruise-control, Kafka itself should be defensive on this
+    // While it should be guaranteed on external component like cruise-control, Kafka itself should be defensive on this.
     if (config.controlledShutdownSafetyCheckEnable && !safeToShutdown(id, actualBrokerEpoch)) {
       passedAllShutdown &= false
       if (!shouldSkipShutdownSafetyCheck) {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -82,6 +82,7 @@ object Defaults {
   val MetadataSnapshotMaxNewRecordBytes = 20 * 1024 * 1024
   val ProducerBatchDecompressionEnable = true
   val PreferredController = false
+  val LiMinPreferredControllerCount = 0
   val AllowPreferredControllerFallback = true
   val MissingPerTopicConfig = "-1"
 
@@ -451,6 +452,7 @@ object KafkaConfig {
   val HeapDumpTimeoutProp = "heap.dump.timeout"
   val ProducerBatchDecompressionEnableProp = "producer.batch.decompression.enable"
   val PreferredControllerProp = "preferred.controller"
+  val LiMinPreferredControllerCountProp = "li.min.preferred.controller.count"
   val LiAsyncFetcherEnableProp = "li.async.fetcher.enable"
   val LiCombinedControlRequestEnableProp = "li.combined.control.request.enable"
   val LiUpdateMetadataDelayMsProp = "li.update.metadata.delay.ms"
@@ -802,6 +804,7 @@ object KafkaConfig {
   val HeapDumpTimeoutDoc = "The max amount of time (in millis) to wait for heap dump to complete before halting regardless"
   val ProducerBatchDecompressionEnableDoc = "Decompress batch sent by producer to perform verification of individual records inside the batch"
   val PreferredControllerDoc = "Specifies whether the broker is a dedicated controller node. If set to true, the broker is a preferred controller node."
+  val LiMinPreferredControllerCountDoc = s"Specifies the desired count of minimum preferred controller. It will refuse to shutdown a broker if taking it down brings alive preferred controller below the threshold."
   val LiAsyncFetcherEnableDoc = "Specifies whether the event-based async fetcher should be used."
   val LiCombinedControlRequestEnableDoc = "Specifies whether the controller should use the LiCombinedControlRequest."
   val LiUpdateMetadataDelayMsDoc = "Specifies how long a UpdateMetadata request with partitions should be delayed before its processing can start. This config is purely for testing the LiCombinedControl feature and should not be enabled in a production environment."
@@ -1258,6 +1261,7 @@ object KafkaConfig {
       .define(HeapDumpTimeoutProp, LONG, Defaults.HeapDumpTimeout, LOW, HeapDumpTimeoutDoc)
       .define(ProducerBatchDecompressionEnableProp, BOOLEAN, Defaults.ProducerBatchDecompressionEnable, LOW, ProducerBatchDecompressionEnableDoc)
       .define(PreferredControllerProp, BOOLEAN, Defaults.PreferredController, HIGH, PreferredControllerDoc)
+      .define(LiMinPreferredControllerCountProp, INT, Defaults.LiMinPreferredControllerCount, HIGH, LiMinPreferredControllerCountDoc)
       .define(LiAsyncFetcherEnableProp, BOOLEAN, Defaults.LiAsyncFetcherEnabled, HIGH, LiAsyncFetcherEnableDoc)
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
       .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, atLeast(0), LOW, LiUpdateMetadataDelayMsDoc)
@@ -1808,6 +1812,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val producerBatchDecompressionEnable = getBoolean(KafkaConfig.ProducerBatchDecompressionEnableProp)
 
   var preferredController = getBoolean(KafkaConfig.PreferredControllerProp)
+  var liMinPreferredControllerCount = getInt(KafkaConfig.LiMinPreferredControllerCountProp)
   def allowPreferredControllerFallback: Boolean = getBoolean(KafkaConfig.AllowPreferredControllerFallbackProp)
 
   val liAsyncFetcherEnable = getBoolean(KafkaConfig.LiAsyncFetcherEnableProp)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1261,7 +1261,7 @@ object KafkaConfig {
       .define(HeapDumpTimeoutProp, LONG, Defaults.HeapDumpTimeout, LOW, HeapDumpTimeoutDoc)
       .define(ProducerBatchDecompressionEnableProp, BOOLEAN, Defaults.ProducerBatchDecompressionEnable, LOW, ProducerBatchDecompressionEnableDoc)
       .define(PreferredControllerProp, BOOLEAN, Defaults.PreferredController, HIGH, PreferredControllerDoc)
-      .define(LiMinPreferredControllerCountProp, INT, Defaults.LiMinPreferredControllerCount, HIGH, LiMinPreferredControllerCountDoc)
+      .define(LiMinPreferredControllerCountProp, INT, Defaults.LiMinPreferredControllerCount, atLeast(0), HIGH, LiMinPreferredControllerCountDoc)
       .define(LiAsyncFetcherEnableProp, BOOLEAN, Defaults.LiAsyncFetcherEnabled, HIGH, LiAsyncFetcherEnableDoc)
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
       .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, atLeast(0), LOW, LiUpdateMetadataDelayMsDoc)

--- a/core/src/test/scala/integration/kafka/server/PreferredControllerTest.scala
+++ b/core/src/test/scala/integration/kafka/server/PreferredControllerTest.scala
@@ -137,7 +137,7 @@ class PreferredControllerTest extends ZooKeeperTestHarness {
   }
 
   private def simulateControlledShutdownRequest(controller: KafkaServer, from: KafkaServer): ControlledShutdownResponse = {
-    // Mimicking what KafkaServer#controlledShutdown
+    // Mimic how KafkaServer#controlledShutdown creates a low-level NetworkClient and send out a ControlledShutdownRequest
     val config = from.config
     val time = new SystemTime()
     val logContext = new LogContext()

--- a/core/src/test/scala/integration/kafka/server/PreferredControllerTest.scala
+++ b/core/src/test/scala/integration/kafka/server/PreferredControllerTest.scala
@@ -15,21 +15,29 @@
   * limitations under the License.
   */
 
-package kafka.server
-
-import java.util.Properties
+package integration.kafka.server
 
 import kafka.server.KafkaConfig.fromProps
+import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.CoreUtils._
 import kafka.utils.TestUtils
 import kafka.utils.TestUtils._
 import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.clients.{ApiVersions, ManualMetadataUpdater, NetworkClient, NetworkClientUtils}
 import org.apache.kafka.clients.admin._
-import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.errors.NotEnoughPreferredControllersException
+import org.apache.kafka.common.message.ControlledShutdownRequestData
+import org.apache.kafka.common.network.{ChannelBuilders, ListenerName, NetworkReceive, Selectable, Selector}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{ControlledShutdownRequest, ControlledShutdownResponse}
+import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.junit.jupiter.api.Assertions.{assertTrue, fail}
+import org.apache.kafka.common.utils.{LogContext, SystemTime}
+import org.easymock.EasyMock
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue, fail}
 import org.junit.jupiter.api.{AfterEach, Test}
 
+import java.util.Properties
 import scala.collection.JavaConverters._
 import scala.collection.Map
 
@@ -128,6 +136,114 @@ class PreferredControllerTest extends ZooKeeperTestHarness {
     ensureControllersInBrokers(Seq(controllerId))
   }
 
+  private def simulateControlledShutdownRequest(controller: KafkaServer, from: KafkaServer): ControlledShutdownResponse = {
+    // Mimicking what KafkaServer#controlledShutdown
+    val config = from.config
+    val time = new SystemTime()
+    val logContext = new LogContext()
+
+    val metadataUpdater = new ManualMetadataUpdater()
+    val channelBuilder = ChannelBuilders.clientChannelBuilder(
+      config.interBrokerSecurityProtocol,
+      JaasContext.Type.SERVER,
+      config,
+      config.interBrokerListenerName,
+      config.saslMechanismInterBrokerProtocol,
+      time,
+      config.saslInterBrokerHandshakeRequestEnable,
+      logContext)
+    val selector = new Selector(
+      NetworkReceive.UNLIMITED,
+      config.connectionsMaxIdleMs,
+      from.metrics,
+      time,
+      "kafka-server-controlled-shutdown",
+      Map.empty.asJava,
+      false,
+      channelBuilder,
+      logContext
+    )
+    val networkClient = new NetworkClient(
+      selector,
+      metadataUpdater,
+      config.brokerId.toString,
+      1,
+      0,
+      0,
+      Selectable.USE_DEFAULT_BUFFER_SIZE,
+      Selectable.USE_DEFAULT_BUFFER_SIZE,
+      config.requestTimeoutMs,
+      config.connectionSetupTimeoutMs,
+      config.connectionSetupTimeoutMaxMs,
+      time,
+      false,
+      new ApiVersions,
+      logContext)
+
+    from.metadataCache
+      .getAliveBrokerNode(controller.config.brokerId, from.config.interBrokerListenerName)
+      .foreach(node => {
+        metadataUpdater.setNodes(Seq(node).asJava)
+        NetworkClientUtils.awaitReady(networkClient, node, time, 10000L)
+      })
+
+    val controlledShutdownRequest = new ControlledShutdownRequest.Builder(
+      new ControlledShutdownRequestData()
+        .setBrokerId(config.brokerId)
+        .setBrokerEpoch(from.kafkaController.brokerEpoch),
+      3
+    )
+    val request = networkClient.newClientRequest(controller.config.brokerId.toString,
+      controlledShutdownRequest,
+      time.milliseconds(),
+      true)
+
+    val clientResponse = NetworkClientUtils.sendAndReceive(networkClient, request, time)
+
+    networkClient.close()
+    selector.close()
+    clientResponse.responseBody.asInstanceOf[ControlledShutdownResponse]
+  }
+
+  @Test
+  def testRefuseStandByPreferredControllerShutdownIfBelowMinPreferredControllerCount(): Unit = {
+    // create 6 brokers, 3 of the them are preferred controllers.
+    val brokerConfigs = Seq((0, false), (1, false), (2, true), (3, true), (4, true), (5, true) )
+    createBrokersWithPreferredControllers(brokerConfigs, allowFallback = false, minPreferredControllerCount = 2)
+
+
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+    val nonPreferredControllerBroker = brokers(0)
+    val activeController = brokers(controllerId)
+    val preferredControllersIds = activeController.kafkaController.controllerContext.getLivePreferredControllerIds
+    val standByControllerIds = (preferredControllersIds - controllerId).toSeq
+    val firstStandByController = brokers(standByControllerIds.head)
+
+
+    // Asserting the response --- active controller & first standby controller should be accepted
+    assertEquals(Errors.NONE, simulateControlledShutdownRequest(controller = activeController, from = activeController).error())
+    assertEquals(Errors.NONE, simulateControlledShutdownRequest(controller = activeController, from = firstStandByController).error())
+    // The threshold should not affect non-preferred controller
+    assertEquals(Errors.NONE, simulateControlledShutdownRequest(controller = activeController, from = nonPreferredControllerBroker).error())
+
+
+    // Previously was asserting on the requests; now do actual shutdown to simulate decrease in live preferred controllers
+    firstStandByController.shutdown()
+    activeController.shutdown()
+
+    // Taking down 2 controller, should still have 2 remain
+    val newActiveController = brokers(TestUtils.waitUntilControllerElected(zkClient))
+    val newLivePreferredControllers = newActiveController.kafkaController.controllerContext.getLivePreferredControllerIds
+    val newStandByControllerIds = newLivePreferredControllers - newActiveController.config.brokerId
+    assertEquals(2, newLivePreferredControllers.size)
+
+    // Now at minPreferredControllerCount.  Taking down anymore controller should be rejected, either active or stand by controller
+    assertEquals(Errors.NOT_ENOUGH_PREFERRED_CONTROLLERS, simulateControlledShutdownRequest(controller = newActiveController, from = newActiveController).error())
+    assertEquals(Errors.NOT_ENOUGH_PREFERRED_CONTROLLERS, simulateControlledShutdownRequest(controller = newActiveController, from = brokers(newStandByControllerIds.head)).error())
+    // The threshold should not affect non-preferred controller
+    assertEquals(Errors.NONE, simulateControlledShutdownRequest(controller = newActiveController,from = nonPreferredControllerBroker).error())
+  }
+
   @Test
   def testAllPreferredControllerDownWithPreferredControllersAndNoFallback(): Unit = {
     // create 5 brokers, 3 of the them are preferred controllers.
@@ -197,12 +313,15 @@ class PreferredControllerTest extends ZooKeeperTestHarness {
     * @param brokerConfigs: a list of (brokerid, preferredController) configs
     * @param allowFallback: "allow.preferred.controller.fallback" config
     */
-  private def createBrokersWithPreferredControllers(brokerConfigs: Seq[(Int, Boolean)],  allowFallback: Boolean): Unit = {
+  private def createBrokersWithPreferredControllers(brokerConfigs: Seq[(Int, Boolean)],
+                                                    allowFallback: Boolean,
+                                                    minPreferredControllerCount: Int = 0): Unit = {
     brokers = brokerConfigs.map {
       case (id, preferredController) =>
         val props: Properties = createBrokerConfig(id, zkConnect)
         props.put(KafkaConfig.PreferredControllerProp, preferredController.toString)
         props.put(KafkaConfig.AllowPreferredControllerFallbackProp, allowFallback.toString)
+        props.put(KafkaConfig.LiMinPreferredControllerCountProp, minPreferredControllerCount.toString)
         createServer(fromProps(props))
     }
   }


### PR DESCRIPTION
LI_DESCRIPTION = LIKAFKA-38857
EXIT_CRITERIA = N/A

Similar to the ISR check in controlled shutdown, this patch offers the check on the preferred controllers during controlled shutdown.

A new config `li.min.preferred.controller.count` is introduced to specify the threshold.
If shutting down a broker would cause the preferred controller count to drop below the threshold, the controller would reject the controlled shutdown requests with corresponding the error code `NOT_ENOUGH_PREFERRED_CONTROLLERS`; this applies to shutting down the active controller itself.

Also added an integration test case.