### PR TITLE
Adding xinfra identifier code to kafka api handler

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1945,7 +1945,15 @@ class KafkaApis(val requestChannel: RequestChannel,
     if (config.unofficialClientLoggingEnable) {
       // Check if the last part of clientSoftwareName (after commitId) is an unexpected software name
       val softwareName = apiVersionRequest.data.clientSoftwareName().split("-").last
-      if (!config.expectedClientSoftwareNames.contains(softwareName)) {
+      val expectedClientSoftwareNames = config.expectedClientSoftwareNames
+      var hasNonXinfraClient = false
+      expectedClientSoftwareNames.forEach { clientName =>
+        if (!clientName.toLowerCase.contains("xinfra")) {
+          hasNonXinfraClient = true;
+        }
+      }
+      observer.checkClientLibrary(hasNonXinfraClient)
+      if (!expectedClientSoftwareNames.contains(softwareName)) {
         val clientIdentity = request.context.clientId() + " " + request.context.clientAddress() + " " + request.context.principal()
         unofficialClientsCache.get(clientIdentity)
         warn(s"received ApiVersionsRequest from user with unofficial client type. clientId clientAddress principal = $clientIdentity")

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1941,7 +1941,6 @@ class KafkaApis(val requestChannel: RequestChannel,
     // with client authentication which is performed at an earlier stage of the connection where the
     // ApiVersionRequest is not available.
     val apiVersionRequest = request.body[ApiVersionsRequest]
-    val expectedClientSoftwareNames = config.expectedClientSoftwareNames
     val softwareName = apiVersionRequest.data.clientSoftwareName().split("-").last
     var isXinfraClient = false
     if (softwareName != null && softwareName.toLowerCase.contains("xinfra")) {
@@ -1951,8 +1950,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     if (config.unofficialClientLoggingEnable) {
       // Check if the last part of clientSoftwareName (after commitId) is an unexpected software name
-      val softwareName = apiVersionRequest.data.clientSoftwareName().split("-").last
-      if (!expectedClientSoftwareNames.contains(softwareName)) {
+      if (!config.expectedClientSoftwareNames.contains(softwareName)) {
         val clientIdentity = request.context.clientId() + " " + request.context.clientAddress() + " " + request.context.principal()
         unofficialClientsCache.get(clientIdentity)
         warn(s"received ApiVersionsRequest from user with unofficial client type. clientId clientAddress principal = $clientIdentity")

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1942,11 +1942,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     // ApiVersionRequest is not available.
     val apiVersionRequest = request.body[ApiVersionsRequest]
     val softwareName = apiVersionRequest.data.clientSoftwareName().split("-").last
-    var isXinfraClient = false
-    if (softwareName != null && softwareName.toLowerCase.contains("xinfra")) {
-      isXinfraClient = true;
-    }
-    observer.checkClientLibrary(isXinfraClient, request.context.clientId())
+
+    val isXinfraClient = (softwareName != null && softwareName.toLowerCase.contains("xinfra"))
+    observer.trackClientLibrary(isXinfraClient, request.context.clientId())
 
     if (config.unofficialClientLoggingEnable) {
       // Check if the last part of clientSoftwareName (after commitId) is an unexpected software name

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1943,9 +1943,11 @@ class KafkaApis(val requestChannel: RequestChannel,
     val apiVersionRequest = request.body[ApiVersionsRequest]
     val expectedClientSoftwareNames = config.expectedClientSoftwareNames
     var hasNonXinfraClient = false
-    expectedClientSoftwareNames.forEach { clientName =>
-      if (!clientName.toLowerCase.contains("xinfra")) {
-        hasNonXinfraClient = true;
+    if (expectedClientSoftwareNames != null) {
+      expectedClientSoftwareNames.forEach { clientName =>
+        if (!clientName.toLowerCase.contains("xinfra")) {
+          hasNonXinfraClient = true;
+        }
       }
     }
     observer.checkClientLibrary(hasNonXinfraClient, request.context.clientId())

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1952,7 +1952,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           hasNonXinfraClient = true;
         }
       }
-      observer.checkClientLibrary(hasNonXinfraClient)
+      observer.checkClientLibrary(hasNonXinfraClient, request.context.clientId())
       if (!expectedClientSoftwareNames.contains(softwareName)) {
         val clientIdentity = request.context.clientId() + " " + request.context.clientAddress() + " " + request.context.principal()
         unofficialClientsCache.get(clientIdentity)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1942,15 +1942,12 @@ class KafkaApis(val requestChannel: RequestChannel,
     // ApiVersionRequest is not available.
     val apiVersionRequest = request.body[ApiVersionsRequest]
     val expectedClientSoftwareNames = config.expectedClientSoftwareNames
-    var hasNonXinfraClient = false
-    if (expectedClientSoftwareNames != null) {
-      expectedClientSoftwareNames.forEach { clientName =>
-        if (!clientName.toLowerCase.contains("xinfra")) {
-          hasNonXinfraClient = true;
-        }
-      }
+    val softwareName = apiVersionRequest.data.clientSoftwareName().split("-").last
+    var isXinfraClient = false
+    if (softwareName != null && softwareName.toLowerCase.contains("xinfra")) {
+      isXinfraClient = true;
     }
-    observer.checkClientLibrary(hasNonXinfraClient, request.context.clientId())
+    observer.checkClientLibrary(isXinfraClient, request.context.clientId())
 
     if (config.unofficialClientLoggingEnable) {
       // Check if the last part of clientSoftwareName (after commitId) is an unexpected software name

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1941,18 +1941,18 @@ class KafkaApis(val requestChannel: RequestChannel,
     // with client authentication which is performed at an earlier stage of the connection where the
     // ApiVersionRequest is not available.
     val apiVersionRequest = request.body[ApiVersionsRequest]
+    val expectedClientSoftwareNames = config.expectedClientSoftwareNames
+    var hasNonXinfraClient = false
+    expectedClientSoftwareNames.forEach { clientName =>
+      if (!clientName.toLowerCase.contains("xinfra")) {
+        hasNonXinfraClient = true;
+      }
+    }
+    observer.checkClientLibrary(hasNonXinfraClient, request.context.clientId())
 
     if (config.unofficialClientLoggingEnable) {
       // Check if the last part of clientSoftwareName (after commitId) is an unexpected software name
       val softwareName = apiVersionRequest.data.clientSoftwareName().split("-").last
-      val expectedClientSoftwareNames = config.expectedClientSoftwareNames
-      var hasNonXinfraClient = false
-      expectedClientSoftwareNames.forEach { clientName =>
-        if (!clientName.toLowerCase.contains("xinfra")) {
-          hasNonXinfraClient = true;
-        }
-      }
-      observer.checkClientLibrary(hasNonXinfraClient, request.context.clientId())
       if (!expectedClientSoftwareNames.contains(softwareName)) {
         val clientIdentity = request.context.clientId() + " " + request.context.clientAddress() + " " + request.context.principal()
         unofficialClientsCache.get(clientIdentity)

--- a/core/src/main/scala/kafka/server/NoOpObserver.scala
+++ b/core/src/main/scala/kafka/server/NoOpObserver.scala
@@ -46,6 +46,6 @@ class NoOpObserver extends Observer {
   /**
    * Check client library.
    */
-  def checkClientLibrary(hasNonXinfraClient: Boolean): Unit = {}
+  def checkClientLibrary(hasNonXinfraClient: Boolean, clientId: String): Unit = {}
 
 }

--- a/core/src/main/scala/kafka/server/NoOpObserver.scala
+++ b/core/src/main/scala/kafka/server/NoOpObserver.scala
@@ -46,6 +46,6 @@ class NoOpObserver extends Observer {
   /**
    * Check client library.
    */
-  def checkClientLibrary(hasNonXinfraClient: Boolean, clientId: String): Unit = {}
+  def checkClientLibrary(isXinfraClient: Boolean, clientId: String): Unit = {}
 
 }

--- a/core/src/main/scala/kafka/server/NoOpObserver.scala
+++ b/core/src/main/scala/kafka/server/NoOpObserver.scala
@@ -44,8 +44,8 @@ class NoOpObserver extends Observer {
   def close(timeout: Long, unit: TimeUnit): Unit = {}
 
   /**
-   * Check client library.
+   * track the client library.
    */
-  def checkClientLibrary(isXinfraClient: Boolean, clientId: String): Unit = {}
+  def trackClientLibrary(isXinfraClient: Boolean, clientId: String): Unit = {}
 
 }

--- a/core/src/main/scala/kafka/server/NoOpObserver.scala
+++ b/core/src/main/scala/kafka/server/NoOpObserver.scala
@@ -43,4 +43,9 @@ class NoOpObserver extends Observer {
     */
   def close(timeout: Long, unit: TimeUnit): Unit = {}
 
+  /**
+   * Check client library.
+   */
+  def checkClientLibrary(hasNonXinfraClient: Boolean): Unit = {}
+
 }

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -19,6 +19,8 @@ package kafka.server
 
 import java.util.concurrent.TimeUnit
 import kafka.network.RequestChannel
+import java.util
+
 import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ProduceRequest, RequestContext}
 import org.apache.kafka.common.Configurable
@@ -61,9 +63,9 @@ trait Observer extends Configurable {
   /**
     * Check client library. Users pass in the client library and version so the client type can be checked
     *
-    * @param clientLibrary  client library name and version
+    * @param hasNonXinfraClient  flag to determine if the topic has been accessed by a non xinfra client
     */
-  def checkClientLibrary(clientLibrary: String): Unit
+  def checkClientLibrary(hasNonXinfraClient: Boolean): Unit
 
   /**
     * Close the observer with timeout.

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.Configurable
   * From that point onwards, every pair of request and response will be routed to the 'record' method.
   *
   * If 'observer.class.name' has no value specified or the specified class does not exist, the <code>NoOpObserver</code>
-  * will be used as a place holder.
+  * will be used as a place holder..
   */
 trait Observer extends Configurable {
 

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.Configurable
   * From that point onwards, every pair of request and response will be routed to the 'record' method.
   *
   * If 'observer.class.name' has no value specified or the specified class does not exist, the <code>NoOpObserver</code>
-  * will be used as a place holder...
+  * will be used as a place holder.
   */
 trait Observer extends Configurable {
 
@@ -45,18 +45,25 @@ trait Observer extends Configurable {
   def observe(requestContext: RequestContext, request: AbstractRequest, response: AbstractResponse): Unit
 
   /**
-    * Observe a produce request. This method handles only the produce request since produce request is special in
-    * two ways. Firstly, if ACK is set to be 0, there is no produce response associated with the produce request.
-    * Secondly, the lifecycle of some inner fields in a ProduceRequest is shorter than the lifecycle of the produce
-    * request itself. That means in some situations, when <code>observe</code> is called on a produce request and
-    * response pair, some fields in the produce request has been null-ed already so that the produce request and
-    * response is not observable (or no useful information). Therefore this method exists for the purpose of allowing
-    * users to observe on the produce request before its corresponding response is created.
-    *
-    * @param requestContext the context information about the request
-    * @param produceRequest  the produce request being observed for a various purpose(s)
-    */
+   * Observe a produce request. This method handles only the produce request since produce request is special in
+   * two ways. Firstly, if ACK is set to be 0, there is no produce response associated with the produce request.
+   * Secondly, the lifecycle of some inner fields in a ProduceRequest is shorter than the lifecycle of the produce
+   * request itself. That means in some situations, when <code>observe</code> is called on a produce request and
+   * response pair, some fields in the produce request has been null-ed already so that the produce request and
+   * response is not observable (or no useful information). Therefore this method exists for the purpose of allowing
+   * users to observe on the produce request before its corresponding response is created.
+   *
+   * @param requestContext the context information about the request
+   * @param produceRequest  the produce request being observed for a various purpose(s)
+   */
   def observeProduceRequest(requestContext: RequestContext, produceRequest: ProduceRequest): Unit
+
+  /**
+   * Check client library. Users pass in the client library and version so the client type can be checked
+   *
+   * @param clientLibrary  client library name and version
+   */
+  def checkClientLibrary(clientLibrary: String): Unit
 
   /**
     * Close the observer with timeout.

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -19,7 +19,6 @@ package kafka.server
 
 import java.util.concurrent.TimeUnit
 import kafka.network.RequestChannel
-
 import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ProduceRequest, RequestContext}
 import org.apache.kafka.common.Configurable

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -24,15 +24,15 @@ import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, Prod
 import org.apache.kafka.common.Configurable
 
 /**
-  * Top level interface that all pluggable observer must implement. Kafka will read the 'observer.class.name' config
-  * value at startup time, create an instance of the specificed class using the default constructor, and call its
-  * 'configure' method.
-  *
-  * From that point onwards, every pair of request and response will be routed to the 'record' method.
-  *
-  * If 'observer.class.name' has no value specified or the specified class does not exist, the <code>NoOpObserver</code>
-  * will be used as a place holder.
-  */
+ * Top level interface that all pluggable observer must implement. Kafka will read the 'observer.class.name' config
+ * value at startup time, create an instance of the specificed class using the default constructor, and call its
+ * 'configure' method.
+ *
+ * From that point onwards, every pair of request and response will be routed to the 'record' method.
+ *
+ * If 'observer.class.name' has no value specified or the specified class does not exist, the <code>NoOpObserver</code>
+ * will be used as a place holder.
+ */
 trait Observer extends Configurable {
 
   /**

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -61,10 +61,10 @@ trait Observer extends Configurable {
   /**
     * Check client library. Users pass in the client library and version so the client type can be checked
     *
-   * @param hasNonXinfraClient  flag to determine if the topic has been accessed by a non xinfra client
+   * @param isXinfraClient  is this clientId a xinfra client
    * @param clientId The clientId for this specific request
     */
-  def checkClientLibrary(hasNonXinfraClient: Boolean, clientId: String): Unit
+  def checkClientLibrary(isXinfraClient: Boolean, clientId: String): Unit
 
   /**
     * Close the observer with timeout.

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -19,7 +19,6 @@ package kafka.server
 
 import java.util.concurrent.TimeUnit
 import kafka.network.RequestChannel
-import java.util
 
 import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ProduceRequest, RequestContext}

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -24,15 +24,15 @@ import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, Prod
 import org.apache.kafka.common.Configurable
 
 /**
- * Top level interface that all pluggable observer must implement. Kafka will read the 'observer.class.name' config
- * value at startup time, create an instance of the specificed class using the default constructor, and call its
- * 'configure' method.
- *
- * From that point onwards, every pair of request and response will be routed to the 'record' method.
- *
- * If 'observer.class.name' has no value specified or the specified class does not exist, the <code>NoOpObserver</code>
- * will be used as a place holder.
- */
+  * Top level interface that all pluggable observer must implement. Kafka will read the 'observer.class.name' config
+  * value at startup time, create an instance of the specificed class using the default constructor, and call its
+  * 'configure' method.
+  *
+  * From that point onwards, every pair of request and response will be routed to the 'record' method.
+  *
+  * If 'observer.class.name' has no value specified or the specified class does not exist, the <code>NoOpObserver</code>
+  * will be used as a place holder.
+  */
 trait Observer extends Configurable {
 
   /**
@@ -45,24 +45,24 @@ trait Observer extends Configurable {
   def observe(requestContext: RequestContext, request: AbstractRequest, response: AbstractResponse): Unit
 
   /**
-   * Observe a produce request. This method handles only the produce request since produce request is special in
-   * two ways. Firstly, if ACK is set to be 0, there is no produce response associated with the produce request.
-   * Secondly, the lifecycle of some inner fields in a ProduceRequest is shorter than the lifecycle of the produce
-   * request itself. That means in some situations, when <code>observe</code> is called on a produce request and
-   * response pair, some fields in the produce request has been null-ed already so that the produce request and
-   * response is not observable (or no useful information). Therefore this method exists for the purpose of allowing
-   * users to observe on the produce request before its corresponding response is created.
-   *
-   * @param requestContext the context information about the request
-   * @param produceRequest  the produce request being observed for a various purpose(s)
-   */
+    * Observe a produce request. This method handles only the produce request since produce request is special in
+    * two ways. Firstly, if ACK is set to be 0, there is no produce response associated with the produce request.
+    * Secondly, the lifecycle of some inner fields in a ProduceRequest is shorter than the lifecycle of the produce
+    * request itself. That means in some situations, when <code>observe</code> is called on a produce request and
+    * response pair, some fields in the produce request has been null-ed already so that the produce request and
+    * response is not observable (or no useful information). Therefore this method exists for the purpose of allowing
+    * users to observe on the produce request before its corresponding response is created.
+    *
+    * @param requestContext the context information about the request
+    * @param produceRequest  the produce request being observed for a various purpose(s)
+    */
   def observeProduceRequest(requestContext: RequestContext, produceRequest: ProduceRequest): Unit
 
   /**
-   * Check client library. Users pass in the client library and version so the client type can be checked
-   *
-   * @param clientLibrary  client library name and version
-   */
+    * Check client library. Users pass in the client library and version so the client type can be checked
+    *
+    * @param clientLibrary  client library name and version
+    */
   def checkClientLibrary(clientLibrary: String): Unit
 
   /**

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -59,12 +59,12 @@ trait Observer extends Configurable {
   def observeProduceRequest(requestContext: RequestContext, produceRequest: ProduceRequest): Unit
 
   /**
-    * Check client library. Users pass in the client library and version so the client type can be checked
+    * Hook to track the client library type so different client types can be compared
     *
    * @param isXinfraClient  is this clientId a xinfra client
    * @param clientId The clientId for this specific request
     */
-  def checkClientLibrary(isXinfraClient: Boolean, clientId: String): Unit
+  def trackClientLibrary(isXinfraClient: Boolean, clientId: String): Unit
 
   /**
     * Close the observer with timeout.

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.common.Configurable
   * From that point onwards, every pair of request and response will be routed to the 'record' method.
   *
   * If 'observer.class.name' has no value specified or the specified class does not exist, the <code>NoOpObserver</code>
-  * will be used as a place holder..
+  * will be used as a place holder...
   */
 trait Observer extends Configurable {
 

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -61,9 +61,10 @@ trait Observer extends Configurable {
   /**
     * Check client library. Users pass in the client library and version so the client type can be checked
     *
-    * @param hasNonXinfraClient  flag to determine if the topic has been accessed by a non xinfra client
+   * @param hasNonXinfraClient  flag to determine if the topic has been accessed by a non xinfra client
+   * @param clientId The clientId for this specific request
     */
-  def checkClientLibrary(hasNonXinfraClient: Boolean): Unit
+  def checkClientLibrary(hasNonXinfraClient: Boolean, clientId: String): Unit
 
   /**
     * Close the observer with timeout.

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -59,10 +59,11 @@ trait Observer extends Configurable {
   def observeProduceRequest(requestContext: RequestContext, produceRequest: ProduceRequest): Unit
 
   /**
-    * Hook to track the client library type so different client types can be compared
+    * Hook to track the client library type so different client types can be compared. This function is in the hot path
+    * of request-handling so all computations that are added to it need to be light
     *
-   * @param isXinfraClient  is this clientId a xinfra client
-   * @param clientId The clientId for this specific request
+    * @param isXinfraClient  is this clientId a xinfra client
+    * @param clientId The clientId for this specific request
     */
   def trackClientLibrary(isXinfraClient: Boolean, clientId: String): Unit
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -501,9 +501,31 @@ class KafkaApisTest {
   @Test
   def testClientLibraryVersionObserverCaching(): Unit = {
     val requestBuilder = new ApiVersionsRequest.Builder()
-    testForwardableApi(ApiKeys.API_VERSIONS, requestBuilder)
+    EasyMock.expect(observer.checkClientLibrary(true, clientId))
+    val kafkaApis = createKafkaApis(enableForwarding = true)
 
-    // EasyMock.expect(observer.checkClientLibrary(true, clientId))
+    val topicHeader = new RequestHeader(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion,
+      clientId, 0)
+
+    val request = buildRequest(requestBuilder.build(topicHeader.apiVersion))
+
+    if (kafkaApis.metadataSupport.isInstanceOf[ZkSupport]) {
+      // The controller check only makes sense for ZK clusters. For KRaft,
+      // controller requests are handled on a separate listener, so there
+      // is no choice but to forward them.
+      EasyMock.expect(controller.isActive).andReturn(false)
+    }
+
+    expectNoThrottling(request)
+
+    EasyMock.expect(forwardingManager.forwardRequest(
+      EasyMock.eq(request),
+      anyObject[Option[AbstractResponse] => Unit]()
+    )).once()
+
+    EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, controller, forwardingManager)
+
+    kafkaApis.handle(request, RequestLocal.withThreadConfinedCaching)
   }
 
   private def testForwardableApi(apiKey: ApiKeys, requestBuilder: AbstractRequest.Builder[_ <: AbstractRequest]): Unit = {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -501,7 +501,7 @@ class KafkaApisTest {
   @Test
   def testClientLibraryVersionObserverCaching(): Unit = {
     val requestBuilder = new ApiVersionsRequest.Builder()
-    EasyMock.expect(observer.checkClientLibrary(true, clientId))
+    EasyMock.expect(observer.trackClientLibrary(true, clientId))
     val kafkaApis = createKafkaApis(enableForwarding = true)
 
     val topicHeader = new RequestHeader(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion,

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -512,7 +512,7 @@ class KafkaApisTest {
     if (kafkaApis.metadataSupport.isInstanceOf[ZkSupport]) {
       // The controller check only makes sense for ZK clusters. For KRaft,
       // controller requests are handled on a separate listener, so there
-      // is no choice but to forward them.
+      // is no choice but to forward them..
       EasyMock.expect(controller.isActive).andReturn(false)
     }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -61,6 +61,7 @@ import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType
+import org.apache.kafka.common.requests.ApiVersionsRequest
 import org.apache.kafka.common.requests.MetadataResponse.TopicMetadata
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest.TxnMarkerEntry
@@ -495,6 +496,12 @@ class KafkaApisTest {
       ApiKeys.DESCRIBE_QUORUM,
       requestBuilder
     )
+  }
+
+  @Test
+  def testClientLibraryVersionObserverCaching(): Unit = {
+    val requestBuilder = new ApiVersionsRequest.Builder()
+    testForwardableApi(ApiKeys.API_VERSIONS, requestBuilder)
   }
 
   private def testForwardableApi(apiKey: ApiKeys, requestBuilder: AbstractRequest.Builder[_ <: AbstractRequest]): Unit = {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -502,6 +502,8 @@ class KafkaApisTest {
   def testClientLibraryVersionObserverCaching(): Unit = {
     val requestBuilder = new ApiVersionsRequest.Builder()
     testForwardableApi(ApiKeys.API_VERSIONS, requestBuilder)
+
+    // EasyMock.expect(observer.checkClientLibrary(true, clientId))
   }
 
   private def testForwardableApi(apiKey: ApiKeys, requestBuilder: AbstractRequest.Builder[_ <: AbstractRequest]): Unit = {


### PR DESCRIPTION
Adding logic to find the client type and library version and passing that into observer. This will allow us to track which clients are accessing which topics

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
