### PR TITLE
[LI-HOTFIX] Ensure ReplicationFactor is at least (minIsr + RedundancyFactor + 1) in topic creation

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1695,7 +1695,7 @@ class KafkaController(val config: KafkaConfig,
         val atRisk = remainingLiveReplicasInIsr < (minISR + config.controlledShutdownSafetyCheckRedundancyFactor)
         if (atRisk) {
           // Consider this topic-partition at-risk if removing one broker will result in the ISR shrinking below minISR
-          info(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Removing broker $id will leave $remainingLiveReplicasInIsr live replicas in the ISR.")
+          warn(s"$partition has min.insync.replicas=$minISR and a redundancy factor of ${config.controlledShutdownSafetyCheckRedundancyFactor}. Removing broker $id will leave $remainingLiveReplicasInIsr live replicas in the ISR.")
         }
         atRisk
       }
@@ -1749,7 +1749,7 @@ class KafkaController(val config: KafkaConfig,
     if (config.controlledShutdownSafetyCheckEnable && !safeToShutdown(id, actualBrokerEpoch)) {
       passedAllShutdown = false
       if (!shouldSkipShutdownSafetyCheck) {
-        info(s"Controlled shutdown safety has prevented broker $id (broker epoch $actualBrokerEpoch) from shutting down.")
+        warn(s"Controlled shutdown safety has prevented broker $id (broker epoch $actualBrokerEpoch) from shutting down.")
         throw new NotEnoughReplicasException(s"Broker id $id cannot initiate shutdown without an impact on topic availability.")
       }
     }

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -175,7 +175,7 @@ class ZkAdminManager(val config: KafkaConfig,
         var resolvedReplicationFactor = if (topic.replicationFactor == NO_REPLICATION_FACTOR)
           defaultReplicationFactor else topic.replicationFactor
 
-        var minRF = Int.MaxValue
+        var minRF = defaultReplicationFactor
         if (config.controlledShutdownSafetyCheckEnable) {
           val minIsrConfig = topic.configs().find(KafkaConfig.MinInSyncReplicasProp);
           val minIsr = if (minIsrConfig != null) {
@@ -188,7 +188,7 @@ class ZkAdminManager(val config: KafkaConfig,
           // The replication factor must be at least the sum of
           // (config.controlledShutdownSafetyCheckRedundancyFactor + minIsr + 1) to be able to safely shut down the broker.
           // The assumption is that these configs are rarely changed, so the calculated minRF at topic creation time
-          // is good for the lifetime of the topic.
+          // is good for the lifetime of the topic. If not, there should be other workarounds to fix the RF.
           if (resolvedReplicationFactor < minRF) {
             resolvedReplicationFactor = minRF.toShort
           }

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -184,13 +184,13 @@ class ZkAdminManager(val config: KafkaConfig,
             kafka.server.Defaults.MinInSyncReplicas.toShort
           }
 
-          minRF = config.controlledShutdownSafetyCheckRedundancyFactor + minIsr + 1
+          minRF = (config.controlledShutdownSafetyCheckRedundancyFactor + minIsr + 1).toShort
           // The replication factor must be at least the sum of
           // (config.controlledShutdownSafetyCheckRedundancyFactor + minIsr + 1) to be able to safely shut down the broker.
           // The assumption is that these configs are rarely changed, so the calculated minRF at topic creation time
           // is good for the lifetime of the topic. If not, there should be other workarounds to fix the RF.
           if (resolvedReplicationFactor < minRF) {
-            resolvedReplicationFactor = minRF.toShort
+            resolvedReplicationFactor = minRF
           }
         }
 

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -172,8 +172,27 @@ class ZkAdminManager(val config: KafkaConfig,
 
         val resolvedNumPartitions = if (topic.numPartitions == NO_NUM_PARTITIONS)
           defaultNumPartitions else topic.numPartitions
-        val resolvedReplicationFactor = if (topic.replicationFactor == NO_REPLICATION_FACTOR)
+        var resolvedReplicationFactor = if (topic.replicationFactor == NO_REPLICATION_FACTOR)
           defaultReplicationFactor else topic.replicationFactor
+
+        var minRF = Int.MaxValue
+        if (config.controlledShutdownSafetyCheckEnable) {
+          val minIsrConfig = topic.configs().find(KafkaConfig.MinInSyncReplicasProp);
+          val minIsr = if (minIsrConfig != null) {
+            minIsrConfig.value().toShort
+          } else {
+            kafka.server.Defaults.MinInSyncReplicas.toShort
+          }
+
+          minRF = config.controlledShutdownSafetyCheckRedundancyFactor + minIsr + 1
+          // The replication factor must be at least the sum of
+          // (config.controlledShutdownSafetyCheckRedundancyFactor + minIsr + 1) to be able to safely shut down the broker.
+          // The assumption is that these configs are rarely changed, so the calculated minRF at topic creation time
+          // is good for the lifetime of the topic.
+          if (resolvedReplicationFactor < minRF) {
+            resolvedReplicationFactor = minRF.toShort
+          }
+        }
 
         val assignments = if (topic.assignments.isEmpty) {
           adminZkClient.assignReplicasToAvailableBrokers(
@@ -186,6 +205,11 @@ class ZkAdminManager(val config: KafkaConfig,
           // Note: we don't check that replicaAssignment contains unknown brokers - unlike in add-partitions case,
           // this follows the existing logic in TopicCommand
           topic.assignments.forEach { assignment =>
+            if (config.controlledShutdownSafetyCheckEnable && assignment.brokerIds().size() < minRF) {
+              throw new InvalidReplicaAssignmentException(
+                s"Topic ${topic.name} has ${assignment.brokerIds().size()} replicas assigned for partition " +
+                  s"${assignment.partitionIndex}, which is less than the required replication factor $minRF.")
+            }
             assignments(assignment.partitionIndex) = assignment.brokerIds.asScala.map(a => a: Int)
           }
           assignments

--- a/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
@@ -91,7 +91,7 @@ abstract class AbstractCreateTopicsRequestTest extends BaseRequestTest {
     topic
   }
 
-  protected def validateValidCreateTopicsRequests(request: CreateTopicsRequest): Unit = {
+  protected def validateValidCreateTopicsRequests(request: CreateTopicsRequest, expectedReplicationFactor: Option[Short] = None): Unit = {
     val response = sendCreateTopicRequest(request)
 
     assertFalse(response.errorCounts().keySet().asScala.exists(_.code() > 0),
@@ -108,10 +108,12 @@ abstract class AbstractCreateTopicsRequestTest extends BaseRequestTest {
         else
           topic.numPartitions
 
-        val replication = if (!topic.assignments().isEmpty)
-          topic.assignments().iterator().next().brokerIds().size()
-        else
-          topic.replicationFactor
+        val replication = if (expectedReplicationFactor.isDefined)
+                            expectedReplicationFactor.get
+                          else if (!topic.assignments().isEmpty)
+                            topic.assignments().iterator().next().brokerIds().size()
+                          else
+                            topic.replicationFactor
 
         if (request.data.validateOnly) {
           assertNotNull(metadataForTopic, s"Topic $topic should be created")

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
@@ -27,37 +27,57 @@ import org.apache.kafka.common.requests.CreateTopicsRequest
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
+import java.util.Properties
 import scala.jdk.CollectionConverters._
 
 class CreateTopicsRequestTest extends AbstractCreateTopicsRequestTest {
 
+  override def brokerCount: Int = 4
+
+  override def brokerPropertyOverrides(properties: Properties): Unit = {
+    properties.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
+    properties.put(KafkaConfig.ControlledShutdownSafetyCheckEnableProp, true.toString)
+  }
+
   @Test
   def testValidCreateTopicsRequests(): Unit = {
     // Generated assignments
-    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic1"))))
-    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic2", replicationFactor = 3))))
+    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic1"))), Option(3))
+    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic2", replicationFactor = 3))), Option(3))
     validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic3",
-      numPartitions = 5, replicationFactor = 2, config = Map("min.insync.replicas" -> "2")))))
+      numPartitions = 5, replicationFactor = 2, config = Map("min.insync.replicas" -> "2")))), Option(4))
     // Manual assignments
-    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic4", assignment = Map(0 -> List(0))))))
+    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic4", assignment = Map(0 -> List(0, 1, 2))))))
     validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic5",
-      assignment = Map(0 -> List(0, 1), 1 -> List(1, 0), 2 -> List(1, 2)),
+      assignment = Map(0 -> List(0, 1, 2, 3), 1 -> List(1, 0, 2, 3), 2 -> List(1, 2, 0, 3)),
       config = Map("min.insync.replicas" -> "2")))))
     // Mixed
     validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic6"),
       topicReq("topic7", numPartitions = 5, replicationFactor = 2),
-      topicReq("topic8", assignment = Map(0 -> List(0, 1), 1 -> List(1, 0), 2 -> List(1, 2))))))
+      topicReq("topic8", assignment = Map(0 -> List(0, 1, 2), 1 -> List(1, 0, 2), 2 -> List(1, 2, 0))))), Option(3))
     validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic9"),
       topicReq("topic10", numPartitions = 5, replicationFactor = 2),
-      topicReq("topic11", assignment = Map(0 -> List(0, 1), 1 -> List(1, 0), 2 -> List(1, 2)))),
-      validateOnly = true))
+      topicReq("topic11", assignment = Map(0 -> List(0, 1, 2), 1 -> List(1, 0, 2), 2 -> List(1, 2, 0)))),
+      validateOnly = true), Option(3))
     // Defaults
     validateValidCreateTopicsRequests(topicsReq(Seq(
-      topicReq("topic12", replicationFactor = -1, numPartitions = -1))))
+      topicReq("topic12", replicationFactor = -1, numPartitions = -1))), Option(3))
     validateValidCreateTopicsRequests(topicsReq(Seq(
-      topicReq("topic13", replicationFactor = 2, numPartitions = -1))))
+      topicReq("topic13", replicationFactor = 2, numPartitions = -1))), Option(3))
     validateValidCreateTopicsRequests(topicsReq(Seq(
-      topicReq("topic14", replicationFactor = -1, numPartitions = 2))))
+      topicReq("topic14", replicationFactor = -1, numPartitions = 2))), Option(3))
+    validateValidCreateTopicsRequests(topicsReq(Seq(
+      topicReq("topic15", replicationFactor = 3, numPartitions = 2))), Option(3))
+    validateValidCreateTopicsRequests(topicsReq(Seq(
+      topicReq("topic16", replicationFactor = 1, numPartitions = 2))), Option(3))
+    validateValidCreateTopicsRequests(topicsReq(Seq(
+      topicReq("topic17", replicationFactor = 4, numPartitions = 2))), Option(4))
+    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic18",
+      numPartitions = 5, replicationFactor = 2, config = Map("min.insync.replicas" -> "2")))), Option(4))
+    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic19",
+      numPartitions = 5, replicationFactor = 4, config = Map("min.insync.replicas" -> "1")))), Option(4))
+    validateValidCreateTopicsRequests(topicsReq(Seq(topicReq("topic20",
+      numPartitions = 5, replicationFactor = 3, config = Map("min.insync.replicas" -> "1")))), Option(3))
   }
 
   @Test
@@ -79,15 +99,17 @@ class CreateTopicsRequestTest extends AbstractCreateTopicsRequestTest {
       config=Map("message.format.version" -> "invalid-value")))),
       Map("error-config-value" -> error(Errors.INVALID_CONFIG)), checkErrorMessage = false)
     validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("error-assignment",
-      assignment=Map(0 -> List(0, 1), 1 -> List(0))))),
+      assignment=Map(0 -> List(0, 1, 2), 1 -> List(0, 1, 2, 3))))),
       Map("error-assignment" -> error(Errors.INVALID_REPLICA_ASSIGNMENT)), checkErrorMessage = false)
+    validateErrorCreateTopicsRequests(topicsReq(Seq(topicReq("not_enough_replica_assignment", assignment = Map(0 -> List(0, 1))))),
+      Map("not_enough_replica_assignment" -> error(Errors.INVALID_REPLICA_ASSIGNMENT)), checkErrorMessage = false)
 
     // Partial
     validateErrorCreateTopicsRequests(topicsReq(Seq(
       topicReq(existingTopic),
       topicReq("partial-partitions", numPartitions = -2),
       topicReq("partial-replication", replicationFactor=brokerCount + 1),
-      topicReq("partial-assignment", assignment=Map(0 -> List(0, 1), 1 -> List(0))),
+      topicReq("partial-assignment", assignment=Map(0 -> List(0, 1, 2), 1 -> List(0, 1, 2, 3))),
       topicReq("partial-none"))),
       Map(
         existingTopic -> error(Errors.TOPIC_ALREADY_EXISTS),
@@ -162,7 +184,7 @@ class CreateTopicsRequestTest extends AbstractCreateTopicsRequestTest {
       assertEquals(Errors.NONE.code, topicResponse.errorCode)
       if (version >= 5) {
         assertEquals(1, topicResponse.numPartitions)
-        assertEquals(1, topicResponse.replicationFactor)
+        assertEquals(4, topicResponse.replicationFactor)
         val config = topicResponse.configs().asScala.find(_.name == "min.insync.replicas")
         assertTrue(config.isDefined)
         assertEquals("2", config.get.value)


### PR DESCRIPTION
This PR is for "[LIKAFKA-65517] Improve the Kafka broker controlled shutdown". 

If a topic has replication factor (RF) that is smaller than (`minIsr` + `controlledShutdownSafetyCheckRedundancyFactor` + 1), the controlled shutdown would be stuck due to error NOT_ENOUGH_REPLICAS. e.g., a topic with RF=3 and minISR=2 with controlledShutdownSafetyCheckRedundancyFactor=1 , it would cause broker stuck in controlled shutdown. 

This PR auto updates RF to be at least (`minIsr` + `controlledShutdownSafetyCheckRedundancyFactor` + 1) during topic creation if replica assigments are not provided; if replica assignments are provided, it would throw error (topic creation will be failed) if the replica set size is smaller than (`minIsr` + `controlledShutdownSafetyCheckRedundancyFactor` + 1). Also updated log level from "info" to "warn" if controlled shutdown could not proceed due to NOT_ENOUGH_REPLICAS.

Added unittests and fixed breaking unittests due to this change.