### PR TITLE
kafka: support federated-topic ZooKeeper RPCs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -135,7 +135,10 @@ public enum ApiKeys {
     // Private 3.0-li APIs retained while ZooKeeper operational tooling is migrated.
     LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK(
             ApiMessageType.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, true, true),
-    LI_MOVE_CONTROLLER(ApiMessageType.LI_MOVE_CONTROLLER, true);
+    LI_MOVE_CONTROLLER(ApiMessageType.LI_MOVE_CONTROLLER, true),
+    LI_CREATE_FEDERATED_TOPIC_ZNODES(ApiMessageType.LI_CREATE_FEDERATED_TOPIC_ZNODES),
+    LI_DELETE_FEDERATED_TOPIC_ZNODES(ApiMessageType.LI_DELETE_FEDERATED_TOPIC_ZNODES),
+    LI_LIST_FEDERATED_TOPIC_ZNODES(ApiMessageType.LI_LIST_FEDERATED_TOPIC_ZNODES);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -354,6 +354,12 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return LiControlledShutdownSkipSafetyCheckRequest.parse(buffer, apiVersion);
             case LI_MOVE_CONTROLLER:
                 return LiMoveControllerRequest.parse(buffer, apiVersion);
+            case LI_CREATE_FEDERATED_TOPIC_ZNODES:
+                return LiCreateFederatedTopicZnodesRequest.parse(buffer, apiVersion);
+            case LI_DELETE_FEDERATED_TOPIC_ZNODES:
+                return LiDeleteFederatedTopicZnodesRequest.parse(buffer, apiVersion);
+            case LI_LIST_FEDERATED_TOPIC_ZNODES:
+                return LiListFederatedTopicZnodesRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -291,6 +291,12 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return LiControlledShutdownSkipSafetyCheckResponse.parse(responseBuffer, version);
             case LI_MOVE_CONTROLLER:
                 return LiMoveControllerResponse.parse(responseBuffer, version);
+            case LI_CREATE_FEDERATED_TOPIC_ZNODES:
+                return LiCreateFederatedTopicZnodesResponse.parse(responseBuffer, version);
+            case LI_DELETE_FEDERATED_TOPIC_ZNODES:
+                return LiDeleteFederatedTopicZnodesResponse.parse(responseBuffer, version);
+            case LI_LIST_FEDERATED_TOPIC_ZNODES:
+                return LiListFederatedTopicZnodesResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCreateFederatedTopicZnodesRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCreateFederatedTopicZnodesRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiCreateFederatedTopicZnodesRequestData;
+import org.apache.kafka.common.message.LiCreateFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiCreateFederatedTopicZnodesRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiCreateFederatedTopicZnodesRequest> {
+        private final LiCreateFederatedTopicZnodesRequestData data;
+
+        public Builder(LiCreateFederatedTopicZnodesRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiCreateFederatedTopicZnodesRequest build(short version) {
+            return new LiCreateFederatedTopicZnodesRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiCreateFederatedTopicZnodesRequestData data;
+
+    LiCreateFederatedTopicZnodesRequest(LiCreateFederatedTopicZnodesRequestData data, short version) {
+        super(ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES, version);
+        this.data = data;
+    }
+
+    public static LiCreateFederatedTopicZnodesRequest parse(ByteBuffer buffer, short version) {
+        return new LiCreateFederatedTopicZnodesRequest(new LiCreateFederatedTopicZnodesRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiCreateFederatedTopicZnodesResponseData data = new LiCreateFederatedTopicZnodesResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiCreateFederatedTopicZnodesResponse(data, version());
+    }
+
+    @Override
+    public LiCreateFederatedTopicZnodesRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiCreateFederatedTopicZnodesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiCreateFederatedTopicZnodesResponse.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.message.LiCreateFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiCreateFederatedTopicZnodesResponse extends AbstractResponse {
+    private final LiCreateFederatedTopicZnodesResponseData data;
+    private final short version;
+
+    public LiCreateFederatedTopicZnodesResponse(LiCreateFederatedTopicZnodesResponseData data, short version) {
+        super(ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES);
+        this.data = data;
+        this.version = version;
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    public LiCreateFederatedTopicZnodesResponseData data() {
+        return data;
+    }
+
+    public static LiCreateFederatedTopicZnodesResponse prepareResponse(Errors error, int throttleTimeMs, short version) {
+        LiCreateFederatedTopicZnodesResponseData data = new LiCreateFederatedTopicZnodesResponseData();
+        data.setErrorCode(error.code());
+        data.setThrottleTimeMs(throttleTimeMs);
+        return new LiCreateFederatedTopicZnodesResponse(data, version);
+    }
+
+    public static LiCreateFederatedTopicZnodesResponse parse(ByteBuffer buffer, short version) {
+        return new LiCreateFederatedTopicZnodesResponse(new LiCreateFederatedTopicZnodesResponseData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiDeleteFederatedTopicZnodesRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiDeleteFederatedTopicZnodesRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesRequestData;
+import org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiDeleteFederatedTopicZnodesRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiDeleteFederatedTopicZnodesRequest> {
+        private final LiDeleteFederatedTopicZnodesRequestData data;
+
+        public Builder(LiDeleteFederatedTopicZnodesRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiDeleteFederatedTopicZnodesRequest build(short version) {
+            return new LiDeleteFederatedTopicZnodesRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiDeleteFederatedTopicZnodesRequestData data;
+
+    LiDeleteFederatedTopicZnodesRequest(LiDeleteFederatedTopicZnodesRequestData data, short version) {
+        super(ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES, version);
+        this.data = data;
+    }
+
+    public static LiDeleteFederatedTopicZnodesRequest parse(ByteBuffer buffer, short version) {
+        return new LiDeleteFederatedTopicZnodesRequest(new LiDeleteFederatedTopicZnodesRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiDeleteFederatedTopicZnodesResponseData data = new LiDeleteFederatedTopicZnodesResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiDeleteFederatedTopicZnodesResponse(data, version());
+    }
+
+    @Override
+    public LiDeleteFederatedTopicZnodesRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiDeleteFederatedTopicZnodesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiDeleteFederatedTopicZnodesResponse.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiDeleteFederatedTopicZnodesResponse extends AbstractResponse {
+    private final LiDeleteFederatedTopicZnodesResponseData data;
+    private final short version;
+
+    public LiDeleteFederatedTopicZnodesResponse(LiDeleteFederatedTopicZnodesResponseData data, short version) {
+        super(ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES);
+        this.data = data;
+        this.version = version;
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    public LiDeleteFederatedTopicZnodesResponseData data() {
+        return data;
+    }
+
+    public static LiDeleteFederatedTopicZnodesResponse prepareResponse(Errors error, int throttleTimeMs, short version) {
+        LiDeleteFederatedTopicZnodesResponseData data = new LiDeleteFederatedTopicZnodesResponseData();
+        data.setErrorCode(error.code());
+        data.setThrottleTimeMs(throttleTimeMs);
+        return new LiDeleteFederatedTopicZnodesResponse(data, version);
+    }
+
+    public static LiDeleteFederatedTopicZnodesResponse parse(ByteBuffer buffer, short version) {
+        return new LiDeleteFederatedTopicZnodesResponse(new LiDeleteFederatedTopicZnodesResponseData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiListFederatedTopicZnodesRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiListFederatedTopicZnodesRequest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.apache.kafka.common.message.LiListFederatedTopicZnodesRequestData;
+import org.apache.kafka.common.message.LiListFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiListFederatedTopicZnodesRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiListFederatedTopicZnodesRequest> {
+
+        private final LiListFederatedTopicZnodesRequestData data;
+
+        public Builder(LiListFederatedTopicZnodesRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiListFederatedTopicZnodesRequest build(short version) {
+            return new LiListFederatedTopicZnodesRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiListFederatedTopicZnodesRequestData data;
+
+    public LiListFederatedTopicZnodesRequest(LiListFederatedTopicZnodesRequestData data, short version) {
+        super(ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES, version);
+        this.data = data;
+    }
+
+    @Override
+    public LiListFederatedTopicZnodesResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiListFederatedTopicZnodesResponseData data = new LiListFederatedTopicZnodesResponseData().
+            setTopics(Collections.emptyList()).
+            setThrottleTimeMs(throttleTimeMs).
+            setErrorCode(Errors.forException(e).code());
+        return new LiListFederatedTopicZnodesResponse(data, version());
+    }
+
+    public static LiListFederatedTopicZnodesRequest parse(ByteBuffer buffer, short version) {
+        return new LiListFederatedTopicZnodesRequest(
+            new LiListFederatedTopicZnodesRequestData(new ByteBufferAccessor(buffer), version), version
+        );
+    }
+
+    @Override
+    public LiListFederatedTopicZnodesRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiListFederatedTopicZnodesResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiListFederatedTopicZnodesResponse.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.kafka.common.message.LiListFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+
+public class LiListFederatedTopicZnodesResponse extends AbstractResponse {
+    private final LiListFederatedTopicZnodesResponseData data;
+    private final short version;
+
+    public LiListFederatedTopicZnodesResponse(LiListFederatedTopicZnodesResponseData data, short version) {
+        super(ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES);
+        this.data = data;
+        this.version = version;
+    }
+
+    @Override
+    public LiListFederatedTopicZnodesResponseData data() {
+        return data;
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        data.setThrottleTimeMs(throttleTimeMs);
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return errorCounts(Errors.forCode(data.errorCode()));
+    }
+
+    public static LiListFederatedTopicZnodesResponse parse(ByteBuffer buffer, short version) {
+        return new LiListFederatedTopicZnodesResponse(
+            new LiListFederatedTopicZnodesResponseData(new ByteBufferAccessor(buffer), version), version
+        );
+    }
+
+    public static LiListFederatedTopicZnodesResponse prepareResponse(Errors error, int throttleTimeMs, short version) {
+        LiListFederatedTopicZnodesResponseData data = new LiListFederatedTopicZnodesResponseData();
+        data.setErrorCode(error.code());
+        data.setThrottleTimeMs(throttleTimeMs);
+        return new LiListFederatedTopicZnodesResponse(data, version);
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/resources/common/message/LiCreateFederatedTopicZnodesRequest.json
+++ b/clients/src/main/resources/common/message/LiCreateFederatedTopicZnodesRequest.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1003,
+  "type": "request",
+  "listeners": ["zkBroker"],
+  "name": "LiCreateFederatedTopicZnodesRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]FederatedTopics", "versions": "0+", "about": "The name and namespace of the federated topic",
+      "fields": [
+        {"name": "Name", "type": "string", "versions": "0+", "about": "The topic name"},
+        {"name": "Namespace", "type": "string", "versions": "0+", "about": "The namespace of the topic"}
+      ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The length of time in milliseconds to wait for the creations to complete." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiCreateFederatedTopicZnodesResponse.json
+++ b/clients/src/main/resources/common/message/LiCreateFederatedTopicZnodesResponse.json
@@ -1,0 +1,27 @@
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1003,
+  "type": "response",
+  "name": "LiCreateFederatedTopicZnodesResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." },
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiDeleteFederatedTopicZnodesRequest.json
+++ b/clients/src/main/resources/common/message/LiDeleteFederatedTopicZnodesRequest.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1004,
+  "type": "request",
+  "listeners": ["zkBroker"],
+  "name": "LiDeleteFederatedTopicZnodesRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]FederatedTopics", "versions": "0+", "about": "The name and namespace of the federated topic",
+      "fields": [
+        {"name": "Name", "type": "string", "versions": "0+", "about": "The topic name"},
+        {"name": "Namespace", "type": "string", "versions": "0+", "about": "The namespace of the topic"}
+      ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The length of time in milliseconds to wait for the deletions to complete." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiDeleteFederatedTopicZnodesResponse.json
+++ b/clients/src/main/resources/common/message/LiDeleteFederatedTopicZnodesResponse.json
@@ -1,0 +1,27 @@
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1004,
+  "type": "response",
+  "name": "LiDeleteFederatedTopicZnodesResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." },
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiListFederatedTopicZnodesRequest.json
+++ b/clients/src/main/resources/common/message/LiListFederatedTopicZnodesRequest.json
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1005,
+  "type": "request",
+  "listeners": ["zkBroker"],
+  "name": "LiListFederatedTopicZnodesRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]FederatedTopics", "versions": "0+", "about": "The simple name of the federated topics",
+      "fields": [
+        {"name": "Name", "type": "string", "versions": "0+", "about": "The topic name"},
+        {"name": "Namespace", "type": "string", "versions": "0+", "about": "The namespace of the topic"}
+      ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/LiListFederatedTopicZnodesResponse.json
+++ b/clients/src/main/resources/common/message/LiListFederatedTopicZnodesResponse.json
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1005,
+  "type": "response",
+  "name": "LiListFederatedTopicZnodesResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "Topics", "type": "[]string", "versions": "0+", "about": "The name and namespace of the federated topic"},
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." },
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/common/message/BridgePrivateApiFixtureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/BridgePrivateApiFixtureTest.java
@@ -44,6 +44,40 @@ public class BridgePrivateApiFixtureTest {
         assertFixture(fixture, new LiMoveControllerRequestData(accessor(fixture), (short) 0));
     }
 
+    @Test
+    public void testCreateFederatedTopic() {
+        byte[] fixture = bytes("02076f7264657273057765737400000004d200");
+        LiCreateFederatedTopicZnodesRequestData data =
+            new LiCreateFederatedTopicZnodesRequestData(accessor(fixture), (short) 0);
+        assertFederatedTopic(data.topics().get(0).name(), data.topics().get(0).namespace());
+        assertEquals(1234, data.timeoutMs());
+        assertFixture(fixture, data);
+    }
+
+    @Test
+    public void testDeleteFederatedTopic() {
+        byte[] fixture = bytes("02076f7264657273057765737400000004d200");
+        LiDeleteFederatedTopicZnodesRequestData data =
+            new LiDeleteFederatedTopicZnodesRequestData(accessor(fixture), (short) 0);
+        assertFederatedTopic(data.topics().get(0).name(), data.topics().get(0).namespace());
+        assertEquals(1234, data.timeoutMs());
+        assertFixture(fixture, data);
+    }
+
+    @Test
+    public void testListFederatedTopic() {
+        byte[] fixture = bytes("02076f726465727305776573740000");
+        LiListFederatedTopicZnodesRequestData data =
+            new LiListFederatedTopicZnodesRequestData(accessor(fixture), (short) 0);
+        assertFederatedTopic(data.topics().get(0).name(), data.topics().get(0).namespace());
+        assertFixture(fixture, data);
+    }
+
+    private static void assertFederatedTopic(String name, String namespace) {
+        assertEquals("orders", name);
+        assertEquals("west", namespace);
+    }
+
     private static ByteBufferAccessor accessor(byte[] fixture) {
         return new ByteBufferAccessor(ByteBuffer.wrap(fixture));
     }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/BridgeProtocolConstantsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/BridgeProtocolConstantsTest.java
@@ -29,9 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BridgeProtocolConstantsTest {
     @Test
-    public void testLinkedInClientProtocolConstants() {
+    public void testLinkedInProtocolConstants() {
         assertEquals(1000, ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK.id);
         assertEquals(1002, ApiKeys.LI_MOVE_CONTROLLER.id);
+        assertEquals(1003, ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES.id);
+        assertEquals(1004, ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES.id);
+        assertEquals(1005, ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES.id);
         assertEquals(2, ElectionType.RECOMMENDED.value);
         assertEquals(-104L, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP);
         assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE, Errors.forCode((short) 1107));
@@ -39,10 +42,13 @@ public class BridgeProtocolConstantsTest {
     }
 
     @Test
-    public void testControlApisAreScopedToZooKeeperBrokers() {
+    public void testPrivateApisAreScopedToZooKeeperBrokers() {
         for (ApiKeys apiKey : Arrays.asList(
             ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK,
-            ApiKeys.LI_MOVE_CONTROLLER
+            ApiKeys.LI_MOVE_CONTROLLER,
+            ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES,
+            ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES,
+            ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES
         )) {
             assertTrue(apiKey.inScope(ListenerType.ZK_BROKER));
             assertFalse(apiKey.inScope(ListenerType.BROKER));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1129,6 +1129,15 @@ public class RequestResponseTest {
             case LI_MOVE_CONTROLLER:
                 return new LiMoveControllerRequest(
                         new org.apache.kafka.common.message.LiMoveControllerRequestData(), version);
+            case LI_CREATE_FEDERATED_TOPIC_ZNODES:
+                return new LiCreateFederatedTopicZnodesRequest(
+                        new org.apache.kafka.common.message.LiCreateFederatedTopicZnodesRequestData(), version);
+            case LI_DELETE_FEDERATED_TOPIC_ZNODES:
+                return new LiDeleteFederatedTopicZnodesRequest(
+                        new org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesRequestData(), version);
+            case LI_LIST_FEDERATED_TOPIC_ZNODES:
+                return new LiListFederatedTopicZnodesRequest(
+                        new org.apache.kafka.common.message.LiListFederatedTopicZnodesRequestData(), version);
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -1227,6 +1236,12 @@ public class RequestResponseTest {
                 return LiControlledShutdownSkipSafetyCheckResponse.prepareResponse(Errors.NONE);
             case LI_MOVE_CONTROLLER:
                 return LiMoveControllerResponse.prepareResponse(Errors.NONE, version);
+            case LI_CREATE_FEDERATED_TOPIC_ZNODES:
+                return LiCreateFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, 0, version);
+            case LI_DELETE_FEDERATED_TOPIC_ZNODES:
+                return LiDeleteFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, 0, version);
+            case LI_LIST_FEDERATED_TOPIC_ZNODES:
+                return LiListFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, 0, version);
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -88,6 +88,12 @@ object RequestConvertToJson {
       case req: LiControlledShutdownSkipSafetyCheckRequest =>
         LiControlledShutdownSkipSafetyCheckRequestDataJsonConverter.write(req.data, request.version)
       case req: LiMoveControllerRequest => LiMoveControllerRequestDataJsonConverter.write(req.data, request.version)
+      case req: LiCreateFederatedTopicZnodesRequest =>
+        LiCreateFederatedTopicZnodesRequestDataJsonConverter.write(req.data, request.version)
+      case req: LiDeleteFederatedTopicZnodesRequest =>
+        LiDeleteFederatedTopicZnodesRequestDataJsonConverter.write(req.data, request.version)
+      case req: LiListFederatedTopicZnodesRequest =>
+        LiListFederatedTopicZnodesRequestDataJsonConverter.write(req.data, request.version)
       case req: ListPartitionReassignmentsRequest => ListPartitionReassignmentsRequestDataJsonConverter.write(req.data, request.version)
       case req: ListTransactionsRequest => ListTransactionsRequestDataJsonConverter.write(req.data, request.version)
       case req: MetadataRequest => MetadataRequestDataJsonConverter.write(req.data, request.version)
@@ -186,6 +192,12 @@ object RequestConvertToJson {
       case res: LiControlledShutdownSkipSafetyCheckResponse =>
         LiControlledShutdownSkipSafetyCheckResponseDataJsonConverter.write(res.data, version)
       case res: LiMoveControllerResponse => LiMoveControllerResponseDataJsonConverter.write(res.data, version)
+      case res: LiCreateFederatedTopicZnodesResponse =>
+        LiCreateFederatedTopicZnodesResponseDataJsonConverter.write(res.data, version)
+      case res: LiDeleteFederatedTopicZnodesResponse =>
+        LiDeleteFederatedTopicZnodesResponseDataJsonConverter.write(res.data, version)
+      case res: LiListFederatedTopicZnodesResponse =>
+        LiListFederatedTopicZnodesResponseDataJsonConverter.write(res.data, version)
       case res: ListPartitionReassignmentsResponse => ListPartitionReassignmentsResponseDataJsonConverter.write(res.data, version)
       case res: ListTransactionsResponse => ListTransactionsResponseDataJsonConverter.write(res.data, version)
       case res: MetadataResponse => MetadataResponseDataJsonConverter.write(res.data, version)

--- a/core/src/main/scala/kafka/server/ApiVersionManager.scala
+++ b/core/src/main/scala/kafka/server/ApiVersionManager.scala
@@ -61,8 +61,15 @@ object ApiVersionManager {
       config.unstableApiVersionsEnabled,
       config.migrationEnabled,
       clientMetricsManager,
-      () => config.liProtocolBridgeMoveControllerActive,
-      () => config.liProtocolBridgeShutdownSafetyOverrideActive
+      apiKey => apiKey match {
+        case ApiKeys.LI_MOVE_CONTROLLER => config.liProtocolBridgeMoveControllerActive
+        case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK =>
+          config.liProtocolBridgeShutdownSafetyOverrideActive
+        case ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES |
+             ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES |
+             ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES => config.liProtocolBridgeFederatedTopicsActive
+        case _ => true
+      }
     )
   }
 }
@@ -145,16 +152,13 @@ class DefaultApiVersionManager(
   val enableUnstableLastVersion: Boolean,
   val zkMigrationEnabled: Boolean = false,
   val clientMetricsManager: Option[ClientMetricsManager] = None,
-  liMoveControllerEnabled: () => Boolean = () => false,
-  liShutdownSafetyOverrideEnabled: () => Boolean = () => false
+  liApiEnabled: ApiKeys => Boolean = _ => false
 ) extends ApiVersionManager {
 
   val enabledApis: mutable.Set[ApiKeys] = ApiKeys.apisForListener(listenerType).asScala
 
-  private def isLiApiEnabled(apiKey: ApiKeys): Boolean = apiKey match {
-    case ApiKeys.LI_MOVE_CONTROLLER => liMoveControllerEnabled()
-    case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => liShutdownSafetyOverrideEnabled()
-    case _ => true
+  private def isLiApiEnabled(apiKey: ApiKeys): Boolean = {
+    if (apiKey == null || apiKey.id < 1000) true else liApiEnabled(apiKey)
   }
 
   override def isApiEnabled(apiKey: ApiKeys, apiVersion: Short): Boolean =

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -100,7 +100,8 @@ object DynamicBrokerConfig {
       KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
       KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
       KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
-      KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp
+      KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp,
+      KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp
     ) ++
     DynamicListenerConfig.ReconfigurableConfigs ++
     SocketServer.ReconfigurableConfigs ++
@@ -114,7 +115,8 @@ object DynamicBrokerConfig {
     KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
     KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
     KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
-    KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp
+    KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp,
+    KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp
   )
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(
     ClusterLevelListenerConfigs)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -234,6 +234,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.ELECT_LEADERS => maybeForwardToController(request, handleElectLeaders)
         case ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK => handleLiShutdownSafetyOverride(request)
         case ApiKeys.LI_MOVE_CONTROLLER => handleLiMoveController(request)
+        case ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES => handleLiCreateFederatedTopics(request)
+        case ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES => handleLiDeleteFederatedTopics(request)
+        case ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES => handleLiListFederatedTopics(request)
         case ApiKeys.INCREMENTAL_ALTER_CONFIGS => handleIncrementalAlterConfigsRequest(request)
         case ApiKeys.ALTER_PARTITION_REASSIGNMENTS => maybeForwardToController(request, handleAlterPartitionReassignmentsRequest)
         case ApiKeys.LIST_PARTITION_REASSIGNMENTS => maybeForwardToController(request, handleListPartitionReassignmentsRequest)
@@ -3423,6 +3426,84 @@ class KafkaApis(val requestChannel: RequestChannel,
         }
         requestHelper.sendResponseExemptThrottle(request, response)
       })
+  }
+
+  private def federatedTopicsDisabled(request: RequestChannel.Request, body: AbstractRequest): Boolean = {
+    if (config.liProtocolBridgeFederatedTopicsActive) {
+      false
+    } else {
+      requestHelper.sendResponseExemptThrottle(request,
+        body.getErrorResponse(new UnsupportedVersionException("LI federated-topic compatibility is disabled")))
+      true
+    }
+  }
+
+  def handleLiCreateFederatedTopics(request: RequestChannel.Request): Unit = {
+    val createRequest = request.body[LiCreateFederatedTopicZnodesRequest]
+    if (federatedTopicsDisabled(request, createRequest)) return
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+    if (!zkSupport.controller.isActive) {
+      requestHelper.sendResponseExemptThrottle(request,
+        LiCreateFederatedTopicZnodesResponse.prepareResponse(Errors.NOT_CONTROLLER, 0, createRequest.version))
+      return
+    }
+    val topics = createRequest.data.topics.asScala.map(topic => topic.name -> topic.namespace).toMap
+    val authorized = authHelper.filterByAuthorized(request.context, CREATE, TOPIC, topics.keys)(identity)
+    if (authorized.size != topics.size) {
+      requestHelper.sendResponseExemptThrottle(request,
+        LiCreateFederatedTopicZnodesResponse.prepareResponse(
+          Errors.TOPIC_AUTHORIZATION_FAILED, 0, createRequest.version))
+      return
+    }
+    topics.foreach { case (topic, namespace) => zkSupport.zkClient.createFederatedTopicZNode(topic, namespace) }
+    requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+      LiCreateFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, throttleMs, createRequest.version))
+  }
+
+  def handleLiDeleteFederatedTopics(request: RequestChannel.Request): Unit = {
+    val deleteRequest = request.body[LiDeleteFederatedTopicZnodesRequest]
+    if (federatedTopicsDisabled(request, deleteRequest)) return
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+    if (!zkSupport.controller.isActive) {
+      requestHelper.sendResponseExemptThrottle(request,
+        LiDeleteFederatedTopicZnodesResponse.prepareResponse(Errors.NOT_CONTROLLER, 0, deleteRequest.version))
+      return
+    }
+    val topics = deleteRequest.data.topics.asScala.map(topic => topic.name -> topic.namespace).toMap
+    val authorized = authHelper.filterByAuthorized(request.context, DELETE, TOPIC, topics.keys)(identity)
+    if (authorized.size != topics.size) {
+      requestHelper.sendResponseExemptThrottle(request,
+        LiDeleteFederatedTopicZnodesResponse.prepareResponse(
+          Errors.TOPIC_AUTHORIZATION_FAILED, 0, deleteRequest.version))
+      return
+    }
+    topics.foreach { case (topic, namespace) => zkSupport.zkClient.deleteFederatedTopicZNode(topic, namespace) }
+    requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+      LiDeleteFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, throttleMs, deleteRequest.version))
+  }
+
+  def handleLiListFederatedTopics(request: RequestChannel.Request): Unit = {
+    val listRequest = request.body[LiListFederatedTopicZnodesRequest]
+    if (federatedTopicsDisabled(request, listRequest)) return
+    val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.shouldNeverReceive(request))
+    if (!authHelper.authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME)) {
+      requestHelper.sendResponseExemptThrottle(request,
+        LiListFederatedTopicZnodesResponse.prepareResponse(
+          Errors.CLUSTER_AUTHORIZATION_FAILED, 0, listRequest.version))
+      return
+    }
+    val topics = if (listRequest.data.topics.isEmpty) {
+      zkSupport.zkClient.getAllFederatedTopics()
+    } else {
+      listRequest.data.topics.asScala.flatMap { topic =>
+        zkSupport.zkClient.getFederatedTopic(topic.name, topic.namespace)
+      }.toSet
+    }
+    requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+      new LiListFederatedTopicZnodesResponse(
+        new LiListFederatedTopicZnodesResponseData()
+          .setTopics(topics.toList.asJava)
+          .setThrottleTimeMs(throttleMs), listRequest.version))
   }
 
   def handleLiMoveController(request: RequestChannel.Request): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -68,6 +68,8 @@ object KafkaConfig {
     "li.protocol.bridge.shutdown.safety.override.enable"
   val LiProtocolBridgePreferredControllerEnableProp =
     "li.protocol.bridge.preferred.controller.enable"
+  val LiProtocolBridgeFederatedTopicsEnableProp =
+    "li.protocol.bridge.federated.topics.enable"
 
   // 3.0-li operational settings consumed by the LinkedIn server wrapper.
   val PreferredControllerProp = "preferred.controller"
@@ -92,6 +94,8 @@ object KafkaConfig {
     "Accept the 3.0-li private API that bypasses controlled shutdown safety for one broker epoch."
   val LiProtocolBridgePreferredControllerEnableDoc =
     "Enable 3.0-li preferred-controller election and shutdown behavior on ZooKeeper brokers."
+  val LiProtocolBridgeFederatedTopicsEnableDoc =
+    "Enable the 3.0-li federated-topic APIs and ZooKeeper metadata used by the LinkedIn authorizer."
   val PreferredControllerDoc = "Whether this broker is eligible for preferred-controller placement."
   val AllowPreferredControllerFallbackDoc =
     "Allow a non-preferred broker to become controller when no preferred controller is available."
@@ -146,6 +150,8 @@ object KafkaConfig {
       ConfigDef.Importance.HIGH, LiProtocolBridgeShutdownSafetyOverrideEnableDoc)
     .define(LiProtocolBridgePreferredControllerEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgePreferredControllerEnableDoc)
+    .define(LiProtocolBridgeFederatedTopicsEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeFederatedTopicsEnableDoc)
     .define(PreferredControllerProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, PreferredControllerDoc)
     .define(AllowPreferredControllerFallbackProp, ConfigDef.Type.BOOLEAN, true,
@@ -267,6 +273,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     getBoolean(KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp)
   def liProtocolBridgePreferredControllerEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgePreferredControllerEnableProp)
+  def liProtocolBridgeFederatedTopicsEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp)
 
   def liProtocolBridgeModeActive: Boolean = processRoles.isEmpty && liProtocolBridgeModeEnable
   def liProtocolBridgeFollowerRecoveryActive: Boolean =
@@ -281,6 +289,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     processRoles.isEmpty && liProtocolBridgeShutdownSafetyOverrideEnable
   def liProtocolBridgePreferredControllerActive: Boolean =
     processRoles.isEmpty && liProtocolBridgePreferredControllerEnable
+  def liProtocolBridgeFederatedTopicsActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeFederatedTopicsEnable
 
   def preferredController: Boolean = getBoolean(KafkaConfig.PreferredControllerProp)
   def allowPreferredControllerFallback: Boolean = getBoolean(KafkaConfig.AllowPreferredControllerFallbackProp)

--- a/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
+++ b/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
@@ -28,9 +28,10 @@ object LiProtocolBridgeMetrics {
   val MoveControllerEnabled = "MoveControllerEnabled"
   val ShutdownSafetyOverrideEnabled = "ShutdownSafetyOverrideEnabled"
   val PreferredControllerEnabled = "PreferredControllerEnabled"
+  val FederatedTopicsEnabled = "FederatedTopicsEnabled"
   val MetricNames: Seq[String] = Seq(ModeEnabled, FollowerRecoveryEnabled,
     RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled, MoveControllerEnabled,
-    ShutdownSafetyOverrideEnabled, PreferredControllerEnabled)
+    ShutdownSafetyOverrideEnabled, PreferredControllerEnabled, FederatedTopicsEnabled)
 }
 
 /** Exposes the effective value of every 3.0-li compatibility flag on each ZooKeeper broker. */
@@ -53,6 +54,8 @@ class LiProtocolBridgeMetrics(config: KafkaConfig) extends AutoCloseable {
     () => enabled(config.liProtocolBridgeShutdownSafetyOverrideActive), tags)
   metricsGroup.newGauge(PreferredControllerEnabled,
     () => enabled(config.liProtocolBridgePreferredControllerActive), tags)
+  metricsGroup.newGauge(FederatedTopicsEnabled,
+    () => enabled(config.liProtocolBridgeFederatedTopicsActive), tags)
 
   private def enabled(value: Boolean): Int = if (value) 1 else 0
 

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -122,6 +122,26 @@ class KafkaZkClient private[zk] (
   def getPreferredControllerList: Seq[Int] =
     getChildren(PreferredControllersZNode.path).map(_.toInt)
 
+  private[kafka] def getFederatedTopic(topic: String, namespace: String): Option[String] = {
+    if (pathExists(FederatedTopicZNode.path(topic, namespace))) Some(s"/$namespace/$topic") else None
+  }
+
+  def getAllFederatedTopics(registerWatch: Boolean = false): Set[String] = {
+    getChildren(FederatedTopicsZNode.path).flatMap { namespace =>
+      getAllFederatedTopicsInNamespace(namespace, registerWatch).map(topic => s"/$namespace/$topic")
+    }.toSet
+  }
+
+  def getAllFederatedTopicsInNamespace(namespace: String, registerWatch: Boolean = false): Set[String] = {
+    val response = retryRequestUntilConnected(
+      GetChildrenRequest(FederatedTopicZNode.namespacePath(namespace), registerWatch))
+    response.resultCode match {
+      case Code.OK => response.children.toSet
+      case Code.NONODE => Set.empty
+      case _ => throw response.resultException.get
+    }
+  }
+
   /**
    * Registers a given broker in zookeeper as the controller and increments controller epoch.
    * @param controllerId the id of the broker that is to be registered as the controller.
@@ -1304,6 +1324,12 @@ class KafkaZkClient private[zk] (
     val deleteRequest = DeleteRequest(ControllerZNode.path, ZkVersion.MatchAnyVersion)
     retryRequestUntilConnected(deleteRequest, expectedControllerEpochZkVersion)
   }
+
+  def createFederatedTopicZNode(topic: String, namespace: String): Unit =
+    createRecursive(FederatedTopicZNode.path(topic, namespace))
+
+  def deleteFederatedTopicZNode(topic: String, namespace: String): Unit =
+    deletePath(FederatedTopicZNode.path(topic, namespace), ZkVersion.MatchAnyVersion, false)
 
   /** Delete the controller znode without an epoch check so operational tooling can force a new election. */
   def deleteControllerRaw(): Unit =

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -101,6 +101,16 @@ object BrokerIdsZNode {
   def encode: Array[Byte] = null
 }
 
+object FederatedTopicsZNode {
+  def path = "/federatedTopics"
+  def encode: Array[Byte] = null
+}
+
+object FederatedTopicZNode {
+  def path(topic: String, namespace: String) = s"${FederatedTopicsZNode.path}/$namespace/$topic"
+  def namespacePath(namespace: String) = s"${FederatedTopicsZNode.path}/$namespace"
+}
+
 object PreferredControllersZNode {
   def path = s"${BrokersZNode.path}/preferred_controllers"
   def encode: Array[Byte] = null
@@ -1114,6 +1124,7 @@ object ZkData {
   val PersistentZkPaths: Seq[String] = Seq(
     ConsumerPathZNode.path, // old consumer path
     BrokerIdsZNode.path,
+    FederatedTopicsZNode.path,
     PreferredControllersZNode.path,
     TopicsZNode.path,
     ConfigEntityChangeNotificationZNode.path,

--- a/core/src/test/scala/unit/kafka/server/ApiVersionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionManagerTest.scala
@@ -42,8 +42,7 @@ class ApiVersionManagerTest {
       brokerFeatures = brokerFeatures,
       metadataCache = metadataCache,
       enableUnstableLastVersion = true,
-      liMoveControllerEnabled = () => true,
-      liShutdownSafetyOverrideEnabled = () => true
+      liApiEnabled = _ => true
     )
     assertEquals(ApiKeys.apisForListener(apiScope).asScala, versionManager.enabledApis)
     assertTrue(ApiKeys.apisForListener(apiScope).asScala.forall { apiKey =>
@@ -80,11 +79,12 @@ class ApiVersionManagerTest {
       brokerFeatures = brokerFeatures,
       metadataCache = metadataCache,
       enableUnstableLastVersion = true,
-      liMoveControllerEnabled = () => enabled,
-      liShutdownSafetyOverrideEnabled = () => enabled
+      liApiEnabled = _ => enabled
     )
 
-    Seq(ApiKeys.LI_MOVE_CONTROLLER, ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK).foreach { apiKey =>
+    Seq(ApiKeys.LI_MOVE_CONTROLLER, ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK,
+      ApiKeys.LI_CREATE_FEDERATED_TOPIC_ZNODES, ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES,
+      ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES).foreach { apiKey =>
       val disabledManager = versionManager(enabled = false)
       assertFalse(disabledManager.isApiEnabled(apiKey, apiKey.latestVersion))
       assertNull(disabledManager.apiVersionResponse(0, alterFeatureLevel0 = false).data.apiKeys.find(apiKey.id))

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -311,7 +311,8 @@ class DynamicBrokerConfigTest {
       KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
       KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
       KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
-      KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp
+      KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp,
+      KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp
     )
     bridgeFlags.foreach(flag => assertFalse(config.getBoolean(flag), s"$flag should be disabled by default"))
 

--- a/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
@@ -47,7 +47,8 @@ class LiProtocolBridgeMetricsTest {
         KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
         KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
         KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
-        KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp
+        KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp,
+        KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp
       ).foreach(props.put(_, "true"))
       config.dynamicConfig.updateDefaultConfig(props)
 

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -102,6 +102,19 @@ class KafkaZkClientTest extends QuorumTestHarness {
   private val topicPartition = new TopicPartition("topic", 0)
 
   @Test
+  def testFederatedTopicLifecycle(): Unit = {
+    zkClient.createFederatedTopicZNode("orders", "west")
+    zkClient.createFederatedTopicZNode("payments", "east")
+
+    assertEquals(Set("/west/orders", "/east/payments"), zkClient.getAllFederatedTopics())
+    assertEquals(Some("/west/orders"), zkClient.getFederatedTopic("orders", "west"))
+    assertEquals(None, zkClient.getFederatedTopic("orders", "east"))
+
+    zkClient.deleteFederatedTopicZNode("orders", "west")
+    assertEquals(Set("/east/payments"), zkClient.getAllFederatedTopics())
+  }
+
+  @Test
   def testConnectionViaNettyClient(): Unit = {
     // Confirm that we can explicitly set client connection configuration, which is necessary for TLS.
     // TLS connectivity itself is tested in system tests rather than here to avoid having to add TLS support


### PR DESCRIPTION
This change implements LinkedIn private APIs 1003, 1004, and 1005 on Kafka 3.9 ZooKeeper brokers.

The APIs create, delete, and list federated-topic state under `/federatedTopics`. The change adds request and response schemas, request wrappers, `KafkaApis` handlers, `KafkaZkClient` operations, per-topic errors, and `ApiVersions` filtering.

One setting controls all three APIs and defaults to false. The APIs are scoped to ZooKeeper broker listeners.

The tests cover request bytes from compiled 3.0-li classes, generic request serialization, listener scope, disabled API behavior, and the create/list/delete ZooKeeper lifecycle.


## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.