### PR TITLE
[LI-HOTFIX] Add backward compatible constructor for KafkaServer

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -106,6 +106,16 @@ class KafkaServer(
     this(config, time, threadNamePrefix, enableForwarding = false, actions = actions)
   }
 
+  // Visible for testing from mario for backwards compatibility.
+  @deprecated
+  def this(
+    config: KafkaConfig,
+    time: Time,
+    threadNamePrefix: Option[String],
+    kafkaMetricsReporters: Seq[KafkaMetricsReporter]) {
+    this(config, time, threadNamePrefix, enableForwarding = false, actions = NoOpKafkaActions)
+  }
+
   private val startupComplete = new AtomicBoolean(false)
   private val isShuttingDown = new AtomicBoolean(false)
   private val isStartingUp = new AtomicBoolean(false)


### PR DESCRIPTION
This pr adds back the 2.4 kafka compatible constructor for KafkaServer.

LI_DESCRIPTION =
In mario testing, we are using reflection to create scala KafkaServer classes in [EmbeddedBroker](https://github.com/linkedin/mario/blob/master/mario-test/src/main/java/com/linkedin/mario/test/EmbeddedBroker.java#L43) where it's using the KafkaServer constructor in 2.4 with 4 params.

While moving to kafka 3.0, this constructor is removed and the new constructor (including deprecated one) requires a trait class [KafkaActions](https://github.com/linkedin/kafka/blob/3.0-li/core/src/main/scala/kafka/server/KafkaServer.scala#L99), which is used to hook up with cruise control and doesn't have any implementation in kafka itself, making it impossible for mario/other library to construct it using reflection (requires concrete class).


EXIT_CRITERIA = We can deprecate this pr when either oss kafka provides concrete implementation for KafkaActions class or mario has found alternative ways of creating KafkaServer for integration testing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
