### PR TITLE
[LI-HOTFIX] Reduce exception log spam in producer IO thread

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -514,7 +514,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 requestTimeoutMs,
                 producerConfig.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG),
                 this.transactionManager,
-                apiVersions);
+                apiVersions,
+                producerConfig.getDouble(ProducerConfig.IO_THREAD_EXCEPTION_LOG_FREQUENCY_CONFIG));
     }
 
     private static int lingerMs(ProducerConfig config) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -515,7 +515,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 producerConfig.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG),
                 this.transactionManager,
                 apiVersions,
-                producerConfig.getDouble(ProducerConfig.IO_THREAD_EXCEPTION_LOG_FREQUENCY_CONFIG));
+                producerConfig.getLong(ProducerConfig.IO_THREAD_EXCEPTION_LOG_INTERVAL_MS_CONFIG));
     }
 
     private static int lingerMs(ProducerConfig config) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.clients.producer;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.LeastLoadedNodeAlgorithm;
@@ -29,12 +34,6 @@ import org.apache.kafka.common.config.EnumValueValidator;
 import org.apache.kafka.common.config.SecurityConfig;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serializer;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.Range.between;
@@ -277,6 +276,10 @@ public class ProducerConfig extends AbstractConfig {
 
     public static final String LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG = CommonClientConfigs.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG;
 
+    public static final String IO_THREAD_EXCEPTION_LOG_FREQUENCY_CONFIG = "io.thread.exception.log.frequency";
+    public static final String IO_THREAD_EXCEPTION_LOG_FREQUENCY_DOC = "The frequency of logging uncaught exceptions from the producer I/O thread. The value is in hertz (hz). If the value is less than or equal to 0, all exceptions will be logged.";
+    public static final double DEFAULT_IO_THREAD_EXCEPTION_LOG_FREQUENCY = 0;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Collections.emptyList(), new ConfigDef.NonNullValidator(), Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
                                 .define(CLIENT_DNS_LOOKUP_CONFIG,
@@ -433,7 +436,12 @@ public class ProducerConfig extends AbstractConfig {
                                         DEFAULT_LEAST_LOADED_NODE_ALGORITHM,
                                         new EnumValueValidator<>(LeastLoadedNodeAlgorithm.class),
                                         Importance.MEDIUM,
-                                        LEAST_LOADED_NODE_ALGORITHM_DOC);
+                                        LEAST_LOADED_NODE_ALGORITHM_DOC)
+                                .define(IO_THREAD_EXCEPTION_LOG_FREQUENCY_CONFIG,
+                                        Type.DOUBLE,
+                                        DEFAULT_IO_THREAD_EXCEPTION_LOG_FREQUENCY,
+                                        Importance.LOW,
+                                        IO_THREAD_EXCEPTION_LOG_FREQUENCY_DOC);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -276,9 +276,9 @@ public class ProducerConfig extends AbstractConfig {
 
     public static final String LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG = CommonClientConfigs.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG;
 
-    public static final String IO_THREAD_EXCEPTION_LOG_FREQUENCY_CONFIG = "io.thread.exception.log.frequency";
-    public static final String IO_THREAD_EXCEPTION_LOG_FREQUENCY_DOC = "The frequency of logging uncaught exceptions from the producer I/O thread. The value is in hertz (hz). If the value is less than or equal to 0, all exceptions will be logged.";
-    public static final double DEFAULT_IO_THREAD_EXCEPTION_LOG_FREQUENCY = 0;
+    public static final String IO_THREAD_EXCEPTION_LOG_INTERVAL_MS_CONFIG = "io.thread.exception.log.interval.ms";
+    public static final String IO_THREAD_EXCEPTION_LOG_INTERVAL_MS_DOC = "The minimum time is milliseconds between logging identical uncaught exceptions from the producer I/O thread. If the value is less than or equal to 0, all exceptions will be logged.";
+    public static final long DEFAULT_IO_THREAD_EXCEPTION_LOG_INTERVAL_MS = 0;
 
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Collections.emptyList(), new ConfigDef.NonNullValidator(), Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
@@ -437,11 +437,9 @@ public class ProducerConfig extends AbstractConfig {
                                         new EnumValueValidator<>(LeastLoadedNodeAlgorithm.class),
                                         Importance.MEDIUM,
                                         LEAST_LOADED_NODE_ALGORITHM_DOC)
-                                .define(IO_THREAD_EXCEPTION_LOG_FREQUENCY_CONFIG,
-                                        Type.DOUBLE,
-                                        DEFAULT_IO_THREAD_EXCEPTION_LOG_FREQUENCY,
-                                        Importance.LOW,
-                                        IO_THREAD_EXCEPTION_LOG_FREQUENCY_DOC);
+                                .define(IO_THREAD_EXCEPTION_LOG_INTERVAL_MS_CONFIG,
+                                        Type.LONG, DEFAULT_IO_THREAD_EXCEPTION_LOG_INTERVAL_MS,
+                                        Importance.LOW, IO_THREAD_EXCEPTION_LOG_INTERVAL_MS_DOC);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -277,7 +277,7 @@ public class ProducerConfig extends AbstractConfig {
     public static final String LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG = CommonClientConfigs.LI_UPDATE_METADATA_LAST_REFRESH_TIME_UPON_NODE_DISCONNECT_CONFIG;
 
     public static final String IO_THREAD_EXCEPTION_LOG_INTERVAL_MS_CONFIG = "io.thread.exception.log.interval.ms";
-    public static final String IO_THREAD_EXCEPTION_LOG_INTERVAL_MS_DOC = "The minimum time is milliseconds between logging identical uncaught exceptions from the producer I/O thread. If the value is less than or equal to 0, all exceptions will be logged.";
+    public static final String IO_THREAD_EXCEPTION_LOG_INTERVAL_MS_DOC = "The minimum time in milliseconds between logging identical uncaught exceptions from the producer I/O thread. If the value is less than or equal to 0, all exceptions will be logged.";
     public static final long DEFAULT_IO_THREAD_EXCEPTION_LOG_INTERVAL_MS = 0;
 
     static {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -126,7 +126,7 @@ public class Sender implements Runnable {
     private final Map<TopicPartition, List<ProducerBatch>> inFlightBatches;
 
     /* Limits how frequently we see logged exceptions in the main loop. This prevents log spam. */
-    private final double exceptionLogPermitsPerSecond;
+    private final long exceptionLogIntervalMs;
     private final ExceptionMap<RateLimiter> exceptionLogRateLimiter;
 
     public Sender(LogContext logContext,
@@ -142,8 +142,7 @@ public class Sender implements Runnable {
                   int requestTimeoutMs,
                   long retryBackoffMs,
                   TransactionManager transactionManager,
-                  ApiVersions apiVersions,
-                  double exceptionLogPermitsPerSecond) {
+                  ApiVersions apiVersions, long exceptionLogIntervalMs) {
         this.log = logContext.logger(Sender.class);
         this.client = client;
         this.accumulator = accumulator;
@@ -160,7 +159,7 @@ public class Sender implements Runnable {
         this.apiVersions = apiVersions;
         this.transactionManager = transactionManager;
         this.inFlightBatches = new HashMap<>();
-        this.exceptionLogPermitsPerSecond = exceptionLogPermitsPerSecond;
+        this.exceptionLogIntervalMs = exceptionLogIntervalMs;
         this.exceptionLogRateLimiter = shouldRateLimitExceptionLogs() ? new ExceptionMap<>() : null;
     }
 
@@ -851,7 +850,7 @@ public class Sender implements Runnable {
     }
 
     private boolean shouldRateLimitExceptionLogs() {
-        return exceptionLogPermitsPerSecond > 0;
+        return exceptionLogIntervalMs > 0;
     }
 
     private boolean shouldErrorLogException(Exception e) {
@@ -861,7 +860,7 @@ public class Sender implements Runnable {
 
         // Check if we can acquire a permit to log this exception.
         RateLimiter rateLimiter =
-            exceptionLogRateLimiter.computeIfAbsent(e, k -> new FixedRateLimiter(time, exceptionLogPermitsPerSecond));
+            exceptionLogRateLimiter.computeIfAbsent(e, k -> new FixedRateLimiter(time, exceptionLogIntervalMs));
         return rateLimiter.tryAcquire();
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -16,6 +16,14 @@
  */
 package org.apache.kafka.clients.producer.internals;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
@@ -52,18 +60,12 @@ import org.apache.kafka.common.requests.InitProducerIdResponse;
 import org.apache.kafka.common.requests.ProduceRequest;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.utils.ExceptionMap;
+import org.apache.kafka.common.utils.FixedRateLimiter;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.RateLimiter;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
 
@@ -123,6 +125,10 @@ public class Sender implements Runnable {
     // A per-partition queue of batches ordered by creation time for tracking the in-flight batches
     private final Map<TopicPartition, List<ProducerBatch>> inFlightBatches;
 
+    /* Limits how frequently we see logged exceptions in the main loop. This prevents log spam. */
+    private final double exceptionLogPermitsPerSecond;
+    private final ExceptionMap<RateLimiter> exceptionLogRateLimiter;
+
     public Sender(LogContext logContext,
                   KafkaClient client,
                   ProducerMetadata metadata,
@@ -136,7 +142,8 @@ public class Sender implements Runnable {
                   int requestTimeoutMs,
                   long retryBackoffMs,
                   TransactionManager transactionManager,
-                  ApiVersions apiVersions) {
+                  ApiVersions apiVersions,
+                  double exceptionLogPermitsPerSecond) {
         this.log = logContext.logger(Sender.class);
         this.client = client;
         this.accumulator = accumulator;
@@ -153,6 +160,8 @@ public class Sender implements Runnable {
         this.apiVersions = apiVersions;
         this.transactionManager = transactionManager;
         this.inFlightBatches = new HashMap<>();
+        this.exceptionLogPermitsPerSecond = exceptionLogPermitsPerSecond;
+        this.exceptionLogRateLimiter = shouldRateLimitExceptionLogs() ? new ExceptionMap<>() : null;
     }
 
     public List<ProducerBatch> inFlightBatches(TopicPartition tp) {
@@ -240,11 +249,7 @@ public class Sender implements Runnable {
 
         // main loop, runs until close is called
         while (running) {
-            try {
-                runOnce();
-            } catch (Exception e) {
-                log.error("Uncaught error in kafka producer I/O thread: ", e);
-            }
+            runOnceCatchingExceptions();
         }
 
         log.debug("Beginning shutdown of Kafka producer I/O thread, sending remaining records.");
@@ -253,11 +258,7 @@ public class Sender implements Runnable {
         // requests in the transaction manager, accumulator or waiting for acknowledgment,
         // wait until these are completed.
         while (!forceClose && ((this.accumulator.hasUndrained() || this.client.inFlightRequestCount() > 0) || hasPendingTransactionalRequests())) {
-            try {
-                runOnce();
-            } catch (Exception e) {
-                log.error("Uncaught error in kafka producer I/O thread: ", e);
-            }
+            runOnceCatchingExceptions();
         }
 
         // Abort the transaction if any commit or abort didn't go through the transaction manager's queue
@@ -266,11 +267,7 @@ public class Sender implements Runnable {
                 log.info("Aborting incomplete transaction due to shutdown");
                 transactionManager.beginAbort();
             }
-            try {
-                runOnce();
-            } catch (Exception e) {
-                log.error("Uncaught error in kafka producer I/O thread: ", e);
-            }
+            runOnceCatchingExceptions();
         }
 
         if (forceClose) {
@@ -290,6 +287,16 @@ public class Sender implements Runnable {
         }
 
         log.debug("Shutdown of Kafka producer I/O thread has completed.");
+    }
+
+    private void runOnceCatchingExceptions() {
+        try {
+            runOnce();
+        } catch (Exception e) {
+            if (shouldErrorLogException(e)) {
+                log.error("Uncaught error in kafka producer I/O thread: ", e);
+            }
+        }
     }
 
     /**
@@ -841,6 +848,21 @@ public class Sender implements Runnable {
         produceThrottleTimeSensor.add(metrics.produceThrottleTimeAvg, new Avg());
         produceThrottleTimeSensor.add(metrics.produceThrottleTimeMax, new Max());
         return produceThrottleTimeSensor;
+    }
+
+    private boolean shouldRateLimitExceptionLogs() {
+        return exceptionLogPermitsPerSecond > 0;
+    }
+
+    private boolean shouldErrorLogException(Exception e) {
+        if (!shouldRateLimitExceptionLogs()) {
+            return true;
+        }
+
+        // Check if we can acquire a permit to log this exception.
+        RateLimiter rateLimiter =
+            exceptionLogRateLimiter.computeIfAbsent(e, k -> new FixedRateLimiter(time, exceptionLogPermitsPerSecond));
+        return rateLimiter.tryAcquire();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/ExceptionMap.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ExceptionMap.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+
+/**
+ * A map that holds exceptions as keys. Exceptions are compared by their concatenated stack trace and cause chain. This
+ * map is not thread-safe.
+ *
+ * @param <V> The type of the value in the map.
+ */
+public class ExceptionMap<V> {
+    private final Map<String, V> map = new HashMap<>();
+
+    public V computeIfAbsent(Exception e, Function<? super Exception, ? extends V> mappingFunction) {
+        String key = getKey(e);
+        return map.computeIfAbsent(key, k -> mappingFunction.apply(e));
+    }
+
+    private String getKey(Exception e) {
+        if (e == null) {
+            return "";
+        }
+
+        return Utils.stackTrace(e);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/FixedRateLimiter.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/FixedRateLimiter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+public class FixedRateLimiter implements RateLimiter {
+    // The timekeeper to use for getting the current time.
+    private final Time time;
+
+    // How frequently the rate limiter will allow a permit to be acquired.
+    private final double permitsPerSecond;
+
+    // The last time a permit was acquired.
+    // Initialized to "negative infinity" so that the first call to tryAcquire() will always return true.
+    private long lastPermitTimeNs = Long.MIN_VALUE;
+
+    /**
+     * Create a new rate limiter.
+     *
+     * @param time             The timekeeper to use for getting the current time.
+     * @param permitsPerSecond How frequently the rate limiter will allow a permit to be acquired. If this is less than or
+     *                         equal to 0, the rate limiter will always allow permits to be acquired.
+     */
+    public FixedRateLimiter(Time time, double permitsPerSecond) {
+        this.time = time;
+        this.permitsPerSecond = permitsPerSecond;
+    }
+
+    @Override
+    public boolean tryAcquire() {
+        if (permitsPerSecond <= 0) {
+            return true;
+        }
+
+        long now = time.nanoseconds();
+        long waitTimeNs = delayBetweenPermitsNs();
+        long targetTimeNs = lastPermitTimeNs + waitTimeNs;
+        if (now >= targetTimeNs) {
+            lastPermitTimeNs = now;
+            return true;
+        }
+
+        return false;
+    }
+
+    private long delayBetweenPermitsNs() {
+        return (long) (1_000_000_000 / permitsPerSecond);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/FixedRateLimiter.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/FixedRateLimiter.java
@@ -21,42 +21,36 @@ public class FixedRateLimiter implements RateLimiter {
     private final Time time;
 
     // How frequently the rate limiter will allow a permit to be acquired.
-    private final double permitsPerSecond;
+    private final long intervalMs;
 
     // The last time a permit was acquired.
     // Initialized to "negative infinity" so that the first call to tryAcquire() will always return true.
-    private long lastPermitTimeNs = Long.MIN_VALUE;
+    private long lastPermitTimeMs = Long.MIN_VALUE;
 
     /**
      * Create a new rate limiter.
      *
      * @param time             The timekeeper to use for getting the current time.
-     * @param permitsPerSecond How frequently the rate limiter will allow a permit to be acquired. If this is less than or
-     *                         equal to 0, the rate limiter will always allow permits to be acquired.
+     * @param intervalMs       The minimum time between successful calls to {@link #tryAcquire()}.
      */
-    public FixedRateLimiter(Time time, double permitsPerSecond) {
+    public FixedRateLimiter(Time time, long intervalMs) {
         this.time = time;
-        this.permitsPerSecond = permitsPerSecond;
+        this.intervalMs = intervalMs;
     }
 
     @Override
     public boolean tryAcquire() {
-        if (permitsPerSecond <= 0) {
+        if (intervalMs <= 0) {
             return true;
         }
 
-        long now = time.nanoseconds();
-        long waitTimeNs = delayBetweenPermitsNs();
-        long targetTimeNs = lastPermitTimeNs + waitTimeNs;
+        long now = time.milliseconds();
+        long targetTimeNs = lastPermitTimeMs + intervalMs;
         if (now >= targetTimeNs) {
-            lastPermitTimeNs = now;
+            lastPermitTimeMs = now;
             return true;
         }
 
         return false;
-    }
-
-    private long delayBetweenPermitsNs() {
-        return (long) (1_000_000_000 / permitsPerSecond);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/RateLimiter.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/RateLimiter.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+public interface RateLimiter {
+    /**
+     * Attempt to get a permit from the rate limiter. This method should be non-blocking.
+     *
+     * @return true if a permit can be acquired, false otherwise
+     */
+    boolean tryAcquire();
+}

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -61,7 +61,20 @@ public class ClientUtilsTest {
         List<String> validatedHostNames = validatedAddresses.stream().map(InetSocketAddress::getHostName)
                 .collect(Collectors.toList());
 
-        List<String> expectedHostNames = Arrays.asList("93.184.215.14", "2606:2800:21f:cb07:6820:80da:af6b:8b2c");
+        List<String> expectedHostNames = Arrays.asList(
+            "a23-215-0-136.deploy.static.akamaitechnologies.com",
+            "a23-192-228-84.deploy.static.akamaitechnologies.com",
+            "a23-215-0-138.deploy.static.akamaitechnologies.com",
+            "a96-7-128-175.deploy.static.akamaitechnologies.com",
+            "a23-192-228-80.deploy.static.akamaitechnologies.com",
+            "a96-7-128-198.deploy.static.akamaitechnologies.com",
+            "2600:1406:3a00:21:0:0:173e:2e66",
+            "2600:1408:ec00:36:0:0:1736:7f31",
+            "2600:1406:3a00:21:0:0:173e:2e65",
+            "2600:1408:ec00:36:0:0:1736:7f24",
+            "2600:1406:bc00:53:0:0:b81e:94ce",
+            "2600:1406:bc00:53:0:0:b81e:94c8"
+        );
         assertTrue("Unexpected addresses " + validatedHostNames, expectedHostNames.containsAll(validatedHostNames));
         validatedAddresses.forEach(address -> assertEquals(10000, address.getPort()));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -316,7 +316,7 @@ public class SenderTest {
         metrics = new Metrics(new MetricConfig().tags(clientTags));
         SenderMetricsRegistry metricsRegistry = new SenderMetricsRegistry(metrics);
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
-                1, metricsRegistry, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions);
+                1, metricsRegistry, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions, 0);
 
         // Append a message so that topic metrics are created
         accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false);
@@ -344,7 +344,7 @@ public class SenderTest {
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
         try {
             Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
-                    maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions);
+                    maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions, 0);
             // do a successful retry
             Future<RecordMetadata> future = accumulator.append(tp0, 0L, "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
             sender.runOnce(); // connect
@@ -402,7 +402,7 @@ public class SenderTest {
 
         try {
             Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                    senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions);
+                    senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, null, apiVersions, 0);
             // Create a two broker cluster, with partition 0 on broker 0 and partition 1 on broker 1
             MetadataResponse metadataUpdate1 = TestUtils.metadataUpdateWith(2, Collections.singletonMap("test", 2));
             client.prepareMetadataUpdate(metadataUpdate1);
@@ -1173,7 +1173,7 @@ public class SenderTest {
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
 
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions, 0);
 
         Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
                 "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
@@ -1215,7 +1215,7 @@ public class SenderTest {
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
 
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, 10,
-            senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+            senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions, 0);
 
         Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
             "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
@@ -1254,7 +1254,7 @@ public class SenderTest {
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
 
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, 10,
-            senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+            senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions, 0);
 
         Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
             "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
@@ -1290,7 +1290,7 @@ public class SenderTest {
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
 
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions, 0);
 
         Future<RecordMetadata> failedResponse = accumulator.append(tp0, time.milliseconds(), "key".getBytes(),
                 "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
@@ -1779,7 +1779,7 @@ public class SenderTest {
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
 
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions, 0);
 
         Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
         client.prepareResponse(new MockClient.RequestMatcher() {
@@ -1821,7 +1821,7 @@ public class SenderTest {
         Metrics m = new Metrics();
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions, 0);
 
         Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // connect.
@@ -1860,7 +1860,7 @@ public class SenderTest {
         SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
 
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+                senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions, 0);
 
         Future<RecordMetadata> responseFuture = accumulator.append(tp0, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, null, MAX_BLOCK_TIMEOUT, false).future;
         sender.runOnce();  // connect.
@@ -1920,7 +1920,7 @@ public class SenderTest {
                 new BufferPool(totalSize, batchSize, metrics, time, "producer-internal-metrics"));
             SenderMetricsRegistry senderMetrics = new SenderMetricsRegistry(m);
             Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
-                    senderMetrics, time, REQUEST_TIMEOUT, 1000L, txnManager, new ApiVersions());
+                    senderMetrics, time, REQUEST_TIMEOUT, 1000L, txnManager, new ApiVersions(), 0);
             // Create a two broker cluster, with partition 0 on broker 0 and partition 1 on broker 1
             MetadataResponse metadataUpdate1 = TestUtils.metadataUpdateWith(2, Collections.singletonMap(topic, 2));
             client.prepareMetadataUpdate(metadataUpdate1);
@@ -2208,7 +2208,7 @@ public class SenderTest {
         try {
             TransactionManager txnManager = new TransactionManager(logContext, "testTransactionalRequestsSentOnShutdown", 6000, 100);
             Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
-                    maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, txnManager, apiVersions);
+                    maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, txnManager, apiVersions, 0);
 
             ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
             TopicPartition tp = new TopicPartition("testTransactionalRequestsSentOnShutdown", 1);
@@ -2241,7 +2241,7 @@ public class SenderTest {
         try {
             TransactionManager txnManager = new TransactionManager(logContext, "testIncompleteTransactionAbortOnShutdown", 6000, 100);
             Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
-                    maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, txnManager, apiVersions);
+                    maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, txnManager, apiVersions, 0);
 
             ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
             TopicPartition tp = new TopicPartition("testIncompleteTransactionAbortOnShutdown", 1);
@@ -2273,7 +2273,7 @@ public class SenderTest {
         try {
             TransactionManager txnManager = new TransactionManager(logContext, "testForceShutdownWithIncompleteTransaction", 6000, 100);
             Sender sender = new Sender(logContext, client, metadata, this.accumulator, false, MAX_REQUEST_SIZE, ACKS_ALL,
-                    maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, txnManager, apiVersions);
+                    maxRetries, senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, txnManager, apiVersions, 0);
 
             ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
             TopicPartition tp = new TopicPartition("testForceShutdownWithIncompleteTransaction", 1);
@@ -2476,7 +2476,7 @@ public class SenderTest {
                 deliveryTimeoutMs, metrics, metricGrpName, time, apiVersions, transactionManager, pool);
         this.senderMetricsRegistry = new SenderMetricsRegistry(this.metrics);
         this.sender = new Sender(logContext, this.client, this.metadata, this.accumulator, guaranteeOrder, MAX_REQUEST_SIZE, ACKS_ALL,
-                Integer.MAX_VALUE, this.senderMetricsRegistry, this.time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
+                Integer.MAX_VALUE, this.senderMetricsRegistry, this.time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions, 0);
 
         metadata.add("test");
         this.client.updateMetadata(TestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -139,7 +139,7 @@ public class TransactionManagerTest {
                 deliveryTimeoutMs, metrics, metricGrpName, time, apiVersions, transactionManager,
                 new BufferPool(totalSize, batchSize, metrics, time, metricGrpName));
         this.sender = new Sender(logContext, this.client, this.metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL,
-                MAX_RETRIES, senderMetrics, this.time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions);
+                MAX_RETRIES, senderMetrics, this.time, REQUEST_TIMEOUT, 50, transactionManager, apiVersions, 0);
         this.metadata.add("test");
         this.client.updateMetadata(TestUtils.metadataUpdateWith(1, singletonMap("test", 2)));
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExceptionMapTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExceptionMapTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExceptionMapTest {
+    @Test
+    public void testIdenticalExceptions() {
+        // Generate exceptions with the same construction site.
+        List<Exception> exceptions = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            try {
+                throw new RuntimeException("test");
+            } catch (RuntimeException e) {
+                exceptions.add(e);
+            }
+        }
+
+        ExceptionMap<Integer> exceptionMap = new ExceptionMap<>();
+        int a = exceptionMap.computeIfAbsent(exceptions.get(0), e -> 1);
+        int b = exceptionMap.computeIfAbsent(exceptions.get(1), e -> 2);
+
+        // The two exceptions are identical, so the same value should be returned.
+        assertEquals(a, b);
+    }
+
+    @Test
+    public void testDifferentSite() {
+        Exception e1 = new RuntimeException("test");
+        Exception e2 = new RuntimeException("test");
+
+        ExceptionMap<Integer> exceptionMap = new ExceptionMap<>();
+        int a = exceptionMap.computeIfAbsent(e1, e -> 1);
+        int b = exceptionMap.computeIfAbsent(e2, e -> 2);
+
+        // The 2 exceptions are very similar, but have different construction sites, so they aren't the same.
+        assertEquals(a, 1);
+        assertEquals(b, 2);
+    }
+
+    @Test
+    public void testDifferentMessage() {
+        // Generate exceptions with the same construction site.
+        List<Exception> exceptions = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            try {
+                throw new RuntimeException("test" + i);
+            } catch (RuntimeException e) {
+                exceptions.add(e);
+            }
+        }
+
+        ExceptionMap<Integer> exceptionMap = new ExceptionMap<>();
+        int a = exceptionMap.computeIfAbsent(exceptions.get(0), e -> 1);
+        int b = exceptionMap.computeIfAbsent(exceptions.get(1), e -> 2);
+
+        // The 2 exceptions have different messages, so they aren't the same.
+        assertEquals(a, 1);
+        assertEquals(b, 2);
+    }
+
+    @Test
+    public void testDifferentCause() {
+        Exception cause1 = new RuntimeException("cause1");
+        Exception cause2 = new RuntimeException("cause2");
+
+        // Generate exceptions with the same construction site.
+        List<Exception> exceptions = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            try {
+                throw new RuntimeException("test", i == 0 ? cause1 : cause2);
+            } catch (RuntimeException e) {
+                exceptions.add(e);
+            }
+        }
+
+        ExceptionMap<Integer> exceptionMap = new ExceptionMap<>();
+        int a = exceptionMap.computeIfAbsent(exceptions.get(0), e -> 1);
+        int b = exceptionMap.computeIfAbsent(exceptions.get(1), e -> 2);
+
+        // The 2 exceptions have different causes, so they aren't the same.
+        assertEquals(a, 1);
+        assertEquals(b, 2);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/FixedRateLimiterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/FixedRateLimiterTest.java
@@ -25,7 +25,7 @@ public class FixedRateLimiterTest {
     @Test
     public void testImmediatelyAvailable() {
         Time time = new MockTime();
-        FixedRateLimiter limiter = new FixedRateLimiter(time, 1.0);
+        FixedRateLimiter limiter = new FixedRateLimiter(time, 100);
         assertTrue(limiter.tryAcquire());
     }
 
@@ -37,24 +37,26 @@ public class FixedRateLimiterTest {
     }
 
     @Test
-    public void testNegativeRate() {
+    public void testNegativeInterval() {
         Time time = new MockTime();
-        FixedRateLimiter limiter = new FixedRateLimiter(time, -1.0);
+        FixedRateLimiter limiter = new FixedRateLimiter(time, -100);
         assertAlwaysAllows(time, limiter);
     }
 
     @Test
-    public void testZeroRate() {
+    public void testZeroInterval() {
         Time time = new MockTime();
-        FixedRateLimiter limiter = new FixedRateLimiter(time, 0.0);
+        FixedRateLimiter limiter = new FixedRateLimiter(time, 0);
         assertAlwaysAllows(time, limiter);
     }
 
     @Test
-    public void testRateLessThanOne() {
+    public void testHighInterval() {
         Time time = new MockTime();
         // Allow 1 permit every 2 seconds.
-        FixedRateLimiter limiter = new FixedRateLimiter(time, 0.5);
+        FixedRateLimiter limiter = new FixedRateLimiter(time, 2000);
+
+        // Try to acquire a permit every second.
         assertTrue(limiter.tryAcquire());
         time.sleep(1000);
         assertFalse(limiter.tryAcquire());
@@ -67,11 +69,12 @@ public class FixedRateLimiterTest {
     }
 
     @Test
-    public void testRateLessGreaterThanOne() {
+    public void testLowInterval() {
         Time time = new MockTime();
         // Allow 1 permit every 0.25 seconds.
-        FixedRateLimiter limiter = new FixedRateLimiter(time, 4);
+        FixedRateLimiter limiter = new FixedRateLimiter(time, 250);
 
+        // Try to acquire a permit every 0.1 seconds.
         assertTrue(limiter.tryAcquire());
         time.sleep(100);
         assertFalse(limiter.tryAcquire());

--- a/clients/src/test/java/org/apache/kafka/common/utils/FixedRateLimiterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/FixedRateLimiterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FixedRateLimiterTest {
+    @Test
+    public void testImmediatelyAvailable() {
+        Time time = new MockTime();
+        FixedRateLimiter limiter = new FixedRateLimiter(time, 1.0);
+        assertTrue(limiter.tryAcquire());
+    }
+
+    private void assertAlwaysAllows(Time time, RateLimiter limiter) {
+        for (int delay = 0; delay < 100; delay++) {
+            time.sleep(delay);
+            assertTrue(limiter.tryAcquire());
+        }
+    }
+
+    @Test
+    public void testNegativeRate() {
+        Time time = new MockTime();
+        FixedRateLimiter limiter = new FixedRateLimiter(time, -1.0);
+        assertAlwaysAllows(time, limiter);
+    }
+
+    @Test
+    public void testZeroRate() {
+        Time time = new MockTime();
+        FixedRateLimiter limiter = new FixedRateLimiter(time, 0.0);
+        assertAlwaysAllows(time, limiter);
+    }
+
+    @Test
+    public void testRateLessThanOne() {
+        Time time = new MockTime();
+        // Allow 1 permit every 2 seconds.
+        FixedRateLimiter limiter = new FixedRateLimiter(time, 0.5);
+        assertTrue(limiter.tryAcquire());
+        time.sleep(1000);
+        assertFalse(limiter.tryAcquire());
+        time.sleep(1000);
+        assertTrue(limiter.tryAcquire());
+        time.sleep(1000);
+        assertFalse(limiter.tryAcquire());
+        time.sleep(1000);
+        assertTrue(limiter.tryAcquire());
+    }
+
+    @Test
+    public void testRateLessGreaterThanOne() {
+        Time time = new MockTime();
+        // Allow 1 permit every 0.25 seconds.
+        FixedRateLimiter limiter = new FixedRateLimiter(time, 4);
+
+        assertTrue(limiter.tryAcquire());
+        time.sleep(100);
+        assertFalse(limiter.tryAcquire());
+        time.sleep(100);
+        assertFalse(limiter.tryAcquire());
+        time.sleep(100);
+        assertTrue(limiter.tryAcquire());
+        time.sleep(100);
+        assertFalse(limiter.tryAcquire());
+        time.sleep(100);
+        assertFalse(limiter.tryAcquire());
+        time.sleep(100);
+        assertTrue(limiter.tryAcquire());
+    }
+}


### PR DESCRIPTION
Fixes LIKAFKA-62226

Certain issues, such as DNS resolution failures, can cause the producer IO thread to spew log messages rapidly. This can cause disks to fill and hide other issues. This commit addresses this issue by adding a producer configuration that throttles exception log messages from the top of the producer IO thread. The throttling is a simple cooldown-based rate limiter, and is applied per-exception. Exceptions are differentiated based on their `printStackTrace` result, which covers exception type, construction point, causes, etc.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
