### PR TITLE
LIKAFKA-62136: Change log level for client quota metric to debug

### DIFF
--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -268,7 +268,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
             val metricConfig = kafkaMetric.config()
             val quota = metricConfig.quota();
             val quotaBoundsStr = if (quota == null) "not configured" else quota.bound().toString()
-            info("Metric name (" + metricName + ") has value (" + quotaValueStr + ") with bound (" + quotaBoundsStr + ")")
+            debug("Metric name (" + metricName + ") has value (" + quotaValueStr + ") with bound (" + quotaBoundsStr + ")")
           }
         }
     }


### PR DESCRIPTION
Kafka server log volume has increased significantly due to logging of client quota metrics. Change it to `debug` since there is no real use of this information in any incident analysis. The client quota violation log should provide enough information.