### PR TITLE
[LI-CHERRY-PICK] LIKAFKA-59153: Adding throttling logs in consumer.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/FetchSessionHandler.java
@@ -300,11 +300,11 @@ public class FetchSessionHandler {
      * @param response  The response.
      * @return          True if the full fetch response partitions are valid.
      */
-    private String verifyFullFetchResponsePartitions(FetchResponse<?> response) {
+    String verifyFullFetchResponsePartitions(FetchResponse<?> response) {
         StringBuilder bld = new StringBuilder();
-        Set<TopicPartition> omitted =
-            findMissing(response.responseData().keySet(), sessionPartitions.keySet());
         Set<TopicPartition> extra =
+            findMissing(response.responseData().keySet(), sessionPartitions.keySet());
+        Set<TopicPartition> omitted =
             findMissing(sessionPartitions.keySet(), response.responseData().keySet());
         if (!omitted.isEmpty()) {
             bld.append("omitted=(").append(Utils.join(omitted, ", ")).append(", ");
@@ -313,7 +313,7 @@ public class FetchSessionHandler {
             bld.append("extra=(").append(Utils.join(extra, ", ")).append(", ");
         }
         if ((!omitted.isEmpty()) || (!extra.isEmpty())) {
-            bld.append("response=(").append(Utils.join(response.responseData().keySet(), ", "));
+            bld.append("response=(").append(Utils.join(response.responseData().keySet(), ", ")).append(")");
             return bld.toString();
         }
         return null;
@@ -325,7 +325,7 @@ public class FetchSessionHandler {
      * @param response  The response.
      * @return          True if the incremental fetch response partitions are valid.
      */
-    private String verifyIncrementalFetchResponsePartitions(FetchResponse<?> response) {
+    String verifyIncrementalFetchResponsePartitions(FetchResponse<?> response) {
         Set<TopicPartition> extra =
             findMissing(response.responseData().keySet(), sessionPartitions.keySet());
         if (!extra.isEmpty()) {
@@ -394,7 +394,22 @@ public class FetchSessionHandler {
                 nextMetadata = nextMetadata.nextCloseExisting();
             }
             return false;
-        } else if (nextMetadata.isFull()) {
+        }
+        if (nextMetadata.isFull()) {
+            if (response.responseData().isEmpty() && response.throttleTimeMs() > 0) {
+                // Normally, an empty full fetch response would be invalid.  However, KIP-219
+                // specifies that if the broker wants to throttle the client, it will respond
+                // to a full fetch request with an empty response and a throttleTimeMs
+                // value set.  We don't want to log this with a warning, since it's not an error.
+                // However, the empty full fetch response can't be processed, so it's still appropriate
+                // to return false here.
+                if (log.isDebugEnabled()) {
+                    log.debug("Node {} sent a empty full fetch response to indicate that this " +
+                        "client should be throttled for {} ms.", node, response.throttleTimeMs());
+                }
+                nextMetadata = FetchMetadata.INITIAL;
+                return false;
+            }
             String problem = verifyFullFetchResponsePartitions(response);
             if (problem != null) {
                 log.info("Node {} sent an invalid full fetch response with {}", node, problem);
@@ -428,9 +443,12 @@ public class FetchSessionHandler {
                 return true;
             } else {
                 // The incremental fetch session was continued by the server.
+                // We don't have to do anything special here to support KIP-219, since an empty incremental
+                // fetch request is perfectly valid.
                 if (log.isDebugEnabled())
-                    log.debug("Node {} sent an incremental fetch response for session {}{}",
-                            node, response.sessionId(), responseDataToLogString(response));
+                    log.debug("Node {} sent an incremental fetch response with throttleTimeMs = {} " +
+                        "for session {}{}", response.throttleTimeMs(), node, response.sessionId(),
+                        responseDataToLogString(response));
                 nextMetadata = nextMetadata.nextIncremental();
                 return true;
             }


### PR DESCRIPTION
### Summary
This cherry-pick is to add logs for consumer throttling. It is part of the [LIKAFKA-59153](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-59153) as a follow up task of [ACTIONITEM-873](https://jira01.corp.linkedin.com:8443/browse/ACTIONITEM-873) and [Incident 641](https://rootly.com/account/incidents/641).

### Tests
Executed FetchSessionHandlerTest.
```
./gradlew -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home clients:test --tests org.apache.kafka.clients.FetchSessionHandlerTest
```

### Original Commit Message
> When the consumer's fetch request is throttled by the KIP-219 mechanism, it receives an empty fetch response.  The consumer should not log this as an error.

Reviewers: Jason Gustafson <jason@confluent.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
