### PR TITLE
clients: support 3.0-li wire compatibility

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1023,6 +1023,28 @@ public interface Admin extends AutoCloseable {
     }
 
     /**
+     * Elect the recommended leader for each supplied partition using default options.
+     *
+     * @param partitionsWithRecommendedLeaders partitions mapped to their recommended broker IDs
+     * @return The ElectLeadersResult.
+     */
+    default ElectLeadersResult electRecommendedLeaders(
+        Map<TopicPartition, Integer> partitionsWithRecommendedLeaders) {
+        return electRecommendedLeaders(partitionsWithRecommendedLeaders, new ElectLeadersOptions());
+    }
+
+    /**
+     * Elect the recommended leader for each supplied partition.
+     *
+     * @param partitionsWithRecommendedLeaders partitions mapped to their recommended broker IDs
+     * @param options options to use when electing leaders
+     * @return The ElectLeadersResult.
+     */
+    ElectLeadersResult electRecommendedLeaders(
+        Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
+        ElectLeadersOptions options);
+
+    /**
      * Elect a replica as leader for the given {@code partitions}, or for all partitions if the argument
      * to {@code partitions} is null.
      * <p>

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -184,6 +184,14 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public ElectLeadersResult electRecommendedLeaders(
+        Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
+        ElectLeadersOptions options
+    ) {
+        return delegate.electRecommendedLeaders(partitionsWithRecommendedLeaders, options);
+    }
+
+    @Override
     public ElectLeadersResult electLeaders(ElectionType electionType, Set<TopicPartition> partitions, ElectLeadersOptions options) {
         return delegate.electLeaders(electionType, partitions, options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3688,9 +3688,25 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
+    public ElectLeadersResult electRecommendedLeaders(
+            Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
+            ElectLeadersOptions options) {
+        return electLeaders(ElectionType.RECOMMENDED, partitionsWithRecommendedLeaders.keySet(),
+                partitionsWithRecommendedLeaders, options);
+    }
+
+    @Override
     public ElectLeadersResult electLeaders(
             final ElectionType electionType,
             final Set<TopicPartition> topicPartitions,
+            ElectLeadersOptions options) {
+        return electLeaders(electionType, topicPartitions, Collections.emptyMap(), options);
+    }
+
+    private ElectLeadersResult electLeaders(
+            final ElectionType electionType,
+            final Set<TopicPartition> topicPartitions,
+            final Map<TopicPartition, Integer> recommendedLeaders,
             ElectLeadersOptions options) {
         final KafkaFutureImpl<Map<TopicPartition, Optional<Throwable>>> electionFuture = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
@@ -3699,7 +3715,10 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             public ElectLeadersRequest.Builder createRequest(int timeoutMs) {
-                return new ElectLeadersRequest.Builder(electionType, topicPartitions, timeoutMs);
+                if (recommendedLeaders.isEmpty()) {
+                    return new ElectLeadersRequest.Builder(electionType, topicPartitions, timeoutMs);
+                }
+                return new ElectLeadersRequest.Builder(-1L, recommendedLeaders, timeoutMs);
             }
 
             @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NoOpConsumerRebalanceListener.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/NoOpConsumerRebalanceListener.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+
+/**
+ * Binary-compatibility adapter for LinkedIn client test utilities built against 3.0-li.
+ * New code should use an application-local no-op listener rather than this internal class.
+ */
+public class NoOpConsumerRebalanceListener implements ConsumerRebalanceListener {
+    @Override
+    public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+    }
+
+    @Override
+    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/ElectionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/ElectionType.java
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 @InterfaceStability.Evolving
 public enum ElectionType {
-    PREFERRED((byte) 0), UNCLEAN((byte) 1);
+    PREFERRED((byte) 0), UNCLEAN((byte) 1), RECOMMENDED((byte) 2);
 
     public final byte value;
 
@@ -42,6 +42,8 @@ public enum ElectionType {
             return PREFERRED;
         } else if (value == UNCLEAN.value) {
             return UNCLEAN;
+        } else if (value == RECOMMENDED.value) {
+            return RECOMMENDED;
         } else {
             throw new IllegalArgumentException(
                     String.format("Value %s must be one of %s", value, Arrays.asList(ElectionType.values())));

--- a/clients/src/main/java/org/apache/kafka/common/errors/NotEnoughPreferredControllersException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/NotEnoughPreferredControllersException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+/**
+ * The requested shutdown would leave too few preferred controllers available.
+ */
+public class NotEnoughPreferredControllersException extends RetriableException {
+    private static final long serialVersionUID = 1L;
+
+    public NotEnoughPreferredControllersException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -90,6 +90,7 @@ import org.apache.kafka.common.errors.NewLeaderElectedException;
 import org.apache.kafka.common.errors.NoReassignmentInProgressException;
 import org.apache.kafka.common.errors.NotControllerException;
 import org.apache.kafka.common.errors.NotCoordinatorException;
+import org.apache.kafka.common.errors.NotEnoughPreferredControllersException;
 import org.apache.kafka.common.errors.NotEnoughReplicasAfterAppendException;
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
@@ -409,9 +410,19 @@ public enum Errors {
     FENCED_STATE_EPOCH(124, "The share coordinator rejected the request because the share-group state epoch did not match.", FencedStateEpochException::new),
     INVALID_VOTER_KEY(125, "The voter key doesn't match the receiving replica's key.", InvalidVoterKeyException::new),
     DUPLICATE_VOTER(126, "The voter is already part of the set of voters.", DuplicateVoterException::new),
-    VOTER_NOT_FOUND(127, "The voter is not part of the set of voters.", VoterNotFoundException::new);
+    VOTER_NOT_FOUND(127, "The voter is not part of the set of voters.", VoterNotFoundException::new),
+
+    // Private 3.0-li error retained while old brokers can respond to controlled shutdown requests.
+    NOT_ENOUGH_PREFERRED_CONTROLLERS(2000, "Not enough live preferred controllers.",
+            NotEnoughPreferredControllersException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
+
+    static final short LI_OFFSET_MOVED_TO_TIERED_STORAGE_CODE = 1107;
+
+    public static short liOffsetMovedToTieredStorageCode() {
+        return LI_OFFSET_MOVED_TO_TIERED_STORAGE_CODE;
+    }
 
     private static final Map<Class<?>, Errors> CLASS_TO_ERROR = new HashMap<>();
     private static final Map<Short, Errors> CODE_TO_ERROR = new HashMap<>();
@@ -425,6 +436,10 @@ public enum Errors {
             if (error.exception != null)
                 CLASS_TO_ERROR.put(error.exception.getClass(), error);
         }
+        // 3.0-li reports this condition with private code 1107; see
+        // d54ff658e478d6314fdf1d51ca98592fb4f4d36f. Treat it as the upstream KIP-405 error
+        // while old brokers remain in the cluster.
+        CODE_TO_ERROR.put(LI_OFFSET_MOVED_TO_TIERED_STORAGE_CODE, OFFSET_MOVED_TO_TIERED_STORAGE);
     }
 
     private final short code;

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectLeadersRequest.java
@@ -31,18 +31,36 @@ import org.apache.kafka.common.protocol.MessageUtil;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class ElectLeadersRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<ElectLeadersRequest> {
         private final ElectionType electionType;
+        private final long brokerEpoch;
         private final Collection<TopicPartition> topicPartitions;
+        private final Map<TopicPartition, Integer> recommendedLeaders;
         private final int timeoutMs;
 
         public Builder(ElectionType electionType, Collection<TopicPartition> topicPartitions, int timeoutMs) {
+            this(electionType, -1L, topicPartitions, Collections.emptyMap(), timeoutMs);
+        }
+
+        public Builder(long brokerEpoch, Map<TopicPartition, Integer> recommendedLeaders, int timeoutMs) {
+            this(ElectionType.RECOMMENDED, brokerEpoch, recommendedLeaders.keySet(), recommendedLeaders, timeoutMs);
+        }
+
+        private Builder(ElectionType electionType,
+                        long brokerEpoch,
+                        Collection<TopicPartition> topicPartitions,
+                        Map<TopicPartition, Integer> recommendedLeaders,
+                        int timeoutMs) {
             super(ApiKeys.ELECT_LEADERS);
             this.electionType = electionType;
+            this.brokerEpoch = brokerEpoch;
             this.topicPartitions = topicPartitions;
+            this.recommendedLeaders = recommendedLeaders;
             this.timeoutMs = timeoutMs;
         }
 
@@ -76,12 +94,20 @@ public class ElectLeadersRequest extends AbstractRequest {
                         data.topicPartitions().add(tps);
                     }
                     tps.partitions().add(tp.partition());
+                    Integer recommendedLeader = recommendedLeaders.get(tp);
+                    if (recommendedLeader != null) {
+                        tps.recommendedPartitionLeaders().add(
+                            new ElectLeadersRequestData.RecommendedPartitionLeaderState()
+                                .setPartitionIndex(tp.partition())
+                                .setRecommendedLeader(recommendedLeader));
+                    }
                 });
             } else {
                 data.setTopicPartitions(null);
             }
 
             data.setElectionType(electionType.value);
+            data.setBrokerEpoch(brokerEpoch);
 
             return data;
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -47,6 +47,17 @@ public class ListOffsetsRequest extends AbstractRequest {
      */
     public static final long EARLIEST_LOCAL_TIMESTAMP = -4L;
 
+    /**
+     * 3.0-li uses -104 for the same earliest-local-offset query; see
+     * https://github.com/linkedin/kafka/commit/d54ff658e478d6314fdf1d51ca98592fb4f4d36f.
+     * Accept it while 3.0-li brokers remain in the cluster.
+     */
+    public static final long LI_EARLIEST_LOCAL_TIMESTAMP = -104L;
+
+    public static boolean isEarliestLocalTimestamp(long timestamp) {
+        return timestamp == EARLIEST_LOCAL_TIMESTAMP || timestamp == LI_EARLIEST_LOCAL_TIMESTAMP;
+    }
+
     public static final long LATEST_TIERED_TIMESTAMP = -5L;
 
     public static final int CONSUMER_REPLICA_ID = -1;

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -36,6 +36,8 @@ public class MetadataRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<MetadataRequest> {
         private static final MetadataRequestData ALL_TOPICS_REQUEST_DATA = new MetadataRequestData().
             setTopics(null).setAllowAutoTopicCreation(true);
+        private static final MetadataRequestData ALL_TOPICS_ONLY_REQUEST_DATA = new MetadataRequestData().
+            setTopics(null).setAllowAutoTopicCreation(false).setExcludePartitions(true);
 
         private final MetadataRequestData data;
 
@@ -83,6 +85,10 @@ public class MetadataRequest extends AbstractRequest {
             // This never causes auto-creation, but we set the boolean to true because that is the default value when
             // deserializing V2 and older. This way, the value is consistent after serialization and deserialization.
             return new Builder(ALL_TOPICS_REQUEST_DATA);
+        }
+
+        public static Builder allTopicsOnly() {
+            return new Builder(ALL_TOPICS_ONLY_REQUEST_DATA);
         }
 
         public boolean emptyTopicList() {
@@ -189,6 +195,10 @@ public class MetadataRequest extends AbstractRequest {
 
     public boolean allowAutoTopicCreation() {
         return data.allowAutoTopicCreation();
+    }
+
+    public boolean excludePartitions() {
+        return data.excludePartitions();
     }
 
     public static MetadataRequest parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/resources/common/message/ElectLeadersRequest.json
+++ b/clients/src/main/resources/common/message/ElectLeadersRequest.json
@@ -25,14 +25,26 @@
   "flexibleVersions": "2+",
   "fields": [
     { "name": "ElectionType", "type": "int8", "versions": "1+",
-      "about": "Type of elections to conduct for the partition. A value of '0' elects the preferred replica. A value of '1' elects the first live replica if there are no in-sync replica." },
+      "about": "Type of elections to conduct for the partition. A value of '0' elects the preferred replica. A value of '1' elects the first live replica if there are no in-sync replica. A value of '2' elects the requested live in-sync replica." },
+    // Compatibility fields introduced by 3.0-li commit 81dd4a6a1a for recommended leader elections.
+    { "name": "BrokerEpoch", "type": "int64", "versions": "2+", "default": "-1", "tag": 0, "taggedVersions": "2+",
+      "about": "The epoch of the broker requesting a recommended leader election." },
     { "name": "TopicPartitions", "type": "[]TopicPartitions", "versions": "0+", "nullableVersions": "0+",
       "about": "The topic partitions to elect leaders.",
       "fields": [
         { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName", "mapKey": true,
           "about": "The name of a topic." },
         { "name": "Partitions", "type": "[]int32", "versions": "0+",
-          "about": "The partitions of this topic whose leader should be elected." }
+          "about": "The partitions of this topic whose leader should be elected." },
+        { "name": "RecommendedPartitionLeaders", "type": "[]RecommendedPartitionLeaderState", "versions": "2+", "tag": 0, "taggedVersions": "2+",
+          "about": "The requested leader for each partition in a recommended leader election.",
+          "fields": [
+            { "name": "PartitionIndex", "type": "int32", "versions": "2+",
+              "about": "The partition index." },
+            { "name": "RecommendedLeader", "type": "int32", "versions": "2+",
+              "about": "The requested leader broker ID." }
+          ]
+        }
       ]
     },
     { "name": "TimeoutMs", "type": "int32", "versions": "0+", "default": "60000",

--- a/clients/src/main/resources/common/message/MetadataRequest.json
+++ b/clients/src/main/resources/common/message/MetadataRequest.json
@@ -50,6 +50,10 @@
     { "name": "IncludeClusterAuthorizedOperations", "type": "bool", "versions": "8-10",
       "about": "Whether to include cluster authorized operations." },
     { "name": "IncludeTopicAuthorizedOperations", "type": "bool", "versions": "8+",
-      "about": "Whether to include topic authorized operations." }
+      "about": "Whether to include topic authorized operations." },
+    // Compatibility field introduced by 3.0-li commit 60325e5905 for AdminClient listTopics.
+    { "name": "ExcludePartitions", "type": "bool", "versions": "9+", "default": "false",
+      "tag": 0, "taggedVersions": "9+",
+      "about": "Whether to omit partition metadata from the response. This preserves compatibility with 3.0-li AdminClient listTopics requests." }
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -742,6 +742,13 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public synchronized ElectLeadersResult electRecommendedLeaders(
+            Map<TopicPartition, Integer> partitionsWithRecommendedLeaders,
+            ElectLeadersOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public synchronized ElectLeadersResult electLeaders(
             ElectionType electionType,
             Set<TopicPartition> partitions,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NoOpConsumerRebalanceListenerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/NoOpConsumerRebalanceListenerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class NoOpConsumerRebalanceListenerTest {
+    private static final class LegacySubclass extends NoOpConsumerRebalanceListener {
+    }
+
+    @Test
+    void testLegacyConstructionCallbacksAndSubclassing() {
+        NoOpConsumerRebalanceListener listener = new LegacySubclass();
+        assertDoesNotThrow(() -> listener.onPartitionsAssigned(Collections.emptyList()));
+        assertDoesNotThrow(() -> listener.onPartitionsRevoked(Collections.emptyList()));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/message/BridgeClientProtocolFixtureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/BridgeClientProtocolFixtureTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.message;
+
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Message;
+import org.apache.kafka.common.protocol.MessageUtil;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Fixtures generated from compiled 3.0-li-3.9-bridge classes. */
+public class BridgeClientProtocolFixtureTest {
+    private static final byte[] ELECT_LEADERS_V2 = bytes(
+        "0202076f7264657273020000000301000a02000000030000000200000004d20100080000000000000063");
+    private static final byte[] METADATA_V12 = bytes("00000001000101");
+
+    @Test
+    public void testRecommendedElectionV2Fixture() {
+        ElectLeadersRequestData data = new ElectLeadersRequestData(
+            new ByteBufferAccessor(ByteBuffer.wrap(ELECT_LEADERS_V2)), (short) 2);
+        assertEquals(2, data.electionType());
+        assertEquals(1234, data.timeoutMs());
+        assertEquals(99L, data.brokerEpoch());
+        ElectLeadersRequestData.TopicPartitions topic = data.topicPartitions().find("orders");
+        assertEquals(3, topic.partitions().get(0));
+        assertEquals(3, topic.recommendedPartitionLeaders().get(0).partitionIndex());
+        assertEquals(2, topic.recommendedPartitionLeaders().get(0).recommendedLeader());
+        assertFixture(ELECT_LEADERS_V2, data, (short) 2);
+    }
+
+    @Test
+    public void testMetadataExcludePartitionsV12Fixture() {
+        MetadataRequestData data = new MetadataRequestData(
+            new ByteBufferAccessor(ByteBuffer.wrap(METADATA_V12)), (short) 12);
+        assertNull(data.topics());
+        assertTrue(data.excludePartitions());
+        assertFixture(METADATA_V12, data, (short) 12);
+    }
+
+    private static void assertFixture(byte[] expected, Message message, short version) {
+        ByteBuffer buffer = MessageUtil.toByteBuffer(message, version);
+        byte[] actual = new byte[buffer.remaining()];
+        buffer.get(actual);
+        assertArrayEquals(expected, actual);
+    }
+
+    private static byte[] bytes(String hex) {
+        byte[] result = new byte[hex.length() / 2];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return result;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/protocol/BridgeProtocolConstantsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/BridgeProtocolConstantsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.protocol;
+
+import org.apache.kafka.common.ElectionType;
+import org.apache.kafka.common.requests.ListOffsetsRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BridgeProtocolConstantsTest {
+    @Test
+    public void testLinkedInClientProtocolConstants() {
+        assertEquals(2, ElectionType.RECOMMENDED.value);
+        assertEquals(-104L, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP);
+        assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE, Errors.forCode((short) 1107));
+        assertEquals(Errors.NOT_ENOUGH_PREFERRED_CONTROLLERS, Errors.forCode((short) 2000));
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ErrorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ErrorsTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.protocol;
 
 import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ErrorsTest {
 
@@ -47,6 +49,18 @@ public class ErrorsTest {
                 exceptionSet.add(error.exception().getClass());
         }
         assertEquals(exceptionSet.size(), Errors.values().length - 1, "Exceptions must be unique"); // Ignore NONE
+    }
+
+    @Test
+    public void testBridgeDecodesLiTieredStorageError() {
+        Errors decoded = Errors.forCode(Errors.LI_OFFSET_MOVED_TO_TIERED_STORAGE_CODE);
+        assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE, decoded);
+        assertEquals((short) 109, decoded.code(), "The bridge normalizes LI code 1107 to upstream code 109");
+    }
+
+    @Test
+    public void testPreferredControllerShutdownErrorIsRetriable() {
+        assertTrue(Errors.NOT_ENOUGH_PREFERRED_CONTROLLERS.exception() instanceof RetriableException);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/ElectLeadersRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ElectLeadersRequestTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.ElectionType;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.ElectLeadersRequestData;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ElectLeadersRequestTest {
+    @Test
+    public void testRecommendedLeaderBuilder() {
+        TopicPartition partition = new TopicPartition("orders", 3);
+        Map<TopicPartition, Integer> recommendations = Collections.singletonMap(partition, 2);
+        ElectLeadersRequest request = new ElectLeadersRequest.Builder(99L, recommendations, 1234)
+            .build((short) 2);
+
+        ElectLeadersRequestData data = request.data();
+        assertEquals(ElectionType.RECOMMENDED.value, data.electionType());
+        assertEquals(99L, data.brokerEpoch());
+        assertEquals(1234, data.timeoutMs());
+        ElectLeadersRequestData.TopicPartitions topic = data.topicPartitions().find("orders");
+        assertEquals(3, topic.partitions().get(0));
+        assertEquals(3, topic.recommendedPartitionLeaders().get(0).partitionIndex());
+        assertEquals(2, topic.recommendedPartitionLeaders().get(0).recommendedLeader());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -42,12 +42,20 @@ import java.util.Map;
 import static org.apache.kafka.common.requests.ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP;
 import static org.apache.kafka.common.requests.ListOffsetsRequest.LATEST_TIERED_TIMESTAMP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ListOffsetsRequestTest {
 
     private final NodeApiVersions versionInfo = new NodeApiVersions(new ApiVersionsResponseData.ApiVersionCollection(), Collections.emptyList(), false);
+
+    @Test
+    public void testBridgeAcceptsBothEarliestLocalTimestamps() {
+        assertTrue(ListOffsetsRequest.isEarliestLocalTimestamp(ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP));
+        assertTrue(ListOffsetsRequest.isEarliestLocalTimestamp(ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP));
+        assertFalse(ListOffsetsRequest.isEarliestLocalTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP));
+    }
 
     @Test
     public void testDuplicatePartitions() {

--- a/clients/src/test/java/org/apache/kafka/common/requests/MetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/MetadataRequestTest.java
@@ -56,6 +56,23 @@ public class MetadataRequestTest {
     }
 
     @Test
+    public void testAllTopicsOnlyBuilder() {
+        MetadataRequest request = MetadataRequest.Builder.allTopicsOnly().build((short) 12);
+        assertTrue(request.isAllTopics());
+        assertTrue(request.excludePartitions());
+        assertFalse(request.allowAutoTopicCreation());
+    }
+
+    @Test
+    public void testLiExcludePartitionsTagRoundTrip() {
+        short version = 9;
+        MetadataRequest request = new MetadataRequest.Builder(
+                new MetadataRequestData().setTopics(null).setExcludePartitions(true)).build(version);
+        MetadataRequest parsed = MetadataRequest.parse(request.serialize(), version);
+        assertTrue(parsed.excludePartitions());
+    }
+
+    @Test
     public void testMetadataRequestVersion() {
         MetadataRequest.Builder builder = new MetadataRequest.Builder(Collections.singletonList("topic"), false);
         assertEquals(ApiKeys.METADATA.oldestVersion(), builder.oldestAllowedVersion());

--- a/core/src/main/scala/kafka/api/package.scala
+++ b/core/src/main/scala/kafka/api/package.scala
@@ -35,6 +35,18 @@ package object api {
       }
     }
 
+    def partitionRecommendedLeaders: Map[TopicPartition, Int] = {
+      if (self.data.topicPartitions == null) {
+        Map.empty
+      } else {
+        self.data.topicPartitions.asScala.iterator.flatMap { topicPartitions =>
+          topicPartitions.recommendedPartitionLeaders.asScala.map { recommendation =>
+            new TopicPartition(topicPartitions.topic, recommendation.partitionIndex) -> recommendation.recommendedLeader
+          }
+        }.toMap
+      }
+    }
+
     def electionType: ElectionType = {
       if (self.version == 0) {
         ElectionType.PREFERRED

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1617,7 +1617,8 @@ class Partition(val topicPartition: TopicPartition,
       case ListOffsetsRequest.LATEST_TIMESTAMP =>
         maybeOffsetsError.map(e => throw e)
           .orElse(Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, lastFetchableOffset, Optional.of(leaderEpoch))))
-      case ListOffsetsRequest.EARLIEST_TIMESTAMP | ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP =>
+      case timestamp if timestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP ||
+        ListOffsetsRequest.isEarliestLocalTimestamp(timestamp) =>
         getOffsetByTimestamp
       case _ =>
         getOffsetByTimestamp.filter(timestampAndOffset => timestampAndOffset.offset < lastFetchableOffset)

--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -19,7 +19,7 @@ package kafka.controller
 import kafka.api.LeaderAndIsr
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.Seq
+import scala.collection.{Map, Seq}
 
 case class ElectionResult(topicPartition: TopicPartition, leaderAndIsr: Option[LeaderAndIsr], liveReplicas: Seq[Int])
 
@@ -103,6 +103,27 @@ object Election {
                         leaderAndIsrs: Seq[(TopicPartition, LeaderAndIsr)]): Seq[ElectionResult] = {
     leaderAndIsrs.map { case (partition, leaderAndIsr) =>
       leaderForReassign(partition, leaderAndIsr, controllerContext)
+    }
+  }
+
+  private def leaderForRecommendation(partition: TopicPartition,
+                                      leaderAndIsr: LeaderAndIsr,
+                                      recommendedLeader: Option[Int],
+                                      controllerContext: ControllerContext): ElectionResult = {
+    val assignment = controllerContext.partitionReplicaAssignment(partition)
+    val liveReplicas = assignment.filter(replica => controllerContext.isReplicaOnline(replica, partition))
+    val leaderOpt = PartitionLeaderElectionAlgorithms.recommendedPartitionLeaderElection(
+      recommendedLeader, leaderAndIsr.isr, liveReplicas.toSet)
+    val newLeaderAndIsr = leaderOpt.map(leaderAndIsr.newLeader)
+    ElectionResult(partition, newLeaderAndIsr, liveReplicas)
+  }
+
+  /** Elect the requested leader when it is both live and in the ISR. */
+  def leaderForRecommendation(controllerContext: ControllerContext,
+                              leaderAndIsrs: Seq[(TopicPartition, LeaderAndIsr)],
+                              recommendedLeaders: Map[TopicPartition, Int]): Seq[ElectionResult] = {
+    leaderAndIsrs.map { case (partition, leaderAndIsr) =>
+      leaderForRecommendation(partition, leaderAndIsr, recommendedLeaders.get(partition), controllerContext)
     }
   }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -321,7 +321,7 @@ class KafkaController(val config: KafkaConfig,
     initializePartitionReassignments()
     topicDeletionManager.tryTopicDeletion()
     val pendingPreferredReplicaElections = fetchPendingPreferredReplicaElections()
-    onReplicaElection(pendingPreferredReplicaElections, ElectionType.PREFERRED, ZkTriggered)
+    onReplicaElection(pendingPreferredReplicaElections, Map.empty, ElectionType.PREFERRED, ZkTriggered)
     info("Starting the controller scheduler")
     kafkaScheduler.startup()
     if (config.autoLeaderRebalanceEnable) {
@@ -908,6 +908,7 @@ class KafkaController(val config: KafkaConfig,
     */
   private[this] def onReplicaElection(
     partitions: Set[TopicPartition],
+    recommendedLeaders: Map[TopicPartition, Int],
     electionType: ElectionType,
     electionTrigger: ElectionTrigger
   ): Map[TopicPartition, Either[Throwable, LeaderAndIsr]] = {
@@ -920,6 +921,10 @@ class KafkaController(val config: KafkaConfig,
            * triggered by the admin client
            */
           OfflinePartitionLeaderElectionStrategy(allowUnclean = electionTrigger == AdminClientTriggered)
+        case ElectionType.RECOMMENDED =>
+          RecommendedLeaderElectionStrategy(recommendedLeaders.filter { case (partition, _) =>
+            partitions.contains(partition)
+          })
       }
 
       val results = partitionStateMachine.handleStateChanges(
@@ -1222,7 +1227,7 @@ class KafkaController(val config: KafkaConfig,
     if (!isTriggeredByAutoRebalance) {
       zkClient.deletePreferredReplicaElection(controllerContext.epochZkVersion)
       // Ensure we detect future preferred replica leader elections
-      eventManager.put(ReplicaLeaderElection(None, ElectionType.PREFERRED, ZkTriggered))
+      eventManager.put(ReplicaLeaderElection(None, None, ElectionType.PREFERRED, ZkTriggered))
     }
   }
 
@@ -1316,7 +1321,7 @@ class KafkaController(val config: KafkaConfig,
           controllerContext.allTopics.contains(tp.topic) &&
           canPreferredReplicaBeLeader(tp)
        )
-        onReplicaElection(candidatePartitions.toSet, ElectionType.PREFERRED, AutoTriggered)
+        onReplicaElection(candidatePartitions.toSet, Map.empty, ElectionType.PREFERRED, AutoTriggered)
       }
     }
   }
@@ -2177,10 +2182,12 @@ class KafkaController(val config: KafkaConfig,
 
   def electLeaders(
     partitions: Set[TopicPartition],
+    recommendedLeaders: Map[TopicPartition, Int],
     electionType: ElectionType,
     callback: ElectLeadersCallback
   ): Unit = {
-    eventManager.put(ReplicaLeaderElection(Some(partitions), electionType, AdminClientTriggered, callback))
+    eventManager.put(ReplicaLeaderElection(
+      Some(partitions), Some(recommendedLeaders), electionType, AdminClientTriggered, callback))
   }
 
   def listPartitionReassignments(partitions: Option[Set[TopicPartition]],
@@ -2200,6 +2207,7 @@ class KafkaController(val config: KafkaConfig,
 
   private def processReplicaLeaderElection(
     partitionsFromAdminClientOpt: Option[Set[TopicPartition]],
+    recommendedLeadersFromAdminClientOpt: Option[Map[TopicPartition, Int]],
     electionType: ElectionType,
     electionTrigger: ElectionTrigger,
     callback: ElectLeadersCallback
@@ -2223,7 +2231,16 @@ class KafkaController(val config: KafkaConfig,
           info(s"Skipping replica leader election ($electionType) for partition $p by $electionTrigger since it doesn't exist.")
         }
 
-        val (partitionsBeingDeleted, livePartitions) = knownPartitions.partition(partition =>
+        val (validRequestPartitions, invalidRequestPartitions) = if (electionType == ElectionType.RECOMMENDED) {
+          recommendedLeadersFromAdminClientOpt match {
+            case Some(recommendedLeaders) => knownPartitions.partition(recommendedLeaders.contains)
+            case None => (Set.empty[TopicPartition], knownPartitions)
+          }
+        } else {
+          (knownPartitions, Set.empty[TopicPartition])
+        }
+
+        val (partitionsBeingDeleted, livePartitions) = validRequestPartitions.partition(partition =>
             topicDeletionManager.isTopicQueuedUpForDeletion(partition.topic))
         if (partitionsBeingDeleted.nonEmpty) {
           warn(s"Skipping replica leader election ($electionType) for partitions $partitionsBeingDeleted " +
@@ -2242,10 +2259,14 @@ class KafkaController(val config: KafkaConfig,
             case ElectionType.UNCLEAN =>
               val currentLeader = controllerContext.partitionLeadershipInfo(partition).get.leaderAndIsr.leader
               currentLeader == LeaderAndIsr.NoLeader || !controllerContext.isLiveBroker(currentLeader)
+            case ElectionType.RECOMMENDED =>
+              val currentLeader = controllerContext.partitionLeadershipInfo(partition).get.leaderAndIsr.leader
+              recommendedLeadersFromAdminClientOpt.exists(_.get(partition).exists(_ != currentLeader))
           }
         }
 
-        val results = onReplicaElection(electablePartitions, electionType, electionTrigger).map {
+        val results = onReplicaElection(electablePartitions,
+          recommendedLeadersFromAdminClientOpt.getOrElse(Map.empty), electionType, electionTrigger).map {
           case (k, Left(ex)) =>
             if (ex.isInstanceOf[StateChangeFailedException]) {
               val error = if (electionType == ElectionType.PREFERRED) {
@@ -2262,6 +2283,9 @@ class KafkaController(val config: KafkaConfig,
         alreadyValidLeader.map(_ -> Left(new ApiError(Errors.ELECTION_NOT_NEEDED))) ++
         partitionsBeingDeleted.map(
           _ -> Left(new ApiError(Errors.INVALID_TOPIC_EXCEPTION, "The topic is being deleted"))
+        ) ++
+        invalidRequestPartitions.map(
+          _ -> Left(new ApiError(Errors.INVALID_REQUEST, "No recommended leader was provided for the partition"))
         ) ++
         unknownPartitions.map(
           _ -> Left(new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, "The partition does not exist."))
@@ -2602,8 +2626,8 @@ class KafkaController(val config: KafkaConfig,
           error("Received a ShutdownEventThread event. This type of event is supposed to be handle by ControllerEventThread")
         case AutoPreferredReplicaLeaderElection =>
           processAutoPreferredReplicaLeaderElection()
-        case ReplicaLeaderElection(partitions, electionType, electionTrigger, callback) =>
-          processReplicaLeaderElection(partitions, electionType, electionTrigger, callback)
+        case ReplicaLeaderElection(partitions, recommendedLeaders, electionType, electionTrigger, callback) =>
+          processReplicaLeaderElection(partitions, recommendedLeaders, electionType, electionTrigger, callback)
         case UncleanLeaderElectionEnable =>
           processUncleanLeaderElectionEnable()
         case TopicUncleanLeaderElectionEnable(topic) =>
@@ -2743,7 +2767,8 @@ object IsrChangeNotificationHandler {
 class PreferredReplicaElectionHandler(eventManager: ControllerEventManager) extends ZNodeChangeHandler {
   override val path: String = PreferredReplicaElectionZNode.path
 
-  override def handleCreation(): Unit = eventManager.put(ReplicaLeaderElection(None, ElectionType.PREFERRED, ZkTriggered))
+  override def handleCreation(): Unit =
+    eventManager.put(ReplicaLeaderElection(None, None, ElectionType.PREFERRED, ZkTriggered))
 }
 
 class ControllerChangeHandler(eventManager: ControllerEventManager) extends ZNodeChangeHandler {
@@ -2928,6 +2953,7 @@ case class AlterPartitionReceived(
 
 case class ReplicaLeaderElection(
   partitionsFromAdminClientOpt: Option[Set[TopicPartition]],
+  recommendedLeadersFromAdminClientOpt: Option[Map[TopicPartition, Int]],
   electionType: ElectionType,
   electionTrigger: ElectionTrigger,
   callback: ElectLeadersCallback = _ => {}

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -426,6 +426,8 @@ class ZkPartitionStateMachine(config: KafkaConfig,
         leaderForPreferredReplica(controllerContext, validLeaderAndIsrs).partition(_.leaderAndIsr.isEmpty)
       case ControlledShutdownPartitionLeaderElectionStrategy =>
         leaderForControlledShutdown(controllerContext, validLeaderAndIsrs).partition(_.leaderAndIsr.isEmpty)
+      case RecommendedLeaderElectionStrategy(recommendedLeaders) =>
+        leaderForRecommendation(controllerContext, validLeaderAndIsrs, recommendedLeaders).partition(_.leaderAndIsr.isEmpty)
     }
     partitionsWithoutLeaders.foreach { electionResult =>
       val partition = electionResult.topicPartition
@@ -546,6 +548,12 @@ object PartitionLeaderElectionAlgorithms {
     reassignment.find(id => liveReplicas.contains(id) && isr.contains(id))
   }
 
+  def recommendedPartitionLeaderElection(recommendedLeader: Option[Int],
+                                           isr: Seq[Int],
+                                           liveReplicas: Set[Int]): Option[Int] = {
+    recommendedLeader.filter(leader => isr.contains(leader) && liveReplicas.contains(leader))
+  }
+
   def preferredReplicaPartitionLeaderElection(assignment: Seq[Int], isr: Seq[Int], liveReplicas: Set[Int]): Option[Int] = {
     assignment.headOption.filter(id => liveReplicas.contains(id) && isr.contains(id))
   }
@@ -560,6 +568,8 @@ final case class OfflinePartitionLeaderElectionStrategy(allowUnclean: Boolean) e
 case object ReassignPartitionLeaderElectionStrategy extends PartitionLeaderElectionStrategy
 case object PreferredReplicaPartitionLeaderElectionStrategy extends PartitionLeaderElectionStrategy
 case object ControlledShutdownPartitionLeaderElectionStrategy extends PartitionLeaderElectionStrategy
+final case class RecommendedLeaderElectionStrategy(recommendedLeaders: Map[TopicPartition, Int])
+  extends PartitionLeaderElectionStrategy
 
 sealed trait PartitionState {
   def state: Byte

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1335,7 +1335,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
 
       // For the earliest and latest, we do not need to return the timestamp.
       if (targetTimestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP ||
-        (!remoteLogEnabled() && targetTimestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)) {
+        (!remoteLogEnabled() && ListOffsetsRequest.isEarliestLocalTimestamp(targetTimestamp))) {
         // The first cached epoch usually corresponds to the log start offset, but we have to verify this since
         // it may not be true following a message format version bump as the epoch will not be available for
         // log entries written in the older format.
@@ -1345,7 +1345,7 @@ class UnifiedLog(@volatile var logStartOffset: Long,
         } else Optional.empty[Integer]()
 
         Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, logStartOffset, epochOpt))
-      } else if (targetTimestamp == ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP) {
+      } else if (ListOffsetsRequest.isEarliestLocalTimestamp(targetTimestamp)) {
         val curLocalLogStartOffset = localLogStartOffset()
 
         val epochResult: Optional[Integer] =

--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -30,6 +30,7 @@ import kafka.server.logger.RuntimeLoggerManager
 import kafka.server.metadata.KRaftMetadataCache
 import kafka.utils.Logging
 import org.apache.kafka.clients.admin.{AlterConfigOp, EndpointType}
+import org.apache.kafka.common.ElectionType
 import org.apache.kafka.common.Uuid.ZERO_UUID
 import org.apache.kafka.common.acl.AclOperation.{ALTER, ALTER_CONFIGS, CLUSTER_ACTION, CREATE, CREATE_TOKENS, DELETE, DESCRIBE, DESCRIBE_CONFIGS}
 import org.apache.kafka.common.config.ConfigResource
@@ -567,6 +568,12 @@ class ControllerApis(
   def handleElectLeaders(request: RequestChannel.Request): CompletableFuture[Unit] = {
     authHelper.authorizeClusterOperation(request, ALTER)
     val electLeadersRequest = request.body[ElectLeadersRequest]
+    if (electLeadersRequest.data.electionType == ElectionType.RECOMMENDED.value) {
+      requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+        electLeadersRequest.getErrorResponse(throttleMs,
+          new InvalidRequestException("Recommended leader election is supported only by ZooKeeper controllers")))
+      return CompletableFuture.completedFuture(())
+    }
     val context = new ControllerRequestContext(request.context.header.data, request.context.principal,
       requestTimeoutMsToDeadlineNs(time, electLeadersRequest.data.timeoutMs))
     val future = controller.electLeaders(context, electLeadersRequest.data)

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -93,14 +93,25 @@ object DynamicBrokerConfig {
     LogCleaner.ReconfigurableConfigs ++
     DynamicLogConfig.ReconfigurableConfigs ++
     DynamicThreadPool.ReconfigurableConfigs ++
-    Set(MetricConfigs.METRIC_REPORTER_CLASSES_CONFIG, KafkaConfig.LiProtocolBridgeModeEnableProp) ++
+    Set(
+      MetricConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+      KafkaConfig.LiProtocolBridgeModeEnableProp,
+      KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp,
+      KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
+      KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp
+    ) ++
     DynamicListenerConfig.ReconfigurableConfigs ++
     SocketServer.ReconfigurableConfigs ++
     DynamicProducerStateManagerConfig ++
     DynamicRemoteLogConfig.ReconfigurableConfigs
 
   private val ClusterLevelListenerConfigs = Set(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, SocketServerConfigs.MAX_CONNECTION_CREATION_RATE_CONFIG, SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG)
-  private val ClusterLevelConfigs = Set(KafkaConfig.LiProtocolBridgeModeEnableProp)
+  private val ClusterLevelConfigs = Set(
+    KafkaConfig.LiProtocolBridgeModeEnableProp,
+    KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp,
+    KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
+    KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp
+  )
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(
     ClusterLevelListenerConfigs)
   private val ListenerMechanismConfigs = Set(SaslConfigs.SASL_JAAS_CONFIG,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -66,7 +66,7 @@ import org.apache.kafka.common.resource.{Resource, ResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.security.token.delegation.{DelegationToken, TokenInformation}
 import org.apache.kafka.common.utils.{ProducerIdAndEpoch, Time}
-import org.apache.kafka.common.{Node, TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.common.{ElectionType, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.coordinator.group.{Group, GroupCoordinator}
 import org.apache.kafka.server.ClientMetricsManager
 import org.apache.kafka.server.authorizer._
@@ -1160,13 +1160,19 @@ class KafkaApis(val requestChannel: RequestChannel,
     val clientId = request.header.clientId
     val offsetRequest = request.body[ListOffsetsRequest]
     val version = request.header.apiVersion
-    val timestampMinSupportedVersion = immutable.Map[Long, Short](
+    val upstreamTimestampMinSupportedVersion = immutable.Map[Long, Short](
       ListOffsetsRequest.EARLIEST_TIMESTAMP -> 1.toShort,
       ListOffsetsRequest.LATEST_TIMESTAMP -> 1.toShort,
       ListOffsetsRequest.MAX_TIMESTAMP -> 7.toShort,
       ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP -> 8.toShort,
       ListOffsetsRequest.LATEST_TIERED_TIMESTAMP -> 9.toShort
     )
+    val timestampMinSupportedVersion = if (config.liProtocolBridgeFollowerRecoveryActive) {
+      // 3.0-li introduced its private earliest-local value in ListOffsets v7.
+      upstreamTimestampMinSupportedVersion + (ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP -> 7.toShort)
+    } else {
+      upstreamTimestampMinSupportedVersion
+    }
 
     def buildErrorResponse(e: Errors, partition: ListOffsetsPartition): ListOffsetsPartitionResponse = {
       new ListOffsetsPartitionResponse()
@@ -1238,6 +1244,12 @@ class KafkaApis(val requestChannel: RequestChannel,
                   s"partition $topicPartition failed due to ${e.getMessage}")
               buildErrorResponse(Errors.forException(e), partition)
 
+            case e: OffsetMovedToTieredStorageException =>
+              val response = buildErrorResponse(Errors.OFFSET_MOVED_TO_TIERED_STORAGE, partition)
+              response.setErrorCode(KafkaApis.offsetMovedErrorCode(
+                config.liProtocolBridgeFollowerRecoveryActive, partition.timestamp))
+              response
+
             // Only V5 and newer ListOffset calls should get OFFSET_NOT_AVAILABLE
             case e: OffsetNotAvailableException =>
               if (request.header.apiVersion >= 5) {
@@ -1273,6 +1285,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   private def getTopicMetadata(
     request: RequestChannel.Request,
     fetchAllTopics: Boolean,
+    excludePartitions: Boolean,
     allowAutoTopicCreation: Boolean,
     topics: Set[String],
     listenerName: ListenerName,
@@ -1281,11 +1294,24 @@ class KafkaApis(val requestChannel: RequestChannel,
   ): Seq[MetadataResponseTopic] = {
     val topicResponses = metadataCache.getTopicMetadata(topics, listenerName,
       errorUnavailableEndpoints, errorUnavailableListeners)
-
-    if (topics.isEmpty || topicResponses.size == topics.size || fetchAllTopics) {
-      topicResponses
+    val effectiveTopicResponses = if (excludePartitions) {
+      topicResponses.map { topic =>
+        new MetadataResponseTopic()
+          .setErrorCode(topic.errorCode)
+          .setName(topic.name)
+          .setTopicId(topic.topicId)
+          .setIsInternal(topic.isInternal)
+          .setPartitions(util.Collections.emptyList())
+          .setTopicAuthorizedOperations(topic.topicAuthorizedOperations)
+      }
     } else {
-      val nonExistingTopics = topics.diff(topicResponses.map(_.name).toSet)
+      topicResponses
+    }
+
+    if (topics.isEmpty || effectiveTopicResponses.size == topics.size || fetchAllTopics) {
+      effectiveTopicResponses
+    } else {
+      val nonExistingTopics = topics.diff(effectiveTopicResponses.map(_.name).toSet)
       val nonExistingTopicResponses = if (allowAutoTopicCreation) {
         val controllerMutationQuota = quotas.controllerMutation.newPermissiveQuotaFor(request)
         autoTopicCreationManager.createTopics(nonExistingTopics, controllerMutationQuota, Some(request.context))
@@ -1309,7 +1335,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         }
       }
 
-      topicResponses ++ nonExistingTopicResponses
+      effectiveTopicResponses ++ nonExistingTopicResponses
     }
   }
 
@@ -1390,8 +1416,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     val errorUnavailableListeners = requestVersion >= 6
 
     val allowAutoCreation = config.autoCreateTopicsEnable && metadataRequest.allowAutoTopicCreation && !metadataRequest.isAllTopics
-    val topicMetadata = getTopicMetadata(request, metadataRequest.isAllTopics, allowAutoCreation, authorizedTopics,
-      request.context.listenerName, errorUnavailableEndpoints, errorUnavailableListeners)
+    val excludePartitions = metadataRequest.excludePartitions && config.liProtocolBridgeExcludePartitionsActive
+    val topicMetadata = getTopicMetadata(request, metadataRequest.isAllTopics, excludePartitions, allowAutoCreation,
+      authorizedTopics, request.context.listenerName, errorUnavailableEndpoints, errorUnavailableListeners)
 
     var clusterAuthorizedOperations = Int.MinValue // Default value in the schema
     if (requestVersion >= 8) {
@@ -3377,6 +3404,13 @@ class KafkaApis(val requestChannel: RequestChannel,
   def handleElectLeaders(request: RequestChannel.Request): Unit = {
     val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldAlwaysForward(request))
     val electionRequest = request.body[ElectLeadersRequest]
+    if (electionRequest.electionType == ElectionType.RECOMMENDED &&
+      !config.liProtocolBridgeRecommendedElectionActive) {
+      requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+        electionRequest.getErrorResponse(throttleMs,
+          new InvalidRequestException("Recommended leader election compatibility is disabled")))
+      return
+    }
 
     def sendResponseCallback(
       error: ApiError
@@ -3438,6 +3472,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       replicaManager.electLeaders(
         zkSupport.controller,
         partitions,
+        electionRequest.partitionRecommendedLeaders,
         electionRequest.electionType,
         sendResponseCallback(ApiError.NONE),
         electionRequest.data.timeoutMs
@@ -4132,6 +4167,12 @@ class KafkaApis(val requestChannel: RequestChannel,
 }
 
 object KafkaApis {
+  private[server] def offsetMovedErrorCode(liFollowerRecovery: Boolean, timestamp: Long): Short =
+    if (liFollowerRecovery && timestamp == ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP)
+      Errors.liOffsetMovedToTieredStorageCode()
+    else
+      Errors.OFFSET_MOVED_TO_TIERED_STORAGE.code
+
   // Traffic from both in-sync and out of sync replicas are accounted for in replication quota to ensure total replication
   // traffic doesn't exceed quota.
   // TODO: remove resolvedResponseData method when sizeOf can take a data object.

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -60,9 +60,19 @@ import scala.collection.{Map, Seq}
 object KafkaConfig {
 
   val LiProtocolBridgeModeEnableProp = "li.protocol.bridge.mode.enable"
+  val LiProtocolBridgeFollowerRecoveryEnableProp = "li.protocol.bridge.follower.recovery.enable"
+  val LiProtocolBridgeRecommendedElectionEnableProp = "li.protocol.bridge.recommended.leader.election.enable"
+  val LiProtocolBridgeExcludePartitionsEnableProp = "li.protocol.bridge.metadata.exclude.partitions.enable"
+
   val LiProtocolBridgeModeEnableDoc =
     "Enable the temporary protocol bridge used while 3.0-li and upstream-based brokers coexist. " +
     "In ZooKeeper mode, bridge controllers send LeaderAndIsr v2, UpdateMetadata v5, and StopReplica v1."
+  val LiProtocolBridgeFollowerRecoveryEnableDoc =
+    "Accept the 3.0-li earliest-local ListOffsets value and use it for follower recovery in bridge mode."
+  val LiProtocolBridgeRecommendedElectionEnableDoc =
+    "Accept 3.0-li recommended leader election requests on ZooKeeper controllers."
+  val LiProtocolBridgeExcludePartitionsEnableDoc =
+    "Honor the 3.0-li Metadata request tag that omits partition metadata from the response."
 
   def main(args: Array[String]): Unit = {
     System.out.println(configDef.toHtml(4, (config: String) => "brokerconfigs_" + config,
@@ -96,6 +106,12 @@ object KafkaConfig {
   val configDef = new ConfigDef(AbstractKafkaConfig.CONFIG_DEF)
     .define(LiProtocolBridgeModeEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeModeEnableDoc)
+    .define(LiProtocolBridgeFollowerRecoveryEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeFollowerRecoveryEnableDoc)
+    .define(LiProtocolBridgeRecommendedElectionEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeRecommendedElectionEnableDoc)
+    .define(LiProtocolBridgeExcludePartitionsEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeExcludePartitionsEnableDoc)
 
   def configNames: Seq[String] = configDef.names.asScala.toBuffer.sorted
   private[server] def defaultValues: Map[String, _] = configDef.defaultValues.asScala
@@ -195,7 +211,21 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   @volatile private var currentConfig = this
   val processRoles: Set[ProcessRole] = parseProcessRoles()
   def liProtocolBridgeModeEnable: Boolean = getBoolean(KafkaConfig.LiProtocolBridgeModeEnableProp)
+  def liProtocolBridgeFollowerRecoveryEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp)
+  def liProtocolBridgeRecommendedElectionEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp)
+  def liProtocolBridgeExcludePartitionsEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp)
+
   def liProtocolBridgeModeActive: Boolean = processRoles.isEmpty && liProtocolBridgeModeEnable
+  def liProtocolBridgeFollowerRecoveryActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeFollowerRecoveryEnable
+  def liProtocolBridgeRecommendedElectionActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeRecommendedElectionEnable
+  def liProtocolBridgeExcludePartitionsActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeExcludePartitionsEnable
+
   private[server] val dynamicConfig = new DynamicBrokerConfig(this)
 
   private[server] def updateCurrentConfig(newConfig: KafkaConfig): Unit = {

--- a/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
+++ b/core/src/main/scala/kafka/server/RemoteLeaderEndPoint.scala
@@ -104,7 +104,12 @@ class RemoteLeaderEndPoint(logPrefix: String,
   }
 
   override def fetchEarliestLocalOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
-    fetchOffset(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)
+    val timestamp = if (brokerConfig.liProtocolBridgeModeActive &&
+      brokerConfig.liProtocolBridgeFollowerRecoveryActive)
+      ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP
+    else
+      ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP
+    fetchOffset(topicPartition, currentLeaderEpoch, timestamp)
   }
 
   private def fetchOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int, timestamp: Long): OffsetAndEpoch = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2621,6 +2621,7 @@ class ReplicaManager(val config: KafkaConfig,
   def electLeaders(
     controller: KafkaController,
     partitions: Set[TopicPartition],
+    recommendedLeaders: Map[TopicPartition, Int],
     electionType: ElectionType,
     responseCallback: Map[TopicPartition, ApiError] => Unit,
     requestTimeout: Int
@@ -2656,7 +2657,7 @@ class ReplicaManager(val config: KafkaConfig,
       }
     }
 
-    controller.electLeaders(partitions, electionType, electionCallback)
+    controller.electLeaders(partitions, recommendedLeaders, electionType, electionCallback)
   }
 
   def activeProducerState(requestPartition: TopicPartition): DescribeProducersResponseData.PartitionResponse = {

--- a/core/src/test/scala/unit/kafka/api/ElectLeadersRequestOpsTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ElectLeadersRequestOpsTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.api
+
+import org.apache.kafka.common.{ElectionType, TopicPartition}
+import org.apache.kafka.common.message.ElectLeadersRequestData
+import org.apache.kafka.common.protocol.MessageUtil
+import org.apache.kafka.common.requests.ElectLeadersRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import java.util.Arrays
+
+class ElectLeadersRequestOpsTest {
+
+  @Test
+  def testRecommendedLeadersFrom30LiRequest(): Unit = {
+    val topic = new ElectLeadersRequestData.TopicPartitions()
+      .setTopic("topic")
+      .setPartitions(Arrays.asList(1, 2))
+      .setRecommendedPartitionLeaders(Arrays.asList(
+        new ElectLeadersRequestData.RecommendedPartitionLeaderState()
+          .setPartitionIndex(1)
+          .setRecommendedLeader(4),
+        new ElectLeadersRequestData.RecommendedPartitionLeaderState()
+          .setPartitionIndex(2)
+          .setRecommendedLeader(5)
+      ))
+    val topics = new ElectLeadersRequestData.TopicPartitionsCollection()
+    topics.add(topic)
+    val data = new ElectLeadersRequestData()
+      .setElectionType(ElectionType.RECOMMENDED.value)
+      .setBrokerEpoch(10L)
+      .setTopicPartitions(topics)
+
+    val version: Short = 2
+    val request = ElectLeadersRequest.parse(MessageUtil.toByteBuffer(data, version), version)
+
+    assertEquals(ElectionType.RECOMMENDED, request.electionType)
+    assertEquals(Map(new TopicPartition("topic", 1) -> 4, new TopicPartition("topic", 2) -> 5),
+      request.partitionRecommendedLeaders)
+    assertEquals(10L, request.data.brokerEpoch)
+  }
+}

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -847,7 +847,7 @@ class ControllerIntegrationTest extends QuorumTestHarness {
     val tp0 = new TopicPartition("t", 0)
     val tp1 = new TopicPartition("t", 1)
     val partitions = Set(tp0, tp1)
-    val event1 = ReplicaLeaderElection(Some(partitions), ElectionType.PREFERRED, ZkTriggered, partitionsMap => {
+    val event1 = ReplicaLeaderElection(Some(partitions), None, ElectionType.PREFERRED, ZkTriggered, partitionsMap => {
       for (partition <- partitionsMap) {
         partition._2 match {
           case Left(e) => assertEquals(Errors.NOT_CONTROLLER, e.error())

--- a/core/src/test/scala/unit/kafka/controller/MockPartitionStateMachine.scala
+++ b/core/src/test/scala/unit/kafka/controller/MockPartitionStateMachine.scala
@@ -114,6 +114,8 @@ class MockPartitionStateMachine(
         leaderForPreferredReplica(controllerContext, validLeaderAndIsrs)
       case ControlledShutdownPartitionLeaderElectionStrategy =>
         leaderForControlledShutdown(controllerContext, validLeaderAndIsrs)
+      case RecommendedLeaderElectionStrategy(recommendedLeaders) =>
+        leaderForRecommendation(controllerContext, validLeaderAndIsrs, recommendedLeaders)
     }
 
     val results: Map[TopicPartition, Either[Exception, LeaderAndIsr]] = electionResults.map { electionResult =>

--- a/core/src/test/scala/unit/kafka/controller/PartitionLeaderElectionAlgorithmsTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionLeaderElectionAlgorithmsTest.scala
@@ -103,6 +103,21 @@ class PartitionLeaderElectionAlgorithmsTest {
   }
 
   @Test
+  def testRecommendedLeaderMustBeLiveAndInSync(): Unit = {
+    val isr = Seq(2, 4)
+    val liveReplicas = Set(2, 4)
+
+    assertEquals(Some(4), PartitionLeaderElectionAlgorithms.recommendedPartitionLeaderElection(
+      Some(4), isr, liveReplicas))
+    assertEquals(None, PartitionLeaderElectionAlgorithms.recommendedPartitionLeaderElection(
+      Some(3), isr, liveReplicas + 3))
+    assertEquals(None, PartitionLeaderElectionAlgorithms.recommendedPartitionLeaderElection(
+      Some(4), isr, liveReplicas - 4))
+    assertEquals(None, PartitionLeaderElectionAlgorithms.recommendedPartitionLeaderElection(
+      None, isr, liveReplicas))
+  }
+
+  @Test
   def testPreferredReplicaPartitionLeaderElection(): Unit = {
     val assignment = Seq(2, 4)
     val isr = Seq(2, 4)

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -300,18 +300,24 @@ class DynamicBrokerConfigTest {
   }
 
   @Test
-  def testProtocolBridgeModeIsClusterWideDynamicConfig(): Unit = {
+  def testProtocolBridgeFlagsAreDisabledByDefaultAndClusterWide(): Unit = {
     val brokerProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     brokerProps.put(ReplicationConfigs.INTER_BROKER_PROTOCOL_VERSION_CONFIG, "3.0")
     val config = KafkaConfig(brokerProps)
     config.dynamicConfig.initialize(None, None)
-    val props = new Properties
-    props.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
+    val bridgeFlags = Seq(
+      KafkaConfig.LiProtocolBridgeModeEnableProp,
+      KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp,
+      KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
+      KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp
+    )
+    bridgeFlags.foreach(flag => assertFalse(config.getBoolean(flag), s"$flag should be disabled by default"))
 
-    assertFalse(config.liProtocolBridgeModeActive)
+    val props = new Properties
+    bridgeFlags.foreach(props.put(_, "true"))
     config.dynamicConfig.validate(props, perBrokerConfig = false)
     config.dynamicConfig.updateDefaultConfig(props)
-    assertTrue(config.liProtocolBridgeModeActive)
+    bridgeFlags.foreach(flag => assertTrue(config.getBoolean(flag), s"$flag should be enabled dynamically"))
     assertThrows(classOf[ConfigException], () => config.dynamicConfig.validate(props, perBrokerConfig = true))
   }
 

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.requests.{ListOffsetsRequest, ListOffsetsResponse
 import org.apache.kafka.common.{IsolationLevel, TopicPartition}
 import org.apache.kafka.server.config.ServerConfigs
 import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -35,6 +36,18 @@ class ListOffsetsRequestTest extends BaseRequestTest {
 
   val topic = "topic"
   val partition = new TopicPartition(topic, 0)
+
+  @Test
+  def testOffsetMovedErrorCodeForOldFollower(): Unit = {
+    assertEquals(1107.toShort, KafkaApis.offsetMovedErrorCode(
+      liFollowerRecovery = true, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP))
+    assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE.code,
+      KafkaApis.offsetMovedErrorCode(liFollowerRecovery = false,
+        ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP))
+    assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE.code,
+      KafkaApis.offsetMovedErrorCode(liFollowerRecovery = true,
+        ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP))
+  }
 
   override def modifyConfigs(props: Seq[Properties]): Unit = {
     super.modifyConfigs(props)


### PR DESCRIPTION
This change adds the 3.0-li client and follower protocol values needed during a mixed 3.0/3.9 roll.

Kafka 3.9 accepts recommended leader election value 2 and its tagged fields, honors the Metadata `ExcludePartitions` tag, recognizes the 3.0-li earliest-local timestamp `-104`, translates tiered-offset error 1107, and defines preferred-controller error 2000.

Follower recovery, recommended election, and Metadata partition exclusion have separate cluster-wide settings. Each setting defaults to false and is active only on ZooKeeper brokers.

The Admin election and Metadata builders preserve the 3.0-li request shapes. `NoOpConsumerRebalanceListener` remains non-final for internal subclasses.

The tests cover constants, election eligibility, Metadata behavior, ListOffsets recovery, error mapping, class shape, and byte fixtures produced by compiled 3.0-li classes.


## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.