### PR TITLE
Catch exceptions for LogDirFailureHandler thread during handleLogDirF…

### DIFF
--- a/core/src/main/scala/kafka/server/LogDirFailureChannel.scala
+++ b/core/src/main/scala/kafka/server/LogDirFailureChannel.scala
@@ -20,6 +20,7 @@ package kafka.server
 
 import java.io.IOException
 import java.util.concurrent.{ArrayBlockingQueue, ConcurrentHashMap}
+import kafka.metrics.KafkaMetricsGroup
 
 import kafka.utils.Logging
 
@@ -38,6 +39,9 @@ class LogDirFailureChannel(logDirNum: Int) extends Logging {
 
   private val offlineLogDirs = new ConcurrentHashMap[String, String]
   private val offlineLogDirQueue = new ArrayBlockingQueue[String](logDirNum)
+  private var numOfflineLogDirsDetected = 0;
+
+  KafkaMetricsGroup.newGauge("NumOfflineLogDirsDetected", () => numOfflineLogDirsDetected)
 
   def hasOfflineLogDir(logDir: String): Boolean = {
     offlineLogDirs.containsKey(logDir)
@@ -48,6 +52,7 @@ class LogDirFailureChannel(logDirNum: Int) extends Logging {
    * set of offline log dirs and enqueue it to the logDirFailureEvent queue
    */
   def maybeAddOfflineLogDir(logDir: String, msg: => String, e: IOException): Unit = {
+    numOfflineLogDirsDetected += 1;
     error(msg, e)
     if (offlineLogDirs.putIfAbsent(logDir, logDir) == null)
       offlineLogDirQueue.add(logDir)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -262,14 +262,24 @@ class ReplicaManager(val config: KafkaConfig,
   val random = new Random
   def getHighWatermarkCheckpoints: Map[String, OffsetCheckpointFile] = highWatermarkCheckpoints
 
+  private var numLogDirFailureHandlerExceptions = 0
+
   private class LogDirFailureHandler(name: String, haltBrokerOnDirFailure: Boolean) extends ShutdownableThread(name) {
     override def doWork(): Unit = {
       val newOfflineLogDir = logDirFailureChannel.takeNextOfflineLogDir()
+
+      // haltBrokerOnDirFailure is only for pre-Kafka-1.0. The following check won't pass for li-kafka-server since it's on 3.0.
       if (haltBrokerOnDirFailure) {
         fatal(s"Halting broker because dir $newOfflineLogDir is offline")
         Exit.halt(1)
       }
-      handleLogDirFailure(newOfflineLogDir)
+      try {
+        handleLogDirFailure(newOfflineLogDir)
+      } catch {
+        case e: Throwable =>
+          numLogDirFailureHandlerExceptions += 1
+          warn(s"Error handling failures for log dir $newOfflineLogDir: ${e.getMessage}", e)
+      }
     }
   }
 
@@ -285,6 +295,7 @@ class ReplicaManager(val config: KafkaConfig,
   newGauge("AtMinIsrPartitionCount", () => leaderPartitionsIterator.count(_.isAtMinIsr))
   newGauge("OneAboveMinIsrPartitionCount", () => leaderPartitionsIterator.count(_.isOneAboveMinIsr))
   newGauge("ReassigningPartitions", () => reassigningPartitionsCount)
+  newGauge("NumLogDirFailureHandlerExceptions", () => numLogDirFailureHandlerExceptions)
   Partition.ISR_STATES_TO_CREATE_METRICS.foreach(c =>
     newGauge(s"${c.getSimpleName}PartitionCount", () => numOfPartitionOfIsrState(c))
   )

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -278,7 +278,7 @@ class ReplicaManager(val config: KafkaConfig,
       } catch {
         case e: Throwable =>
           numLogDirFailureHandlerExceptions += 1
-          warn(s"Error handling failures for log dir $newOfflineLogDir: ${e.getMessage}", e)
+          error(s"Error handling failures for log dir $newOfflineLogDir: ${e.getMessage}", e)
       }
     }
   }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -276,9 +276,9 @@ class ReplicaManager(val config: KafkaConfig,
       try {
         handleLogDirFailure(newOfflineLogDir)
       } catch {
-        case e: Throwable =>
+        case t: Throwable =>
           numLogDirFailureHandlerExceptions += 1
-          error(s"Error handling failures for log dir $newOfflineLogDir: ${e.getMessage}", e)
+          error(s"Error handling failures for log dir $newOfflineLogDir", t)
       }
     }
   }


### PR DESCRIPTION
LITICKET=[ACTIONITEM-5825](https://jira01.corp.linkedin.com:8443/browse/ACTIONITEM-5825)

We recently found an issue that Kafka didn't shutdown itself when there is bad disk issue detected. The current assumption is Kafka detected the issue but the LogDirFailureHandler thread was not working correctly. Unfortunately we don't have enough logs or heapdump to identify what exactly happens, so our best bet is to catch the exceptions for that thread to avoid it happens in the future. We also add a new metric to notify when such exception is thrown, which usually indicate some critical issues.

A more aggressive strategy is to exit the program whenever add offline log dir, which might make sense for LinkedIn setup. I don't see huge risk of doing it, but we may still want to start from being a bit conservative. So I decided to add metrics to indicate when a server detects failed disks, so at least our monitoring systems could detect it and potentially taking further actions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
