### PR TITLE
checking newNode size to make sure its not 0

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -990,6 +990,10 @@ public class NetworkClient implements KafkaClient {
                 newNodes.add(new Node(nodeId--, address.getHostString(), address.getPort()));
             }
 
+            if (newNodes.size() == 0) {
+                return null;
+            }
+            
             int offset = this.randOffset.nextInt(newNodes.size());
             Node node = newNodes.get(offset);
             log.trace("Resolved bootstrap server again, randomly picked node {} as least loaded node from the resolved node set", node);

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients;
 
 import java.util.PriorityQueue;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.errors.AuthenticationException;

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -639,6 +639,8 @@ public class NetworkClientTest {
             LeastLoadedNodeAlgorithm.VANILLA, new ArrayList<>());
         nc.ready(node, time.milliseconds());
         assertFalse(client.isReady(node, time.milliseconds()));
+        assertThrows(ConfigException.class, () -> nc.leastLoadedNode(time.milliseconds()));
+
         assertEquals(null, nc.leastLoadedNode(time.milliseconds()));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -632,6 +632,12 @@ public class NetworkClientTest {
     }
 
     @Test
+    public void noLeastLoadedNode() {
+        clusterClient.ready(null, time.milliseconds());
+        assertNotEquals(null, clusterClient.leastLoadedNode(time.milliseconds()));
+    }
+
+    @Test
     public void testLeastLoadedNode() {
         client.ready(node, time.milliseconds());
         assertFalse(client.isReady(node, time.milliseconds()));

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -633,8 +633,13 @@ public class NetworkClientTest {
 
     @Test
     public void noLeastLoadedNode() {
-        clusterClient.ready(null, time.milliseconds());
-        assertNotEquals(null, clusterClient.leastLoadedNode(time.milliseconds()));
+        NetworkClient nc = new NetworkClient(selector, clusterMetadataUpdater, "mock-cluster-md", Integer.MAX_VALUE,
+            0, 0, 64 * 1024, 64 * 1024,
+            defaultRequestTimeoutMs, connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, time, true, new ApiVersions(), new LogContext(),
+            LeastLoadedNodeAlgorithm.VANILLA, new ArrayList<>());
+        nc.ready(node, time.milliseconds());
+        assertFalse(client.isReady(node, time.milliseconds()));
+        assertEquals(null, nc.leastLoadedNode(time.milliseconds()));
     }
 
     @Test


### PR DESCRIPTION
Adding a check inside NetworkClient for newNodes.size equalling 0 so that 0 isn't passed into:

int offset = this.randOffset.nextInt(newNodes.size());

resulting in logs blowing up due to "java.lang.IllegalArgumentException: bound must be positive". 

For tests I have set no bootstrap urls in the client so when i try and resolve addresses none are found and thus no newNodes are found thus setting the size equal to 0 and return null after its initial exception is thrown.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
