### PR TITLE
[LI-HOTFIX] Fix dynamic config reconfigure

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2052,7 +2052,6 @@ class Log(@volatile private var _dir: File,
             )
           }
           // FIXME: this code path involves not only data plane segments but also KRaft metadata logs.  Should find a way to distinguish after moving to KRaft.
-          
           // XXX: An internal dashboard depends on parsing this warn log line. Get SRE reviews before changing the format.
           warn(s"Attempted truncating to offset $targetOffset. Resulted in truncated to $offsetTruncatedTo from the original log end offset $originalLogEndOffset, " +
             s"with $messagesTruncated messages and $bytesTruncated bytes truncated")

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2052,6 +2052,7 @@ class Log(@volatile private var _dir: File,
             )
           }
           // FIXME: this code path involves not only data plane segments but also KRaft metadata logs.  Should find a way to distinguish after moving to KRaft.
+
           // XXX: An internal dashboard depends on parsing this warn log line. Get SRE reviews before changing the format.
           warn(s"Attempted truncating to offset $targetOffset. Resulted in truncated to $offsetTruncatedTo from the original log end offset $originalLogEndOffset, " +
             s"with $messagesTruncated messages and $bytesTruncated bytes truncated")

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2052,7 +2052,6 @@ class Log(@volatile private var _dir: File,
             )
           }
           // FIXME: this code path involves not only data plane segments but also KRaft metadata logs.  Should find a way to distinguish after moving to KRaft.
-
           // XXX: An internal dashboard depends on parsing this warn log line. Get SRE reviews before changing the format.
           warn(s"Attempted truncating to offset $targetOffset. Resulted in truncated to $offsetTruncatedTo from the original log end offset $originalLogEndOffset, " +
             s"with $messagesTruncated messages and $bytesTruncated bytes truncated")

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2052,7 +2052,7 @@ class Log(@volatile private var _dir: File,
             )
           }
           // FIXME: this code path involves not only data plane segments but also KRaft metadata logs.  Should find a way to distinguish after moving to KRaft.
-
+          
           // XXX: An internal dashboard depends on parsing this warn log line. Get SRE reviews before changing the format.
           warn(s"Attempted truncating to offset $targetOffset. Resulted in truncated to $offsetTruncatedTo from the original log end offset $originalLogEndOffset, " +
             s"with $messagesTruncated messages and $bytesTruncated bytes truncated")

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -678,9 +678,12 @@ class DynamicLogConfig(logManager: LogManager, server: KafkaBroker) extends Brok
     val origUncleanLeaderElectionEnable = logManager.currentDefaultConfig.uncleanLeaderElectionEnable
     val newBrokerDefaults = new util.HashMap[String, Object](currentLogConfig.originals)
     // Call extractLogConfigMap to get the new LogConfig because there are some special handling for some configs, e.g.,
-    // RetentionMsProp. This is to ensure that the new LogConfig is consistent with LogManager's behavior.
+    // RetentionMsProp. This is to ensure that the new LogConfig is consistent with LogManager's LogConfig creation behavior.
     val newLogConfig = LogConfig.extractLogConfigMap(newConfig)
     newLogConfig.forEach { (k, v) =>
+      // Only update the config if it is a reconfigurable config. ReconfigurableConfigs is a subset of TopicConfigSynonyms.values.
+      // TopicConfigSynonyms is a map from log config name to kafka config name. Here we get the value of k and
+      // then check whether ReconfigurableConfigs contains it.
       if (LogConfig.TopicConfigSynonyms.contains(k) && DynamicLogConfig.ReconfigurableConfigs.contains(LogConfig.TopicConfigSynonyms(k))) {
         if (v == null) {
           newBrokerDefaults.remove(k)

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -684,8 +684,9 @@ class DynamicLogConfig(logManager: LogManager, server: KafkaBroker) extends Brok
       if (LogConfig.TopicConfigSynonyms.contains(k) && DynamicLogConfig.ReconfigurableConfigs.contains(LogConfig.TopicConfigSynonyms(k))) {
         if (v == null) {
           newBrokerDefaults.remove(k)
-        } else
+        } else {
           newBrokerDefaults.put(k, v.asInstanceOf[AnyRef])
+        }
       }
     }
 

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -677,14 +677,15 @@ class DynamicLogConfig(logManager: LogManager, server: KafkaBroker) extends Brok
     val currentLogConfig = logManager.currentDefaultConfig
     val origUncleanLeaderElectionEnable = logManager.currentDefaultConfig.uncleanLeaderElectionEnable
     val newBrokerDefaults = new util.HashMap[String, Object](currentLogConfig.originals)
-    newConfig.valuesFromThisConfig.forEach { (k, v) =>
-      if (DynamicLogConfig.ReconfigurableConfigs.contains(k)) {
-        DynamicLogConfig.KafkaConfigToLogConfigName.get(k).foreach { configName =>
-          if (v == null)
-             newBrokerDefaults.remove(configName)
-          else
-            newBrokerDefaults.put(configName, v.asInstanceOf[AnyRef])
-        }
+    // Call extractLogConfigMap to get the new LogConfig because there are some special handling for some configs, e.g.,
+    // RetentionMsProp. This is to ensure that the new LogConfig is consistent with LogManager's behavior.
+    val newLogConfig = LogConfig.extractLogConfigMap(newConfig)
+    newLogConfig.forEach { (k, v) =>
+      if (LogConfig.TopicConfigSynonyms.contains(k) && DynamicLogConfig.ReconfigurableConfigs.contains(LogConfig.TopicConfigSynonyms(k))) {
+        if (v == null) {
+          newBrokerDefaults.remove(k)
+        } else
+          newBrokerDefaults.put(k, v.asInstanceOf[AnyRef])
       }
     }
 


### PR DESCRIPTION
TICKET = [LIKAFKA-57566](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-57566)
LI_DESCRIPTION =
LogConfig is obtained from KafkaConfig with special handlings for some configs, e.g., RetentionMs is calculated from LogRetentionTimeMillis if it set, else from LogRetentionTimeMinutes if it is set, else by LogRetentionTimeHours. However, in DynamicLogConfig reconfigure, this special handling was not run, instead, it was using the config directly from KafkaConfig. As a result, if the static config has only LogRetentionTimeHours set without setting LogRetentionTimeMillis, LogRetentionTimeHours was not honored in LogConfig.

In this PR, we change reconfigure to run LogConfig.extractLogConfigMap on KafkaConfig first (this is the same method LogManager used to get LogConfig initially) and then apply the changes to newBrokerDefaults.  

EXIT_CRITERIA = NA

Testing Done
Tested with newly added test; Also tested in kafka.tango