### PR TITLE
[LI-HOTFIX] Log client endpoint when accept connections

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -727,6 +727,7 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
     try {
       connectionQuotas.inc(endPoint.listenerName, socketChannel.socket.getInetAddress, blockedPercentMeter)
       configureAcceptedSocketChannel(socketChannel)
+      info(s"Accepted channel from ${endPoint.connectionString}")
       Some(socketChannel)
     } catch {
       case e: TooManyConnectionsException =>


### PR DESCRIPTION
Log client endpoint when accept connections. This is for debugging purpose when there is a connection burst issue.

After pulling in this change, I'm planning to add a new log appender in the kafka-server, so that the socket level logs doesn't pollute the kafka-server logs.
