### PR TITLE
[LI-HOTFIX] Fix zk listener for federated topics znode

### DIFF
--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -623,7 +623,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
    * @return sequence of topics in the cluster.
    *
    */
-  def getAllFederatedTopicsInNamespace(namespace: String, registerWatch: Boolean = false): Set[String] = {
+  def getAllFederatedTopicsInNamespace(namespace: String, registerWatch: Boolean = true): Set[String] = {
     val getChildrenResponse = retryRequestUntilConnected(
       if (paginateTopics) {
         debug(s"upgrading GetChildrenRequest to GetChildrenPaginatedRequest for " +

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -157,7 +157,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
     val namespaces = getChildren(FederatedTopicsZNode.path)
     namespaces
       // For all topics, generate (topic -> namespace) tuple
-      .flatMap(namespace => getAllFederatedTopicsInNamespace(namespace).map(_ -> namespace))
+      .flatMap(namespace => getAllFederatedTopicsInNamespace(namespace, registerWatch = true).map(_ -> namespace))
       // To map to merge potential duplicate of topic -> namespace
       .toMap
       // Serialize to znode paths
@@ -624,6 +624,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
    *
    */
   def getAllFederatedTopicsInNamespace(namespace: String, registerWatch: Boolean = false): Set[String] = {
+    zooKeeperClient.reRegisterFederatedTopicsZNodeChangeHandler(namespace)
     val getChildrenResponse = retryRequestUntilConnected(
       if (paginateTopics) {
         debug(s"upgrading GetChildrenRequest to GetChildrenPaginatedRequest for " +
@@ -1731,10 +1732,6 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
    */
   def registerZNodeChildChangeHandler(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {
     zooKeeperClient.registerZNodeChildChangeHandler(zNodeChildChangeHandler)
-  }
-
-  def registerZNodeChildChangeHandlerRecursive(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {
-    zooKeeperClient.registerZNodeChildChangeHandlerRecursive(zNodeChildChangeHandler)
   }
 
   /**

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -623,7 +623,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
    * @return sequence of topics in the cluster.
    *
    */
-  def getAllFederatedTopicsInNamespace(namespace: String, registerWatch: Boolean = true): Set[String] = {
+  def getAllFederatedTopicsInNamespace(namespace: String, registerWatch: Boolean = false): Set[String] = {
     val getChildrenResponse = retryRequestUntilConnected(
       if (paginateTopics) {
         debug(s"upgrading GetChildrenRequest to GetChildrenPaginatedRequest for " +

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -1733,6 +1733,10 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
     zooKeeperClient.registerZNodeChildChangeHandler(zNodeChildChangeHandler)
   }
 
+  def registerZNodeChildChangeHandlerRecursive(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {
+    zooKeeperClient.registerZNodeChildChangeHandlerRecursive(zNodeChildChangeHandler)
+  }
+
   /**
    * See ZooKeeperClient.unregisterZNodeChildChangeHandler
    * @param path

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -1065,6 +1065,7 @@ object ZkData {
     PreferredControllersZNode.path,
     CorruptedBrokersZNode.path,
     TopicsZNode.path,
+    FederatedTopicsZNode.path,
     ConfigEntityChangeNotificationZNode.path,
     DeleteTopicsZNode.path,
     BrokerSequenceIdZNode.path,

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -332,7 +332,6 @@ class ZooKeeperClient(connectString: String,
    */
   def registerZNodeChildChangeHandler(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {
     zNodeChildChangeHandlers.put(zNodeChildChangeHandler.path, zNodeChildChangeHandler)
-    zooKeeper.addWatch(zNodeChildChangeHandler.path, AddWatchMode.PERSISTENT_RECURSIVE)
   }
 
   def registerZNodeChildChangeHandlerRecursive(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -458,7 +458,7 @@ class ZooKeeperClient(connectString: String,
   // package level visibility for testing only
   private[zookeeper] object ZooKeeperClientWatcher extends Watcher {
     override def process(event: WatchedEvent): Unit = {
-      error(s"Received event: $event")
+      debug(s"Received event: $event")
       Option(event.getPath) match {
         case None =>
           val state = event.getState

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -210,7 +210,7 @@ class ZooKeeperClient(connectString: String,
       case GetChildrenPaginatedRequest(path, _, ctx) =>
         CompletableFuture.supplyAsync(new Supplier[GetChildrenPaginatedResponse]() {
           def get(): GetChildrenPaginatedResponse = {
-            var topicsList: JList[String] = null 
+            var topicsList: JList[String] = null
             var resultCode: Code = Code.OK
             try {
               topicsList = zooKeeper.getAllChildrenPaginated(path, shouldWatch(request))
@@ -332,6 +332,7 @@ class ZooKeeperClient(connectString: String,
    */
   def registerZNodeChildChangeHandler(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {
     zNodeChildChangeHandlers.put(zNodeChildChangeHandler.path, zNodeChildChangeHandler)
+    zooKeeper.addWatch(zNodeChildChangeHandler.path, AddWatchMode.PERSISTENT_RECURSIVE)
   }
 
   /**

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -22,11 +22,11 @@ import java.util.concurrent.locks.{ReentrantLock, ReentrantReadWriteLock}
 import java.util.concurrent._
 import java.util.function.{Consumer, Supplier}
 import java.util.{List => JList}
-
 import com.yammer.metrics.core.MetricName
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils.CoreUtils.{inLock, inReadLock, inWriteLock}
 import kafka.utils.{KafkaScheduler, Logging}
+import kafka.zk.FederatedTopicsZNode
 import kafka.zookeeper.ZooKeeperClient._
 import org.apache.kafka.common.utils.Time
 import org.apache.zookeeper.AsyncCallback.{Children2Callback, DataCallback, StatCallback}
@@ -334,9 +334,11 @@ class ZooKeeperClient(connectString: String,
     zNodeChildChangeHandlers.put(zNodeChildChangeHandler.path, zNodeChildChangeHandler)
   }
 
-  def registerZNodeChildChangeHandlerRecursive(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {
-    zNodeChildChangeHandlers.put(zNodeChildChangeHandler.path, zNodeChildChangeHandler)
-    zooKeeper.addWatch(zNodeChildChangeHandler.path, AddWatchMode.PERSISTENT_RECURSIVE)
+  def reRegisterFederatedTopicsZNodeChangeHandler(namespace: String): Unit = {
+    if (zNodeChildChangeHandlers.contains(FederatedTopicsZNode.path)) {
+      zNodeChildChangeHandlers.putIfAbsent(s"${FederatedTopicsZNode.path}/$namespace",
+        zNodeChildChangeHandlers(FederatedTopicsZNode.path))
+    }
   }
 
   /**
@@ -456,7 +458,7 @@ class ZooKeeperClient(connectString: String,
   // package level visibility for testing only
   private[zookeeper] object ZooKeeperClientWatcher extends Watcher {
     override def process(event: WatchedEvent): Unit = {
-      debug(s"Received event: $event")
+      error(s"Received event: $event")
       Option(event.getPath) match {
         case None =>
           val state = event.getState

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -335,6 +335,11 @@ class ZooKeeperClient(connectString: String,
     zooKeeper.addWatch(zNodeChildChangeHandler.path, AddWatchMode.PERSISTENT_RECURSIVE)
   }
 
+  def registerZNodeChildChangeHandlerRecursive(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {
+    zNodeChildChangeHandlers.put(zNodeChildChangeHandler.path, zNodeChildChangeHandler)
+    zooKeeper.addWatch(zNodeChildChangeHandler.path, AddWatchMode.PERSISTENT_RECURSIVE)
+  }
+
   /**
    * Unregister the handler from ZooKeeperClient. This is just a local operation.
    * @param path the path of the handler to unregister

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -161,8 +161,16 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       new ListFederatedTopicZnodesOptions()).topics().get()
     assertEquals(0, expectedFail.size())
 
+    // 4. create another topic with same namespace
+    val federatedTopic1 = Map("federated-test-topic-1" -> "tracking").asJava
+    client.createFederatedTopicZnodes(federatedTopic1)
+
+    val federatedTopics1 = zkClient.getAllFederatedTopics
+    assertEquals(2, federatedTopics1.size)
+
     // delete federated topic znode
     client.deleteFederatedTopicZnodes(federatedTopic)
+    client.deleteFederatedTopicZnodes(federatedTopic1)
 
     waitForFederatedTopicZnodes(zkClient, List(), expectedFedTopic)
 

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -309,10 +309,49 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     assertTrue(zkClient.topicExists(topic1))
   }
 
+  @Test
+  def testGetAllFederatedTopicsInClusterTriggersWatch(): Unit = {
+    zkClient.createTopLevelPaths()
+    val latch = registerFederatedTopicChildChangeHandler(5)
+
+    // Listing all the topics and register the watch
+    assertTrue(zkClient.getAllFederatedTopics.isEmpty)
+
+    zkClient.createFederatedTopicZNode("testTopic", "tracking")
+    assertEquals(1, zkClient.getAllFederatedTopics.size)
+
+    zkClient.createFederatedTopicZNode("testTopic1", "tracking")
+    assertEquals(2, zkClient.getAllFederatedTopics.size)
+
+    zkClient.createFederatedTopicZNode("testTopic2", "tracking")
+    assertEquals(3, zkClient.getAllFederatedTopics.size)
+
+    zkClient.createFederatedTopicZNode("testTopic3", "metrics")
+    assertEquals(4, zkClient.getAllFederatedTopics.size)
+
+    zkClient.deleteFederatedTopicZNode("testTopic2", "tracking")
+
+    assertTrue(latch.await(5, TimeUnit.SECONDS),
+      "Failed to receive watch notification")
+  }
+
   private def registerChildChangeHandler(count: Int): CountDownLatch = {
-    val znodeChildChangeHandlerCountDownLatch = new CountDownLatch(1)
+    val znodeChildChangeHandlerCountDownLatch = new CountDownLatch(count)
     val znodeChildChangeHandler = new ZNodeChildChangeHandler {
       override val path: String = TopicsZNode.path
+
+      override def handleChildChange(): Unit = {
+        znodeChildChangeHandlerCountDownLatch.countDown()
+      }
+    }
+    zkClient.registerZNodeChildChangeHandler(znodeChildChangeHandler)
+    znodeChildChangeHandlerCountDownLatch
+  }
+
+  private def registerFederatedTopicChildChangeHandler(count: Int): CountDownLatch = {
+    val znodeChildChangeHandlerCountDownLatch = new CountDownLatch(count)
+    val znodeChildChangeHandler = new ZNodeChildChangeHandler {
+      override val path: String = FederatedTopicsZNode.path
 
       override def handleChildChange(): Unit = {
         znodeChildChangeHandlerCountDownLatch.countDown()


### PR DESCRIPTION
This pr fixes the zk listener for federated topics znode that requires to listen to child change events for both parent path and child paths.

LI_DESCRIPTION =
To be able to listen to change events under federated topics znode path, for both parent and child node changes, a listener for the namespace path is added/re-registered if not registered previously.

Added integ-test to verify the listener got triggered.

EXIT_CRITERIA = We can deprecate this pr when all kafka clients have been migrated to xinfra clients and all topic CUDs go through xmd, then we don't need kafka broker to understand both old and new topic acl, it will only need to understand the new acl.
