### PR TITLE
[LI-CHERRY-PICK] MINOR: example.com moved (#15758) (#512)

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -60,7 +60,8 @@ public class ClientUtilsTest {
         assertTrue("Unexpected addresses " + validatedAddresses, validatedAddresses.size() >= 1);
         List<String> validatedHostNames = validatedAddresses.stream().map(InetSocketAddress::getHostName)
                 .collect(Collectors.toList());
-        List<String> expectedHostNames = Arrays.asList("93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946");
+
+        List<String> expectedHostNames = Arrays.asList("93.184.215.14", "2606:2800:21f:cb07:6820:80da:af6b:8b2c");
         assertTrue("Unexpected addresses " + validatedHostNames, expectedHostNames.containsAll(validatedHostNames));
         validatedAddresses.forEach(address -> assertEquals(10000, address.getPort()));
     }


### PR DESCRIPTION
### Summary
- In the `ClientUtilsTest` class, unit test `testParseAndValidateAddressesWithReverseLookup` has hardcoded IP addresses of `example.com`. The IP address has been changed and this PR is to cherry pick the commit that updates the hardcoded IP addresses.
- This PR also include conflicts fixing. The original PR from upstream and the 3.0-li branch were based on a newer implementation of the `ClientUtilsTest`.

### Tests
Executed impacted unit tests and it was successful.
```
./gradlew -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home clients:test --tests org.apache.kafka.clients.ClientUtilsTest
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
