### PR TITLE
Remove overly strict key.password check 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -287,8 +287,8 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
         } else if (PEM_TYPE.equals(type) && path != null) {
             if (password != null)
                 throw new InvalidConfigurationException("SSL key store password cannot be specified with PEM format, only key password may be specified");
-            else if (keyPassword == null)
-                throw new InvalidConfigurationException("SSL PEM key store is specified, but key password is not specified.");
+// else if (keyPassword == null)
+//                throw new InvalidConfigurationException("SSL PEM key store is specified, but key password is not specified.");
             else
                 return new FileBasedPemStore(path, keyPassword, true);
         } else if (path == null && password != null) {


### PR DESCRIPTION
This PR removes the overly strict key.password check when creating a `PEM` keystore. It's okay to pass no password for PEM-formatted keystore file. [Kafka 3.3](https://github.com/apache/kafka/blob/3.3/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java#L288) removed this erroneous condition. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
