### PR TITLE
[LI-HOTFIX] Add log de-duplicate for ConfigException() in parseAndValidateAddresses()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -76,7 +76,9 @@ public final class ClientUtils {
                             String resolvedCanonicalName = inetAddress.getCanonicalHostName();
                             InetSocketAddress address = new InetSocketAddress(resolvedCanonicalName, port);
                             if (address.isUnresolved()) {
-                                log.warn("Couldn't resolve server {} from {} as DNS resolution of the canonical hostname {} failed for {}", url, CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, resolvedCanonicalName, host);
+                                String message = String.format("Couldn't resolve server %s from %s as DNS resolution of the canonical hostname %s failed for %s",
+                                    url, CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, resolvedCanonicalName, host);
+                                dedupeAndHandleMessage(message, false);
                             } else {
                                 addresses.add(address);
                             }
@@ -84,7 +86,8 @@ public final class ClientUtils {
                     } else {
                         InetSocketAddress address = new InetSocketAddress(host, port);
                         if (address.isUnresolved()) {
-                            log.warn("Couldn't resolve server {} from {} as DNS resolution failed for {}", url, CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, host);
+                            String message = String.format("Couldn't resolve server %s from %s as DNS resolution failed for %s", url, CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, host);
+                            dedupeAndHandleMessage(message, false);
                         } else {
                             addresses.add(address);
                         }
@@ -98,15 +101,19 @@ public final class ClientUtils {
             }
         }
         if (addresses.isEmpty())
-            dedupeError("No resolvable bootstrap server in provided urls: " + String.join(",", urls));
+            dedupeAndHandleMessage("No resolvable bootstrap server in provided urls: " + String.join(",", urls), true);
         return addresses;
     }
 
-    public static void dedupeError(String message) {
+    public static void dedupeAndHandleMessage(String message, Boolean isError) {
         long currentTime = System.currentTimeMillis();
         if (!isDuplicateError(message, currentTime)) {
             ERROR_DEDUPLICATION_CACHE.put(message, currentTime);
-            throw new ConfigException(message);
+            if (isError) {
+                throw new ConfigException(message);
+            } else {
+                log.warn(message);
+            }
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.clients;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
@@ -40,6 +42,8 @@ import static org.apache.kafka.common.utils.Utils.getPort;
 
 public final class ClientUtils {
     private static final Logger log = LoggerFactory.getLogger(ClientUtils.class);
+    private static final long DUPLICATE_WINDOW_MS = 1000; // 1 second
+    private static final Map<String, Long> ERROR_DEDUPLICATION_CACHE = new ConcurrentHashMap<>();
 
     private ClientUtils() {
     }
@@ -94,9 +98,21 @@ public final class ClientUtils {
             }
         }
         if (addresses.isEmpty())
-            throw new ConfigException("No resolvable bootstrap server in provided urls: " +
-                String.join(",", urls));
+            dedupeError("No resolvable bootstrap server in provided urls: " + String.join(",", urls));
         return addresses;
+    }
+
+    public static void dedupeError(String message) {
+        long currentTime = System.currentTimeMillis();
+        if (!isDuplicateError(message, currentTime)) {
+            ERROR_DEDUPLICATION_CACHE.put(message, currentTime);
+            throw new ConfigException(message);
+        }
+    }
+
+    private static boolean isDuplicateError(String message, long currentTime) {
+        Long previousTime = ERROR_DEDUPLICATION_CACHE.get(message);
+        return previousTime != null && (currentTime - previousTime) < DUPLICATE_WINDOW_MS;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -115,6 +115,25 @@ public class ClientUtilsTest {
         assertEquals(asList(addresses), ClientUtils.resolve("kafka.apache.org", hostResolver));
     }
 
+    @Test
+    public void testParseAndValidateAddressesDedupesErrors() {
+        int expectedNumberOfErrors = 1;
+        int actualNumberOfErrors = 0;
+        String expectedErrorMessage = "No resolvable bootstrap server in provided urls: ";
+
+        for (int i = 0; i < 10; i++) {
+            try {
+                ClientUtils.parseAndValidateAddresses(Collections.emptyList());
+            } catch (ConfigException e) {
+                assertEquals(expectedErrorMessage, e.getMessage());
+                actualNumberOfErrors++;
+            }
+        }
+
+        // Verify that only one error was thrown during the loop
+        assertEquals(expectedNumberOfErrors, actualNumberOfErrors);
+    }
+
     private List<InetSocketAddress> checkWithoutLookup(String... url) {
         return ClientUtils.parseAndValidateAddresses(asList(url), ClientDnsLookup.USE_ALL_DNS_IPS);
     }


### PR DESCRIPTION
BUG=[LIKAFKA-55206](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-55206)

Add log de-duplicate for ConfigException() in parseAndValidateAddresses() for errors of "No resolvable bootstrap server in provided urls:"
Add unit test for log dedup.