### PR TITLE
Fix logging order issue in GroupCoordinator

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1363,10 +1363,9 @@ class GroupCoordinator(val brokerId: Int,
     else
       new DelayedJoin(this, group, group.rebalanceTimeoutMs)
 
-    group.transitionTo(PreparingRebalance)
-
     info(s"Preparing to rebalance group ${group.groupId} in state ${group.currentState} with old generation " +
       s"${group.generationId} (${Topic.GROUP_METADATA_TOPIC_NAME}-${partitionFor(group.groupId)}) (reason: $reason)")
+    group.transitionTo(PreparingRebalance)
 
     val groupKey = GroupJoinKey(group.groupId)
     rebalancePurgatory.tryCompleteElseWatch(delayedRebalance, Seq(groupKey))


### PR DESCRIPTION
Currently the GroupCoordinator always log "Preparing to rebalance group XXX in state PreparingRebalance", because it sets the state to PreparingRebalance right before log. This makes the previous state of the group being lost at the logging moment. We need to log first, and then change the state.

