### PR TITLE
Replace expensive exception hashcode computation with ExceptionFingerprint

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ExceptionMap.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ExceptionMap.java
@@ -22,24 +22,74 @@ import java.util.function.Function;
 
 
 /**
- * A map that holds exceptions as keys. Exceptions are compared by their concatenated stack trace and cause chain. This
- * map is not thread-safe.
+ * A map that holds exceptions as keys. Exceptions are compared by a custom fingerprint that depends on the message
+ * and cause chain. This map is not thread-safe.
  *
  * @param <V> The type of the value in the map.
  */
 public class ExceptionMap<V> {
-    private final Map<String, V> map = new HashMap<>();
+    public static class ExceptionFingerprint {
+        public static final ExceptionFingerprint EMPTY = new ExceptionFingerprint(null);
+        private final long hashCode;
 
-    public V computeIfAbsent(Exception e, Function<? super Exception, ? extends V> mappingFunction) {
-        String key = getKey(e);
-        return map.computeIfAbsent(key, k -> mappingFunction.apply(e));
-    }
-
-    private String getKey(Exception e) {
-        if (e == null) {
-            return "";
+        /**
+         * Create a fingerprint from an exception
+         */
+        public ExceptionFingerprint(Throwable throwable) {
+            this.hashCode = computeHashCode(throwable);
         }
 
-        return Utils.stackTrace(e);
+        /**
+         * Compute a hash code for the entire exception chain
+         */
+        private long computeHashCode(Throwable throwable) {
+            long result = 1L;
+            Throwable current = throwable;
+
+            while (current != null) {
+                // Include class type, message, and first stack element in the hash
+                StackTraceElement[] stackTrace = current.getStackTrace();
+                StackTraceElement origin = stackTrace.length > 0 ? stackTrace[0] : null;
+
+                long elementHash = 31L;
+                elementHash = 31L * elementHash + current.getClass().getName().hashCode();
+                elementHash = 31L * elementHash + (current.getMessage() != null ? current.getMessage().hashCode() : 0);
+
+                if (origin != null) {
+                    elementHash = 31L * elementHash + origin.getClassName().hashCode();
+                    elementHash = 31L * elementHash + origin.getMethodName().hashCode();
+                    elementHash = 31L * elementHash + origin.getLineNumber();
+                }
+
+                // Combine with running result
+                result = 31L * result + elementHash;
+
+                // Move to the next exception in the chain
+                current = current.getCause();
+            }
+
+            return result;
+        }
+
+        @Override
+        public int hashCode() {
+            return (int) (hashCode ^ (hashCode >>> 32));
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+
+            ExceptionFingerprint other = (ExceptionFingerprint) obj;
+            return this.hashCode == other.hashCode;
+        }
+    }
+
+    private final Map<ExceptionFingerprint, V> map = new HashMap<>();
+
+    public V computeIfAbsent(Exception e, Function<? super Exception, ? extends V> mappingFunction) {
+        ExceptionFingerprint fingerprint = e == null ? ExceptionFingerprint.EMPTY : new ExceptionFingerprint(e);
+        return map.computeIfAbsent(fingerprint, k -> mappingFunction.apply(e));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExceptionMapTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExceptionMapTest.java
@@ -102,4 +102,32 @@ public class ExceptionMapTest {
         assertEquals(a, 1);
         assertEquals(b, 2);
     }
+
+    @Test
+    public void testExceptionWithNoMessage() {
+        Exception e = new RuntimeException();
+        ExceptionMap<Integer> exceptionMap = new ExceptionMap<>();
+        int a = exceptionMap.computeIfAbsent(e, ex -> 1);
+        assertEquals(a, 1);
+    }
+
+    @Test
+    public void testExceptionWithEmptyMessage() {
+        Exception e = new RuntimeException("");
+        ExceptionMap<Integer> exceptionMap = new ExceptionMap<>();
+        int a = exceptionMap.computeIfAbsent(e, ex -> 1);
+        assertEquals(a, 1);
+    }
+
+    @Test
+    public void testExceptionMapWithNullThrowable() {
+        ExceptionMap<Integer> exceptionMap = new ExceptionMap<>();
+        exceptionMap.computeIfAbsent(null, e -> 1);
+    }
+
+    @Test
+    public void testExceptionFingerprintWithNullException() {
+        ExceptionMap.ExceptionFingerprint exceptionFingerprint = new ExceptionMap.ExceptionFingerprint(null);
+        assertEquals(1, exceptionFingerprint.hashCode());
+    }
 }


### PR DESCRIPTION
## Problem
Logging ratelimiter uses a mapping of `Exception` --> `RateLimiter`. The existing implementation uses a `String` key to lookup in the map. It serializes each exception to a `String` using `printStackTrace`, which is very expensive. Odp performance analysis showed up to 37% of time spent in just `printStackTrace`.

BUG=[LIKAFKA-64503](https://jira01.corp.linkedin.com:8443/browse/LIKAFKA-64503)

## Solution
This PR uses a less expensive mapping of an exception to `ExceptionFingerprint`. ExceptionFingerprint is a custom class that computes a hashcode based on the exception message and cause chain. It does not rely on the entire stack trace, which could be many levels deep. 

For each exception and its cause, the `ExceptionFingerprint` uses the top of the stack trace, the class name, method name, and line number to compute a hashcode. This implementation is linear in the number of exceptions in the chain, rather than the number of stack frames in the chain.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
