### PR TITLE
[LI-HOTFIX] Exclude logback as a dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -883,6 +883,7 @@ project(':core') {
       implementation libs.dropwizardMetrics
       exclude module: 'slf4j-log4j12'
       exclude module: 'log4j'
+      exclude group: 'ch.qos.logback', module: 'logback-classic'
     }
     // ZooKeeperMain depends on commons-cli but declares the dependency as `provided`
     implementation libs.commonsCli


### PR DESCRIPTION
TICKET = N/A
LI_DESCRIPTION = Exclude logback as a dependency as the assumption is that log4j will be used.
Tested the change with a info level logging in one of the tools script and seeing that it's no longer showing up.
EXIT_CRITERIA = N/A

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
