### PR TITLE
kafka: support controlled-shutdown and move-controller RPCs

### DIFF
--- a/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
+++ b/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
@@ -19,7 +19,7 @@
   // The current implementation of this feature involves recording the shutting down broker's epoch on zk,
   // so probably doesn't make sense for the listener type "broker" for now.
   // In the future, if/when we adopt KIP-500 changes, this request can be augmented to include the "broker" listener.
-  "listeners": [],
+  "listeners": ["zkBroker"],
   "name": "LiControlledShutdownSkipSafetyCheckRequest",
   "validVersions": "0-1",
   "flexibleVersions": "0+",

--- a/clients/src/main/resources/common/message/LiMoveControllerRequest.json
+++ b/clients/src/main/resources/common/message/LiMoveControllerRequest.json
@@ -16,7 +16,7 @@
 {
   "apiKey": 1002,
   "type": "request",
-  "listeners": [],
+  "listeners": ["zkBroker"],
   "name": "LiMoveControllerRequest",
   "validVersions": "0-1",
   "flexibleVersions": "0+",

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.protocol.types.Schema;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
@@ -83,9 +84,8 @@ public class ApiKeysTest {
                 apisMissingScope.add(apiKey);
             }
         }
-        // These wire definitions stay unadvertised until the broker handlers are added.
-        assertEquals(EnumSet.of(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, ApiKeys.LI_MOVE_CONTROLLER),
-            apisMissingScope, "Only the pending control RPC definitions may lack listener scopes");
+        assertEquals(Collections.emptySet(), apisMissingScope,
+            "Found some APIs missing scope definition");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/protocol/BridgeProtocolConstantsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/BridgeProtocolConstantsTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BridgeProtocolConstantsTest {
     @Test
@@ -38,14 +39,14 @@ public class BridgeProtocolConstantsTest {
     }
 
     @Test
-    public void testControlApiDefinitionsAreNotAdvertisedWithoutHandlers() {
+    public void testControlApisAreScopedToZooKeeperBrokers() {
         for (ApiKeys apiKey : Arrays.asList(
             ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK,
             ApiKeys.LI_MOVE_CONTROLLER
         )) {
-            for (ListenerType listener : ListenerType.values()) {
-                assertFalse(apiKey.inScope(listener));
-            }
+            assertTrue(apiKey.inScope(ListenerType.ZK_BROKER));
+            assertFalse(apiKey.inScope(ListenerType.BROKER));
+            assertFalse(apiKey.inScope(ListenerType.CONTROLLER));
         }
     }
 }

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -78,6 +78,8 @@ class ControllerContext extends ControllerChannelContext {
   var offlinePartitionCount = 0
   var preferredReplicaImbalanceCount = 0
   val shuttingDownBrokerIds = mutable.Set.empty[Int]
+  val skipShutdownSafetyCheck = mutable.Map.empty[Int, Long]
+  @volatile private var livePreferredControllerIds = Set.empty[Int]
   private val liveBrokers = mutable.Set.empty[Broker]
   private val liveBrokerEpochs = mutable.Map.empty[Int, Long]
   var epoch: Int = KafkaController.InitialControllerEpoch
@@ -215,6 +217,12 @@ class ControllerContext extends ControllerChannelContext {
   }
 
   // getter
+  def setLivePreferredControllerIds(brokerIds: Set[Int]): Unit = {
+    livePreferredControllerIds = brokerIds
+  }
+
+  def getLivePreferredControllerIds: Set[Int] = livePreferredControllerIds
+
   def liveBrokerIds: Set[Int] = liveBrokerEpochs.keySet.diff(shuttingDownBrokerIds)
   // To just check if a broker is live, we should use this method instead of liveBrokerIds.contains(brokerId)
   // which is more expensive because it constructs the set of live broker IDs.

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 import kafka.api._
 import kafka.common._
 import kafka.cluster.Broker
-import kafka.controller.KafkaController.{ActiveBrokerCountMetricName, ActiveControllerCountMetricName, AlterReassignmentsCallback, ControllerStateMetricName, ElectLeadersCallback, FencedBrokerCountMetricName, GlobalPartitionCountMetricName, GlobalTopicCountMetricName, ListReassignmentsCallback, OfflinePartitionsCountMetricName, PreferredReplicaImbalanceCountMetricName, ReplicasIneligibleToDeleteCountMetricName, ReplicasToDeleteCountMetricName, TopicsIneligibleToDeleteCountMetricName, TopicsToDeleteCountMetricName, UpdateFeaturesCallback, ZkMigrationStateMetricName}
+import kafka.controller.KafkaController.{ActiveBrokerCountMetricName, ActiveControllerCountMetricName, ActivePreferredControllerCountMetricName, AlterReassignmentsCallback, ControllerStateMetricName, ElectLeadersCallback, FencedBrokerCountMetricName, GlobalPartitionCountMetricName, GlobalTopicCountMetricName, ListReassignmentsCallback, OfflinePartitionsCountMetricName, PreferredReplicaImbalanceCountMetricName, ReplicasIneligibleToDeleteCountMetricName, ReplicasToDeleteCountMetricName, TopicsIneligibleToDeleteCountMetricName, TopicsToDeleteCountMetricName, UpdateFeaturesCallback, ZkMigrationStateMetricName, StandbyPreferredControllerCountMetricName}
 import kafka.coordinator.transaction.ZkProducerIdManager
 import kafka.server._
 import kafka.server.metadata.ZkFinalizedFeatureCache
@@ -37,7 +37,7 @@ import org.apache.kafka.common.ElectionType
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.Uuid
-import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException, StaleBrokerEpochException}
+import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException, NotEnoughPreferredControllersException, StaleBrokerEpochException}
 import org.apache.kafka.common.message.{AllocateProducerIdsRequestData, AllocateProducerIdsResponseData, AlterPartitionRequestData, AlterPartitionResponseData}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
@@ -46,6 +46,7 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.migration.ZkMigrationState
 import org.apache.kafka.server.common.{AdminOperationException, ProducerIdsBlock}
+import org.apache.kafka.server.config.{ConfigType, ServerLogConfigs}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.KafkaScheduler
 import org.apache.zookeeper.KeeperException
@@ -71,6 +72,8 @@ object KafkaController extends Logging {
   type UpdateFeaturesCallback = Either[ApiError, Map[String, ApiError]] => Unit
 
   private val ActiveControllerCountMetricName = "ActiveControllerCount"
+  private val ActivePreferredControllerCountMetricName = "ActivePreferredControllerCount"
+  private val StandbyPreferredControllerCountMetricName = "StandbyPreferredControllerCount"
   private val OfflinePartitionsCountMetricName = "OfflinePartitionsCount"
   private val PreferredReplicaImbalanceCountMetricName = "PreferredReplicaImbalanceCount"
   private val ControllerStateMetricName = "ControllerState"
@@ -88,6 +91,8 @@ object KafkaController extends Logging {
   private[controller] val MetricNames = Set(
     ZkMigrationStateMetricName,
     ActiveControllerCountMetricName,
+    ActivePreferredControllerCountMetricName,
+    StandbyPreferredControllerCountMetricName,
     OfflinePartitionsCountMetricName,
     PreferredReplicaImbalanceCountMetricName,
     ControllerStateMetricName,
@@ -152,6 +157,7 @@ class KafkaController(val config: KafkaConfig,
 
   private val controllerChangeHandler = new ControllerChangeHandler(eventManager)
   private val brokerChangeHandler = new BrokerChangeHandler(eventManager)
+  private val preferredControllerChangeHandler = new PreferredControllerChangeHandler(eventManager)
   private val brokerModificationsHandlers: mutable.Map[Int, BrokerModificationsHandler] = mutable.Map.empty
   private val topicChangeHandler = new TopicChangeHandler(eventManager)
   private val topicDeletionHandler = new TopicDeletionHandler(eventManager)
@@ -177,6 +183,10 @@ class KafkaController(val config: KafkaConfig,
 
   metricsGroup.newGauge(ZkMigrationStateMetricName, () => ZkMigrationState.ZK.value().intValue())
   metricsGroup.newGauge(ActiveControllerCountMetricName, () => if (isActive) 1 else 0)
+  metricsGroup.newGauge(ActivePreferredControllerCountMetricName,
+    () => if (isActive && config.liProtocolBridgePreferredControllerActive && config.preferredController) 1 else 0)
+  metricsGroup.newGauge(StandbyPreferredControllerCountMetricName,
+    () => if (!isActive && config.liProtocolBridgePreferredControllerActive && config.preferredController) 1 else 0)
   metricsGroup.newGauge(OfflinePartitionsCountMetricName, () => offlinePartitionCount)
   metricsGroup.newGauge(PreferredReplicaImbalanceCountMetricName, () => preferredReplicaImbalanceCount)
   metricsGroup.newGauge(ControllerStateMetricName, () => state.value)
@@ -248,6 +258,11 @@ class KafkaController(val config: KafkaConfig,
   def controlledShutdown(id: Int, brokerEpoch: Long, controlledShutdownCallback: Try[Set[TopicPartition]] => Unit): Unit = {
     val controlledShutdownEvent = ControlledShutdown(id, brokerEpoch, controlledShutdownCallback)
     eventManager.put(controlledShutdownEvent)
+  }
+
+  def skipControlledShutdownSafetyCheck(id: Int, brokerEpoch: Long,
+                                        callback: Try[Unit] => Unit): Unit = {
+    eventManager.put(SkipControlledShutdownSafetyCheck(id, brokerEpoch, callback))
   }
 
   private[kafka] def updateBrokerInfo(newBrokerInfo: BrokerInfo): Unit = {
@@ -1362,6 +1377,43 @@ class KafkaController(val config: KafkaConfig,
     controlledShutdownCallback(controlledShutdownResult)
   }
 
+  private def processSkipControlledShutdownSafetyCheck(id: Int, brokerEpoch: Long,
+                                                        callback: Try[Unit] => Unit): Unit = {
+    callback(Try(doSkipControlledShutdownSafetyCheck(id, brokerEpoch)))
+  }
+
+  private def doSkipControlledShutdownSafetyCheck(id: Int, brokerEpoch: Long): Unit = {
+    if (!isActive)
+      throw new ControllerMovedException("Controller moved while handling the shutdown safety override")
+    if (!controllerContext.liveOrShuttingDownBrokerIds.contains(id))
+      throw new BrokerNotAvailableException(s"Broker id $id does not exist")
+
+    val currentBrokerEpoch = controllerContext.liveBrokerIdAndEpochs(id)
+    if (brokerEpoch < currentBrokerEpoch)
+      throw new StaleBrokerEpochException(
+        s"Broker $id has epoch $currentBrokerEpoch, which is newer than requested epoch $brokerEpoch")
+    controllerContext.skipShutdownSafetyCheck.put(id, brokerEpoch)
+  }
+
+  private[controller] def safeToShutdown(id: Int): Boolean = {
+    if (controllerContext.shuttingDownBrokerIds.contains(id))
+      return true
+
+    val liveBrokerIds = controllerContext.liveBrokerIds
+    val partitions = controllerContext.partitionsOnBroker(id)
+      .filterNot(partition => topicDeletionManager.isTopicQueuedUpForDeletion(partition.topic))
+    // Read each topic once through the batched ZooKeeper API. This runs on the controller event thread.
+    val topicConfigs = zkClient.getEntitiesConfigs(ConfigType.TOPIC, partitions.map(_.topic).toSet)
+    partitions.forall { partition =>
+      val minIsr = Option(topicConfigs(partition.topic).getProperty(ServerLogConfigs.MIN_IN_SYNC_REPLICAS_CONFIG))
+        .map(_.toInt)
+        .getOrElse(config.minInSyncReplicas.intValue())
+      val isr = controllerContext.partitionLeadershipInfo(partition).map(_.leaderAndIsr.isr).getOrElse(List.empty)
+      val remainingLiveIsr = isr.count(replica => replica != id && liveBrokerIds.contains(replica))
+      remainingLiveIsr >= minIsr + config.controlledShutdownSafetyCheckRedundancyFactor
+    }
+  }
+
   private def doControlledShutdown(id: Int, brokerEpoch: Long): Set[TopicPartition] = {
     if (!isActive) {
       throw new ControllerMovedException("Controller moved to another broker. Aborting controlled shutdown")
@@ -1383,6 +1435,18 @@ class KafkaController(val config: KafkaConfig,
 
     if (!controllerContext.liveOrShuttingDownBrokerIds.contains(id))
       throw new BrokerNotAvailableException(s"Broker id $id does not exist.")
+
+    val currentBrokerEpoch = controllerContext.liveBrokerIdAndEpochs(id)
+    val safetyCheckSkipped = controllerContext.skipShutdownSafetyCheck.get(id).exists(_ >= currentBrokerEpoch)
+    if (config.controlledShutdownSafetyCheckEnable && !safetyCheckSkipped && !safeToShutdown(id))
+      throw new org.apache.kafka.common.errors.NotEnoughReplicasException(
+        s"Shutting down broker $id would leave too few live ISR replicas")
+
+    if (config.liProtocolBridgePreferredControllerActive && !safetyCheckSkipped &&
+      controllerContext.getLivePreferredControllerIds.contains(id) &&
+      controllerContext.getLivePreferredControllerIds.size <= config.liMinPreferredControllerCount)
+      throw new NotEnoughPreferredControllersException(
+        s"Shutting down broker $id would leave fewer than ${config.liMinPreferredControllerCount} preferred controllers")
 
     controllerContext.shuttingDownBrokerIds.add(id)
     debug(s"All shutting down brokers: ${controllerContext.shuttingDownBrokerIds.mkString(",")}")
@@ -1477,6 +1541,8 @@ class KafkaController(val config: KafkaConfig,
 
   private def processStartup(): Unit = {
     zkClient.registerZNodeChangeHandlerAndCheckExistence(controllerChangeHandler)
+    if (config.liProtocolBridgePreferredControllerActive)
+      zkClient.registerZNodeChildChangeHandler(preferredControllerChangeHandler)
     elect()
   }
 
@@ -1550,6 +1616,10 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def elect(): Unit = {
+    if (config.liProtocolBridgePreferredControllerActive)
+      controllerContext.setLivePreferredControllerIds(zkClient.getPreferredControllerList.toSet)
+    else
+      controllerContext.setLivePreferredControllerIds(Set.empty)
     activeControllerId = zkClient.getControllerId.getOrElse(-1)
     /*
      * We can get here during the initial startup and the handleDeleted ZK callback. Because of the potential race condition,
@@ -1558,6 +1628,12 @@ class KafkaController(val config: KafkaConfig,
      */
     if (activeControllerId != -1) {
       debug(s"Broker $activeControllerId has been elected as the controller, so stopping the election process.")
+      return
+    }
+
+    if (config.liProtocolBridgePreferredControllerActive && !config.preferredController &&
+      (!config.allowPreferredControllerFallback || controllerContext.getLivePreferredControllerIds.nonEmpty)) {
+      debug("Skipping controller election because this broker is not a preferred controller")
       return
     }
 
@@ -1667,6 +1743,18 @@ class KafkaController(val config: KafkaConfig,
 
     if (newBrokerIds.nonEmpty || deadBrokerIds.nonEmpty || bouncedBrokerIds.nonEmpty) {
       info(s"Updated broker epochs cache: ${controllerContext.liveBrokerIdAndEpochs}")
+    }
+  }
+
+  private def processPreferredControllerChange(): Unit = {
+    if (!config.liProtocolBridgePreferredControllerActive)
+      return
+    controllerContext.setLivePreferredControllerIds(zkClient.getPreferredControllerList.toSet)
+    if (isActive && !config.preferredController && controllerContext.getLivePreferredControllerIds.nonEmpty) {
+      info("Resigning because a preferred controller is available")
+      triggerControllerMove()
+    } else if (!isActive && controllerContext.getLivePreferredControllerIds.isEmpty) {
+      processReelect()
     }
   }
 
@@ -2606,6 +2694,8 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def processRegisterBrokerAndReelect(): Unit = {
+    if (config.liProtocolBridgePreferredControllerActive && config.preferredController)
+      zkClient.registerPreferredControllerId(brokerInfo.broker.id)
     _brokerEpoch = zkClient.registerBroker(brokerInfo)
     processReelect()
   }
@@ -2634,6 +2724,8 @@ class KafkaController(val config: KafkaConfig,
           processTopicUncleanLeaderElectionEnable(topic)
         case ControlledShutdown(id, brokerEpoch, callback) =>
           processControlledShutdown(id, brokerEpoch, callback)
+        case SkipControlledShutdownSafetyCheck(id, brokerEpoch, callback) =>
+          processSkipControlledShutdownSafetyCheck(id, brokerEpoch, callback)
         case LeaderAndIsrResponseReceived(response, brokerId) =>
           processLeaderAndIsrResponseReceived(response, brokerId)
         case UpdateMetadataResponseReceived(response, brokerId) =>
@@ -2642,6 +2734,8 @@ class KafkaController(val config: KafkaConfig,
           processTopicDeletionStopReplicaResponseReceived(replicaId, requestError, partitionErrors)
         case BrokerChange =>
           processBrokerChange()
+        case PreferredControllerChange =>
+          processPreferredControllerChange()
         case BrokerModifications(brokerId) =>
           processBrokerModification(brokerId)
         case ControllerChange =>
@@ -2701,6 +2795,11 @@ class BrokerChangeHandler(eventManager: ControllerEventManager) extends ZNodeChi
   override def handleChildChange(): Unit = {
     eventManager.put(BrokerChange)
   }
+}
+
+class PreferredControllerChangeHandler(eventManager: ControllerEventManager) extends ZNodeChildChangeHandler {
+  override val path: String = PreferredControllersZNode.path
+  override def handleChildChange(): Unit = eventManager.put(PreferredControllerChange)
 }
 
 class BrokerModificationsHandler(eventManager: ControllerEventManager, brokerId: Int) extends ZNodeChangeHandler {
@@ -2894,6 +2993,17 @@ case object Startup extends ControllerEvent {
 case object BrokerChange extends ControllerEvent {
   override def state: ControllerState = ControllerState.BrokerChange
   override def preempt(): Unit = {}
+}
+
+case object PreferredControllerChange extends ControllerEvent {
+  override def state: ControllerState = ControllerState.ControllerChange
+  override def preempt(): Unit = {}
+}
+
+case class SkipControlledShutdownSafetyCheck(id: Int, brokerEpoch: Long, callback: Try[Unit] => Unit)
+  extends ControllerEvent {
+  override def state: ControllerState = ControllerState.ControlledShutdown
+  override def preempt(): Unit = callback(Failure(new ControllerMovedException("Controller moved")))
 }
 
 case class BrokerModifications(brokerId: Int) extends ControllerEvent {

--- a/core/src/main/scala/kafka/server/ApiVersionManager.scala
+++ b/core/src/main/scala/kafka/server/ApiVersionManager.scala
@@ -19,6 +19,7 @@ package kafka.server
 import kafka.network
 import kafka.network.RequestChannel
 import org.apache.kafka.common.feature.SupportedVersionRange
+import org.apache.kafka.common.message.ApiVersionsResponseData
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.ApiVersionsResponse
@@ -59,7 +60,9 @@ object ApiVersionManager {
       metadataCache,
       config.unstableApiVersionsEnabled,
       config.migrationEnabled,
-      clientMetricsManager
+      clientMetricsManager,
+      () => config.liProtocolBridgeMoveControllerActive,
+      () => config.liProtocolBridgeShutdownSafetyOverrideActive
     )
   }
 }
@@ -141,10 +144,21 @@ class DefaultApiVersionManager(
   metadataCache: MetadataCache,
   val enableUnstableLastVersion: Boolean,
   val zkMigrationEnabled: Boolean = false,
-  val clientMetricsManager: Option[ClientMetricsManager] = None
+  val clientMetricsManager: Option[ClientMetricsManager] = None,
+  liMoveControllerEnabled: () => Boolean = () => false,
+  liShutdownSafetyOverrideEnabled: () => Boolean = () => false
 ) extends ApiVersionManager {
 
   val enabledApis: mutable.Set[ApiKeys] = ApiKeys.apisForListener(listenerType).asScala
+
+  private def isLiApiEnabled(apiKey: ApiKeys): Boolean = apiKey match {
+    case ApiKeys.LI_MOVE_CONTROLLER => liMoveControllerEnabled()
+    case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => liShutdownSafetyOverrideEnabled()
+    case _ => true
+  }
+
+  override def isApiEnabled(apiKey: ApiKeys, apiVersion: Short): Boolean =
+    super.isApiEnabled(apiKey, apiVersion) && isLiApiEnabled(apiKey)
 
   override def apiVersionResponse(
     throttleTimeMs: Int,
@@ -156,7 +170,7 @@ class DefaultApiVersionManager(
       case Some(manager) => manager.isTelemetryReceiverConfigured
       case None => false
     }
-    val apiVersions = if (controllerApiVersions.isDefined) {
+    val unfilteredApiVersions = if (controllerApiVersions.isDefined) {
       ApiVersionsResponse.controllerApiVersions(
         finalizedFeatures.metadataVersion().highestSupportedRecordVersion,
         controllerApiVersions.get,
@@ -170,6 +184,13 @@ class DefaultApiVersionManager(
         enableUnstableLastVersion,
         clientTelemetryEnabled)
     }
+    // Generated message collections are intrusive: an element cannot belong to both the
+    // collection returned above and the filtered response collection. Duplicate each retained
+    // element rather than attempting to insert the already-linked instance.
+    val apiVersions = new ApiVersionsResponseData.ApiVersionCollection(unfilteredApiVersions.size)
+    unfilteredApiVersions.iterator.asScala
+      .filter(apiVersion => isLiApiEnabled(ApiKeys.forId(apiVersion.apiKey)))
+      .foreach(apiVersion => apiVersions.add(apiVersion.duplicate()))
     new ApiVersionsResponse.Builder().
       setThrottleTimeMs(throttleTimeMs).
       setApiVersions(apiVersions).

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -98,7 +98,9 @@ object DynamicBrokerConfig {
       KafkaConfig.LiProtocolBridgeModeEnableProp,
       KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp,
       KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
-      KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp
+      KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
+      KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
+      KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp
     ) ++
     DynamicListenerConfig.ReconfigurableConfigs ++
     SocketServer.ReconfigurableConfigs ++
@@ -110,7 +112,9 @@ object DynamicBrokerConfig {
     KafkaConfig.LiProtocolBridgeModeEnableProp,
     KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp,
     KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
-    KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp
+    KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
+    KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
+    KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp
   )
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(
     ClusterLevelListenerConfigs)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -232,6 +232,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.DESCRIBE_DELEGATION_TOKEN => handleDescribeTokensRequest(request)
         case ApiKeys.DELETE_GROUPS => handleDeleteGroupsRequest(request, requestLocal).exceptionally(handleError)
         case ApiKeys.ELECT_LEADERS => maybeForwardToController(request, handleElectLeaders)
+        case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => handleLiShutdownSafetyOverride(request)
+        case ApiKeys.LI_MOVE_CONTROLLER => handleLiMoveController(request)
         case ApiKeys.INCREMENTAL_ALTER_CONFIGS => handleIncrementalAlterConfigsRequest(request)
         case ApiKeys.ALTER_PARTITION_REASSIGNMENTS => maybeForwardToController(request, handleAlterPartitionReassignmentsRequest)
         case ApiKeys.LIST_PARTITION_REASSIGNMENTS => maybeForwardToController(request, handleListPartitionReassignmentsRequest)
@@ -3399,6 +3401,48 @@ class KafkaApis(val requestChannel: RequestChannel,
       false
     else
       true
+  }
+
+  def handleLiShutdownSafetyOverride(request: RequestChannel.Request): Unit = {
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val overrideRequest = request.body[LiControlledShutdownSkipSafetyCheckRequest]
+    if (!config.liProtocolBridgeShutdownSafetyOverrideActive) {
+      requestHelper.sendResponseExemptThrottle(request,
+        overrideRequest.getErrorResponse(new UnsupportedVersionException(
+          "LI controlled-shutdown safety override is disabled")))
+      return
+    }
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+    zkSupport.controller.skipControlledShutdownSafetyCheck(
+      overrideRequest.data.brokerId,
+      overrideRequest.data.brokerEpoch,
+      result => {
+        val response = result match {
+          case Success(_) => LiControlledShutdownSkipSafetyCheckResponse.prepareResponse(Errors.NONE)
+          case Failure(error) => overrideRequest.getErrorResponse(error)
+        }
+        requestHelper.sendResponseExemptThrottle(request, response)
+      })
+  }
+
+  def handleLiMoveController(request: RequestChannel.Request): Unit = {
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
+    val moveControllerRequest = request.body[LiMoveControllerRequest]
+    if (!config.liProtocolBridgeMoveControllerActive) {
+      requestHelper.sendResponseExemptThrottle(request,
+        moveControllerRequest.getErrorResponse(new UnsupportedVersionException(
+          "LI move-controller compatibility is disabled")))
+      return
+    }
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+
+    val response = try {
+      zkSupport.zkClient.deleteControllerRaw()
+      LiMoveControllerResponse.prepareResponse(Errors.NONE, moveControllerRequest.version)
+    } catch {
+      case throwable: Throwable => moveControllerRequest.getErrorResponse(throwable)
+    }
+    requestHelper.sendResponseExemptThrottle(request, response)
   }
 
   def handleElectLeaders(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -63,6 +63,19 @@ object KafkaConfig {
   val LiProtocolBridgeFollowerRecoveryEnableProp = "li.protocol.bridge.follower.recovery.enable"
   val LiProtocolBridgeRecommendedElectionEnableProp = "li.protocol.bridge.recommended.leader.election.enable"
   val LiProtocolBridgeExcludePartitionsEnableProp = "li.protocol.bridge.metadata.exclude.partitions.enable"
+  val LiProtocolBridgeMoveControllerEnableProp = "li.protocol.bridge.move.controller.enable"
+  val LiProtocolBridgeShutdownSafetyOverrideEnableProp =
+    "li.protocol.bridge.shutdown.safety.override.enable"
+  val LiProtocolBridgePreferredControllerEnableProp =
+    "li.protocol.bridge.preferred.controller.enable"
+
+  // 3.0-li operational settings consumed by the LinkedIn server wrapper.
+  val PreferredControllerProp = "preferred.controller"
+  val AllowPreferredControllerFallbackProp = "allow.preferred.controller.fallback"
+  val LiMinPreferredControllerCountProp = "li.min.preferred.controller.count"
+  val ControlledShutdownSafetyCheckEnableProp = "controlled.shutdown.safety.check.enable"
+  val ControlledShutdownSafetyCheckRedundancyFactorProp =
+    "controlled.shutdown.safety.check.redundancy.factor"
 
   val LiProtocolBridgeModeEnableDoc =
     "Enable the temporary protocol bridge used while 3.0-li and upstream-based brokers coexist. " +
@@ -73,6 +86,21 @@ object KafkaConfig {
     "Accept 3.0-li recommended leader election requests on ZooKeeper controllers."
   val LiProtocolBridgeExcludePartitionsEnableDoc =
     "Honor the 3.0-li Metadata request tag that omits partition metadata from the response."
+  val LiProtocolBridgeMoveControllerEnableDoc =
+    "Accept the 3.0-li private API that forces a ZooKeeper controller election."
+  val LiProtocolBridgeShutdownSafetyOverrideEnableDoc =
+    "Accept the 3.0-li private API that bypasses controlled shutdown safety for one broker epoch."
+  val LiProtocolBridgePreferredControllerEnableDoc =
+    "Enable 3.0-li preferred-controller election and shutdown behavior on ZooKeeper brokers."
+  val PreferredControllerDoc = "Whether this broker is eligible for preferred-controller placement."
+  val AllowPreferredControllerFallbackDoc =
+    "Allow a non-preferred broker to become controller when no preferred controller is available."
+  val LiMinPreferredControllerCountDoc =
+    "Reject a preferred controller shutdown when it would leave fewer than this many preferred controllers."
+  val ControlledShutdownSafetyCheckEnableDoc =
+    "Reject controlled shutdown when the remaining live ISR would be below min ISR plus the configured redundancy."
+  val ControlledShutdownSafetyCheckRedundancyFactorDoc =
+    "Additional live ISR replicas required by the controlled shutdown safety check."
 
   def main(args: Array[String]): Unit = {
     System.out.println(configDef.toHtml(4, (config: String) => "brokerconfigs_" + config,
@@ -112,6 +140,22 @@ object KafkaConfig {
       ConfigDef.Importance.HIGH, LiProtocolBridgeRecommendedElectionEnableDoc)
     .define(LiProtocolBridgeExcludePartitionsEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeExcludePartitionsEnableDoc)
+    .define(LiProtocolBridgeMoveControllerEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeMoveControllerEnableDoc)
+    .define(LiProtocolBridgeShutdownSafetyOverrideEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeShutdownSafetyOverrideEnableDoc)
+    .define(LiProtocolBridgePreferredControllerEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgePreferredControllerEnableDoc)
+    .define(PreferredControllerProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, PreferredControllerDoc)
+    .define(AllowPreferredControllerFallbackProp, ConfigDef.Type.BOOLEAN, true,
+      ConfigDef.Importance.HIGH, AllowPreferredControllerFallbackDoc)
+    .define(LiMinPreferredControllerCountProp, ConfigDef.Type.INT, 0, ConfigDef.Range.atLeast(0),
+      ConfigDef.Importance.HIGH, LiMinPreferredControllerCountDoc)
+    .define(ControlledShutdownSafetyCheckEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, ControlledShutdownSafetyCheckEnableDoc)
+    .define(ControlledShutdownSafetyCheckRedundancyFactorProp, ConfigDef.Type.INT, 0,
+      ConfigDef.Range.atLeast(0), ConfigDef.Importance.HIGH, ControlledShutdownSafetyCheckRedundancyFactorDoc)
 
   def configNames: Seq[String] = configDef.names.asScala.toBuffer.sorted
   private[server] def defaultValues: Map[String, _] = configDef.defaultValues.asScala
@@ -217,6 +261,12 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     getBoolean(KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp)
   def liProtocolBridgeExcludePartitionsEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp)
+  def liProtocolBridgeMoveControllerEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeMoveControllerEnableProp)
+  def liProtocolBridgeShutdownSafetyOverrideEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp)
+  def liProtocolBridgePreferredControllerEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgePreferredControllerEnableProp)
 
   def liProtocolBridgeModeActive: Boolean = processRoles.isEmpty && liProtocolBridgeModeEnable
   def liProtocolBridgeFollowerRecoveryActive: Boolean =
@@ -225,6 +275,20 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     processRoles.isEmpty && liProtocolBridgeRecommendedElectionEnable
   def liProtocolBridgeExcludePartitionsActive: Boolean =
     processRoles.isEmpty && liProtocolBridgeExcludePartitionsEnable
+  def liProtocolBridgeMoveControllerActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeMoveControllerEnable
+  def liProtocolBridgeShutdownSafetyOverrideActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeShutdownSafetyOverrideEnable
+  def liProtocolBridgePreferredControllerActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgePreferredControllerEnable
+
+  def preferredController: Boolean = getBoolean(KafkaConfig.PreferredControllerProp)
+  def allowPreferredControllerFallback: Boolean = getBoolean(KafkaConfig.AllowPreferredControllerFallbackProp)
+  def liMinPreferredControllerCount: Int = getInt(KafkaConfig.LiMinPreferredControllerCountProp)
+  def controlledShutdownSafetyCheckEnable: Boolean =
+    getBoolean(KafkaConfig.ControlledShutdownSafetyCheckEnableProp)
+  def controlledShutdownSafetyCheckRedundancyFactor: Int =
+    getInt(KafkaConfig.ControlledShutdownSafetyCheckRedundancyFactorProp)
 
   private[server] val dynamicConfig = new DynamicBrokerConfig(this)
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -404,6 +404,8 @@ class KafkaServer(
         replicaManager.startup()
 
         val brokerInfo = createBrokerInfo
+        if (config.liProtocolBridgePreferredControllerActive && config.preferredController)
+          zkClient.registerPreferredControllerId(brokerInfo.broker.id)
         val brokerEpoch = zkClient.registerBroker(brokerInfo)
 
         /* start token manager */

--- a/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
+++ b/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import org.apache.kafka.server.metrics.KafkaMetricsGroup
+
+import scala.jdk.CollectionConverters._
+
+object LiProtocolBridgeMetrics {
+  val ModeEnabled = "ModeEnabled"
+  val FollowerRecoveryEnabled = "FollowerRecoveryEnabled"
+  val RecommendedLeaderElectionEnabled = "RecommendedLeaderElectionEnabled"
+  val ExcludePartitionsEnabled = "ExcludePartitionsEnabled"
+  val MoveControllerEnabled = "MoveControllerEnabled"
+  val ShutdownSafetyOverrideEnabled = "ShutdownSafetyOverrideEnabled"
+  val PreferredControllerEnabled = "PreferredControllerEnabled"
+  val MetricNames: Seq[String] = Seq(ModeEnabled, FollowerRecoveryEnabled,
+    RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled, MoveControllerEnabled,
+    ShutdownSafetyOverrideEnabled, PreferredControllerEnabled)
+}
+
+/** Exposes the effective value of every 3.0-li compatibility flag on each ZooKeeper broker. */
+class LiProtocolBridgeMetrics(config: KafkaConfig) extends AutoCloseable {
+  import LiProtocolBridgeMetrics._
+
+  private val metricsGroup = new KafkaMetricsGroup(this.getClass)
+  private val tags = Map("broker-id" -> config.brokerId.toString).asJava
+
+  metricsGroup.newGauge(ModeEnabled, () => enabled(config.liProtocolBridgeModeActive), tags)
+  metricsGroup.newGauge(FollowerRecoveryEnabled,
+    () => enabled(config.liProtocolBridgeFollowerRecoveryActive), tags)
+  metricsGroup.newGauge(RecommendedLeaderElectionEnabled,
+    () => enabled(config.liProtocolBridgeRecommendedElectionActive), tags)
+  metricsGroup.newGauge(ExcludePartitionsEnabled,
+    () => enabled(config.liProtocolBridgeExcludePartitionsEnable), tags)
+  metricsGroup.newGauge(MoveControllerEnabled,
+    () => enabled(config.liProtocolBridgeMoveControllerActive), tags)
+  metricsGroup.newGauge(ShutdownSafetyOverrideEnabled,
+    () => enabled(config.liProtocolBridgeShutdownSafetyOverrideActive), tags)
+  metricsGroup.newGauge(PreferredControllerEnabled,
+    () => enabled(config.liProtocolBridgePreferredControllerActive), tags)
+
+  private def enabled(value: Boolean): Int = if (value) 1 else 0
+
+  override def close(): Unit = {
+    MetricNames.foreach { name =>
+      metricsGroup.removeMetric(name, tags)
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -165,7 +165,12 @@ class ZkAdminManager(val config: KafkaConfig,
                    responseCallback: Map[String, ApiError] => Unit): Unit = {
 
     // 1. map over topics creating assignment and calling zookeeper
-    val brokers = metadataCache.getAliveBrokers()
+    val liveBrokers = metadataCache.getAliveBrokers()
+    val preferredControllerIds = if (config.liProtocolBridgePreferredControllerActive)
+      zkClient.getPreferredControllerList.toSet
+    else
+      Set.empty[Int]
+    val brokers = liveBrokers.filterNot(broker => preferredControllerIds.contains(broker.id))
     val metadata = toCreate.values.map(topic =>
       try {
         if (metadataCache.contains(topic.name))
@@ -310,7 +315,12 @@ class ZkAdminManager(val config: KafkaConfig,
                        validateOnly: Boolean,
                        controllerMutationQuota: ControllerMutationQuota,
                        callback: Map[String, ApiError] => Unit): Unit = {
-    val allBrokers = adminZkClient.getBrokerMetadatas()
+    val brokerMetadatas = adminZkClient.getBrokerMetadatas()
+    val preferredControllerIds = if (config.liProtocolBridgePreferredControllerActive)
+      zkClient.getPreferredControllerList.toSet
+    else
+      Set.empty[Int]
+    val allBrokers = brokerMetadatas.filterNot(broker => preferredControllerIds.contains(broker.id))
     val allBrokerIds = allBrokers.map(_.id)
 
     // 1. map over topics creating assignment and calling AdminUtils

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -114,6 +114,14 @@ class KafkaZkClient private[zk] (
     stat.getCzxid
   }
 
+  /** Register this broker as a preferred ZooKeeper controller for the lifetime of its session. */
+  def registerPreferredControllerId(brokerId: Int): Unit = {
+    checkedEphemeralCreate(PreferredControllerIdZNode.path(brokerId), null)
+  }
+
+  def getPreferredControllerList: Seq[Int] =
+    getChildren(PreferredControllersZNode.path).map(_.toInt)
+
   /**
    * Registers a given broker in zookeeper as the controller and increments controller epoch.
    * @param controllerId the id of the broker that is to be registered as the controller.
@@ -1296,6 +1304,10 @@ class KafkaZkClient private[zk] (
     val deleteRequest = DeleteRequest(ControllerZNode.path, ZkVersion.MatchAnyVersion)
     retryRequestUntilConnected(deleteRequest, expectedControllerEpochZkVersion)
   }
+
+  /** Delete the controller znode without an epoch check so operational tooling can force a new election. */
+  def deleteControllerRaw(): Unit =
+    deletePath(ControllerZNode.path, recursiveDelete = false)
 
   /**
    * Gets the controller epoch.

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -101,6 +101,15 @@ object BrokerIdsZNode {
   def encode: Array[Byte] = null
 }
 
+object PreferredControllersZNode {
+  def path = s"${BrokersZNode.path}/preferred_controllers"
+  def encode: Array[Byte] = null
+}
+
+object PreferredControllerIdZNode {
+  def path(id: Int) = s"${PreferredControllersZNode.path}/$id"
+}
+
 object BrokerInfo {
 
   /**
@@ -1105,6 +1114,7 @@ object ZkData {
   val PersistentZkPaths: Seq[String] = Seq(
     ConsumerPathZNode.path, // old consumer path
     BrokerIdsZNode.path,
+    PreferredControllersZNode.path,
     TopicsZNode.path,
     ConfigEntityChangeNotificationZNode.path,
     DeleteTopicsZNode.path,

--- a/core/src/test/scala/integration/kafka/admin/BrokerApiVersionsCommandTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/BrokerApiVersionsCommandTest.scala
@@ -80,7 +80,8 @@ class BrokerApiVersionsCommandTest extends KafkaServerTestHarness {
     val nodeApiVersions = new NodeApiVersions(clientApis.map(ApiVersionsResponse.toApiVersion).asJava, Collections.emptyList(), false)
     for (apiKey <- clientApis) {
       val terminator = if (apiKey == clientApis.last) "" else ","
-      if (apiKey.inScope(listenerType)) {
+      // Private APIs require explicit compatibility flags. This fixture uses defaults.
+      if (apiKey.inScope(listenerType) && apiKey.id < 1000) {
         val apiVersion = nodeApiVersions.apiVersion(apiKey)
         assertNotNull(apiVersion)
 

--- a/core/src/test/scala/integration/kafka/server/LiControllerOperationsTest.scala
+++ b/core/src/test/scala/integration/kafka/server/LiControllerOperationsTest.scala
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.{ApiVersions, ManualMetadataUpdater, MetadataRecoveryStrategy, NetworkClient, NetworkClientUtils}
+import org.apache.kafka.common.message.{ControlledShutdownRequestData, LiControlledShutdownSkipSafetyCheckRequestData}
+import org.apache.kafka.common.network.{ChannelBuilders, NetworkReceive, Selectable, Selector}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ControlledShutdownRequest, ControlledShutdownResponse, LiControlledShutdownSkipSafetyCheckRequest, LiControlledShutdownSkipSafetyCheckResponse}
+import org.apache.kafka.common.security.JaasContext
+import org.apache.kafka.common.utils.{LogContext, Time}
+import org.apache.kafka.server.config.{ServerConfigs, ServerLogConfigs}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue, fail}
+import org.junit.jupiter.api.{AfterEach, Test}
+
+import java.util.Properties
+import scala.collection.Seq
+import scala.jdk.CollectionConverters._
+
+class LiControllerOperationsTest extends QuorumTestHarness {
+  private var brokers = Seq.empty[KafkaServer]
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    TestUtils.shutdownServers(brokers)
+    brokers = Seq.empty
+    super.tearDown()
+  }
+
+  @Test
+  def testPreferredControllerTakesOverAndFallbackRestoresAvailability(): Unit = {
+    brokers = createBrokers(Seq((0, false), (1, true), (2, false)), allowFallback = true)
+
+    ensureControllerIsOneOf(Seq(1))
+    brokers(1).shutdown()
+    ensureControllerIsOneOf(Seq(0, 2))
+
+    brokers(1).startup()
+    ensureControllerIsOneOf(Seq(1))
+  }
+
+  @Test
+  def testNoControllerIsElectedWithoutPreferredBrokerOrFallback(): Unit = {
+    brokers = createBrokers(Seq((0, false), (1, false), (2, false)), allowFallback = false)
+    ensureControllerIsOneOf(Seq.empty, 5000L)
+  }
+
+  @Test
+  def testShutdownSafetyOverrideAllowsPreviouslyRejectedControlledShutdown(): Unit = {
+    brokers = (0 to 1).map { brokerId =>
+      val props = TestUtils.createBrokerConfig(brokerId, zkConnect)
+      props.put(ServerConfigs.CONTROLLED_SHUTDOWN_ENABLE_CONFIG, "true")
+      props.put(KafkaConfig.ControlledShutdownSafetyCheckEnableProp, "true")
+      props.put(KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp, "true")
+      props.put(ServerLogConfigs.MIN_IN_SYNC_REPLICAS_CONFIG, "2")
+      createBroker(KafkaConfig.fromProps(props)).asInstanceOf[KafkaServer]
+    }
+
+    TestUtils.createTopic(zkClient, "shutdown-safety", 1, 2, brokers)
+    val controllerId = TestUtils.waitUntilControllerElected(zkClient)
+    val controller = brokers.find(_.config.brokerId == controllerId).get
+    val target = brokers.find(_.config.brokerId != controllerId).get
+    assertShutdownOverrideAllowsShutdown(controller, target, Errors.NOT_ENOUGH_REPLICAS)
+  }
+
+  @Test
+  def testShutdownSafetyOverrideAllowsLastPreferredControllerToStop(): Unit = {
+    val props = TestUtils.createBrokerConfig(0, zkConnect)
+    props.put(KafkaConfig.LiProtocolBridgePreferredControllerEnableProp, "true")
+    props.put(KafkaConfig.PreferredControllerProp, "true")
+    props.put(KafkaConfig.LiMinPreferredControllerCountProp, "1")
+    props.put(KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp, "true")
+    brokers = Seq(createBroker(KafkaConfig.fromProps(props)).asInstanceOf[KafkaServer])
+    ensureControllerIsOneOf(Seq(0))
+    assertShutdownOverrideAllowsShutdown(brokers.head, brokers.head, Errors.NOT_ENOUGH_PREFERRED_CONTROLLERS)
+  }
+
+  private def assertShutdownOverrideAllowsShutdown(controller: KafkaServer, target: KafkaServer,
+                                                    expectedRejection: Errors): Unit = {
+    val brokerEpoch = target.kafkaController.brokerEpoch
+    val rejected = sendRequest(controller, target,
+      new ControlledShutdownRequest.Builder(
+        new ControlledShutdownRequestData()
+          .setBrokerId(target.config.brokerId)
+          .setBrokerEpoch(brokerEpoch),
+        3)).asInstanceOf[ControlledShutdownResponse]
+    assertEquals(expectedRejection, rejected.error())
+
+    val overrideResponse = sendRequest(controller, target,
+      new LiControlledShutdownSkipSafetyCheckRequest.Builder(
+        new LiControlledShutdownSkipSafetyCheckRequestData()
+          .setBrokerId(target.config.brokerId)
+          .setBrokerEpoch(brokerEpoch),
+        0)).asInstanceOf[LiControlledShutdownSkipSafetyCheckResponse]
+    assertEquals(Errors.NONE, Errors.forCode(overrideResponse.data.errorCode))
+
+    val accepted = sendRequest(controller, target,
+      new ControlledShutdownRequest.Builder(
+        new ControlledShutdownRequestData()
+          .setBrokerId(target.config.brokerId)
+          .setBrokerEpoch(brokerEpoch),
+        3)).asInstanceOf[ControlledShutdownResponse]
+    assertEquals(Errors.NONE, accepted.error())
+  }
+
+  private def createBrokers(brokerConfigs: Seq[(Int, Boolean)],
+                            allowFallback: Boolean): Seq[KafkaServer] = {
+    brokerConfigs.map { case (brokerId, preferredController) =>
+      val props: Properties = TestUtils.createBrokerConfig(brokerId, zkConnect)
+      props.put(KafkaConfig.LiProtocolBridgePreferredControllerEnableProp, "true")
+      props.put(KafkaConfig.PreferredControllerProp, preferredController.toString)
+      props.put(KafkaConfig.AllowPreferredControllerFallbackProp, allowFallback.toString)
+      createBroker(KafkaConfig.fromProps(props)).asInstanceOf[KafkaServer]
+    }
+  }
+
+  private def ensureControllerIsOneOf(expectedBrokerIds: Seq[Int], timeoutMs: Long = 15000L): Unit = {
+    val (controllerId, _) = TestUtils.computeUntilTrue(zkClient.getControllerId, waitTime = timeoutMs) {
+      _.exists(controllerId => expectedBrokerIds.isEmpty || expectedBrokerIds.contains(controllerId))
+    }
+    if (expectedBrokerIds.isEmpty)
+      assertTrue(controllerId.isEmpty, "no broker should be elected controller")
+    else
+      assertTrue(expectedBrokerIds.contains(controllerId.getOrElse(fail("controller was not elected"))),
+        s"controller should be one of $expectedBrokerIds")
+  }
+
+  private def sendRequest(controller: KafkaServer,
+                          from: KafkaServer,
+                          requestBuilder: AbstractRequest.Builder[_ <: AbstractRequest]): AbstractResponse = {
+    val config = from.config
+    val time = Time.SYSTEM
+    val logContext = new LogContext
+    val metadataUpdater = new ManualMetadataUpdater
+    val channelBuilder = ChannelBuilders.clientChannelBuilder(
+      config.interBrokerSecurityProtocol,
+      JaasContext.Type.SERVER,
+      config,
+      config.interBrokerListenerName,
+      config.saslMechanismInterBrokerProtocol,
+      time,
+      config.saslInterBrokerHandshakeRequestEnable,
+      logContext)
+    val selector = new Selector(
+      NetworkReceive.UNLIMITED,
+      config.connectionsMaxIdleMs,
+      from.metrics,
+      time,
+      "li-controller-operations-test",
+      Map.empty[String, String].asJava,
+      false,
+      channelBuilder,
+      logContext)
+    val networkClient = new NetworkClient(
+      selector,
+      metadataUpdater,
+      config.brokerId.toString,
+      1,
+      0,
+      0,
+      Selectable.USE_DEFAULT_BUFFER_SIZE,
+      Selectable.USE_DEFAULT_BUFFER_SIZE,
+      config.requestTimeoutMs,
+      config.connectionSetupTimeoutMs,
+      config.connectionSetupTimeoutMaxMs,
+      time,
+      false,
+      new ApiVersions,
+      logContext,
+      MetadataRecoveryStrategy.NONE)
+
+    try {
+      TestUtils.waitUntilTrue(() => from.metadataCache
+        .getAliveBrokerNode(controller.config.brokerId, config.interBrokerListenerName).isDefined,
+        "Controller was not visible in broker metadata", 10000L)
+      val node = from.metadataCache
+        .getAliveBrokerNode(controller.config.brokerId, config.interBrokerListenerName)
+        .getOrElse(fail("controller was not visible in broker metadata"))
+      metadataUpdater.setNodes(Seq(node).asJava)
+      assertTrue(NetworkClientUtils.awaitReady(networkClient, node, time, 10000L))
+      val request = networkClient.newClientRequest(
+        controller.config.brokerId.toString,
+        requestBuilder,
+        time.milliseconds(),
+        true)
+      NetworkClientUtils.sendAndReceive(networkClient, request, time).responseBody
+    } finally {
+      networkClient.close()
+      selector.close()
+    }
+  }
+}

--- a/core/src/test/scala/unit/kafka/controller/LiShutdownSafetyTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/LiShutdownSafetyTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.controller
+
+import java.util.Properties
+import kafka.api.LeaderAndIsr
+import kafka.cluster.Broker
+import kafka.server.{BrokerFeatures, DelegationTokenManager, KafkaConfig}
+import kafka.server.metadata.ZkMetadataCache
+import kafka.utils.TestUtils
+import kafka.zk.{BrokerInfo, KafkaZkClient}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.utils.MockTime
+import org.apache.kafka.server.config.ConfigType
+import org.junit.jupiter.api.Assertions.{assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.{mock, times, verify, verifyNoMoreInteractions, when}
+
+class LiShutdownSafetyTest {
+  @Test
+  def testTopicConfigsAreReadOncePerShutdownCheck(): Unit = {
+    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect))
+    val zkClient = mock(classOf[KafkaZkClient])
+    val controller = new KafkaController(config, zkClient, new MockTime, mock(classOf[Metrics]),
+      mock(classOf[BrokerInfo]), 0L, mock(classOf[DelegationTokenManager]), mock(classOf[BrokerFeatures]),
+      mock(classOf[ZkMetadataCache]))
+    try {
+      val context = controller.controllerContext
+      context.setLiveBrokers(Map(Broker(0, Seq.empty, None) -> 1L, Broker(1, Seq.empty, None) -> 2L))
+      (0 until 100).foreach { index =>
+        val partition = new TopicPartition("orders", index)
+        context.updatePartitionFullReplicaAssignment(partition, ReplicaAssignment(Seq(0, 1)))
+        context.putPartitionLeadershipInfo(partition,
+          LeaderIsrAndControllerEpoch(LeaderAndIsr(0, List(0, 1)), 1))
+      }
+      val topicConfig = new Properties
+      when(zkClient.getEntitiesConfigs(ConfigType.TOPIC, Set("orders")))
+        .thenReturn(Map("orders" -> topicConfig))
+      assertTrue(controller.safeToShutdown(0))
+      verify(zkClient, times(1)).getEntitiesConfigs(ConfigType.TOPIC, Set("orders"))
+
+      topicConfig.setProperty("min.insync.replicas", "2")
+      assertFalse(controller.safeToShutdown(0))
+      verify(zkClient, times(2)).getEntitiesConfigs(ConfigType.TOPIC, Set("orders"))
+      context.shuttingDownBrokerIds.add(0)
+      assertTrue(controller.safeToShutdown(0))
+      verifyNoMoreInteractions(zkClient)
+    } finally controller.shutdown()
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -101,7 +101,9 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
       )
     }
 
-    assertEquals(expectedApis.size, apiVersionsResponse.data.apiKeys.size,
+    // These fixtures keep LI private APIs disabled through the default compatibility settings.
+    val expectedEnabledApiCount = expectedApis.iterator.asScala.count(_.apiKey < 1000)
+    assertEquals(expectedEnabledApiCount, apiVersionsResponse.data.apiKeys.size,
       "API keys in ApiVersionsResponse must match API keys supported by broker.")
 
     val defaultApiVersionsResponse = if (!cluster.isKRaftTest) {
@@ -112,7 +114,8 @@ abstract class AbstractApiVersionsRequestTest(cluster: ClusterInstance) {
       TestUtils.createApiVersionsResponse(0, expectedApis)
     }
 
-    for (expectedApiVersion: ApiVersion <- defaultApiVersionsResponse.data.apiKeys.asScala) {
+    for (expectedApiVersion: ApiVersion <- defaultApiVersionsResponse.data.apiKeys.asScala
+         if expectedApiVersion.apiKey < 1000) {
       val actualApiVersion = apiVersionsResponse.apiVersion(expectedApiVersion.apiKey)
       assertNotNull(actualApiVersion, s"API key ${expectedApiVersion.apiKey()} is supported by broker, but not received in ApiVersionsResponse.")
       assertEquals(expectedApiVersion.apiKey, actualApiVersion.apiKey, "API key must be supported by the broker.")

--- a/core/src/test/scala/unit/kafka/server/ApiVersionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionManagerTest.scala
@@ -41,7 +41,9 @@ class ApiVersionManagerTest {
       forwardingManager = None,
       brokerFeatures = brokerFeatures,
       metadataCache = metadataCache,
-      enableUnstableLastVersion = true
+      enableUnstableLastVersion = true,
+      liMoveControllerEnabled = () => true,
+      liShutdownSafetyOverrideEnabled = () => true
     )
     assertEquals(ApiKeys.apisForListener(apiScope).asScala, versionManager.enabledApis)
     assertTrue(ApiKeys.apisForListener(apiScope).asScala.forall { apiKey =>
@@ -67,6 +69,29 @@ class ApiVersionManagerTest {
         assertFalse(versionManager.isApiEnabled(apiKey, apiKey.latestVersion),
           s"$apiKey version ${apiKey.latestVersion} should be disabled.")
       }
+    }
+  }
+
+  @Test
+  def testPrivateApiFeatureFlags(): Unit = {
+    def versionManager(enabled: Boolean) = new DefaultApiVersionManager(
+      listenerType = ListenerType.ZK_BROKER,
+      forwardingManager = None,
+      brokerFeatures = brokerFeatures,
+      metadataCache = metadataCache,
+      enableUnstableLastVersion = true,
+      liMoveControllerEnabled = () => enabled,
+      liShutdownSafetyOverrideEnabled = () => enabled
+    )
+
+    Seq(ApiKeys.LI_MOVE_CONTROLLER, ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK).foreach { apiKey =>
+      val disabledManager = versionManager(enabled = false)
+      assertFalse(disabledManager.isApiEnabled(apiKey, apiKey.latestVersion))
+      assertNull(disabledManager.apiVersionResponse(0, alterFeatureLevel0 = false).data.apiKeys.find(apiKey.id))
+
+      val enabledManager = versionManager(enabled = true)
+      assertTrue(enabledManager.isApiEnabled(apiKey, apiKey.latestVersion))
+      assertNotNull(enabledManager.apiVersionResponse(0, alterFeatureLevel0 = false).data.apiKeys.find(apiKey.id))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -309,7 +309,9 @@ class DynamicBrokerConfigTest {
       KafkaConfig.LiProtocolBridgeModeEnableProp,
       KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp,
       KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
-      KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp
+      KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
+      KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
+      KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp
     )
     bridgeFlags.foreach(flag => assertFalse(config.getBoolean(flag), s"$flag should be disabled by default"))
 

--- a/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import com.yammer.metrics.core.Gauge
+import kafka.utils.TestUtils
+import org.apache.kafka.server.config.ReplicationConfigs
+import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+import java.util.Properties
+import scala.jdk.CollectionConverters._
+
+class LiProtocolBridgeMetricsTest {
+
+  @Test
+  def testMetricsFollowDynamicFlags(): Unit = {
+    val brokerId = 987
+    val brokerProps = TestUtils.createBrokerConfig(brokerId, TestUtils.MockZkConnect)
+    brokerProps.put(ReplicationConfigs.INTER_BROKER_PROTOCOL_VERSION_CONFIG, "3.0")
+    val config = KafkaConfig(brokerProps)
+    config.dynamicConfig.initialize(None, None)
+    val metrics = new LiProtocolBridgeMetrics(config)
+
+    try {
+      assertTrue(metricValues(brokerId).values.forall(_ == 0))
+
+      val props = new Properties
+      Seq(
+        KafkaConfig.LiProtocolBridgeModeEnableProp,
+        KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp,
+        KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
+        KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
+        KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
+        KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp
+      ).foreach(props.put(_, "true"))
+      config.dynamicConfig.updateDefaultConfig(props)
+
+      val updatedValues = metricValues(brokerId)
+      assertEquals(LiProtocolBridgeMetrics.MetricNames.toSet, updatedValues.keySet)
+      assertEquals(0, updatedValues(LiProtocolBridgeMetrics.PreferredControllerEnabled))
+      assertTrue(updatedValues.filterNot(_._1 == LiProtocolBridgeMetrics.PreferredControllerEnabled)
+        .values.forall(_ == 1))
+    } finally {
+      metrics.close()
+    }
+    assertTrue(metricValues(brokerId).isEmpty)
+  }
+
+  private def metricValues(brokerId: Int): Map[String, Int] = {
+    KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.collect {
+      case (name, gauge: Gauge[_])
+        if name.getMBeanName.contains("type=LiProtocolBridgeMetrics") &&
+          name.getMBeanName.contains(s"broker-id=$brokerId") =>
+        name.getName -> gauge.value.asInstanceOf[Int]
+    }.toMap
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -193,29 +193,24 @@ class RequestQuotaTest extends BaseRequestTest {
   def testUnauthorizedThrottle(quorum: String): Unit = {
     RequestQuotaTest.principal = RequestQuotaTest.UnauthorizedPrincipal
 
-    val apiKeys = if (isKRaftTest()) ApiKeys.kraftBrokerApis else ApiKeys.zkBrokerApis
-    for (apiKey <- apiKeys.asScala.toSet -- RequestQuotaTest.Envelope) {
+    for (apiKey <- enabledBrokerApis -- RequestQuotaTest.Envelope) {
       submitTest(apiKey, () => checkUnauthorizedRequestThrottle(apiKey))
     }
 
     waitAndCheckResults()
   }
 
-  private def clientActions: Set[ApiKeys] = {
-    if (isKRaftTest()) {
-      ApiKeys.kraftBrokerApis.asScala.toSet -- clusterActions -- RequestQuotaTest.SaslActions -- RequestQuotaTest.Envelope
-    } else {
-      ApiKeys.zkBrokerApis.asScala.toSet -- clusterActions -- RequestQuotaTest.SaslActions -- RequestQuotaTest.Envelope
-    }
+  private def enabledBrokerApis: Set[ApiKeys] = {
+    val brokerApis = if (isKRaftTest()) ApiKeys.kraftBrokerApis else ApiKeys.zkBrokerApis
+    // Private compatibility APIs are disabled in these default-config quota fixtures.
+    brokerApis.asScala.filter(_.id < 1000).toSet
   }
 
-  private def clusterActions: Set[ApiKeys] = {
-    if (isKRaftTest()) {
-      ApiKeys.kraftBrokerApis.asScala.filter(_.clusterAction).toSet
-    } else {
-      ApiKeys.zkBrokerApis.asScala.filter(_.clusterAction).toSet
-    }
-  }
+  private def clientActions: Set[ApiKeys] =
+    enabledBrokerApis -- clusterActions -- RequestQuotaTest.SaslActions -- RequestQuotaTest.Envelope
+
+  private def clusterActions: Set[ApiKeys] =
+    enabledBrokerApis.filter(_.clusterAction)
 
   private def clusterActionsWithThrottleForBroker: Set[ApiKeys] = {
     if (isKRaftTest()) {

--- a/core/src/test/scala/unit/kafka/zk/LiControllerZkOperationsTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/LiControllerZkOperationsTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.zk
+
+import kafka.server.QuorumTestHarness
+import org.apache.kafka.common.utils.Time
+import org.apache.zookeeper.{KeeperException, ZooDefs}
+import org.apache.zookeeper.client.ZKClientConfig
+import org.junit.jupiter.api.Assertions.{assertFalse, assertThrows}
+import org.junit.jupiter.api.Test
+
+class LiControllerZkOperationsTest extends QuorumTestHarness {
+  @Test
+  def testDeleteControllerIsIdempotent(): Unit = {
+    zkClient.createRecursive(ControllerZNode.path)
+    zkClient.deleteControllerRaw()
+    assertFalse(zkClient.pathExists(ControllerZNode.path))
+    zkClient.deleteControllerRaw()
+  }
+
+  @Test
+  def testDeleteControllerPropagatesZooKeeperAuthorizationError(): Unit = {
+    zkClient.createRecursive("/read-only/controller")
+    zkClient.currentZooKeeper.setACL("/read-only", ZooDefs.Ids.READ_ACL_UNSAFE, -1)
+    val client = KafkaZkClient(s"$zkConnect/read-only", isSecure = false,
+      zkSessionTimeout, zkConnectionTimeout, zkMaxInFlightRequests, Time.SYSTEM,
+      name = "LiControllerZkOperationsTest", zkClientConfig = new ZKClientConfig)
+    try assertThrows(classOf[KeeperException.NoAuthException], () => client.deleteControllerRaw())
+    finally client.close()
+  }
+}


### PR DESCRIPTION
Add the ZooKeeper-only, config-gated shutdown-safety and controller-movement handlers. Wire definitions and byte fixtures are now in #565. Keep permission checks, old JVM signatures and disabled behavior covered by tests.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.