### PR TITLE
[LI-HOTFIX] Track successful auto-topic creations 

### DIFF
--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -187,18 +187,19 @@ class DefaultAutoTopicCreationManager(
         } else if (response.versionMismatch() != null) {
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with invalid version exception")
         } else {
-          // response.responseBody() may be null in unexpected edge cases (e.g., internal errors
-          // before the response is fully constructed), so guard against NPE here.
-          val responseBody = response.responseBody()
-          if (responseBody == null) {
-            warn(s"[AutoTopicCreation] Received null response body for topics: ${creatableTopics.keys}")
-          } else {
-            // Log outcomes to track true new creations vs topics that already existed,
-            // helping distinguish real auto-creations from pod startup races where the
-            // broker's metadata cache hasn't fully loaded yet.
-            val createTopicsResponse = responseBody.asInstanceOf[CreateTopicsResponse]
-            logAutoTopicCreationResults(createTopicsResponse.data.topics.asScala
-              .map(t => t.name() -> Errors.forCode(t.errorCode)).toMap)
+          // Use pattern matching instead of asInstanceOf to safely handle both a null
+          // response body and an unexpected response type without throwing NPE or ClassCastException.
+          response.responseBody() match {
+            case createTopicsResponse: CreateTopicsResponse =>
+              // Log outcomes to track true new creations vs topics that already existed,
+              // helping distinguish real auto-creations from pod startup races where the
+              // broker's metadata cache hasn't fully loaded yet.
+              logAutoTopicCreationResults(createTopicsResponse.data.topics.asScala
+                .map(t => t.name() -> Errors.forCode(t.errorCode)).toMap)
+            case null =>
+              warn(s"[AutoTopicCreation] Received null response body for topics: ${creatableTopics.keys}")
+            case unexpected =>
+              warn(s"[AutoTopicCreation] Unexpected response type ${unexpected.getClass.getName} for topics: ${creatableTopics.keys}")
           }
           debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
         }

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData
 import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreateableTopicConfig, CreateableTopicConfigCollection}
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
-import org.apache.kafka.common.requests.{ApiError, CreateTopicsRequest, RequestContext, RequestHeader}
+import org.apache.kafka.common.requests.{ApiError, CreateTopicsRequest, CreateTopicsResponse, RequestContext, RequestHeader}
 
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
@@ -125,6 +125,14 @@ class DefaultAutoTopicCreationManager(
 
       val creatableTopicResponses = Option(topicErrors.get) match {
         case Some(errors) =>
+          val silentFailures = errors.collect { case (topic, apiError) if apiError.error == Errors.TOPIC_ALREADY_EXISTS => topic }
+          val successfulCreations = errors.collect { case (topic, apiError) if apiError.error == Errors.NONE || apiError.error == Errors.REQUEST_TIMED_OUT => topic }
+
+          if (silentFailures.nonEmpty)
+            debug(s"Auto topic creation skipped for topics that already exist: $silentFailures")
+          if (successfulCreations.nonEmpty)
+            info(s"Successfully auto-created new topics: $successfulCreations")
+
           errors.toSeq.map { case (topic, apiError) =>
             val error = apiError.error match {
               case Errors.TOPIC_ALREADY_EXISTS | Errors.REQUEST_TIMED_OUT =>
@@ -182,6 +190,16 @@ class DefaultAutoTopicCreationManager(
         } else if (response.versionMismatch() != null) {
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with invalid version exception")
         } else {
+          val createTopicsResponse = response.responseBody.asInstanceOf[CreateTopicsResponse]
+          val topics = createTopicsResponse.data.topics.asScala
+          val successfulCreations = topics.filter(t => Errors.forCode(t.errorCode) == Errors.NONE || Errors.forCode(t.errorCode) == Errors.LEADER_NOT_AVAILABLE)
+          val silentFailures = topics.filter(t => Errors.forCode(t.errorCode) == Errors.TOPIC_ALREADY_EXISTS)
+
+          if (successfulCreations.nonEmpty)
+            info(s"Successfully auto-created new topics: ${successfulCreations.map(_.name()).mkString(", ")}")
+          if (silentFailures.nonEmpty)
+            debug(s"Auto topic creation skipped for topics that already exist: ${silentFailures.map(_.name()).mkString(", ")}")
+
           debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
         }
       }

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -125,16 +125,10 @@ class DefaultAutoTopicCreationManager(
 
       val creatableTopicResponses = Option(topicErrors.get) match {
         case Some(errors) =>
-          val topicAlreadyExists = errors.collect { case (topic, apiError) if apiError.error == Errors.TOPIC_ALREADY_EXISTS => topic }
-          val successfulCreations = errors.collect { case (topic, apiError) if apiError.error == Errors.NONE || apiError.error == Errors.REQUEST_TIMED_OUT => topic }
-          val otherErrors = errors.collect { case (topic, apiError) if apiError.error != Errors.TOPIC_ALREADY_EXISTS && apiError.error != Errors.NONE && apiError.error != Errors.REQUEST_TIMED_OUT => topic -> apiError.error }
-
-          if (successfulCreations.nonEmpty)
-            info(s"[AutoTopicCreation] Topics successfully created: $successfulCreations")
-          if (topicAlreadyExists.nonEmpty)
-            info(s"[AutoTopicCreation] Topics already exist: $topicAlreadyExists")
-          if (otherErrors.nonEmpty)
-            warn(s"[AutoTopicCreation] Topics failed to create: $otherErrors")
+          // Log outcomes to track true new creations vs topics that already existed,
+          // helping distinguish real auto-creations from pod startup races where the
+          // broker's metadata cache hasn't fully loaded yet.
+          logAutoTopicCreationResults(errors.map { case (topic, apiError) => topic -> apiError.error })
 
           errors.toSeq.map { case (topic, apiError) =>
             val error = apiError.error match {
@@ -193,19 +187,19 @@ class DefaultAutoTopicCreationManager(
         } else if (response.versionMismatch() != null) {
           warn(s"Auto topic creation failed for ${creatableTopics.keys} with invalid version exception")
         } else {
-          val createTopicsResponse = response.responseBody.asInstanceOf[CreateTopicsResponse]
-          val topics = createTopicsResponse.data.topics.asScala
-          val successfulCreations = topics.filter(t => Errors.forCode(t.errorCode) == Errors.NONE || Errors.forCode(t.errorCode) == Errors.LEADER_NOT_AVAILABLE)
-          val topicAlreadyExists = topics.filter(t => Errors.forCode(t.errorCode) == Errors.TOPIC_ALREADY_EXISTS)
-          val otherErrors = topics.filter(t => Errors.forCode(t.errorCode) != Errors.NONE && Errors.forCode(t.errorCode) != Errors.LEADER_NOT_AVAILABLE && Errors.forCode(t.errorCode) != Errors.TOPIC_ALREADY_EXISTS)
-
-          if (successfulCreations.nonEmpty)
-            info(s"[AutoTopicCreation] Topics successfully created: ${successfulCreations.map(_.name()).mkString(", ")}")
-          if (topicAlreadyExists.nonEmpty)
-            info(s"[AutoTopicCreation] Topics already exist: ${topicAlreadyExists.map(_.name()).mkString(", ")}")
-          if (otherErrors.nonEmpty)
-            warn(s"[AutoTopicCreation] Topics failed to create: ${otherErrors.map(t => s"${t.name()}:${Errors.forCode(t.errorCode)}").mkString(", ")}")
-
+          // response.responseBody() may be null in unexpected edge cases (e.g., internal errors
+          // before the response is fully constructed), so guard against NPE here.
+          val responseBody = response.responseBody()
+          if (responseBody == null) {
+            warn(s"[AutoTopicCreation] Received null response body for topics: ${creatableTopics.keys}")
+          } else {
+            // Log outcomes to track true new creations vs topics that already existed,
+            // helping distinguish real auto-creations from pod startup races where the
+            // broker's metadata cache hasn't fully loaded yet.
+            val createTopicsResponse = responseBody.asInstanceOf[CreateTopicsResponse]
+            logAutoTopicCreationResults(createTopicsResponse.data.topics.asScala
+              .map(t => t.name() -> Errors.forCode(t.errorCode)).toMap)
+          }
           debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
         }
       }
@@ -247,6 +241,30 @@ class DefaultAutoTopicCreationManager(
 
     info(s"Sent auto-creation request for ${creatableTopics.keys} to the active controller.")
     creatableTopicResponses
+  }
+
+  /**
+   * Classifies and logs auto topic creation results using a consistent [AutoTopicCreation] prefix
+   * for easy inLog searching. Three outcome categories are tracked:
+   *   - Successfully created: topics newly written to ZooKeeper.
+   *     REQUEST_TIMED_OUT is treated as success because it means the topic metadata was
+   *     written successfully but leader election did not complete within the timeout.
+   *   - Already exist: topics attempted but already present (TOPIC_ALREADY_EXISTS).
+   *     These are common at broker startup when the metadata cache hasn't fully loaded,
+   *     causing the broker to attempt auto-creation of topics that are already there.
+   *   - Failed: topics that failed for other reasons (e.g., quota exceeded, invalid config).
+   */
+  private def logAutoTopicCreationResults(topicErrors: Map[String, Errors]): Unit = {
+    val successfulCreations = topicErrors.collect { case (topic, error) if error == Errors.NONE || error == Errors.REQUEST_TIMED_OUT => topic }
+    val topicAlreadyExists = topicErrors.collect { case (topic, error) if error == Errors.TOPIC_ALREADY_EXISTS => topic }
+    val otherErrors = topicErrors.collect { case (topic, error) if error != Errors.NONE && error != Errors.REQUEST_TIMED_OUT && error != Errors.TOPIC_ALREADY_EXISTS => topic -> error }
+
+    if (successfulCreations.nonEmpty)
+      info(s"[AutoTopicCreation] Topics successfully created: $successfulCreations")
+    if (topicAlreadyExists.nonEmpty)
+      info(s"[AutoTopicCreation] Topics already exist: $topicAlreadyExists")
+    if (otherErrors.nonEmpty)
+      warn(s"[AutoTopicCreation] Topics failed to create: ${otherErrors.map { case (t, e) => s"$t:$e" }.mkString(", ")}")
   }
 
   private def clearInflightRequests(creatableTopics: Map[String, CreatableTopic]): Unit = {

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -132,7 +132,7 @@ class DefaultAutoTopicCreationManager(
           if (successfulCreations.nonEmpty)
             info(s"[AutoTopicCreation] Topics successfully created: $successfulCreations")
           if (topicAlreadyExists.nonEmpty)
-            debug(s"[AutoTopicCreation] Topics already exist: $topicAlreadyExists")
+            info(s"[AutoTopicCreation] Topics already exist: $topicAlreadyExists")
           if (otherErrors.nonEmpty)
             warn(s"[AutoTopicCreation] Topics failed to create: $otherErrors")
 
@@ -202,7 +202,7 @@ class DefaultAutoTopicCreationManager(
           if (successfulCreations.nonEmpty)
             info(s"[AutoTopicCreation] Topics successfully created: ${successfulCreations.map(_.name()).mkString(", ")}")
           if (topicAlreadyExists.nonEmpty)
-            debug(s"[AutoTopicCreation] Topics already exist: ${topicAlreadyExists.map(_.name()).mkString(", ")}")
+            info(s"[AutoTopicCreation] Topics already exist: ${topicAlreadyExists.map(_.name()).mkString(", ")}")
           if (otherErrors.nonEmpty)
             warn(s"[AutoTopicCreation] Topics failed to create: ${otherErrors.map(t => s"${t.name()}:${Errors.forCode(t.errorCode)}").mkString(", ")}")
 

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -125,13 +125,16 @@ class DefaultAutoTopicCreationManager(
 
       val creatableTopicResponses = Option(topicErrors.get) match {
         case Some(errors) =>
-          val silentFailures = errors.collect { case (topic, apiError) if apiError.error == Errors.TOPIC_ALREADY_EXISTS => topic }
+          val topicAlreadyExists = errors.collect { case (topic, apiError) if apiError.error == Errors.TOPIC_ALREADY_EXISTS => topic }
           val successfulCreations = errors.collect { case (topic, apiError) if apiError.error == Errors.NONE || apiError.error == Errors.REQUEST_TIMED_OUT => topic }
+          val otherErrors = errors.collect { case (topic, apiError) if apiError.error != Errors.TOPIC_ALREADY_EXISTS && apiError.error != Errors.NONE && apiError.error != Errors.REQUEST_TIMED_OUT => topic -> apiError.error }
 
-          if (silentFailures.nonEmpty)
-            debug(s"Auto topic creation skipped for topics that already exist: $silentFailures")
           if (successfulCreations.nonEmpty)
-            info(s"Successfully auto-created new topics: $successfulCreations")
+            info(s"[AutoTopicCreation] Topics successfully created: $successfulCreations")
+          if (topicAlreadyExists.nonEmpty)
+            debug(s"[AutoTopicCreation] Topics already exist: $topicAlreadyExists")
+          if (otherErrors.nonEmpty)
+            warn(s"[AutoTopicCreation] Topics failed to create: $otherErrors")
 
           errors.toSeq.map { case (topic, apiError) =>
             val error = apiError.error match {
@@ -193,12 +196,15 @@ class DefaultAutoTopicCreationManager(
           val createTopicsResponse = response.responseBody.asInstanceOf[CreateTopicsResponse]
           val topics = createTopicsResponse.data.topics.asScala
           val successfulCreations = topics.filter(t => Errors.forCode(t.errorCode) == Errors.NONE || Errors.forCode(t.errorCode) == Errors.LEADER_NOT_AVAILABLE)
-          val silentFailures = topics.filter(t => Errors.forCode(t.errorCode) == Errors.TOPIC_ALREADY_EXISTS)
+          val topicAlreadyExists = topics.filter(t => Errors.forCode(t.errorCode) == Errors.TOPIC_ALREADY_EXISTS)
+          val otherErrors = topics.filter(t => Errors.forCode(t.errorCode) != Errors.NONE && Errors.forCode(t.errorCode) != Errors.LEADER_NOT_AVAILABLE && Errors.forCode(t.errorCode) != Errors.TOPIC_ALREADY_EXISTS)
 
           if (successfulCreations.nonEmpty)
-            info(s"Successfully auto-created new topics: ${successfulCreations.map(_.name()).mkString(", ")}")
-          if (silentFailures.nonEmpty)
-            debug(s"Auto topic creation skipped for topics that already exist: ${silentFailures.map(_.name()).mkString(", ")}")
+            info(s"[AutoTopicCreation] Topics successfully created: ${successfulCreations.map(_.name()).mkString(", ")}")
+          if (topicAlreadyExists.nonEmpty)
+            debug(s"[AutoTopicCreation] Topics already exist: ${topicAlreadyExists.map(_.name()).mkString(", ")}")
+          if (otherErrors.nonEmpty)
+            warn(s"[AutoTopicCreation] Topics failed to create: ${otherErrors.map(t => s"${t.name()}:${Errors.forCode(t.errorCode)}").mkString(", ")}")
 
           debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
         }

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -251,16 +251,24 @@ class DefaultAutoTopicCreationManager(
   private def logAutoTopicCreationResults(topicErrors: Map[String, Errors]): Unit = {
     // REQUEST_TIMED_OUT is treated as success: it means the topic metadata was written to ZooKeeper
     // but leader election did not complete within the timeout.
-    val successfulCreations = topicErrors.filter(e => e._2 == Errors.NONE || e._2 == Errors.REQUEST_TIMED_OUT).keys
-    val topicAlreadyExists = topicErrors.filter(e => e._2 == Errors.TOPIC_ALREADY_EXISTS).keys
-    val otherErrors = topicErrors.filter(e => e._2 != Errors.NONE && e._2 != Errors.REQUEST_TIMED_OUT && e._2 != Errors.TOPIC_ALREADY_EXISTS)
+    val successfulCreations = mutable.Buffer.empty[String]
+    val topicAlreadyExists = mutable.Buffer.empty[String]
+    val otherErrors = mutable.Buffer.empty[String]
+
+    topicErrors.foreach { case (topic, error) =>
+      error match {
+        case Errors.NONE | Errors.REQUEST_TIMED_OUT => successfulCreations += topic
+        case Errors.TOPIC_ALREADY_EXISTS => topicAlreadyExists += topic
+        case _ => otherErrors += s"$topic:$error"
+      }
+    }
 
     if (successfulCreations.nonEmpty)
-      info(s"AutoTopicCreation: Topics successfully created: $successfulCreations")
+      info(s"AutoTopicCreation: Topics successfully created: ${successfulCreations.mkString(", ")}")
     if (topicAlreadyExists.nonEmpty)
-      info(s"AutoTopicCreation: Topics already exist: $topicAlreadyExists")
+      info(s"AutoTopicCreation: Topics already exist: ${topicAlreadyExists.mkString(", ")}")
     if (otherErrors.nonEmpty)
-      warn(s"AutoTopicCreation: Topics failed to create: ${otherErrors.map(e => s"${e._1}:${e._2}").mkString(", ")}")
+      warn(s"AutoTopicCreation: Topics failed to create: ${otherErrors.mkString(", ")}")
   }
 
   private def clearInflightRequests(creatableTopics: Map[String, CreatableTopic]): Unit = {

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -125,9 +125,6 @@ class DefaultAutoTopicCreationManager(
 
       val creatableTopicResponses = Option(topicErrors.get) match {
         case Some(errors) =>
-          // Log outcomes to track true new creations vs topics that already existed,
-          // helping distinguish real auto-creations from pod startup races where the
-          // broker's metadata cache hasn't fully loaded yet.
           logAutoTopicCreationResults(errors.map { case (topic, apiError) => topic -> apiError.error })
 
           errors.toSeq.map { case (topic, apiError) =>
@@ -191,15 +188,12 @@ class DefaultAutoTopicCreationManager(
           // response body and an unexpected response type without throwing NPE or ClassCastException.
           response.responseBody() match {
             case createTopicsResponse: CreateTopicsResponse =>
-              // Log outcomes to track true new creations vs topics that already existed,
-              // helping distinguish real auto-creations from pod startup races where the
-              // broker's metadata cache hasn't fully loaded yet.
               logAutoTopicCreationResults(createTopicsResponse.data.topics.asScala
                 .map(t => t.name() -> Errors.forCode(t.errorCode)).toMap)
             case null =>
-              warn(s"[AutoTopicCreation] Received null response body for topics: ${creatableTopics.keys}")
+              warn(s"AutoTopicCreation: Received null response body for topics: ${creatableTopics.keys}")
             case unexpected =>
-              warn(s"[AutoTopicCreation] Unexpected response type ${unexpected.getClass.getName} for topics: ${creatableTopics.keys}")
+              warn(s"AutoTopicCreation: Unexpected response type ${unexpected.getClass.getName} for topics: ${creatableTopics.keys}")
           }
           debug(s"Auto topic creation completed for ${creatableTopics.keys} with response ${response.responseBody}.")
         }
@@ -245,27 +239,34 @@ class DefaultAutoTopicCreationManager(
   }
 
   /**
-   * Classifies and logs auto topic creation results using a consistent [AutoTopicCreation] prefix
-   * for easy inLog searching. Three outcome categories are tracked:
-   *   - Successfully created: topics newly written to ZooKeeper.
-   *     REQUEST_TIMED_OUT is treated as success because it means the topic metadata was
-   *     written successfully but leader election did not complete within the timeout.
-   *   - Already exist: topics attempted but already present (TOPIC_ALREADY_EXISTS).
-   *     These are common at broker startup when the metadata cache hasn't fully loaded,
-   *     causing the broker to attempt auto-creation of topics that are already there.
-   *   - Failed: topics that failed for other reasons (e.g., quota exceeded, invalid config).
+   * As part of the effort to disable auto-topic creation, we need to identify which topics are genuinely
+   * being created through this mechanism before reaching out to clients to stop relying on it.
+   *
+   * The existing "Automatically creating topic:" log fires before the creation attempt and cannot
+   * distinguish true new creations from false positives — cases where the broker triggers auto-creation
+   * because its metadata cache hasn't fully loaded yet (e.g., at pod startup), but the topic already
+   * exists in the cluster. This inflates observed counts and makes it impossible to identify real usage.
+   *
+   * This method logs the actual outcome of each auto-creation attempt, categorized into three groups,
+   * all prefixed with "AutoTopicCreation:" for easy inLog querying:
+   *   - Successfully created: topic was genuinely new and written to the cluster.
+   *   - Already exist: topic was already present (TOPIC_ALREADY_EXISTS), common at pod startup.
+   *   - Failed: creation failed for other reasons (e.g., quota exceeded, invalid topic name).
    */
   private def logAutoTopicCreationResults(topicErrors: Map[String, Errors]): Unit = {
+    // REQUEST_TIMED_OUT is treated as success: it means the topic metadata was written to ZooKeeper
+    // but leader election did not complete within the timeout. The topic will become fully available
+    // once a leader is elected, so this is a successful creation from the auto-topic perspective.
     val successfulCreations = topicErrors.collect { case (topic, error) if error == Errors.NONE || error == Errors.REQUEST_TIMED_OUT => topic }
     val topicAlreadyExists = topicErrors.collect { case (topic, error) if error == Errors.TOPIC_ALREADY_EXISTS => topic }
     val otherErrors = topicErrors.collect { case (topic, error) if error != Errors.NONE && error != Errors.REQUEST_TIMED_OUT && error != Errors.TOPIC_ALREADY_EXISTS => topic -> error }
 
     if (successfulCreations.nonEmpty)
-      info(s"[AutoTopicCreation] Topics successfully created: $successfulCreations")
+      info(s"AutoTopicCreation: Topics successfully created: $successfulCreations")
     if (topicAlreadyExists.nonEmpty)
-      info(s"[AutoTopicCreation] Topics already exist: $topicAlreadyExists")
+      info(s"AutoTopicCreation: Topics already exist: $topicAlreadyExists")
     if (otherErrors.nonEmpty)
-      warn(s"[AutoTopicCreation] Topics failed to create: ${otherErrors.map { case (t, e) => s"$t:$e" }.mkString(", ")}")
+      warn(s"AutoTopicCreation: Topics failed to create: ${otherErrors.map { case (t, e) => s"$t:$e" }.mkString(", ")}")
   }
 
   private def clearInflightRequests(creatableTopics: Map[String, CreatableTopic]): Unit = {

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -247,16 +247,10 @@ class DefaultAutoTopicCreationManager(
    * because its metadata cache hasn't fully loaded yet (e.g., at pod startup), but the topic already
    * exists in the cluster. This inflates observed counts and makes it impossible to identify real usage.
    *
-   * This method logs the actual outcome of each auto-creation attempt, categorized into three groups,
-   * all prefixed with "AutoTopicCreation:" for easy inLog querying:
-   *   - Successfully created: topic was genuinely new and written to the cluster.
-   *   - Already exist: topic was already present (TOPIC_ALREADY_EXISTS), common at pod startup.
-   *   - Failed: creation failed for other reasons (e.g., quota exceeded, invalid topic name).
    */
   private def logAutoTopicCreationResults(topicErrors: Map[String, Errors]): Unit = {
     // REQUEST_TIMED_OUT is treated as success: it means the topic metadata was written to ZooKeeper
-    // but leader election did not complete within the timeout. The topic will become fully available
-    // once a leader is elected, so this is a successful creation from the auto-topic perspective.
+    // but leader election did not complete within the timeout.
     val successfulCreations = topicErrors.collect { case (topic, error) if error == Errors.NONE || error == Errors.REQUEST_TIMED_OUT => topic }
     val topicAlreadyExists = topicErrors.collect { case (topic, error) if error == Errors.TOPIC_ALREADY_EXISTS => topic }
     val otherErrors = topicErrors.collect { case (topic, error) if error != Errors.NONE && error != Errors.REQUEST_TIMED_OUT && error != Errors.TOPIC_ALREADY_EXISTS => topic -> error }

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -251,16 +251,16 @@ class DefaultAutoTopicCreationManager(
   private def logAutoTopicCreationResults(topicErrors: Map[String, Errors]): Unit = {
     // REQUEST_TIMED_OUT is treated as success: it means the topic metadata was written to ZooKeeper
     // but leader election did not complete within the timeout.
-    val successfulCreations = topicErrors.collect { case (topic, error) if error == Errors.NONE || error == Errors.REQUEST_TIMED_OUT => topic }
-    val topicAlreadyExists = topicErrors.collect { case (topic, error) if error == Errors.TOPIC_ALREADY_EXISTS => topic }
-    val otherErrors = topicErrors.collect { case (topic, error) if error != Errors.NONE && error != Errors.REQUEST_TIMED_OUT && error != Errors.TOPIC_ALREADY_EXISTS => topic -> error }
+    val successfulCreations = topicErrors.filter(e => e._2 == Errors.NONE || e._2 == Errors.REQUEST_TIMED_OUT).keys
+    val topicAlreadyExists = topicErrors.filter(e => e._2 == Errors.TOPIC_ALREADY_EXISTS).keys
+    val otherErrors = topicErrors.filter(e => e._2 != Errors.NONE && e._2 != Errors.REQUEST_TIMED_OUT && e._2 != Errors.TOPIC_ALREADY_EXISTS)
 
     if (successfulCreations.nonEmpty)
       info(s"AutoTopicCreation: Topics successfully created: $successfulCreations")
     if (topicAlreadyExists.nonEmpty)
       info(s"AutoTopicCreation: Topics already exist: $topicAlreadyExists")
     if (otherErrors.nonEmpty)
-      warn(s"AutoTopicCreation: Topics failed to create: ${otherErrors.map { case (t, e) => s"$t:$e" }.mkString(", ")}")
+      warn(s"AutoTopicCreation: Topics failed to create: ${otherErrors.map(e => s"${e._1}:${e._2}").mkString(", ")}")
   }
 
   private def clearInflightRequests(creatableTopics: Map[String, CreatableTopic]): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1260,8 +1260,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       val nonExistingTopics = topics.diff(topicResponses.map(_.name).toSet)
       val nonExistingTopicResponses = if (allowAutoTopicCreation) {
         nonExistingTopics.foreach { topic =>
-          debug(
-            "Attempting auto topic creation: {" +
+          info(
+            "Automatically creating topic: {" +
               s"name=${topic}, partitions=${config.numPartitions}, replicationFactor=${config.defaultReplicationFactor}, " +
               s"principal=${request.context.principal}, IP=${request.context.clientAddress}, header=${request.context.header}" +
             "}"

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1260,8 +1260,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       val nonExistingTopics = topics.diff(topicResponses.map(_.name).toSet)
       val nonExistingTopicResponses = if (allowAutoTopicCreation) {
         nonExistingTopics.foreach { topic =>
-          info(
-            "Automatically creating topic: {" +
+          debug(
+            "Attempting auto topic creation: {" +
               s"name=${topic}, partitions=${config.numPartitions}, replicationFactor=${config.defaultReplicationFactor}, " +
               s"principal=${request.context.principal}, IP=${request.context.clientAddress}, header=${request.context.header}" +
             "}"

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -442,6 +442,36 @@ class AutoTopicCreationManagerTest {
         e.getMessage.toString.contains(s"$topicName:${Errors.INVALID_REPLICATION_FACTOR}")))
   }
 
+  @Test
+  def testCreateTopicsInZkWithMultipleTopicsLogsSeparateCategories(): Unit = {
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config, None, Some(adminManager), Some(controller), groupCoordinator, transactionCoordinator)
+    Mockito.when(controller.isActive).thenReturn(false)
+
+    val topicErrors = Map("topic1" -> new ApiError(Errors.NONE), "topic2" -> new ApiError(Errors.TOPIC_ALREADY_EXISTS))
+    Mockito.when(adminManager.createTopics(
+      ArgumentMatchers.eq(0),
+      ArgumentMatchers.eq(false),
+      any(),
+      ArgumentMatchers.eq(Map.empty),
+      any(classOf[ControllerMutationQuota]),
+      any(classOf[Map[String, ApiError] => Unit])
+    )).thenAnswer((invocation: InvocationOnMock) => {
+      invocation.getArgument(5).asInstanceOf[Map[String, ApiError] => Unit].apply(topicErrors)
+    })
+
+    val messages = executeWithLogCapture {
+      autoTopicCreationManager.createTopics(Set("topic1", "topic2"), UnboundedControllerMutationQuota, None)
+    }
+
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics successfully created") &&
+        e.getMessage.toString.contains("topic1")))
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics already exist") &&
+        e.getMessage.toString.contains("topic2")))
+  }
+
   // ---- Tests for onComplete logging in sendCreateTopicRequest ----
 
   @Test
@@ -496,6 +526,27 @@ class AutoTopicCreationManagerTest {
   }
 
   @Test
+  def testOnCompleteWithMultipleTopicsLogsSeparateCategories(): Unit = {
+    val topicNames = Set("topic1", "topic2")
+    val handler = setupAndCaptureCompletionHandler(topicNames)
+    val messages = executeWithLogCapture {
+      handler.onComplete(buildCreateTopicsClientResponse(
+        Map("topic1" -> Errors.NONE, "topic2" -> Errors.TOPIC_ALREADY_EXISTS)))
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics successfully created") &&
+        e.getMessage.toString.contains("topic1")))
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics already exist") &&
+        e.getMessage.toString.contains("topic2")))
+    // Verify both topics are cleared from inflight
+    Mockito.reset(brokerToController)
+    Mockito.when(brokerToController.controllerApiVersions()).thenReturn(None)
+    autoTopicCreationManager.createTopics(topicNames, UnboundedControllerMutationQuota, None)
+    Mockito.verify(brokerToController).sendRequest(any(), any())
+  }
+
+  @Test
   def testOnCompleteWithNullResponseBodyLogsWarning(): Unit = {
     val topicName = "topic"
     val handler = setupAndCaptureCompletionHandler(topicName)
@@ -537,7 +588,10 @@ class AutoTopicCreationManagerTest {
     }
   }
 
-  private def setupAndCaptureCompletionHandler(topicName: String): RequestCompletionHandler = {
+  private def setupAndCaptureCompletionHandler(topicName: String): RequestCompletionHandler =
+    setupAndCaptureCompletionHandler(Set(topicName))
+
+  private def setupAndCaptureCompletionHandler(topicNames: Set[String]): RequestCompletionHandler = {
     autoTopicCreationManager = new DefaultAutoTopicCreationManager(
       config,
       Some(brokerToController),
@@ -547,7 +601,7 @@ class AutoTopicCreationManagerTest {
       transactionCoordinator)
     Mockito.when(controller.isActive).thenReturn(false)
     Mockito.when(brokerToController.controllerApiVersions()).thenReturn(None)
-    autoTopicCreationManager.createTopics(Set(topicName), UnboundedControllerMutationQuota, None)
+    autoTopicCreationManager.createTopics(topicNames, UnboundedControllerMutationQuota, None)
 
     val captor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
     Mockito.verify(brokerToController).sendRequest(any(), captor.capture())
@@ -563,9 +617,12 @@ class AutoTopicCreationManagerTest {
     Mockito.verify(brokerToController).sendRequest(any(), any())
   }
 
-  private def buildCreateTopicsClientResponse(topicName: String, error: Errors): ClientResponse = {
+  private def buildCreateTopicsClientResponse(topicName: String, error: Errors): ClientResponse =
+    buildCreateTopicsClientResponse(Map(topicName -> error))
+
+  private def buildCreateTopicsClientResponse(topicsWithErrors: Map[String, Errors]): ClientResponse = {
     val responseData = new CreateTopicsResponseData()
-    responseData.topics().add(new CreatableTopicResult().setName(topicName).setErrorCode(error.code))
+    topicsWithErrors.foreach(e => responseData.topics().add(new CreatableTopicResult().setName(e._1).setErrorCode(e._2.code)))
     val header = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion, "client", 1)
     new ClientResponse(header, null, null, 0, 0, false, null, null, new CreateTopicsResponse(responseData))
   }

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -448,7 +448,14 @@ class AutoTopicCreationManagerTest {
       config, None, Some(adminManager), Some(controller), groupCoordinator, transactionCoordinator)
     Mockito.when(controller.isActive).thenReturn(false)
 
-    val topicErrors = Map("topic1" -> new ApiError(Errors.NONE), "topic2" -> new ApiError(Errors.TOPIC_ALREADY_EXISTS))
+    val topicErrors = Map(
+      "topic1" -> new ApiError(Errors.NONE),
+      "topic2" -> new ApiError(Errors.NONE),
+      "topic3" -> new ApiError(Errors.TOPIC_ALREADY_EXISTS),
+      "topic4" -> new ApiError(Errors.TOPIC_ALREADY_EXISTS),
+      "topic5" -> new ApiError(Errors.INVALID_REPLICATION_FACTOR),
+      "topic6" -> new ApiError(Errors.INVALID_TOPIC_EXCEPTION)
+    )
     Mockito.when(adminManager.createTopics(
       ArgumentMatchers.eq(0),
       ArgumentMatchers.eq(false),
@@ -461,15 +468,20 @@ class AutoTopicCreationManagerTest {
     })
 
     val messages = executeWithLogCapture {
-      autoTopicCreationManager.createTopics(Set("topic1", "topic2"), UnboundedControllerMutationQuota, None)
+      autoTopicCreationManager.createTopics(
+        Set("topic1", "topic2", "topic3", "topic4", "topic5", "topic6"), UnboundedControllerMutationQuota, None)
     }
 
     assertTrue(messages.exists(e =>
       e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics successfully created") &&
-        e.getMessage.toString.contains("topic1")))
+        e.getMessage.toString.contains("topic1") && e.getMessage.toString.contains("topic2")))
     assertTrue(messages.exists(e =>
       e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics already exist") &&
-        e.getMessage.toString.contains("topic2")))
+        e.getMessage.toString.contains("topic3") && e.getMessage.toString.contains("topic4")))
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.WARN && e.getMessage.toString.contains("AutoTopicCreation: Topics failed to create") &&
+        e.getMessage.toString.contains(s"topic5:${Errors.INVALID_REPLICATION_FACTOR}") &&
+        e.getMessage.toString.contains(s"topic6:${Errors.INVALID_TOPIC_EXCEPTION}")))
   }
 
   // ---- Tests for onComplete logging in sendCreateTopicRequest ----
@@ -527,19 +539,29 @@ class AutoTopicCreationManagerTest {
 
   @Test
   def testOnCompleteWithMultipleTopicsLogsSeparateCategories(): Unit = {
-    val topicNames = Set("topic1", "topic2")
+    val topicNames = Set("topic1", "topic2", "topic3", "topic4", "topic5", "topic6")
     val handler = setupAndCaptureCompletionHandler(topicNames)
     val messages = executeWithLogCapture {
-      handler.onComplete(buildCreateTopicsClientResponse(
-        Map("topic1" -> Errors.NONE, "topic2" -> Errors.TOPIC_ALREADY_EXISTS)))
+      handler.onComplete(buildCreateTopicsClientResponse(Map(
+        "topic1" -> Errors.NONE,
+        "topic2" -> Errors.NONE,
+        "topic3" -> Errors.TOPIC_ALREADY_EXISTS,
+        "topic4" -> Errors.TOPIC_ALREADY_EXISTS,
+        "topic5" -> Errors.INVALID_REPLICATION_FACTOR,
+        "topic6" -> Errors.INVALID_TOPIC_EXCEPTION
+      )))
     }
     assertTrue(messages.exists(e =>
       e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics successfully created") &&
-        e.getMessage.toString.contains("topic1")))
+        e.getMessage.toString.contains("topic1") && e.getMessage.toString.contains("topic2")))
     assertTrue(messages.exists(e =>
       e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics already exist") &&
-        e.getMessage.toString.contains("topic2")))
-    // Verify both topics are cleared from inflight
+        e.getMessage.toString.contains("topic3") && e.getMessage.toString.contains("topic4")))
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.WARN && e.getMessage.toString.contains("AutoTopicCreation: Topics failed to create") &&
+        e.getMessage.toString.contains(s"topic5:${Errors.INVALID_REPLICATION_FACTOR}") &&
+        e.getMessage.toString.contains(s"topic6:${Errors.INVALID_TOPIC_EXCEPTION}")))
+    // Verify all topics are cleared from inflight
     Mockito.reset(brokerToController)
     Mockito.when(brokerToController.controllerApiVersions()).thenReturn(None)
     autoTopicCreationManager.createTopics(topicNames, UnboundedControllerMutationQuota, None)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -397,6 +397,51 @@ class AutoTopicCreationManagerTest {
     assertEquals(expectedResponses, topicResponses)
   }
 
+  // ---- Tests for createTopicsInZk logging ----
+
+  @Test
+  def testCreateTopicsInZkWithNoneLogsAsSuccessfulCreation(): Unit = {
+    val topicName = "topic"
+    val messages = executeWithLogCapture {
+      testErrorWithCreationInZk(Errors.NONE, topicName, isInternal = false)
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics successfully created")))
+  }
+
+  @Test
+  def testCreateTopicsInZkWithRequestTimedOutLogsAsSuccessfulCreation(): Unit = {
+    val topicName = "topic"
+    val messages = executeWithLogCapture {
+      testErrorWithCreationInZk(Errors.REQUEST_TIMED_OUT, topicName, isInternal = false,
+        expectedError = Some(Errors.LEADER_NOT_AVAILABLE))
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics successfully created")))
+  }
+
+  @Test
+  def testCreateTopicsInZkWithTopicAlreadyExistsLogsAsAlreadyExist(): Unit = {
+    val topicName = "topic"
+    val messages = executeWithLogCapture {
+      testErrorWithCreationInZk(Errors.TOPIC_ALREADY_EXISTS, topicName, isInternal = false,
+        expectedError = Some(Errors.LEADER_NOT_AVAILABLE))
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics already exist")))
+  }
+
+  @Test
+  def testCreateTopicsInZkWithOtherErrorLogsAsFailure(): Unit = {
+    val topicName = "topic"
+    val messages = executeWithLogCapture {
+      testErrorWithCreationInZk(Errors.INVALID_REPLICATION_FACTOR, topicName, isInternal = false)
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.WARN && e.getMessage.toString.contains("AutoTopicCreation: Topics failed to create") &&
+        e.getMessage.toString.contains(s"$topicName:${Errors.INVALID_REPLICATION_FACTOR}")))
+  }
+
   // ---- Tests for onComplete logging in sendCreateTopicRequest ----
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -45,6 +45,9 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.{ArgumentCaptor, ArgumentMatchers, Mockito}
 
+import kafka.utils.LogCaptureAppender
+import org.apache.log4j.Level
+
 import scala.collection.{Map, Seq}
 
 class AutoTopicCreationManagerTest {
@@ -400,7 +403,11 @@ class AutoTopicCreationManagerTest {
   def testOnCompleteWithNoneLogsAsSuccessfulCreation(): Unit = {
     val topicName = "topic"
     val handler = setupAndCaptureCompletionHandler(topicName)
-    handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.NONE))
+    val messages = executeWithLogCapture {
+      handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.NONE))
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics successfully created")))
     verifyInflightCleared(topicName)
   }
 
@@ -410,7 +417,11 @@ class AutoTopicCreationManagerTest {
     val handler = setupAndCaptureCompletionHandler(topicName)
     // REQUEST_TIMED_OUT means the topic was written to ZooKeeper but leader election
     // did not complete within the timeout — treated as a successful creation.
-    handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.REQUEST_TIMED_OUT))
+    val messages = executeWithLogCapture {
+      handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.REQUEST_TIMED_OUT))
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics successfully created")))
     verifyInflightCleared(topicName)
   }
 
@@ -418,7 +429,11 @@ class AutoTopicCreationManagerTest {
   def testOnCompleteWithTopicAlreadyExistsLogsAsAlreadyExist(): Unit = {
     val topicName = "topic"
     val handler = setupAndCaptureCompletionHandler(topicName)
-    handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.TOPIC_ALREADY_EXISTS))
+    val messages = executeWithLogCapture {
+      handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.TOPIC_ALREADY_EXISTS))
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.INFO && e.getMessage.toString.contains("AutoTopicCreation: Topics already exist")))
     verifyInflightCleared(topicName)
   }
 
@@ -426,7 +441,12 @@ class AutoTopicCreationManagerTest {
   def testOnCompleteWithOtherErrorLogsAsFailure(): Unit = {
     val topicName = "topic"
     val handler = setupAndCaptureCompletionHandler(topicName)
-    handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.INVALID_TOPIC_EXCEPTION))
+    val messages = executeWithLogCapture {
+      handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.INVALID_TOPIC_EXCEPTION))
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.WARN && e.getMessage.toString.contains("AutoTopicCreation: Topics failed to create") &&
+        e.getMessage.toString.contains(s"$topicName:${Errors.INVALID_TOPIC_EXCEPTION}")))
     verifyInflightCleared(topicName)
   }
 
@@ -436,7 +456,11 @@ class AutoTopicCreationManagerTest {
     val handler = setupAndCaptureCompletionHandler(topicName)
     val header = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion, "client", 1)
     val clientResponse = new ClientResponse(header, null, null, 0, 0, false, null, null, null)
-    handler.onComplete(clientResponse)
+    val messages = executeWithLogCapture {
+      handler.onComplete(clientResponse)
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.WARN && e.getMessage.toString.contains("AutoTopicCreation: Received null response body")))
     verifyInflightCleared(topicName)
   }
 
@@ -448,8 +472,24 @@ class AutoTopicCreationManagerTest {
     // EnvelopeResponse is not a CreateTopicsResponse — exercises the unexpected-type branch
     val unexpectedResponse = new EnvelopeResponse(ByteBuffer.allocate(0), Errors.NONE)
     val clientResponse = new ClientResponse(header, null, null, 0, 0, false, null, null, unexpectedResponse)
-    handler.onComplete(clientResponse)
+    val messages = executeWithLogCapture {
+      handler.onComplete(clientResponse)
+    }
+    assertTrue(messages.exists(e =>
+      e.getLevel == Level.WARN && e.getMessage.toString.contains("AutoTopicCreation: Unexpected response type")))
     verifyInflightCleared(topicName)
+  }
+
+  private def executeWithLogCapture(body: => Unit) = {
+    val appender = LogCaptureAppender.createAndRegister()
+    val previousLevel = LogCaptureAppender.setClassLoggerLevel(classOf[DefaultAutoTopicCreationManager], Level.INFO)
+    try {
+      body
+      appender.getMessages
+    } finally {
+      LogCaptureAppender.setClassLoggerLevel(classOf[DefaultAutoTopicCreationManager], previousLevel)
+      LogCaptureAppender.unregister(appender)
+    }
   }
 
   private def setupAndCaptureCompletionHandler(topicName: String): RequestCompletionHandler = {

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -30,8 +30,9 @@ import org.apache.kafka.clients.{ClientResponse, NodeApiVersions, RequestComplet
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME}
-import org.apache.kafka.common.message.{ApiVersionsResponseData, CreateTopicsRequestData}
+import org.apache.kafka.common.message.{ApiVersionsResponseData, CreateTopicsRequestData, CreateTopicsResponseData}
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic
+import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
@@ -391,6 +392,97 @@ class AutoTopicCreationManagerTest {
       .setName(topicName))
 
     assertEquals(expectedResponses, topicResponses)
+  }
+
+  // ---- Tests for onComplete logging in sendCreateTopicRequest ----
+
+  @Test
+  def testOnCompleteWithNoneLogsAsSuccessfulCreation(): Unit = {
+    val topicName = "topic"
+    val handler = setupAndCaptureCompletionHandler(topicName)
+    handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.NONE))
+    verifyInflightCleared(topicName)
+  }
+
+  @Test
+  def testOnCompleteWithRequestTimedOutLogsAsSuccessfulCreation(): Unit = {
+    val topicName = "topic"
+    val handler = setupAndCaptureCompletionHandler(topicName)
+    // REQUEST_TIMED_OUT means the topic was written to ZooKeeper but leader election
+    // did not complete within the timeout — treated as a successful creation.
+    handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.REQUEST_TIMED_OUT))
+    verifyInflightCleared(topicName)
+  }
+
+  @Test
+  def testOnCompleteWithTopicAlreadyExistsLogsAsAlreadyExist(): Unit = {
+    val topicName = "topic"
+    val handler = setupAndCaptureCompletionHandler(topicName)
+    handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.TOPIC_ALREADY_EXISTS))
+    verifyInflightCleared(topicName)
+  }
+
+  @Test
+  def testOnCompleteWithOtherErrorLogsAsFailure(): Unit = {
+    val topicName = "topic"
+    val handler = setupAndCaptureCompletionHandler(topicName)
+    handler.onComplete(buildCreateTopicsClientResponse(topicName, Errors.INVALID_TOPIC_EXCEPTION))
+    verifyInflightCleared(topicName)
+  }
+
+  @Test
+  def testOnCompleteWithNullResponseBodyLogsWarning(): Unit = {
+    val topicName = "topic"
+    val handler = setupAndCaptureCompletionHandler(topicName)
+    val header = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion, "client", 1)
+    val clientResponse = new ClientResponse(header, null, null, 0, 0, false, null, null, null)
+    handler.onComplete(clientResponse)
+    verifyInflightCleared(topicName)
+  }
+
+  @Test
+  def testOnCompleteWithUnexpectedResponseTypeLogsWarning(): Unit = {
+    val topicName = "topic"
+    val handler = setupAndCaptureCompletionHandler(topicName)
+    val header = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion, "client", 1)
+    // EnvelopeResponse is not a CreateTopicsResponse — exercises the unexpected-type branch
+    val unexpectedResponse = new EnvelopeResponse(ByteBuffer.allocate(0), Errors.NONE)
+    val clientResponse = new ClientResponse(header, null, null, 0, 0, false, null, null, unexpectedResponse)
+    handler.onComplete(clientResponse)
+    verifyInflightCleared(topicName)
+  }
+
+  private def setupAndCaptureCompletionHandler(topicName: String): RequestCompletionHandler = {
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+      config,
+      Some(brokerToController),
+      Some(adminManager),
+      Some(controller),
+      groupCoordinator,
+      transactionCoordinator)
+    Mockito.when(controller.isActive).thenReturn(false)
+    Mockito.when(brokerToController.controllerApiVersions()).thenReturn(None)
+    autoTopicCreationManager.createTopics(Set(topicName), UnboundedControllerMutationQuota, None)
+
+    val captor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+    Mockito.verify(brokerToController).sendRequest(any(), captor.capture())
+    captor.getValue.asInstanceOf[RequestCompletionHandler]
+  }
+
+  private def verifyInflightCleared(topicName: String): Unit = {
+    // After onComplete, inflight topics must be cleared so a subsequent createTopics
+    // call for the same topic triggers a new sendRequest rather than being suppressed.
+    Mockito.reset(brokerToController)
+    Mockito.when(brokerToController.controllerApiVersions()).thenReturn(None)
+    autoTopicCreationManager.createTopics(Set(topicName), UnboundedControllerMutationQuota, None)
+    Mockito.verify(brokerToController).sendRequest(any(), any())
+  }
+
+  private def buildCreateTopicsClientResponse(topicName: String, error: Errors): ClientResponse = {
+    val responseData = new CreateTopicsResponseData()
+    responseData.topics().add(new CreatableTopicResult().setName(topicName).setErrorCode(error.code))
+    val header = new RequestHeader(ApiKeys.CREATE_TOPICS, ApiKeys.CREATE_TOPICS.latestVersion, "client", 1)
+    new ClientResponse(header, null, null, 0, 0, false, null, null, new CreateTopicsResponse(responseData))
   }
 
   private def getNewTopic(topicName: String, numPartitions: Int = 1, replicationFactor: Short = 1): CreatableTopic = {


### PR DESCRIPTION
 ## Background
TICKET = LIKAFKA-61529
We are planning to disable the auto-topic creation feature. Before doing so, we need to identify which topics are genuinely being created through this mechanism and reach out to the clients relying on it.

## Problem
The existing "Automatically creating topic:" log fires before the creation attempt and cannot distinguish:
  - True new creations — the topic did not exist and was successfully written to the cluster.
  - False positives — the broker triggers auto-creation because its metadata cache hasn't fully loaded yet (e.g., at pod startup), but the topic already exists (TOPIC_ALREADY_EXISTS). These inflate inLog counts
  without representing any actual new topic creation.

 ## Solution
Add auto-topic creation outcome logging in DefaultAutoTopicCreationManager after the creation result is known.
