### PR TITLE
kafka: add protocol bridge mode to 3.0-li

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -45,6 +45,58 @@ import scala.collection.{Map, Seq, Set, mutable}
 object ControllerChannelManager {
   val QueueSizeMetricName = "QueueSize"
   val RequestRateAndQueueTimeMetricName = "RequestRateAndQueueTimeMs"
+
+  // Commit 74dca03f5bf3561c3694605fd15dc7b7c6502de8 added MaxBrokerEpoch to LeaderAndIsr v3,
+  // UpdateMetadata v6, and StopReplica v2 in 3.0-li. Apache later used those version numbers for
+  // different changes. The preceding versions are therefore the newest formats shared by both
+  // codebases. This can be checked by comparing the three request schemas under
+  // clients/src/main/resources/common/message at these revisions:
+  //   3.0-li:          31df5cec3298e31b55888307929904df83cc8753
+  //   Apache 3.9.2:   5e9866f43ab8e7e41ef39e5584ac50019381328d
+  // Cross-artifact tests must still compare the encoded requests and responses before the bridge is
+  // used with an upstream-based broker.
+  private[controller] val BridgeLeaderAndIsrRequestVersion: Short = 2
+  private[controller] val BridgeUpdateMetadataRequestVersion: Short = 5
+  private[controller] val BridgeStopReplicaRequestVersion: Short = 1
+
+  private[controller] def leaderAndIsrRequestVersion(interBrokerProtocolVersion: ApiVersion,
+                                                      bridgeMode: Boolean): Short = {
+    // KafkaConfig rejects bridge mode below 2.2. Keep this guard so direct callers still select a
+    // request version that the configured IBP supports.
+    if (bridgeMode && interBrokerProtocolVersion >= KAFKA_2_2_IV0) BridgeLeaderAndIsrRequestVersion
+    else if (interBrokerProtocolVersion >= KAFKA_2_8_IV1) 6
+    else if (interBrokerProtocolVersion >= KAFKA_2_4_IV1) 5
+    else if (interBrokerProtocolVersion >= KAFKA_2_4_IV0) 4
+    else if (interBrokerProtocolVersion >= KAFKA_2_3_IV2) 3
+    else if (interBrokerProtocolVersion >= KAFKA_2_2_IV0) 2
+    else if (interBrokerProtocolVersion >= KAFKA_1_0_IV0) 1
+    else 0
+  }
+
+  private[controller] def updateMetadataRequestVersion(interBrokerProtocolVersion: ApiVersion,
+                                                        bridgeMode: Boolean): Short = {
+    if (bridgeMode && interBrokerProtocolVersion >= KAFKA_2_2_IV0) BridgeUpdateMetadataRequestVersion
+    else if (interBrokerProtocolVersion >= KAFKA_2_8_IV1) 8
+    else if (interBrokerProtocolVersion >= KAFKA_2_4_IV1) 7
+    else if (interBrokerProtocolVersion >= KAFKA_2_3_IV2) 6
+    else if (interBrokerProtocolVersion >= KAFKA_2_2_IV0) 5
+    else if (interBrokerProtocolVersion >= KAFKA_1_0_IV0) 4
+    else if (interBrokerProtocolVersion >= KAFKA_0_10_2_IV0) 3
+    else if (interBrokerProtocolVersion >= KAFKA_0_10_0_IV1) 2
+    else if (interBrokerProtocolVersion >= KAFKA_0_9_0) 1
+    else 0
+  }
+
+  private[controller] def stopReplicaRequestVersion(interBrokerProtocolVersion: ApiVersion,
+                                                     bridgeMode: Boolean): Short = {
+    if (bridgeMode && interBrokerProtocolVersion >= KAFKA_2_2_IV0) BridgeStopReplicaRequestVersion
+    else if (interBrokerProtocolVersion >= KAFKA_2_6_IV0) 4
+    else if (interBrokerProtocolVersion >= KAFKA_2_4_IV1) 3
+    else if (interBrokerProtocolVersion >= KAFKA_2_3_IV2) 2
+    else if (interBrokerProtocolVersion >= KAFKA_2_2_IV0) 1
+    else 0
+  }
+
   val SupportedRequestApiKeys: Set[ApiKeys] = Set(
     ApiKeys.STOP_REPLICA,
     ApiKeys.LEADER_AND_ISR,
@@ -72,7 +124,6 @@ class ControllerChannelManager(controllerContext: ControllerContext,
       brokerStateInfo.values.iterator.map(_.messageQueue.size).sum
     }
   )
-
   def startup() = {
     controllerContext.liveOrShuttingDownBrokers.foreach(addNewBroker)
 
@@ -257,7 +308,7 @@ class RequestSendThread(val controllerId: Int,
 
   private val controllerRequestMerger = new ControllerRequestMerger(config)
 
-  private var firstUpdateMetadataWithPartitionsSent = false
+  private[controller] var firstUpdateMetadataWithPartitionsSent = false
 
   @volatile private var latestRequestStatus = LatestRequestStatus(isInFlight = false, isInQueue = false, 0)
 
@@ -298,6 +349,13 @@ class RequestSendThread(val controllerId: Int,
    */
   private def takeFromQueueAndMerge(): Option[(Long, Boolean)] = {
     val queueItem = queue.take()
+    // The sender may have blocked in take() before activation. Decide whether to admit this
+    // item to the merger only after dequeueing it. Put it back for the ordinary send path if
+    // bridge mode is now visible; its callback must not be discarded or delivered twice.
+    if (config.liProtocolBridgeModeEnable) {
+      queue.putFirst(queueItem)
+      return None
+    }
     val QueueItem(apiKey, requestBuilder, callback, enqueueTimeMs) = queueItem
     // Request can either be a control request (that can be sent only from a controller to a broker), or a
     // generic Kafka request (like ListOffsetsRequest).
@@ -321,11 +379,19 @@ class RequestSendThread(val controllerId: Int,
     (requestBuilder, callback)
   }
 
-  private def nextRequestAndCallback(): (AbstractRequest.Builder[_ <: AbstractRequest], AbstractResponse => Unit) = {
-    if (controllerRequestMerger.hasPendingRequests() ||
-      (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1 &&
-        config.liCombinedControlRequestEnable &&
-        firstUpdateMetadataWithPartitionsSent)) {
+  private[controller] def nextRequestAndCallback(): (AbstractRequest.Builder[_ <: AbstractRequest], AbstractResponse => Unit) = {
+    val bridgeMode = config.liProtocolBridgeModeEnable
+    if (bridgeMode && controllerRequestMerger.hasPendingRequests()) {
+      // A dynamic activation can find a batch already admitted to the merger. Drain it without
+      // admitting more work. The admission check can race with config publication, so the rollout
+      // must still restart the all-3.0 controller before starting any 3.9 broker. The new controller
+      // starts with empty queues and never enters the merging path.
+      (controllerRequestMerger.pollLatestRequest(), controllerRequestMerger.triggerCallback _)
+    } else if (!bridgeMode &&
+      (controllerRequestMerger.hasPendingRequests() ||
+        (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1 &&
+          config.liCombinedControlRequestEnable &&
+          firstUpdateMetadataWithPartitionsSent))) {
       // Only start the merging logic after the first UpdateMetadata request with partitions,
       // since the first UpdateMetadata request with partitions may contain hundreds of thousands of partitions,
       // and thus needs to be cached and shared by all brokers in order to prevent OOM
@@ -358,7 +424,7 @@ class RequestSendThread(val controllerId: Int,
       // one concurrent access case considering the producer of the queue:
       // an item is put to the queue right after the condition check below.
       // That behavior does not change correctness since the inserted item will be picked up in the next round
-      while (!queue.isEmpty && shouldContinueMerging) {
+      while (!config.liProtocolBridgeModeEnable && !queue.isEmpty && shouldContinueMerging) {
         // Continue merging if the item taken from the queue is a
         // control request and has set `shouldContinueMerging` to true
         shouldContinueMerging = takeFromQueueAndMerge().exists(_._2)
@@ -514,11 +580,14 @@ class ControllerBrokerRequestBatch(config: KafkaConfig,
 abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
                                                     controllerContext: ControllerContext,
                                                     stateChangeLogger: StateChangeLogger) extends Logging {
+  import ControllerChannelManager._
+
   val controllerId: Int = config.brokerId
   val leaderAndIsrRequestMap = mutable.Map.empty[Int, mutable.Map[TopicPartition, LeaderAndIsrPartitionState]]
   val stopReplicaRequestMap = mutable.Map.empty[Int, mutable.Map[TopicPartition, StopReplicaPartitionState]]
   val updateMetadataRequestBrokerSet = mutable.Set.empty[Int]
   val updateMetadataRequestPartitionInfoMap = mutable.Map.empty[TopicPartition, UpdateMetadataPartitionState]
+  private var lastLoggedBridgeMode: Option[Boolean] = None
 
   def sendEvent(event: ControllerEvent): Unit
 
@@ -651,15 +720,10 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
       beingDeleted = controllerContext.topicsToBeDeleted.contains(partition.topic)))  // [PERF:  topicsToBeDeleted's contrib is nonexistent in orig profile (makes sense: not deleting any topics), but should profile Venice cluster's controller init: TODO]
   }
 
-  private def sendLeaderAndIsrRequest(controllerEpoch: Int, stateChangeLog: StateChangeLogger): Unit = {
-    val leaderAndIsrRequestVersion: Short =
-      if (config.interBrokerProtocolVersion >= KAFKA_2_8_IV1) 6
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 5
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV0) 4
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_3_IV2) 3
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_2_IV0) 2
-      else if (config.interBrokerProtocolVersion >= KAFKA_1_0_IV0) 1
-      else 0
+  private def sendLeaderAndIsrRequest(controllerEpoch: Int, stateChangeLog: StateChangeLogger,
+                                      bridgeMode: Boolean): Unit = {
+    val leaderAndIsrRequestVersion = ControllerChannelManager.leaderAndIsrRequestVersion(
+      config.interBrokerProtocolVersion, bridgeMode)
 
     val maxBrokerEpoch = controllerContext.maxBrokerEpoch
     leaderAndIsrRequestMap.forKeyValue { (broker, leaderAndIsrPartitionStates) =>
@@ -709,21 +773,14 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
     leaderAndIsrRequestMap.clear()
   }
 
-  private def sendUpdateMetadataRequests(controllerEpoch: Int, stateChangeLog: StateChangeLogger): Unit = {
+  private def sendUpdateMetadataRequests(controllerEpoch: Int, stateChangeLog: StateChangeLogger,
+                                         bridgeMode: Boolean): Unit = {
     stateChangeLog.info(s"Sending UpdateMetadata request to brokers $updateMetadataRequestBrokerSet " +
       s"for ${updateMetadataRequestPartitionInfoMap.size} partitions")
 
     val partitionStates = updateMetadataRequestPartitionInfoMap.values.toBuffer
-    val updateMetadataRequestVersion: Short =
-      if (config.interBrokerProtocolVersion >= KAFKA_2_8_IV1) 8
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 7
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_3_IV2) 6
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_2_IV0) 5
-      else if (config.interBrokerProtocolVersion >= KAFKA_1_0_IV0) 4
-      else if (config.interBrokerProtocolVersion >= KAFKA_0_10_2_IV0) 3
-      else if (config.interBrokerProtocolVersion >= KAFKA_0_10_0_IV1) 2
-      else if (config.interBrokerProtocolVersion >= KAFKA_0_9_0) 1
-      else 0
+    val updateMetadataRequestVersion = ControllerChannelManager.updateMetadataRequestVersion(
+      config.interBrokerProtocolVersion, bridgeMode)
 
     val liveBrokers = controllerContext.liveOrShuttingDownBrokers.iterator.map { broker =>
       val endpoints = if (updateMetadataRequestVersion == 0) {
@@ -785,14 +842,11 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
     updateMetadataRequestPartitionInfoMap.clear()
   }
 
-  private def sendStopReplicaRequests(controllerEpoch: Int, stateChangeLog: StateChangeLogger): Unit = {
+  private def sendStopReplicaRequests(controllerEpoch: Int, stateChangeLog: StateChangeLogger,
+                                      bridgeMode: Boolean): Unit = {
     val traceEnabled = stateChangeLog.isTraceEnabled
-    val stopReplicaRequestVersion: Short =
-      if (config.interBrokerProtocolVersion >= KAFKA_2_6_IV0) 4
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_4_IV1) 3
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_3_IV2) 2
-      else if (config.interBrokerProtocolVersion >= KAFKA_2_2_IV0) 1
-      else 0
+    val stopReplicaRequestVersion = ControllerChannelManager.stopReplicaRequestVersion(
+      config.interBrokerProtocolVersion, bridgeMode)
 
     /**
      * For StopReplica request version < 4, we rely on the isPartitionDeleted function to check a partition's delete flag,
@@ -888,9 +942,25 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
   def sendRequestsToBrokers(controllerEpoch: Int): Unit = {
     try {
       val stateChangeLog = stateChangeLogger.withControllerEpoch(controllerEpoch)
-      sendLeaderAndIsrRequest(controllerEpoch, stateChangeLog)
-      sendUpdateMetadataRequests(controllerEpoch, stateChangeLog)
-      sendStopReplicaRequests(controllerEpoch, stateChangeLog)
+      val bridgeMode = config.liProtocolBridgeModeEnable
+      if (!lastLoggedBridgeMode.contains(bridgeMode)) {
+        if (bridgeMode) {
+          info(s"LI protocol bridge mode enabled: LeaderAndIsr=v$BridgeLeaderAndIsrRequestVersion, " +
+            s"UpdateMetadata=v$BridgeUpdateMetadataRequestVersion, StopReplica=v$BridgeStopReplicaRequestVersion, " +
+            "LiCombinedControl=disabled")
+          warn("Protocol bridge mode disables shared MaxBrokerEpoch and new combined-control requests. " +
+            "Restart the controller before adding a 3.9 broker, then monitor controller heap, GC, request queues, " +
+            "and failover time while bridge mode is enabled.")
+        } else if (lastLoggedBridgeMode.contains(true)) {
+          info("LI protocol bridge mode disabled: using request versions selected by inter.broker.protocol.version")
+        }
+        lastLoggedBridgeMode = Some(bridgeMode)
+      }
+      // Use one bridge-mode snapshot for the whole controller batch. A dynamic config update takes
+      // effect on the next batch rather than producing mixed request generations in this batch.
+      sendLeaderAndIsrRequest(controllerEpoch, stateChangeLog, bridgeMode)
+      sendUpdateMetadataRequests(controllerEpoch, stateChangeLog, bridgeMode)
+      sendStopReplicaRequests(controllerEpoch, stateChangeLog, bridgeMode)
     } catch {
       case e: Throwable =>
         if (leaderAndIsrRequestMap.nonEmpty) {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -360,7 +360,12 @@ class KafkaController(val config: KafkaConfig,
     info(s"Sending update metadata request ${KafkaController.timing(-1, failoverStartMs, time)}")
     val controllerContextSnapshot = ControllerContextSnapshot(controllerContext)
     // PERF TODO:  add controllerContextSnapshot as optional (defaultable) 3rd arg:
-    sendUpdateMetadataRequest(controllerContextSnapshot.liveOrShuttingDownBrokerIds.toSeq, Set.empty)
+    val initialMetadataPartitions = if (config.liProtocolBridgeTopicDeletionStateCleanupActive)
+      controllerContext.partitionsLeadershipInfo.keySet.toSet
+    else Set.empty[TopicPartition]
+    // With cleanup enabled, each new controller epoch starts with a complete cache image.
+    // This lets receivers discard entries whose deletion update was lost during failover.
+    sendUpdateMetadataRequest(controllerContextSnapshot.liveOrShuttingDownBrokerIds.toSeq, initialMetadataPartitions)
 
     maybeCleanIsrsForCorruptedBrokers(controllerContext.corruptedBrokers)
 

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -273,6 +273,11 @@ class TopicDeletionManager(config: KafkaConfig,
     // controller will remove this replica from the state machine as well as its partition assignment cache
     replicaStateMachine.handleStateChanges(replicasForDeletedTopic.toSeq, NonExistentReplica)
     client.deleteTopic(topic, controllerContext.epochZkVersion)
+    if (config.liProtocolBridgeTopicDeletionStateCleanupActive) {
+      // A reassignment can block deletion just before its last callback succeeds.
+      // Do not let a later topic with the same name inherit that old block.
+      controllerContext.topicsIneligibleForDeletion -= topic
+    }
     controllerContext.removeTopic(topic)
   }
 
@@ -340,6 +345,13 @@ class TopicDeletionManager(config: KafkaConfig,
       }
     }
 
+    if (config.liProtocolBridgeModeEnable && allDeadReplicas.nonEmpty) {
+      // Bridge requests cannot encode the full-state cleanup used by LI after rejoin.
+      // Retain these assignments until the returning broker acknowledges StopReplica.
+      replicaStateMachine.handleStateChanges(allDeadReplicas, ReplicaDeletionIneligible)
+      markTopicIneligibleForDeletion(allDeadReplicas.map(_.topic).toSet, reason = "offline replicas in bridge mode")
+    }
+
     // send stop replica to all followers that are not in the OfflineReplica state so they stop sending fetch requests to the leader
     replicaStateMachine.handleStateChanges(allReplicasForDeletionRetry, OfflineReplica)
     replicaStateMachine.handleStateChanges(allReplicasForDeletionRetry, ReplicaDeletionStarted)
@@ -353,9 +365,17 @@ class TopicDeletionManager(config: KafkaConfig,
     if (topicsQueuedForDeletion.nonEmpty)
       info(s"Handling deletion for topics ${topicsQueuedForDeletion.mkString(",")}")
 
+    // LI's native full-control path can clean up an offline replica later. In bridge mode,
+    // completing an all-offline deletion here would skip onTopicDeletion's metadata tombstone
+    // and discard the assignment before StopReplica can reach the returning broker. That leaves
+    // ghost topics in live metadata caches (CreateTopics says exists; DeleteTopics says absent).
+    val completedStates: Set[ReplicaState] = if (config.liProtocolBridgeModeEnable)
+      Set(ReplicaDeletionSuccessful)
+    else Set(ReplicaDeletionSuccessful, OfflineReplica)
+
     topicsQueuedForDeletion.foreach { topic =>
-      // if all replicas are marked as deleted successfully, then topic deletion is done
-      if (controllerContext.areAllReplicasInStates(topic, Set(ReplicaDeletionSuccessful, OfflineReplica))) {
+      // In bridge mode every replica must explicitly acknowledge deletion.
+      if (controllerContext.areAllReplicasInStates(topic, completedStates)) {
         // clear up all state for this topic from controller cache and zookeeper
         completeDeleteTopic(topic)
         info(s"Deletion of topic $topic successfully completed")

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -82,17 +82,24 @@ object DynamicBrokerConfig {
     LogCleaner.ReconfigurableConfigs ++
     DynamicLogConfig.ReconfigurableConfigs ++
     DynamicThreadPool.ReconfigurableConfigs ++
-    Set(KafkaConfig.MetricReporterClassesProp) ++
-    Set(KafkaConfig.AutoCreateTopicsEnableProp) ++
-    Set(KafkaConfig.AllowPreferredControllerFallbackProp) ++
-    Set(KafkaConfig.LiCombinedControlRequestEnableProp) ++
+    Set(
+      KafkaConfig.MetricReporterClassesProp,
+      KafkaConfig.AutoCreateTopicsEnableProp,
+      KafkaConfig.AllowPreferredControllerFallbackProp,
+      KafkaConfig.LiCombinedControlRequestEnableProp,
+      KafkaConfig.LiProtocolBridgeModeEnableProp,
+      KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp
+    ) ++
     DynamicListenerConfig.ReconfigurableConfigs ++
     ProduceRequestInstrumentationLogger.ReconfigurableConfigs ++
     SocketServer.ReconfigurableConfigs
 
   private val ClusterLevelListenerConfigs = Set(KafkaConfig.MaxConnectionsProp, KafkaConfig.MaxConnectionCreationRateProp)
-  private val ClusterLevelConfigs = Set(KafkaConfig.AllowPreferredControllerFallbackProp) ++
-    DynamicConfig.Broker.ClusterLevelConfigs
+  private val ClusterLevelConfigs = Set(
+    KafkaConfig.AllowPreferredControllerFallbackProp,
+    KafkaConfig.LiProtocolBridgeModeEnableProp,
+    KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp
+  ) ++ DynamicConfig.Broker.ClusterLevelConfigs
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(
     ClusterLevelListenerConfigs)
   private val ListenerMechanismConfigs = Set(KafkaConfig.SaslJaasConfigProp,

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -22,7 +22,7 @@ import kafka.admin.RackAwareReplicaAssignmentRackIdMapper
 import java.io.File
 import java.util
 import java.util.{Collections, Locale, Properties}
-import kafka.api.{ApiVersion, ApiVersionValidator, KAFKA_0_10_0_IV1, KAFKA_2_1_IV0, KAFKA_2_7_IV0, KAFKA_2_8_IV0, KAFKA_3_0_IV1}
+import kafka.api.{ApiVersion, ApiVersionValidator, KAFKA_0_10_0_IV1, KAFKA_2_1_IV0, KAFKA_2_2_IV0, KAFKA_2_7_IV0, KAFKA_2_8_IV0, KAFKA_3_0_IV1}
 import kafka.cluster.EndPoint
 import kafka.coordinator.group.OffsetConfig
 import kafka.coordinator.transaction.{TransactionLog, TransactionStateManager}
@@ -330,6 +330,7 @@ object Defaults {
 
   /** Linkedin Internal states */
   val LiCombinedControlRequestEnabled = false
+  val LiProtocolBridgeModeEnabled = false
   val LiUpdateMetadataDelayMs = 0
   val LiDropFetchFollowerEnable = false
   val LiDenyAlterIsr = false
@@ -457,6 +458,9 @@ object KafkaConfig {
   val LiMinPreferredControllerCountProp = "li.min.preferred.controller.count"
   val LiAsyncFetcherEnableProp = "li.async.fetcher.enable"
   val LiCombinedControlRequestEnableProp = "li.combined.control.request.enable"
+  val LiProtocolBridgeModeEnableProp = "li.protocol.bridge.mode.enable"
+  val LiProtocolBridgeTopicDeletionStateCleanupEnableProp =
+    "li.protocol.bridge.topic.deletion.state.cleanup.enable"
   val LiUpdateMetadataDelayMsProp = "li.update.metadata.delay.ms"
   val LiDropFetchFollowerEnableProp = "li.stop.replication.enable"
   val LiDenyAlterIsrProp = "li.deny.alter.isr"
@@ -814,6 +818,11 @@ object KafkaConfig {
   val LiMinPreferredControllerCountDoc = s"Specifies the desired count of minimum preferred controller. It will refuse to shutdown a broker if taking it down brings alive preferred controller below the threshold."
   val LiAsyncFetcherEnableDoc = "Specifies whether the event-based async fetcher should be used."
   val LiCombinedControlRequestEnableDoc = "Specifies whether the controller should use the LiCombinedControlRequest."
+  val LiProtocolBridgeModeEnableDoc = "Enables the temporary 3.0-li to upstream bridge protocol. " +
+    "When enabled, the controller sends LeaderAndIsr v2, UpdateMetadata v5, and StopReplica v1, and does not " +
+    "merge new LiCombinedControl requests. The setting is supported only on ZooKeeper brokers, requires " +
+    "inter.broker.protocol.version 2.2 or newer, and is a cluster-wide dynamic config only for a controlled " +
+    "rolling upgrade."
   val LiUpdateMetadataDelayMsDoc = "Specifies how long a UpdateMetadata request with partitions should be delayed before its processing can start. This config is purely for testing the LiCombinedControl feature and should not be enabled in a production environment."
   val LiDropCorruptedFilesEnableDoc = "Specifies whether the broker should delete corrupted files during startup."
   val LiConsumerFetchSampleRatioDoc = "Specifies the ratio of consumer Fetch requests to sample, which must be a number in the range [0.0, 1.0]. For now, the sampling is used to derive the age of consumed data."
@@ -1277,6 +1286,10 @@ object KafkaConfig {
       .define(LiMinPreferredControllerCountProp, INT, Defaults.LiMinPreferredControllerCount, atLeast(0), HIGH, LiMinPreferredControllerCountDoc)
       .define(LiAsyncFetcherEnableProp, BOOLEAN, Defaults.LiAsyncFetcherEnabled, HIGH, LiAsyncFetcherEnableDoc)
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
+      .define(LiProtocolBridgeModeEnableProp, BOOLEAN, Defaults.LiProtocolBridgeModeEnabled, HIGH, LiProtocolBridgeModeEnableDoc)
+      .define(LiProtocolBridgeTopicDeletionStateCleanupEnableProp, BOOLEAN, false, HIGH,
+        "Clear stale topic deletion state and reconcile the metadata cache " +
+          "from the first full update of each ZooKeeper controller epoch. Enable on every broker together.")
       .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, atLeast(0), LOW, LiUpdateMetadataDelayMsDoc)
       .define(LiDropFetchFollowerEnableProp, BOOLEAN, Defaults.LiDropFetchFollowerEnable, LOW, LiDropFetchFollowerEnableDoc)
       .define(LiDenyAlterIsrProp, BOOLEAN, Defaults.LiDenyAlterIsr, HIGH, LiDenyAlterIsrDoc)
@@ -1833,6 +1846,9 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
 
   val liAsyncFetcherEnable = getBoolean(KafkaConfig.LiAsyncFetcherEnableProp)
   def liCombinedControlRequestEnable = getBoolean(KafkaConfig.LiCombinedControlRequestEnableProp)
+  def liProtocolBridgeModeEnable = getBoolean(KafkaConfig.LiProtocolBridgeModeEnableProp)
+  def liProtocolBridgeTopicDeletionStateCleanupActive: Boolean =
+    requiresZookeeper && getBoolean(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp)
   def liUpdateMetadataDelayMs = getLong(KafkaConfig.LiUpdateMetadataDelayMsProp)
   def liDropFetchFollowerEnable = getBoolean(KafkaConfig.LiDropFetchFollowerEnableProp)
   def liDenyAlterIsr = getBoolean(KafkaConfig.LiDenyAlterIsrProp)
@@ -2347,5 +2363,10 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
     require(classOf[KafkaPrincipalSerde].isAssignableFrom(principalBuilderClass),
       s"${KafkaConfig.PrincipalBuilderClassProp} must implement KafkaPrincipalSerde")
     require(liMinOriginalAliveReplicas >= Defaults.MinInSyncReplicas, KafkaConfig.liMinOriginalAliveReplicasDoc)
+    require(!liProtocolBridgeModeEnable || requiresZookeeper,
+      s"${KafkaConfig.LiProtocolBridgeModeEnableProp}=true is supported only on ZooKeeper brokers")
+    require(!liProtocolBridgeModeEnable || interBrokerProtocolVersion >= KAFKA_2_2_IV0,
+      s"${KafkaConfig.LiProtocolBridgeModeEnableProp}=true requires " +
+        s"${KafkaConfig.InterBrokerProtocolVersionProp}=${KAFKA_2_2_IV0.shortVersion} or newer")
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -189,6 +189,7 @@ class KafkaServer(
 
   private var _clusterId: String = null
   private var _brokerTopicStats: BrokerTopicStats = null
+  private var liProtocolBridgeMetrics: LiProtocolBridgeMetrics = null
 
   private var _featureChangeListener: FinalizedFeatureChangeListener = null
 
@@ -305,6 +306,7 @@ class KafkaServer(
 
         /* register broker metrics */
         _brokerTopicStats = new BrokerTopicStats
+        liProtocolBridgeMetrics = new LiProtocolBridgeMetrics(config)
 
         quotaManagers = QuotaFactory.instantiate(config, metrics, time, Some(kafkaScheduler), threadNamePrefix.getOrElse(""))
         KafkaBroker.notifyClusterListeners(clusterId, kafkaMetricsReporters ++ metrics.reporters.asScala)
@@ -911,6 +913,8 @@ class KafkaServer(
         // avoid any failures (e.g. when metrics are recorded)
         if (socketServer != null)
           CoreUtils.swallow(socketServer.shutdown(), this)
+        if (liProtocolBridgeMetrics != null)
+          CoreUtils.swallow(liProtocolBridgeMetrics.close(), this)
         if (metrics != null)
           CoreUtils.swallow(metrics.close(), this)
         if (kafkaYammerMetrics != null)

--- a/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
+++ b/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.metrics.KafkaMetricsGroup
+
+import scala.util.Try
+
+object LiProtocolBridgeMetrics {
+  val ModeEnabled = "ModeEnabled"
+  val TopicDeletionStateCleanupEnabled = "TopicDeletionStateCleanupEnabled"
+  val FollowerRecoveryEnabled = "FollowerRecoveryEnabled"
+  val RecommendedLeaderElectionEnabled = "RecommendedLeaderElectionEnabled"
+  val ExcludePartitionsEnabled = "ExcludePartitionsEnabled"
+  val MoveControllerEnabled = "MoveControllerEnabled"
+  val ShutdownSafetyOverrideEnabled = "ShutdownSafetyOverrideEnabled"
+  val PreferredControllerEnabled = "PreferredControllerEnabled"
+  val FederatedTopicsEnabled = "FederatedTopicsEnabled"
+  val RackIdMapperEnabled = "RackIdMapperEnabled"
+  val ZookeeperPaginationEnabled = "ZookeeperPaginationEnabled"
+  val DynamicTopicDeletionEnabled = "DynamicTopicDeletionEnabled"
+  val ControllerInitializationThreads = "ControllerInitializationThreads"
+  val ProduceRequestInstrumentationEnabled = "ProduceRequestInstrumentationEnabled"
+  val RequestMetricBucketsEnabled = "RequestMetricBucketsEnabled"
+  val RequestChannelWatchdogEnabled = "RequestChannelWatchdogEnabled"
+  val MinimumLogRollEnabled = "MinimumLogRollEnabled"
+  val ReassignmentCancellationSafetyEnabled = "ReassignmentCancellationSafetyEnabled"
+  val ListOffsetsInstrumentationEnabled = "ListOffsetsInstrumentationEnabled"
+  val StaticDefaultQuotasEnabled = "StaticDefaultQuotasEnabled"
+  val ReplicaRequestTimeoutEnabled = "ReplicaRequestTimeoutEnabled"
+  val OffsetsTopicConfigEnabled = "OffsetsTopicConfigEnabled"
+  val LeaderTransferEnabled = "LeaderTransferEnabled"
+  val LegacyRequestMetricsEnabled = "LegacyRequestMetricsEnabled"
+  val LogTruncationMetricsEnabled = "LogTruncationMetricsEnabled"
+
+  val MetricNames: Seq[String] = Seq(ModeEnabled, TopicDeletionStateCleanupEnabled, FollowerRecoveryEnabled,
+    RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled, MoveControllerEnabled,
+    ShutdownSafetyOverrideEnabled, PreferredControllerEnabled, FederatedTopicsEnabled,
+    RackIdMapperEnabled, ZookeeperPaginationEnabled, DynamicTopicDeletionEnabled,
+    ControllerInitializationThreads, ProduceRequestInstrumentationEnabled,
+    RequestMetricBucketsEnabled, RequestChannelWatchdogEnabled, MinimumLogRollEnabled,
+    ReassignmentCancellationSafetyEnabled, ListOffsetsInstrumentationEnabled,
+    StaticDefaultQuotasEnabled, ReplicaRequestTimeoutEnabled, OffsetsTopicConfigEnabled,
+    LeaderTransferEnabled, LegacyRequestMetricsEnabled, LogTruncationMetricsEnabled)
+}
+
+final class LiProtocolBridgeMetrics(config: KafkaConfig) extends KafkaMetricsGroup with AutoCloseable {
+  import LiProtocolBridgeMetrics._
+
+  private val tags = Map("broker-id" -> config.brokerId.toString)
+
+  newGauge(ModeEnabled, () => if (config.liProtocolBridgeModeEnable) 1 else 0, tags)
+  newGauge(TopicDeletionStateCleanupEnabled,
+    () => if (config.liProtocolBridgeTopicDeletionStateCleanupActive) 1 else 0, tags)
+  // These behaviors are built in and ungated on the 3.0-li line. A value of one tells operators
+  // which equivalent default-off settings must be enabled on 3.9-li during the mixed roll.
+  Seq(FollowerRecoveryEnabled, RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled,
+    MoveControllerEnabled, ShutdownSafetyOverrideEnabled, PreferredControllerEnabled,
+    FederatedTopicsEnabled, DynamicTopicDeletionEnabled, RequestMetricBucketsEnabled,
+    RequestChannelWatchdogEnabled, ReassignmentCancellationSafetyEnabled,
+    ListOffsetsInstrumentationEnabled, ReplicaRequestTimeoutEnabled, OffsetsTopicConfigEnabled,
+    LeaderTransferEnabled, LegacyRequestMetricsEnabled, LogTruncationMetricsEnabled).foreach { name =>
+    newGauge(name, () => 1, tags)
+  }
+  newGauge(RackIdMapperEnabled, () => {
+    val mapper = config.getString(KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp)
+    if (mapper == null || mapper.isEmpty) 0 else 1
+  }, tags)
+  newGauge(ZookeeperPaginationEnabled,
+    () => if (config.liZookeeperPaginationEnable) 1 else 0, tags)
+  newGauge(ControllerInitializationThreads, () => config.liNumControllerInitThreads, tags)
+  newGauge(ProduceRequestInstrumentationEnabled,
+    () => if (config.longTailProduceRequestLogRatio > 0.0) 1 else 0, tags)
+  newGauge(MinimumLogRollEnabled, () => {
+    // This is a topic-level log setting, so KafkaConfig does not validate a broker-level original.
+    // Treat a malformed original as disabled rather than letting an MBean read fail.
+    val configuredValue = Option(config.originals.get(KafkaConfig.LiMinLogRollTimeMillisProp))
+      .flatMap(value => Try(value.toString.toLong).toOption)
+      .getOrElse(0L)
+    if (configuredValue > 0L) 1 else 0
+  }, tags)
+  newGauge(StaticDefaultQuotasEnabled, () => {
+    val producerDefault = config.producerQuotaBytesPerSecondDefault
+    val consumerDefault = config.consumerQuotaBytesPerSecondDefault
+    if (producerDefault < Long.MaxValue || consumerDefault < Long.MaxValue) 1 else 0
+  }, tags)
+
+  override def close(): Unit = MetricNames.foreach(name => removeMetric(name, tags))
+}

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1488,7 +1488,8 @@ class ReplicaManager(val config: KafkaConfig,
         throw new ControllerMovedException(stateChangeLogger.messageWithPrefix(stateControllerEpochErrorMessage))
       } else {
         val zkMetadataCache = metadataCache.asInstanceOf[ZkMetadataCache]
-        val deletedPartitions = zkMetadataCache.updateMetadata(correlationId, updateMetadataRequest)
+        val deletedPartitions = zkMetadataCache.updateMetadata(correlationId, updateMetadataRequest,
+          config.liProtocolBridgeTopicDeletionStateCleanupActive)
         controllerEpoch = updateMetadataRequest.controllerEpoch
         deletedPartitions
       }

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -299,9 +299,19 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
       snapshot.controllerId.map(id => node(id)).orNull)
   }
 
-  // This method returns the deleted TopicPartitions received from UpdateMetadataRequest
-  def updateMetadata(correlationId: Int, updateMetadataRequest: UpdateMetadataRequest): Seq[TopicPartition] = {
+  private var lastMetadataControllerEpoch = -1
+
+  // Preserve the existing JVM method for callers that do not enable bridge cleanup.
+  def updateMetadata(correlationId: Int, request: UpdateMetadataRequest): Seq[TopicPartition] =
+    updateMetadata(correlationId, request, reconcileOnControllerChange = false)
+
+  // With cleanup enabled, upgraded controllers send a full first update for each epoch.
+  // Later updates in that epoch remain incremental, including after a dynamic flag change.
+  def updateMetadata(correlationId: Int, updateMetadataRequest: UpdateMetadataRequest,
+                     reconcileOnControllerChange: Boolean): Seq[TopicPartition] = {
     inWriteLock(partitionMetadataLock) {
+      val replaceMetadata = reconcileOnControllerChange &&
+        updateMetadataRequest.controllerEpoch > lastMetadataControllerEpoch
 
       val aliveBrokers = new mutable.LongMap[Broker](metadataSnapshot.aliveBrokers.size)
       val aliveNodes = new mutable.LongMap[collection.Map[ListenerName, Node]](metadataSnapshot.aliveNodes.size)
@@ -334,19 +344,34 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
         .map(topicState => (topicState.topicName(), topicState.topicId()))
         .filter(_._2 != Uuid.ZERO_UUID).toMap
       val topicIds = mutable.Map.empty[String, Uuid]
-      topicIds ++= metadataSnapshot.topicIds
+      if (!replaceMetadata) topicIds ++= metadataSnapshot.topicIds
       topicIds ++= newTopicIds
 
       val deletedPartitions = new mutable.ArrayBuffer[TopicPartition]
+      if (replaceMetadata) {
+        val incoming = updateMetadataRequest.partitionStates.asScala.map(state =>
+          new TopicPartition(state.topicName, state.partitionIndex)).toSet
+        metadataSnapshot.partitionStates.forKeyValue { (topic, partitions) =>
+          partitions.keysIterator.foreach { partition =>
+            val tp = new TopicPartition(topic, partition.toInt)
+            if (!incoming.contains(tp)) deletedPartitions += tp
+          }
+        }
+      }
       if (!updateMetadataRequest.partitionStates.iterator.hasNext) {
-        metadataSnapshot = MetadataSnapshot(metadataSnapshot.partitionStates, topicIds.toMap, controllerIdOpt, aliveBrokers, aliveNodes)
+        val partitions = if (replaceMetadata)
+          mutable.AnyRefMap.empty[String, mutable.LongMap[UpdateMetadataPartitionState]]
+        else metadataSnapshot.partitionStates
+        metadataSnapshot = MetadataSnapshot(partitions, topicIds.toMap, controllerIdOpt, aliveBrokers, aliveNodes)
       } else {
         //since kafka may do partial metadata updates, we start by copying the previous state
         val partitionStates = new mutable.AnyRefMap[String, mutable.LongMap[UpdateMetadataPartitionState]](metadataSnapshot.partitionStates.size)
-        metadataSnapshot.partitionStates.forKeyValue { (topic, oldPartitionStates) =>
-          val copy = new mutable.LongMap[UpdateMetadataPartitionState](oldPartitionStates.size)
-          copy ++= oldPartitionStates
-          partitionStates(topic) = copy
+        if (!replaceMetadata) {
+          metadataSnapshot.partitionStates.forKeyValue { (topic, oldPartitionStates) =>
+            val copy = new mutable.LongMap[UpdateMetadataPartitionState](oldPartitionStates.size)
+            copy ++= oldPartitionStates
+            partitionStates(topic) = copy
+          }
         }
 
         val traceEnabled = stateChangeLogger.isTraceEnabled
@@ -369,12 +394,15 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
                 s"UpdateMetadata request sent by controller $controllerId epoch $controllerEpoch with correlation id $correlationId")
           }
         }
-        val cachedPartitionsCount = newStates.size - deletedPartitions.size
+        val cachedPartitionsCount = if (replaceMetadata)
+          newStates.count(_.leader != LeaderAndIsr.LeaderDuringDelete)
+        else newStates.size - deletedPartitions.size
         stateChangeLogger.info(s"Add $cachedPartitionsCount partitions and deleted ${deletedPartitions.size} partitions from metadata cache " +
           s"in response to UpdateMetadata request sent by controller $controllerId epoch $controllerEpoch with correlation id $correlationId")
 
         metadataSnapshot = MetadataSnapshot(partitionStates, topicIds.toMap, controllerIdOpt, aliveBrokers, aliveNodes)
       }
+      lastMetadataControllerEpoch = math.max(lastMetadataControllerEpoch, updateMetadataRequest.controllerEpoch)
       deletedPartitions
     }
   }

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -19,7 +19,7 @@ package kafka.admin
 
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
-import java.util.{Collections, HashMap, List}
+import java.util.{Collections, HashMap, List, Properties}
 import kafka.admin.ReassignPartitionsCommand._
 import kafka.api.KAFKA_2_7_IV1
 import kafka.server.{IsrChangePropagationConfig, KafkaConfig, KafkaServer, ZkIsrManager}
@@ -61,6 +61,39 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
     cluster = new ReassignPartitionsTestCluster(zkConnect)
     cluster.setup()
     executeAndVerifyReassignment()
+  }
+
+  @Test
+  def testReassignmentInProtocolBridgeMode(): Unit = {
+    val configOverrides = Map(
+      KafkaConfig.LiProtocolBridgeModeEnableProp -> "true",
+      KafkaConfig.LiCombinedControlRequestEnableProp -> "true"
+    )
+    cluster = new ReassignPartitionsTestCluster(zkConnect, configOverrides = configOverrides)
+    cluster.setup()
+    executeAndVerifyReassignment()
+  }
+
+  @Test
+  def testReassignmentStartedBeforeProtocolBridgeActivationCompletes(): Unit = {
+    cluster = new ReassignPartitionsTestCluster(zkConnect)
+    cluster.setup()
+    cluster.produceMessages("foo", 0, 100)
+
+    val assignment =
+      """{"version":1,"partitions":[{"topic":"foo","partition":0,"replicas":[0,1,3],"log_dirs":["any","any","any"]}]}"""
+    runExecuteAssignment(cluster.adminClient, false, assignment, 100000L, -1L)
+
+    val bridgeProps = new Properties
+    bridgeProps.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
+    TestUtils.incrementalAlterConfigs(cluster.servers, cluster.adminClient, bridgeProps, perBrokerConfig = false).all.get()
+    TestUtils.waitUntilTrue(
+      () => cluster.servers.forall(_.config.liProtocolBridgeModeEnable),
+      "protocol bridge config did not propagate to every broker")
+
+    val finalAssignment = Map(new TopicPartition("foo", 0) ->
+      PartitionReassignmentState(Seq(0, 1, 3), Seq(0, 1, 3), true))
+    waitForVerifyAssignment(cluster.adminClient, assignment, false, VerifyAssignmentResult(finalAssignment))
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/api/LiCombinedControlRequestTest.scala
+++ b/core/src/test/scala/integration/kafka/api/LiCombinedControlRequestTest.scala
@@ -91,6 +91,23 @@ class LiCombinedControlRequestTest extends KafkaServerTestHarness  with Logging 
   }
 
   @Test
+  def testProtocolBridgeModeStopsNewLiCombinedControlRequests(): Unit = {
+    val props = new Properties
+    props.put(KafkaConfig.LiCombinedControlRequestEnableProp, "true")
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LiCombinedControlRequestEnableProp, "true"))
+    createTopic("bridge-warmup")
+    assertTrue(createTopicAndGetCombinedRequestCount(Set("bridge-before-1", "bridge-before-2")) > 0)
+
+    props.clear()
+    props.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.LiProtocolBridgeModeEnableProp, "true"))
+
+    val countAfterActivation = createTopicAndGetCombinedRequestCount(Set("bridge-after-1", "bridge-after-2"))
+    val countAfterMoreRequests = createTopicAndGetCombinedRequestCount(Set("bridge-after-3", "bridge-after-4"))
+    assertEquals(countAfterActivation, countAfterMoreRequests)
+  }
+
+  @Test
   def testLiCombinedControlRequestNoPartitionBroker(): Unit = {
     // This test is to verify that commit 8c5b1ec033577cb6ca2b445a70e7347581d5b7c6 would fix the bug described below.
     // https://github.com/linkedin/kafka/commit/8c5b1ec033577cb6ca2b445a70e7347581d5b7c6

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -17,7 +17,7 @@
 package kafka.controller
 
 import java.util.Properties
-import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, KAFKA_0_10_2_IV0, KAFKA_0_9_0, KAFKA_1_0_IV0, KAFKA_2_2_IV0, KAFKA_2_3_IV2, KAFKA_2_4_IV0, KAFKA_2_4_IV1, KAFKA_2_6_IV0, KAFKA_2_8_IV1, LeaderAndIsr}
+import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, KAFKA_0_10_2_IV0, KAFKA_0_9_0, KAFKA_1_0_IV0, KAFKA_2_1_IV2, KAFKA_2_2_IV0, KAFKA_2_3_IV2, KAFKA_2_4_IV0, KAFKA_2_4_IV1, KAFKA_2_6_IV0, KAFKA_2_8_IV1, LeaderAndIsr}
 import kafka.cluster.{Broker, EndPoint}
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
@@ -174,9 +174,10 @@ class ControllerChannelManagerTest {
   }
 
   private def testLeaderAndIsrRequestFollowsInterBrokerProtocolVersion(interBrokerProtocolVersion: ApiVersion,
-                                                                       expectedLeaderAndIsrVersion: Short): Unit = {
+                                                                       expectedLeaderAndIsrVersion: Short,
+                                                                       bridgeMode: Boolean = false): Unit = {
     val context = initContext(Seq(1, 2, 3), 2, 3, Set("foo", "bar"))
-    val config = createConfig(interBrokerProtocolVersion)
+    val config = createConfig(interBrokerProtocolVersion, bridgeMode)
     val batch = new MockControllerBrokerRequestBatch(context, config)
 
     val partition = new TopicPartition("foo", 0)
@@ -198,7 +199,12 @@ class ControllerChannelManagerTest {
     val byteBuffer = request.serialize
     val deserializedRequest = LeaderAndIsrRequest.parse(byteBuffer, expectedLeaderAndIsrVersion)
 
-    if (interBrokerProtocolVersion >= KAFKA_2_8_IV1) {
+    if (bridgeMode) {
+      assertEquals(context.liveBrokerIdAndEpochs(2), deserializedRequest.brokerEpoch)
+      assertEquals(AbstractControlRequest.UNKNOWN_BROKER_EPOCH, deserializedRequest.maxBrokerEpoch)
+    }
+
+    if (expectedLeaderAndIsrVersion >= 6) {
       assertFalse(request.topicIds().get("foo").equals(Uuid.ZERO_UUID))
       assertFalse(deserializedRequest.topicIds().get("foo").equals(Uuid.ZERO_UUID))
     } else if (interBrokerProtocolVersion >= KAFKA_2_2_IV0) {
@@ -378,9 +384,10 @@ class ControllerChannelManagerTest {
   }
 
   private def testUpdateMetadataFollowsInterBrokerProtocolVersion(interBrokerProtocolVersion: ApiVersion,
-                                                                  expectedUpdateMetadataVersion: Short): Unit = {
+                                                                  expectedUpdateMetadataVersion: Short,
+                                                                  bridgeMode: Boolean = false): Unit = {
     val context = initContext(Seq(1, 2, 3), 2, 3, Set("foo", "bar"))
-    val config = createConfig(interBrokerProtocolVersion)
+    val config = createConfig(interBrokerProtocolVersion, bridgeMode)
     val batch = new MockControllerBrokerRequestBatch(context, config)
 
     batch.newBatch()
@@ -395,6 +402,13 @@ class ControllerChannelManagerTest {
     val allVersions = requests.map(_.version)
     assertTrue(allVersions.forall(_ == expectedUpdateMetadataVersion),
       s"IBP $interBrokerProtocolVersion should use version $expectedUpdateMetadataVersion, but found versions $allVersions")
+    if (bridgeMode) {
+      requests.foreach { request =>
+        val parsedRequest = UpdateMetadataRequest.parse(request.serialize, request.version)
+        assertEquals(context.liveBrokerIdAndEpochs(2), parsedRequest.brokerEpoch)
+        assertEquals(AbstractControlRequest.UNKNOWN_BROKER_EPOCH, parsedRequest.maxBrokerEpoch)
+      }
+    }
   }
 
   @Test
@@ -772,9 +786,10 @@ class ControllerChannelManagerTest {
   }
 
   private def testStopReplicaFollowsInterBrokerProtocolVersion(interBrokerProtocolVersion: ApiVersion,
-                                                               expectedStopReplicaRequestVersion: Short): Unit = {
+                                                               expectedStopReplicaRequestVersion: Short,
+                                                               bridgeMode: Boolean = false): Unit = {
     val context = initContext(Seq(1, 2, 3), 2, 3, Set("foo"))
-    val config = createConfig(interBrokerProtocolVersion)
+    val config = createConfig(interBrokerProtocolVersion, bridgeMode)
     val batch = new MockControllerBrokerRequestBatch(context, config)
 
     val partition = new TopicPartition("foo", 0)
@@ -794,6 +809,50 @@ class ControllerChannelManagerTest {
     val allVersions = requests.map(_.version)
     assertTrue(allVersions.forall(_ == expectedStopReplicaRequestVersion),
       s"IBP $interBrokerProtocolVersion should use version $expectedStopReplicaRequestVersion, but found versions $allVersions")
+    if (bridgeMode) {
+      requests.foreach { request =>
+        val parsedRequest = StopReplicaRequest.parse(request.serialize, request.version)
+        assertEquals(context.liveBrokerIdAndEpochs(2), parsedRequest.brokerEpoch)
+        assertEquals(AbstractControlRequest.UNKNOWN_BROKER_EPOCH, parsedRequest.maxBrokerEpoch)
+      }
+    }
+  }
+
+  @Test
+  def testProtocolBridgeVersionSelection(): Unit = {
+    ApiVersion.allVersions.foreach { version =>
+      val bridgeSupported = version >= KAFKA_2_2_IV0
+      val expectedLeaderAndIsrVersion = if (bridgeSupported)
+        ControllerChannelManager.BridgeLeaderAndIsrRequestVersion
+      else ControllerChannelManager.leaderAndIsrRequestVersion(version, bridgeMode = false)
+      val expectedUpdateMetadataVersion = if (bridgeSupported)
+        ControllerChannelManager.BridgeUpdateMetadataRequestVersion
+      else ControllerChannelManager.updateMetadataRequestVersion(version, bridgeMode = false)
+      val expectedStopReplicaVersion = if (bridgeSupported)
+        ControllerChannelManager.BridgeStopReplicaRequestVersion
+      else ControllerChannelManager.stopReplicaRequestVersion(version, bridgeMode = false)
+
+      assertEquals(expectedLeaderAndIsrVersion,
+        ControllerChannelManager.leaderAndIsrRequestVersion(version, bridgeMode = true))
+      assertEquals(expectedUpdateMetadataVersion,
+        ControllerChannelManager.updateMetadataRequestVersion(version, bridgeMode = true))
+      assertEquals(expectedStopReplicaVersion,
+        ControllerChannelManager.stopReplicaRequestVersion(version, bridgeMode = true))
+    }
+
+    val latestVersion = ApiVersion.latestVersion
+    testLeaderAndIsrRequestFollowsInterBrokerProtocolVersion(latestVersion,
+      ControllerChannelManager.BridgeLeaderAndIsrRequestVersion, bridgeMode = true)
+    testUpdateMetadataFollowsInterBrokerProtocolVersion(latestVersion,
+      ControllerChannelManager.BridgeUpdateMetadataRequestVersion, bridgeMode = true)
+    testStopReplicaFollowsInterBrokerProtocolVersion(latestVersion,
+      ControllerChannelManager.BridgeStopReplicaRequestVersion, bridgeMode = true)
+  }
+
+  @Test
+  def testProtocolBridgeModeRequiresIbp22(): Unit = {
+    assertThrows(classOf[IllegalArgumentException],
+      () => createConfig(KAFKA_2_1_IV2, bridgeMode = true))
   }
 
   private case class LeaderAndDelete(leaderAndIsr: LeaderAndIsr,
@@ -872,10 +931,11 @@ class ControllerChannelManagerTest {
     }
   }
 
-  private def createConfig(interBrokerVersion: ApiVersion): KafkaConfig = {
+  private def createConfig(interBrokerVersion: ApiVersion, bridgeMode: Boolean = false): KafkaConfig = {
     val props = new Properties()
     props.put(KafkaConfig.BrokerIdProp, controllerId.toString)
     props.put(KafkaConfig.ZkConnectProp, "zkConnect")
+    props.put(KafkaConfig.LiProtocolBridgeModeEnableProp, bridgeMode.toString)
     TestUtils.setIbpAndMessageFormatVersions(props, interBrokerVersion)
     KafkaConfig.fromProps(props)
   }

--- a/core/src/test/scala/unit/kafka/controller/RequestSendThreadBridgeTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/RequestSendThreadBridgeTest.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.controller
+
+import java.util.Collections
+import java.util.concurrent.{CountDownLatch, Executors, LinkedBlockingDeque, TimeUnit}
+import java.util.concurrent.atomic.AtomicBoolean
+import com.yammer.metrics.core.Timer
+import kafka.server.KafkaConfig
+import org.apache.kafka.clients.NetworkClient
+import org.apache.kafka.common.Node
+import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataBroker
+import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartitionState, StopReplicaTopicState}
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{AbstractResponse, StopReplicaRequest, UpdateMetadataRequest}
+import org.apache.kafka.common.utils.Time
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{Test, Timeout}
+import org.mockito.Mockito._
+import scala.collection.mutable
+
+@Timeout(15)
+class RequestSendThreadBridgeTest {
+  private def sender(queue: LinkedBlockingDeque[QueueItem], enabled: AtomicBoolean): RequestSendThread = {
+    val props = new java.util.Properties
+    props.put("broker.id", "0")
+    props.put("zookeeper.connect", "localhost:2181")
+    props.put("inter.broker.protocol.version", "3.0")
+    props.put("li.combined.control.request.enable", "true")
+    val config = spy(KafkaConfig.fromProps(props))
+    doAnswer(_ => Boolean.box(enabled.get())).when(config).liProtocolBridgeModeEnable
+    val manager = mock(classOf[ControllerChannelManager])
+    when(manager.brokerResponseSensors).thenReturn(mutable.Map(
+      ApiKeys.UPDATE_METADATA -> mock(classOf[BrokerResponseTimeStats]),
+      ApiKeys.STOP_REPLICA -> mock(classOf[BrokerResponseTimeStats])))
+    val result = new RequestSendThread(0, new ControllerContext, queue, mock(classOf[NetworkClient]),
+      new Node(1, "localhost", 9092), config, Time.SYSTEM, mock(classOf[Timer]),
+      new StateChangeLogger(0, true, None), "bridge-cutoff-test", manager)
+    result.firstUpdateMetadataWithPartitionsSent = true
+    result
+  }
+
+  private def item(callback: AbstractResponse => Unit): QueueItem = {
+    val request = new UpdateMetadataRequest.Builder(5.toShort, 0, 1, 5L, 5L,
+      Collections.emptyList(), Collections.singletonList(new UpdateMetadataBroker().setId(1)),
+      Collections.emptyMap())
+    QueueItem(ApiKeys.UPDATE_METADATA, request, callback, 0L)
+  }
+
+  @Test
+  def testActivationWhileBlockedDoesNotMergeNewWork(): Unit = {
+    val enabled = new AtomicBoolean(false)
+    val blocked = new CountDownLatch(1)
+    val queue = new LinkedBlockingDeque[QueueItem] {
+      override def take(): QueueItem = {
+        blocked.countDown()
+        super.take()
+      }
+    }
+    val thread = sender(queue, enabled)
+    val executor = Executors.newSingleThreadExecutor()
+    var callbacks = 0
+    val callback: AbstractResponse => Unit = _ => callbacks += 1
+    try {
+      val result = executor.submit(new java.util.concurrent.Callable[ApiKeys] {
+        override def call(): ApiKeys = {
+          val (request, receivedCallback) = thread.nextRequestAndCallback()
+          assertSame(callback, receivedCallback)
+          receivedCallback(null)
+          request.apiKey
+        }
+      })
+      assertTrue(blocked.await(5, TimeUnit.SECONDS))
+      enabled.set(true)
+      queue.put(item(callback))
+      assertEquals(ApiKeys.UPDATE_METADATA, result.get(5, TimeUnit.SECONDS))
+      assertEquals(1, callbacks)
+      assertTrue(queue.isEmpty)
+    } finally {
+      executor.shutdownNow()
+      thread.removeMetric("maxRequestAge", Map("broker-id" -> "1"))
+    }
+  }
+
+  @Test
+  def testAdmittedDeletionCallbackDrainsOnceAfterActivation(): Unit = {
+    val enabled = new AtomicBoolean(false)
+    val queue = new LinkedBlockingDeque[QueueItem] {
+      override def isEmpty: Boolean = {
+        enabled.set(true) // first item is already merged when the drain loop checks the queue
+        super.isEmpty
+      }
+    }
+    val thread = sender(queue, enabled)
+    var callbacks = 0
+    val state = new StopReplicaTopicState().setTopicName("deleting")
+      .setPartitionStates(Collections.singletonList(new StopReplicaPartitionState().setPartitionIndex(0)
+        .setLeaderEpoch(2).setDeletePartition(true)))
+    val builder = new StopReplicaRequest.Builder(1.toShort, 0, 1, 5L, 5L, true, Collections.singletonList(state))
+    queue.put(QueueItem(ApiKeys.STOP_REPLICA, builder, _ => callbacks += 1, 0L))
+    try {
+      val (request, callback) = thread.nextRequestAndCallback()
+      assertEquals(ApiKeys.LI_COMBINED_CONTROL, request.apiKey)
+      callback(request.build().getErrorResponse(0, Errors.STALE_CONTROLLER_EPOCH.exception()))
+      assertEquals(1, callbacks)
+      queue.put(item(_ => ()))
+      assertEquals(ApiKeys.UPDATE_METADATA, thread.nextRequestAndCallback()._1.apiKey)
+      assertEquals(1, callbacks)
+    } finally {
+      thread.removeMetric("maxRequestAge", Map("broker-id" -> "1"))
+    }
+  }
+
+  @Test
+  def testActivationDuringDrainLeavesNewWorkAndCallbacksInQueue(): Unit = {
+    val enabled = new AtomicBoolean(false)
+    val admitted = new CountDownLatch(1)
+    val resume = new CountDownLatch(1)
+    val queue = new LinkedBlockingDeque[QueueItem] {
+      override def isEmpty: Boolean = {
+        // Called after the first item is merged. Hold the sender at the drain boundary.
+        admitted.countDown()
+        assertTrue(resume.await(5, TimeUnit.SECONDS))
+        super.isEmpty
+      }
+    }
+    val thread = sender(queue, enabled)
+    queue.put(item(null))
+    val executor = Executors.newSingleThreadExecutor()
+    var callbacks = 0
+    val callback: AbstractResponse => Unit = _ => callbacks += 1
+    try {
+      val first = executor.submit(new java.util.concurrent.Callable[ApiKeys] {
+        override def call(): ApiKeys = thread.nextRequestAndCallback()._1.apiKey
+      })
+      assertTrue(admitted.await(5, TimeUnit.SECONDS))
+      (1 to 100).foreach(_ => queue.put(item(callback)))
+      enabled.set(true)
+      resume.countDown()
+      assertEquals(ApiKeys.LI_COMBINED_CONTROL, first.get(5, TimeUnit.SECONDS))
+      assertEquals(100, queue.size())
+      (1 to 100).foreach { _ =>
+        val (request, receivedCallback) = thread.nextRequestAndCallback()
+        assertEquals(ApiKeys.UPDATE_METADATA, request.apiKey)
+        receivedCallback(null)
+      }
+      assertEquals(100, callbacks)
+      assertEquals(0, queue.size())
+    } finally {
+      resume.countDown()
+      executor.shutdownNow()
+      thread.removeMetric("maxRequestAge", Map("broker-id" -> "1"))
+    }
+  }
+}

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -33,6 +33,29 @@ class TopicDeletionManagerTest {
   private val deletionClient = mock(classOf[DeletionClient])
 
   @Test
+  def testTopicNameReuseCleanupRequiresItsFlag(): Unit = {
+    assertFalse(config.liProtocolBridgeTopicDeletionStateCleanupActive)
+    Seq(false, true).foreach { enabled =>
+      val props = TestUtils.createBrokerConfig(brokerId, "zkConnect")
+      props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, enabled.toString)
+      val context = initContext(Seq(1, 2), Set("foo"), 1, 2)
+      val replicas = new MockReplicaStateMachine(context)
+      replicas.startup(ControllerContextSnapshot(context))
+      val partitions = new MockPartitionStateMachine(context, uncleanLeaderElectionEnabled = false)
+      partitions.startup()
+      val manager = new TopicDeletionManager(KafkaConfig.fromProps(props), context,
+        replicas, partitions, mock(classOf[DeletionClient]))
+      manager.init(Set.empty, Set.empty)
+      manager.enqueueTopicsForDeletion(Set("foo"))
+      manager.markTopicIneligibleForDeletion(Set("foo"), "reassignment completed during deletion")
+      manager.completeReplicaDeletion(context.replicasForTopic("foo"))
+      assertTrue(context.partitionsForTopic("foo").isEmpty)
+      assertEquals(!enabled, context.topicsIneligibleForDeletion.contains("foo"),
+        "Only the enabled cleanup flag may change the existing deletion behavior")
+    }
+  }
+
+  @Test
   def testInitialization(): Unit = {
     val controllerContext = initContext(
       brokers = Seq(1, 2, 3),
@@ -164,6 +187,43 @@ class TopicDeletionManagerTest {
     assertEquals(Set(), controllerContext.topicsWithDeletionStarted)
     assertEquals(Set(), controllerContext.topicsIneligibleForDeletion)
     assertFalse(controllerContext.allTopics.contains("foo"))
+  }
+
+  @Test
+  def testBridgeDeletionWaitsForOfflineReplicaAfterControllerFailover(): Unit = {
+    Seq(false, true).foreach { bridge =>
+      val properties = TestUtils.createBrokerConfig(brokerId, "zkConnect")
+      properties.put(KafkaConfig.LiProtocolBridgeModeEnableProp, bridge.toString)
+      val config = KafkaConfig.fromProps(properties)
+      val client = mock(classOf[DeletionClient])
+      val context = initContext(Seq(1, 2), Set("foo"), numPartitions = 1, replicationFactor = 1)
+      val originalBroker = context.liveOrShuttingDownBroker(1).get
+      context.removeLiveBrokers(Set(1))
+      val replicas = new MockReplicaStateMachine(context)
+      replicas.startup(ControllerContextSnapshot(context))
+      val partitions = new MockPartitionStateMachine(context, uncleanLeaderElectionEnabled = false)
+      partitions.startup()
+      val manager = new TopicDeletionManager(config, context, replicas, partitions, client)
+      // Reconstruct a deletion with its only replica offline, as during controller failover.
+      manager.init(Set("foo"), Set.empty)
+      val topicPartitions = context.partitionsForTopic("foo")
+      val topicReplicas = context.replicasForTopic("foo")
+      manager.tryTopicDeletion()
+      if (bridge) {
+        // Common control versions cannot send a full-state cleanup on rejoin. Keep the
+        // assignment/znode until the actual replica deletion is acknowledged and notify caches.
+        verify(client).sendMetadataUpdate(topicPartitions)
+        verify(client, never()).deleteTopic("foo", context.epochZkVersion)
+        assertTrue(context.topicsToBeDeleted.contains("foo"))
+        assertEquals(topicReplicas, context.replicasInState("foo", ReplicaDeletionIneligible))
+        context.addLiveBrokers(Map(originalBroker -> 2L))
+        manager.resumeDeletionForTopics(Set("foo"))
+        assertEquals(topicReplicas, context.replicasInState("foo", ReplicaDeletionStarted))
+        manager.completeReplicaDeletion(topicReplicas)
+      }
+      verify(client).deleteTopic("foo", context.epochZkVersion)
+      assertTrue(context.partitionsForTopic("foo").isEmpty)
+    }
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/BridgeMetadataCacheEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BridgeMetadataCacheEpochTest.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.UpdateMetadataRequestData
+import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataPartitionState, UpdateMetadataTopicState}
+import org.apache.kafka.common.requests.UpdateMetadataRequest
+import org.apache.kafka.common.protocol.MessageUtil
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import scala.jdk.CollectionConverters._
+
+class BridgeMetadataCacheEpochTest {
+  private def cache = MetadataCache.zkMetadataCache(1)
+
+  private def request(epoch: Int, topics: String*): UpdateMetadataRequest = {
+    val states = topics.map { topic =>
+      new UpdateMetadataTopicState().setTopicName(topic).setPartitionStates(
+        List(new UpdateMetadataPartitionState().setTopicName(topic).setPartitionIndex(0)
+          .setLeader(1).setLeaderEpoch(1).setControllerEpoch(epoch)
+          .setReplicas(List(Int.box(1)).asJava).setIsr(List(Int.box(1)).asJava)).asJava)
+    }
+    val data = new UpdateMetadataRequestData().setControllerId(1)
+      .setControllerEpoch(epoch).setBrokerEpoch(1L).setTopicStates(states.asJava)
+    UpdateMetadataRequest.parse(MessageUtil.toByteBuffer(data, 5.toShort), 5.toShort)
+  }
+
+  @Test
+  def testLostDeletionIsReconciledOnlyWhenEnabled(): Unit = {
+    Seq(false, true).foreach { enabled =>
+      val metadata = cache
+      metadata.updateMetadata(0, request(1, "deleted", "kept"), enabled)
+      // The old controller deleted the znode but died before delivering its tombstone.
+      val deleted = metadata.updateMetadata(1, request(2, "kept"), enabled)
+      assertEquals(!enabled, metadata.contains("deleted"))
+      assertTrue(metadata.contains("kept"))
+      assertEquals(if (enabled) Seq(new TopicPartition("deleted", 0)) else Seq.empty, deleted)
+    }
+  }
+
+  @Test
+  def testSameEpochUpdatesStayIncrementalIncludingAfterFlagActivation(): Unit = {
+    val metadata = cache
+    metadata.updateMetadata(0, request(1, "first", "second"))
+    metadata.updateMetadata(1, request(1, "third"), reconcileOnControllerChange = true)
+    assertEquals(Set("first", "second", "third"), metadata.getAllTopics())
+    metadata.updateMetadata(2, request(2, "first", "third"), reconcileOnControllerChange = true)
+    assertEquals(Set("first", "third"), metadata.getAllTopics())
+    metadata.updateMetadata(3, request(2, "fourth"), reconcileOnControllerChange = true)
+    assertEquals(Set("first", "third", "fourth"), metadata.getAllTopics())
+  }
+
+  @Test
+  def testEmptySnapshotDropsOldEntries(): Unit = {
+    val metadata = cache
+    metadata.updateMetadata(0, request(1, "deleted"), reconcileOnControllerChange = true)
+    assertEquals(Seq(new TopicPartition("deleted", 0)),
+      metadata.updateMetadata(1, request(2), reconcileOnControllerChange = true))
+    assertTrue(metadata.getAllTopics().isEmpty)
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
@@ -17,7 +17,7 @@
 
 package kafka.server
 
-import java.util.{Arrays, Collections}
+import java.util.{Arrays, Collections, Properties}
 
 import kafka.network.SocketServer
 import kafka.utils._
@@ -32,6 +32,19 @@ import org.junit.jupiter.api.Test
 import scala.jdk.CollectionConverters._
 
 class DeleteTopicsRequestTest extends BaseRequestTest {
+
+  @Test
+  def testDeleteTopicInProtocolBridgeMode(): Unit = {
+    val bridgeProps = new Properties
+    bridgeProps.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
+    servers.foreach(_.config.dynamicConfig.updateDefaultConfig(bridgeProps))
+
+    createTopic("bridge-delete-topic", 3, 2)
+    validateValidDeleteTopicRequests(new DeleteTopicsRequest.Builder(
+      new DeleteTopicsRequestData()
+        .setTopicNames(Arrays.asList("bridge-delete-topic"))
+        .setTimeoutMs(10000)).build())
+  }
 
   @Test
   def testValidDeleteTopicRequests(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -20,6 +20,7 @@ package kafka.server
 import java.{lang, util}
 import java.util.Properties
 import java.util.concurrent.CompletionStage
+import kafka.api.KAFKA_2_1_IV2
 import kafka.utils.TestUtils
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.{Endpoint, Reconfigurable}
@@ -172,6 +173,34 @@ class DynamicBrokerConfigTest {
     verifyUpdate(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "JKS")
     verifyUpdate(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "password")
     verifyUpdate(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "password")
+  }
+
+  @Test
+  def testProtocolBridgeModeIsClusterWideDynamicConfig(): Unit = {
+    val config = KafkaConfig(TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181))
+    val props = new Properties
+    props.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
+    props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, "true")
+
+    assertFalse(config.liProtocolBridgeModeEnable)
+    assertFalse(config.liProtocolBridgeTopicDeletionStateCleanupActive)
+    config.dynamicConfig.validate(props, perBrokerConfig = false)
+    config.dynamicConfig.updateDefaultConfig(props)
+    assertTrue(config.liProtocolBridgeModeEnable)
+    assertTrue(config.liProtocolBridgeTopicDeletionStateCleanupActive)
+    assertThrows(classOf[ConfigException], () => config.dynamicConfig.validate(props, perBrokerConfig = true))
+  }
+
+  @Test
+  def testProtocolBridgeModeDynamicUpdateRejectsOldIbp(): Unit = {
+    val brokerProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
+    TestUtils.setIbpAndMessageFormatVersions(brokerProps, KAFKA_2_1_IV2)
+    val config = KafkaConfig(brokerProps)
+    val bridgeProps = new Properties
+    bridgeProps.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
+
+    assertThrows(classOf[IllegalArgumentException],
+      () => config.dynamicConfig.validate(bridgeProps, perBrokerConfig = false))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1129,6 +1129,18 @@ class KafkaConfigTest {
   }
 
   @Test
+  def testProtocolBridgeModeRejectsRaftBroker(): Unit = {
+    val props = new Properties()
+    props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.QuorumVotersProp, "2@localhost:9093")
+    props.put(KafkaConfig.NodeIdProp, "1")
+    assertTrue(isValidKafkaConfig(props))
+
+    props.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
+    assertFalse(isValidKafkaConfig(props))
+  }
+
+  @Test
   def testRejectsNegativeNodeIdForRaftBasedBrokerCaseWithAutoGenEnabled(): Unit = {
     // -1 is the default for both node.id and broker.id
     val props = new Properties()

--- a/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import com.yammer.metrics.core.Gauge
+import kafka.metrics.KafkaYammerMetrics
+import kafka.utils.TestUtils
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+import scala.collection.JavaConverters._
+
+class LiProtocolBridgeMetricsTest {
+  @Test
+  def testEffectiveValuesAndCleanup(): Unit = {
+    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(4, "localhost:2181"))
+    val metrics = new LiProtocolBridgeMetrics(config)
+    try {
+      val values = metricValues(4)
+      assertEquals(LiProtocolBridgeMetrics.MetricNames.toSet, values.keySet)
+      assertEquals(0, values(LiProtocolBridgeMetrics.ModeEnabled))
+      assertEquals(0, values(LiProtocolBridgeMetrics.TopicDeletionStateCleanupEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.FollowerRecoveryEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.ControllerInitializationThreads))
+      assertEquals(0, values(LiProtocolBridgeMetrics.ProduceRequestInstrumentationEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.RequestMetricBucketsEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.RequestChannelWatchdogEnabled))
+      assertEquals(0, values(LiProtocolBridgeMetrics.MinimumLogRollEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.ReassignmentCancellationSafetyEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.ListOffsetsInstrumentationEnabled))
+      assertEquals(0, values(LiProtocolBridgeMetrics.StaticDefaultQuotasEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.ReplicaRequestTimeoutEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.OffsetsTopicConfigEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.LeaderTransferEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.LegacyRequestMetricsEnabled))
+      assertEquals(1, values(LiProtocolBridgeMetrics.LogTruncationMetricsEnabled))
+    } finally {
+      metrics.close()
+    }
+    assertTrue(metricValues(4).isEmpty)
+  }
+
+  @Test
+  def testModeGaugeTracksDynamicConfig(): Unit = {
+    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(5, "localhost:2181"))
+    val metrics = new LiProtocolBridgeMetrics(config)
+    try {
+      assertEquals(0, metricValues(5)(LiProtocolBridgeMetrics.ModeEnabled))
+      val props = new java.util.Properties
+      props.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
+      props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, "true")
+      config.dynamicConfig.updateDefaultConfig(props)
+      assertEquals(1, metricValues(5)(LiProtocolBridgeMetrics.ModeEnabled))
+      assertEquals(1, metricValues(5)(LiProtocolBridgeMetrics.TopicDeletionStateCleanupEnabled))
+    } finally {
+      metrics.close()
+    }
+  }
+
+  @Test
+  def testMalformedMinimumLogRollValueDoesNotBreakGauge(): Unit = {
+    val props = TestUtils.createBrokerConfig(6, "localhost:2181")
+    props.put(KafkaConfig.LiMinLogRollTimeMillisProp, "not-a-number")
+    val metrics = new LiProtocolBridgeMetrics(KafkaConfig.fromProps(props))
+    try {
+      assertEquals(0, metricValues(6)(LiProtocolBridgeMetrics.MinimumLogRollEnabled))
+    } finally {
+      metrics.close()
+    }
+  }
+
+  private def metricValues(brokerId: Int): Map[String, Int] = {
+    KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.collect {
+      case (name, gauge: Gauge[_])
+        if name.getMBeanName.contains("type=LiProtocolBridgeMetrics") &&
+          name.getMBeanName.contains(s"broker-id=$brokerId") =>
+        name.getName -> gauge.value.asInstanceOf[Int]
+    }.toMap
+  }
+}


### PR DESCRIPTION
Add the dormant 3.0 protocol bridge with common v2/v5/v1 control versions. Reject old IBP and KRaft roles. Recheck activation after queue waits, retain admitted callbacks, and wait for offline-replica deletion acknowledgements. Add the separate default-off deletion-state/cache recovery flag. The wire fixtures are in the preceding PR; the final stray-log repair follows this PR.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.