### PR TITLE
Remove shutdown hook in KafkaYammerMetrics

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -61,7 +62,20 @@ public class ClientUtilsTest {
         assertTrue(validatedAddresses.size() >= 1, "Unexpected addresses " + validatedAddresses);
         List<String> validatedHostNames = validatedAddresses.stream().map(InetSocketAddress::getHostName)
                 .collect(Collectors.toList());
-        List<String> expectedHostNames = asList("93.184.215.14", "2606:2800:21f:cb07:6820:80da:af6b:8b2c");
+        List<String> expectedHostNames = Arrays.asList(
+            "a23-215-0-136.deploy.static.akamaitechnologies.com",
+            "a23-192-228-84.deploy.static.akamaitechnologies.com",
+            "a23-215-0-138.deploy.static.akamaitechnologies.com",
+            "a96-7-128-175.deploy.static.akamaitechnologies.com",
+            "a23-192-228-80.deploy.static.akamaitechnologies.com",
+            "a96-7-128-198.deploy.static.akamaitechnologies.com",
+            "2600:1406:3a00:21:0:0:173e:2e66",
+            "2600:1408:ec00:36:0:0:1736:7f31",
+            "2600:1406:3a00:21:0:0:173e:2e65",
+            "2600:1408:ec00:36:0:0:1736:7f24",
+            "2600:1406:bc00:53:0:0:b81e:94ce",
+            "2600:1406:bc00:53:0:0:b81e:94c8"
+        );
         assertTrue(expectedHostNames.containsAll(validatedHostNames), "Unexpected addresses " + validatedHostNames);
         validatedAddresses.forEach(address -> assertEquals(10000, address.getPort()));
     }

--- a/core/src/main/java/kafka/metrics/KafkaYammerMetrics.java
+++ b/core/src/main/java/kafka/metrics/KafkaYammerMetrics.java
@@ -50,7 +50,10 @@ public class KafkaYammerMetrics implements Reconfigurable {
 
     private KafkaYammerMetrics() {
         jmxReporter.start();
-        Runtime.getRuntime().addShutdownHook(new Thread(jmxReporter::shutdown));
+    }
+
+    public void shutdownJmxReporter() {
+        jmxReporter.shutdown();
     }
 
     @Override

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -920,6 +920,7 @@ class KafkaServer(
         config.dynamicConfig.clear()
 
         _brokerState = BrokerState.NOT_RUNNING
+        kafkaYammerMetrics.shutdownJmxReporter();
 
         startupComplete.set(false)
         isShuttingDown.set(false)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -923,7 +923,6 @@ class KafkaServer(
 
         _brokerState = BrokerState.NOT_RUNNING
 
-
         startupComplete.set(false)
         isShuttingDown.set(false)
         CoreUtils.swallow(AppInfoParser.unregisterAppInfo(Server.MetricsPrefix, config.brokerId.toString, metrics), this)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -913,6 +913,8 @@ class KafkaServer(
           CoreUtils.swallow(socketServer.shutdown(), this)
         if (metrics != null)
           CoreUtils.swallow(metrics.close(), this)
+        if (kafkaYammerMetrics != null)
+          CoreUtils.swallow(kafkaYammerMetrics.shutdownJmxReporter(), this)
         if (brokerTopicStats != null)
           CoreUtils.swallow(brokerTopicStats.close(), this)
 
@@ -920,7 +922,7 @@ class KafkaServer(
         config.dynamicConfig.clear()
 
         _brokerState = BrokerState.NOT_RUNNING
-        kafkaYammerMetrics.shutdownJmxReporter();
+
 
         startupComplete.set(false)
         isShuttingDown.set(false)


### PR DESCRIPTION
LI-TICKET: [LIKAFKA-64484](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-64484)

### Description
Today, if a Kafka broker is stuck at safety shutdown check during controlled shutdown because of NOT_ENOUGH_REPLICAS, the metrics will be missing for the whole time. This is because Kafka registered a shutdown hook in KafkaYammerMetrics which will call jmxReporter.shutdown() and unregister all its mbean sensors.

To fix the issue, we should explicitly control the metrics shutdown logic. With this change, we shutdown the metrics reporter after everything is shutdown. In the case of controlled shutdown being stuck, we should still see the metrics because the reporter is shutdown at the last step.

