### PR TITLE
[LI-HOTFIX] LogCleaner: Enable retry for partition cleaning failure before marking it uncleanable

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -63,18 +63,10 @@ public class ClientUtilsTest {
         List<String> validatedHostNames = validatedAddresses.stream().map(InetSocketAddress::getHostName)
                 .collect(Collectors.toList());
         List<String> expectedHostNames = Arrays.asList(
-            "a23-215-0-136.deploy.static.akamaitechnologies.com",
-            "a23-192-228-84.deploy.static.akamaitechnologies.com",
-            "a23-215-0-138.deploy.static.akamaitechnologies.com",
-            "a96-7-128-175.deploy.static.akamaitechnologies.com",
-            "a23-192-228-80.deploy.static.akamaitechnologies.com",
-            "a96-7-128-198.deploy.static.akamaitechnologies.com",
-            "2600:1406:3a00:21:0:0:173e:2e66",
-            "2600:1408:ec00:36:0:0:1736:7f31",
-            "2600:1406:3a00:21:0:0:173e:2e65",
-            "2600:1408:ec00:36:0:0:1736:7f24",
-            "2600:1406:bc00:53:0:0:b81e:94ce",
-            "2600:1406:bc00:53:0:0:b81e:94c8"
+            "104.18.26.120",
+            "104.18.27.120",
+            "2606:4700:0:0:0:0:6812:1a78",
+            "2606:4700:0:0:0:0:6812:1b78"
         );
         assertTrue(expectedHostNames.containsAll(validatedHostNames), "Unexpected addresses " + validatedHostNames);
         validatedAddresses.forEach(address -> assertEquals(10000, address.getPort()));

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -336,8 +336,8 @@ class LogCleaner(initialConfig: CleanerConfig,
         cleanFilthiestLog()
       } catch {
         case e: LogCleaningException =>
-          warn(s"Unexpected exception thrown when cleaning log ${e.log}. Marking its partition (${e.log.topicPartition}) as uncleanable", e)
-          cleanerManager.markPartitionUncleanable(e.log.parentDir, e.log.topicPartition)
+          error(s"Unexpected exception thrown when cleaning log ${e.log}.", e)
+          cleanerManager.updatePartitionCleaningFailureState(e.log.parentDir, e.log.topicPartition, succeeded = false)
 
           false
       }
@@ -354,6 +354,8 @@ class LogCleaner(initialConfig: CleanerConfig,
           this.lastPreCleanStats = preCleanStats
           try {
             cleanLog(cleanable)
+            // Reset failure count on successful cleaning
+            cleanerManager.updatePartitionCleaningFailureState(cleanable.log.parentDir, cleanable.log.topicPartition, succeeded = true)
             true
           } catch {
             case e @ (_: ThreadShutdownException | _: ControlThrowable) => throw e
@@ -367,7 +369,9 @@ class LogCleaner(initialConfig: CleanerConfig,
             log.deleteOldSegments()
           } catch {
             case e @ (_: ThreadShutdownException | _: ControlThrowable) => throw e
-            case e: Exception => throw new LogCleaningException(log, e.getMessage, e)
+            // log the error and the thread can retry deleting this log in the next call.
+            case e: Exception => error(s"Unexpected error occurred when deleting old segment '${log.name}' for topic '${log.topicPartition.topic()}" +
+              s"partition '${log.topicPartition.partition()}'", e)
           }
         }
       } finally  {

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -370,8 +370,8 @@ class LogCleaner(initialConfig: CleanerConfig,
           } catch {
             case e @ (_: ThreadShutdownException | _: ControlThrowable) => throw e
             // log the error and the thread can retry deleting this log in the next call.
-            case e: Exception => error(s"Unexpected error occurred when deleting old segment '${log.name}' for topic '${log.topicPartition.topic()}" +
-              s"partition '${log.topicPartition.partition()}'", e)
+            case e: Exception => error(s"Unexpected error occurred when deleting old segment '${log.name}' for topic '${log.topicPartition.topic()}'" +
+              s" partition '${log.topicPartition.partition()}'", e)
           }
         }
       } finally  {

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -99,7 +99,10 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
     newGauge("uncleanable-partitions-count",
       () => inLock(lock) {
         partitionCleaningFailureCounts.get(dir.getAbsolutePath)
-          .map(_.count(_._2 >= maxConsecutiveCleaningFailures))
+          .map(partitionMap => partitionMap.count {
+            case (_, failureCount) =>
+              failureCount >= maxConsecutiveCleaningFailures
+          })
           .getOrElse(0)
       },
       Map("logDirectory" -> dir.getAbsolutePath)
@@ -114,13 +117,16 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
           case Some(partitionCounts) =>
             val lastClean = allCleanerCheckpoints
             val now = Time.SYSTEM.milliseconds
-            partitionCounts.filter(_._2 >= maxConsecutiveCleaningFailures).keys.map { tp =>
-              val log = logs.get(tp)
-              val lastCleanOffset = lastClean.get(tp)
-              val offsetsToClean = cleanableOffsets(log, lastCleanOffset, now)
-              val (_, uncleanableBytes) = calculateCleanableBytes(log, offsetsToClean.firstDirtyOffset, offsetsToClean.firstUncleanableDirtyOffset)
-              uncleanableBytes
-            }.sum
+            partitionCounts.iterator
+              .collect { case (tp, failureCount) if failureCount >= maxConsecutiveCleaningFailures => tp }
+              .map { tp =>
+                val log = logs.get(tp)
+                val lastCleanOffset = lastClean.get(tp)
+                val offsetsToClean = cleanableOffsets(log, lastCleanOffset, now)
+                val (_, uncleanableBytes) = calculateCleanableBytes(log, offsetsToClean.firstDirtyOffset, offsetsToClean.firstUncleanableDirtyOffset)
+                uncleanableBytes
+              }
+              .sum
           case None => 0
         }
       },

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -78,9 +78,12 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   /* the set of logs currently being cleaned */
   private val inProgress = mutable.HashMap[TopicPartition, LogCleaningState]()
 
-  /* the set of uncleanable partitions (partitions that have raised an unexpected error during cleaning)
-   *   for each log directory */
-  private val uncleanablePartitions = mutable.HashMap[String, mutable.Set[TopicPartition]]()
+  /* tracks consecutive cleaning failures per [logDir, partition]. A partition becomes uncleanable
+   * when its failure count reaches maxConsecutiveCleaningFailures */
+  private val partitionCleaningFailureCounts = mutable.HashMap[String, mutable.Map[TopicPartition, Int]]()
+
+  /* the number of consecutive cleaning failures before a partition is marked as uncleanable */
+  private val maxConsecutiveCleaningFailures: Int = 3
 
   /* a global lock used to control all access to the in-progress set and the offset checkpoints */
   private val lock = new ReentrantLock
@@ -94,7 +97,11 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   /* gauges for tracking the number of partitions marked as uncleanable for each log directory */
   for (dir <- logDirs) {
     newGauge("uncleanable-partitions-count",
-      () => inLock(lock) { uncleanablePartitions.get(dir.getAbsolutePath).map(_.size).getOrElse(0) },
+      () => inLock(lock) {
+        partitionCleaningFailureCounts.get(dir.getAbsolutePath)
+          .map(_.count(_._2 >= maxConsecutiveCleaningFailures))
+          .getOrElse(0)
+      },
       Map("logDirectory" -> dir.getAbsolutePath)
     )
   }
@@ -103,11 +110,11 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   for (dir <- logDirs) {
     newGauge("uncleanable-bytes",
       () => inLock(lock) {
-        uncleanablePartitions.get(dir.getAbsolutePath) match {
-          case Some(partitions) =>
+        partitionCleaningFailureCounts.get(dir.getAbsolutePath) match {
+          case Some(partitionCounts) =>
             val lastClean = allCleanerCheckpoints
             val now = Time.SYSTEM.milliseconds
-            partitions.iterator.map { tp =>
+            partitionCounts.filter(_._2 >= maxConsecutiveCleaningFailures).keys.map { tp =>
               val log = logs.get(tp)
               val lastCleanOffset = lastClean.get(tp)
               val offsetsToClean = cleanableOffsets(log, lastCleanOffset, now)
@@ -503,10 +510,12 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
           error(s"Failed to access checkpoint file in dir ${sourceLogDir.getAbsolutePath}", e)
       }
 
-      val logUncleanablePartitions = uncleanablePartitions.getOrElse(sourceLogDir.toString, mutable.Set[TopicPartition]())
-      if (logUncleanablePartitions.contains(topicPartition)) {
-        logUncleanablePartitions.remove(topicPartition)
-        markPartitionUncleanable(destLogDir.toString, topicPartition)
+      // Transfer failure count when partition moves directories
+      partitionCleaningFailureCounts.get(sourceLogDir.toString).foreach { sourcePartitionCounts =>
+        sourcePartitionCounts.remove(topicPartition).foreach { count =>
+          val destPartitionCounts = partitionCleaningFailureCounts.getOrElseUpdate(destLogDir.toString, mutable.Map[TopicPartition, Int]())
+          destPartitionCounts.put(topicPartition, count)
+        }
       }
     }
   }
@@ -579,29 +588,45 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   }
 
   /**
-   * Returns an immutable set of the uncleanable partitions for a given log directory
+   * Returns a map of uncleanable partitions to their failure counts for a given log directory
    * Only used for testing
    */
-  private[log] def uncleanablePartitions(logDir: String): Set[TopicPartition] = {
-    var partitions: Set[TopicPartition] = Set()
-    inLock(lock) { partitions ++= uncleanablePartitions.getOrElse(logDir, partitions) }
-    partitions
+  private[log] def uncleanablePartitions(log: Log): Map[TopicPartition, Int] = {
+    inLock(lock) {
+      partitionCleaningFailureCounts.get(log.parentDir)
+        .map(_.filter { case (tp, _) => isUncleanablePartition(log, tp) }.toMap)
+        .getOrElse(Map.empty)
+    }
   }
 
-  def markPartitionUncleanable(logDir: String, partition: TopicPartition): Unit = {
+  /**
+   * Update the cleaning failure state for a partition.
+   * If succeeded is true, reset the failure count. If false, increment the failure count.
+   * A partition becomes uncleanable when its failure count reaches maxConsecutiveCleaningFailures.
+   */
+  def updatePartitionCleaningFailureState(logDir: String, partition: TopicPartition, succeeded: Boolean): Unit = {
     inLock(lock) {
-      uncleanablePartitions.get(logDir) match {
-        case Some(partitions) =>
-          partitions.add(partition)
-        case None =>
-          uncleanablePartitions.put(logDir, mutable.Set(partition))
+      if (succeeded) {
+        // Reset failure count on success
+        partitionCleaningFailureCounts.get(logDir).foreach(_.remove(partition))
+      } else {
+        // Increment failure count on failure
+        val partitionCounts = partitionCleaningFailureCounts.getOrElseUpdate(logDir, mutable.Map[TopicPartition, Int]())
+        val currentCount = partitionCounts.getOrElse(partition, 0) + 1
+        partitionCounts.put(partition, currentCount)
+
+        if (currentCount >= maxConsecutiveCleaningFailures) {
+          warn(s"Partition $partition in $logDir marked uncleanable after $currentCount consecutive failures")
+        }
       }
     }
   }
 
   private def isUncleanablePartition(log: Log, topicPartition: TopicPartition): Boolean = {
     inLock(lock) {
-      uncleanablePartitions.get(log.parentDir).exists(partitions => partitions.contains(topicPartition))
+      partitionCleaningFailureCounts.get(log.parentDir)
+        .flatMap(_.get(topicPartition))
+        .exists(_ >= maxConsecutiveCleaningFailures)
     }
   }
 }

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -117,16 +117,13 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
           case Some(partitionCounts) =>
             val lastClean = allCleanerCheckpoints
             val now = Time.SYSTEM.milliseconds
-            partitionCounts.iterator
-              .collect { case (tp, failureCount) if failureCount >= maxConsecutiveCleaningFailures => tp }
-              .map { tp =>
-                val log = logs.get(tp)
-                val lastCleanOffset = lastClean.get(tp)
-                val offsetsToClean = cleanableOffsets(log, lastCleanOffset, now)
-                val (_, uncleanableBytes) = calculateCleanableBytes(log, offsetsToClean.firstDirtyOffset, offsetsToClean.firstUncleanableDirtyOffset)
-                uncleanableBytes
-              }
-              .sum
+            partitionCounts.filter(_._2 >= maxConsecutiveCleaningFailures).keys.map { tp =>
+              val log = logs.get(tp)
+              val lastCleanOffset = lastClean.get(tp)
+              val offsetsToClean = cleanableOffsets(log, lastCleanOffset, now)
+              val (_, uncleanableBytes) = calculateCleanableBytes(log, offsetsToClean.firstDirtyOffset, offsetsToClean.firstUncleanableDirtyOffset)
+              uncleanableBytes
+            }.sum
           case None => 0
         }
       },

--- a/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
@@ -83,7 +83,7 @@ class LogCleanerIntegrationTest extends AbstractLogCleanerIntegrationTest with K
     TestUtils.waitUntilTrue(() => uncleanableBytesGauge.value() == expectedTotalUncleanableBytes,
       s"There should be $expectedTotalUncleanableBytes uncleanable bytes", 1000L)
 
-    val uncleanablePartitions = cleaner.cleanerManager.uncleanablePartitions(uncleanableDirectory)
+    val uncleanablePartitions = cleaner.cleanerManager.uncleanablePartitions(log)
     assertTrue(uncleanablePartitions.contains(topicPartitions(0)))
     assertTrue(uncleanablePartitions.contains(topicPartitions(1)))
     assertFalse(uncleanablePartitions.contains(topicPartitions(2)))

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -293,21 +293,24 @@ class LogCleanerManagerTest extends Logging {
     val logs = new Pool[TopicPartition, Log]()
     val log0 = createLogInDir(logDir, 2048, LogConfig.Compact, tp0)
     val log1 = createLogInDir(logDir2, 2048, LogConfig.Compact, tp1)
+    val log0_2 = createLogInDir(logDir, 2048, LogConfig.Compact, tp2)
+    assertEquals(log0.parentDir, log0_2.parentDir,
+      "Both logs for tp0 and tp2 should be in the same directory to test independent tracking")
     val logDir3 = TestUtils.randomPartitionLogDir(tmpDir)
-    val log2 = createLogInDir(logDir3, 2048, LogConfig.Compact, tp1)
+    val log2 = createLogInDir(logDir3, 2048, LogConfig.Compact, tp3)
     logs.put(tp0, log0)
     logs.put(tp1, log1)
-    logs.put(tp2, log0)
+    logs.put(tp2, log0_2)
     logs.put(tp3, log2)
 
-    val cleanerManager = new LogCleanerManager(Seq(logDir, logDir2), logs, null, 0L, true)
+    val cleanerManager = new LogCleanerManager(Seq(logDir, logDir2, logDir3), logs, null, 0L, true)
 
     // tp0 in log0: 3 failures (uncleanable)
     (1 to 3).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(log0.parentDir, tp0, succeeded = false))
     // tp1 in log1: 2 failures (not uncleanable)
     (1 to 2).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = false))
     // tp2 in log0: 1 failure (not uncleanable)
-    cleanerManager.updatePartitionCleaningFailureState(log0.parentDir, tp2, succeeded = false)
+    cleanerManager.updatePartitionCleaningFailureState(log0_2.parentDir, tp2, succeeded = false)
 
     // Verify each partition is tracked in its own directory
     var uncleanable = cleanerManager.uncleanablePartitions(log0)
@@ -333,7 +336,7 @@ class LogCleanerManagerTest extends Logging {
     assertEquals(3, uncleanable(tp0))
 
     // Reset tp2 and some random tp - no change/no break
-    cleanerManager.updatePartitionCleaningFailureState(log0.parentDir, tp2, succeeded = true)
+    cleanerManager.updatePartitionCleaningFailureState(log0_2.parentDir, tp2, succeeded = true)
     cleanerManager.updatePartitionCleaningFailureState(log2.parentDir, tp3, succeeded = true)
     cleanerManager.updatePartitionCleaningFailureState(log2.parentDir, tp2, succeeded = true)
     uncleanable = cleanerManager.uncleanablePartitions(log0)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -173,7 +173,8 @@ class LogCleanerManagerTest extends Logging {
     val cleanerManager = createCleanerManagerMock(logs)
     partitions.foreach(partition => cleanerCheckpoints.put(partition, 20))
 
-    cleanerManager.markPartitionUncleanable(logs.get(tp2).dir.getParent, tp2)
+    // Mark partition as uncleanable by failing 3 consecutive times
+    (1 to 3).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(logs.get(tp2).dir.getParent, tp2, succeeded = false))
 
     val filthiestLog: LogToClean = cleanerManager.grabFilthiestCompactedLog(time).get
     assertEquals(tp1, filthiestLog.topicPartition)
@@ -213,10 +214,180 @@ class LogCleanerManagerTest extends Logging {
     partitions.foreach(partition => cleanerCheckpoints.put(partition, 20))
 
     cleanerManager.setCleaningState(tp2, LogCleaningInProgress)
-    cleanerManager.markPartitionUncleanable(logs.get(tp1).dir.getParent, tp1)
+    // Mark partition as uncleanable by failing 3 consecutive times
+    (1 to 3).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(logs.get(tp1).dir.getParent, tp1, succeeded = false))
 
     val filthiestLog: Option[LogToClean] = cleanerManager.grabFilthiestCompactedLog(time)
     assertEquals(None, filthiestLog)
+  }
+
+  @Test
+  def testPartitionCleaningFailureCountsUpdateAndCleanableState(): Unit = {
+    val tp0 = new TopicPartition("wishing-well", 0)
+    val tp1 = new TopicPartition("wishing-well", 1)
+    val partitions = Seq(tp0, tp1)
+
+    // Setup logs: tp0 has 20 batches, tp1 has 25 batches
+    // With checkpoint at 15: tp0 has 5 dirty batches, tp1 has 10 dirty batches
+    // This ensures tp0 meets the dirty threshold but is less dirty than tp1
+    val logs = setupIncreasinglyFilthyLogs(partitions, startNumBatches = 20, batchIncrement = 5)
+    val cleanerManager = createCleanerManagerMock(logs)
+    partitions.foreach(partition => cleanerCheckpoints.put(partition, 15))
+
+    val log1 = logs.get(tp1)
+
+    // Fail once - partition should NOT be uncleanable yet
+    cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = false)
+
+    // Partition should still be cleanable and picked up
+    assertTrue(cleanerManager.uncleanablePartitions(log1).isEmpty,
+      "Partition should not be uncleanable after 1 failure")
+    var filthiestLog = cleanerManager.grabFilthiestCompactedLog(time).get
+    assertEquals(tp1, filthiestLog.topicPartition, "Partition with 1 failure should still be picked")
+
+    // Fail twice - partition should NOT be uncleanable yet
+    cleanerManager.doneCleaning(tp1, log1.parentDirFile, 10L) // simulate a successful cleaning to reset in-progress state
+    cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = false)
+    // Partition should still be cleanable and picked up
+    assertTrue(cleanerManager.uncleanablePartitions(log1).isEmpty,
+      "Partition should not be uncleanable after 2 failures")
+    filthiestLog = cleanerManager.grabFilthiestCompactedLog(time).get
+    assertEquals(tp1, filthiestLog.topicPartition, "Partition with 2 failures should still be picked")
+
+    // Fail third - partition should be uncleanable
+    cleanerManager.doneCleaning(tp1, log1.parentDirFile, 10L) // simulate a successful cleaning to reset in-progress state
+    cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = false)
+    var uncleanable = cleanerManager.uncleanablePartitions(log1)
+    assertTrue(uncleanable.contains(tp1), "Partition should be uncleanable after 3 failures")
+    assertEquals(1, uncleanable.size)
+    assertEquals(3, uncleanable(tp1), "Failure count should be 3")
+    // tp0 should be picked instead of tp1 (tp0 is less dirty but still meets threshold)
+    filthiestLog = cleanerManager.grabFilthiestCompactedLog(time).get
+    assertEquals(tp0, filthiestLog.topicPartition, "Uncleanable partition should not be picked")
+    cleanerManager.doneCleaning(tp0, logs.get(tp0).parentDirFile, 10L) // reset tp0's in-progress state
+
+    // Success should reset the count
+    // reset on tp0 does not affect tp1
+    cleanerManager.updatePartitionCleaningFailureState(logs.get(tp0).parentDir, tp0, succeeded = true)
+    cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp0, succeeded = true)
+    uncleanable = cleanerManager.uncleanablePartitions(log1)
+    assertTrue(uncleanable.contains(tp1), "Partition should be uncleanable after 3 failures")
+    assertEquals(3, uncleanable(tp1))
+    cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = true)
+    assertTrue(cleanerManager.uncleanablePartitions(log1).isEmpty,
+      "Partition should not be uncleanable - count was reset by success")
+    cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = true)
+    (1 to 2).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = false))
+    assertTrue(cleanerManager.uncleanablePartitions(log1).isEmpty,
+      "Partition should not be uncleanable - count was reset by success")
+  }
+
+  @Test
+  def testPartitionCleaningFailureCountsMultiplePartitionsTrackedIndependently(): Unit = {
+    val tp0 = new TopicPartition("wishing-well", 0)
+    val tp1 = new TopicPartition("wishing-well", 1)
+    val tp2 = new TopicPartition("wishing-well", 2)
+    val tp3 = new TopicPartition("wishing-well", 3)
+
+    // Create logs in different directories
+    val logs = new Pool[TopicPartition, Log]()
+    val log0 = createLogInDir(logDir, 2048, LogConfig.Compact, tp0)
+    val log1 = createLogInDir(logDir2, 2048, LogConfig.Compact, tp1)
+    val logDir3 = TestUtils.randomPartitionLogDir(tmpDir)
+    val log2 = createLogInDir(logDir3, 2048, LogConfig.Compact, tp1)
+    logs.put(tp0, log0)
+    logs.put(tp1, log1)
+    logs.put(tp2, log0)
+    logs.put(tp3, log2)
+
+    val cleanerManager = new LogCleanerManager(Seq(logDir, logDir2), logs, null, 0L, true)
+
+    // tp0 in log0: 3 failures (uncleanable)
+    (1 to 3).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(log0.parentDir, tp0, succeeded = false))
+    // tp1 in log1: 2 failures (not uncleanable)
+    (1 to 2).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = false))
+    // tp2 in log0: 1 failure (not uncleanable)
+    cleanerManager.updatePartitionCleaningFailureState(log0.parentDir, tp2, succeeded = false)
+
+    // Verify each partition is tracked in its own directory
+    var uncleanable = cleanerManager.uncleanablePartitions(log0)
+    assertEquals(1, uncleanable.size, "tp0 should be uncleanable in logDir")
+    assertTrue(uncleanable.contains(tp0))
+    assertEquals(3, uncleanable(tp0), "tp0 should have 3 failures")
+
+    uncleanable = cleanerManager.uncleanablePartitions(log1)
+    assertEquals(0, uncleanable.size, "tp1 should not be uncleanable in logDir2 (only 2 failures)")
+
+    // Verify failure counts are independent: adding failures in one dir doesn't affect others
+    // Fail tp1 one more time - should now be uncleanable
+    cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = false)
+    uncleanable = cleanerManager.uncleanablePartitions(log1)
+    assertEquals(1, uncleanable.size, "tp1 should now be uncleanable after 3 failures")
+    assertTrue(uncleanable.contains(tp1))
+    assertEquals(3, uncleanable(tp1), "tp1 should have 3 failures")
+
+    // tp0 and tp2 should be unchanged
+    uncleanable = cleanerManager.uncleanablePartitions(log0)
+    assertEquals(1, uncleanable.size)
+    assertTrue(uncleanable.contains(tp0))
+    assertEquals(3, uncleanable(tp0))
+
+    // Reset tp2 and some random tp - no change/no break
+    cleanerManager.updatePartitionCleaningFailureState(log0.parentDir, tp2, succeeded = true)
+    cleanerManager.updatePartitionCleaningFailureState(log2.parentDir, tp3, succeeded = true)
+    cleanerManager.updatePartitionCleaningFailureState(log2.parentDir, tp2, succeeded = true)
+    uncleanable = cleanerManager.uncleanablePartitions(log0)
+    assertEquals(1, uncleanable.size)
+    assertTrue(uncleanable.contains(tp0))
+    assertEquals(3, uncleanable(tp0))
+    uncleanable = cleanerManager.uncleanablePartitions(log1)
+    assertEquals(1, uncleanable.size)
+    assertTrue(uncleanable.contains(tp1))
+    assertEquals(3, uncleanable(tp1))
+
+    // Reset tp1
+    cleanerManager.updatePartitionCleaningFailureState(log1.parentDir, tp1, succeeded = true)
+    uncleanable = cleanerManager.uncleanablePartitions(log0)
+    assertEquals(1, uncleanable.size)
+    assertTrue(uncleanable.contains(tp0))
+    assertEquals(3, uncleanable(tp0))
+    uncleanable = cleanerManager.uncleanablePartitions(log1)
+    assertEquals(0, uncleanable.size)
+  }
+
+  @Test
+  def testFailureCountTransfersOnAlterCheckpointDir(): Unit = {
+    val tp = new TopicPartition("test-transfer", 0)
+    val logs = new Pool[TopicPartition, Log]()
+    // Create logs in both directories to enable uncleanablePartitions checks
+    val sourceLog = createLogInDir(logDir, 2048, LogConfig.Compact, tp)
+    val destLog = createLogInDir(logDir2, 2048, LogConfig.Compact, tp)
+    logs.put(tp, sourceLog)
+
+    val cleanerManager = new LogCleanerManager(Seq(logDir, logDir2), logs, null, 0L, true)
+
+    // Fail twice in the source directory
+    (1 to 2).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(sourceLog.parentDir, tp, succeeded = false))
+
+    // Transfer to destination directory
+    cleanerManager.alterCheckpointDir(tp, logDir, logDir2)
+
+    // Verify failure count was transferred - partition should not be uncleanable in source
+    assertTrue(cleanerManager.uncleanablePartitions(sourceLog).isEmpty,
+      "Source dir should have no failure count after transfer")
+
+    // Fail once more in destination - should now be uncleanable (2 + 1 = 3)
+    cleanerManager.updatePartitionCleaningFailureState(destLog.parentDir, tp, succeeded = false)
+    // Fail once more in source - should have no effect on uncleanable state in source
+    cleanerManager.updatePartitionCleaningFailureState(sourceLog.parentDir, tp, succeeded = false)
+
+    var uncleanable = cleanerManager.uncleanablePartitions(destLog)
+    assertEquals(1, uncleanable.size)
+    assertTrue(uncleanable.contains(tp), "Partition should be uncleanable after transfer + 1 more failure")
+    assertEquals(3, uncleanable(tp), "Failure count should be 3 (2 transferred + 1 new)")
+
+    uncleanable = cleanerManager.uncleanablePartitions(sourceLog)
+    assertEquals(0, uncleanable.size, "Partition should be cleanable in source dir after transfer")
   }
 
   @Test
@@ -522,7 +693,8 @@ class LogCleanerManagerTest extends Logging {
     val records = TestUtils.singletonRecords("test".getBytes, key="test".getBytes)
     val log: Log = createLog(records.sizeInBytes * 5, LogConfig.Compact)
     val cleanerManager: LogCleanerManager = createCleanerManager(log)
-    cleanerManager.markPartitionUncleanable(log.dir.getParent, topicPartition)
+    // Mark partition as uncleanable by failing 3 consecutive times
+    (1 to 3).foreach(_ => cleanerManager.updatePartitionCleaningFailureState(log.dir.getParent, topicPartition, succeeded = false))
 
     val readyToDelete = cleanerManager.deletableLogs().size
     assertEquals(0, readyToDelete, "should have 0 logs ready to be deleted")
@@ -765,8 +937,15 @@ class LogCleanerManagerTest extends Logging {
   private def createLog(segmentSize: Int,
                         cleanupPolicy: String,
                         topicPartition: TopicPartition = new TopicPartition("log", 0)): Log = {
+    createLogInDir(logDir, segmentSize, cleanupPolicy, topicPartition)
+  }
+
+  private def createLogInDir(dir: File,
+                             segmentSize: Int,
+                             cleanupPolicy: String,
+                             topicPartition: TopicPartition): Log = {
     val config = createLowRetentionLogConfig(segmentSize, cleanupPolicy)
-    val partitionDir = new File(logDir, Log.logDirName(topicPartition))
+    val partitionDir = new File(dir, Log.logDirName(topicPartition))
 
     Log(partitionDir,
       config,


### PR DESCRIPTION
### Summary
- In [LIKAFKA-67579](https://linkedin.atlassian.net/browse/LIKAFKA-67579), a partition is marked as uncleanable due to a previous log cleaning failure, and then the partition remains uncleaned until a server restarting.
-  In this PR, we only disable log cleaning for a partition if it fails for 3 consecutive times, such that the cleaner could retry and succeed in case of transient failures to be more robust.

### Details
- Track consecutive log-cleaning failures per (logDir, TopicPartition) and only treat a partition as uncleanable after reaching the configured threshold (currently 3).
- Reset a partition’s failure counter after a successful cleaning run.
- Transfer counters when a partition’s checkpoint directory changes.
- Update uncleanable partition/bytes metrics.

### Test
Add unit tests in :core:test --tests kafka.log.LogCleanerManagerTest 
Fixed the failing ClientUtilsTest

