### PR TITLE
clients: restore LinkedIn Admin methods

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -203,6 +203,32 @@ public interface Admin extends AutoCloseable {
      */
     CreateTopicsResult createTopics(Collection<NewTopic> newTopics, CreateTopicsOptions options);
 
+    default CreateOrDeleteFederatedTopicZnodesResult createFederatedTopicZnodes(
+        Map<String, String> federatedTopics) {
+        return createFederatedTopicZnodes(federatedTopics, new CreateFederatedTopicZnodesOptions());
+    }
+
+    CreateOrDeleteFederatedTopicZnodesResult createFederatedTopicZnodes(
+        Map<String, String> federatedTopics,
+        CreateFederatedTopicZnodesOptions options);
+
+    default CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(
+        Map<String, String> federatedTopics) {
+        return deleteFederatedTopicZnodes(federatedTopics, new DeleteFederatedTopicZnodesOptions());
+    }
+
+    CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(
+        Map<String, String> federatedTopics,
+        DeleteFederatedTopicZnodesOptions options);
+
+    default ListFederatedTopicZnodesResult listFederatedTopicZnodes() {
+        return listFederatedTopicZnodes(Collections.emptyMap(), new ListFederatedTopicZnodesOptions());
+    }
+
+    ListFederatedTopicZnodesResult listFederatedTopicZnodes(
+        Map<String, String> federatedTopics,
+        ListFederatedTopicZnodesOptions options);
+
     /**
      * This is a convenience method for {@link #deleteTopics(TopicCollection, DeleteTopicsOptions)}
      * with default options. See the overload for more details.
@@ -1085,6 +1111,9 @@ public interface Admin extends AutoCloseable {
         Set<TopicPartition> partitions,
         ElectLeadersOptions options);
 
+    MoveControllerResult moveController(MoveControllerOptions options);
+
+    SkipShutdownSafetyCheckResult skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions options);
 
     /**
      * Change the reassignments for one or more partitions.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateFederatedTopicZnodesOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateFederatedTopicZnodesOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * Options for {@link Admin#createFederatedTopicZnodes(Map, CreateFederatedTopicZnodesOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class CreateFederatedTopicZnodesOptions extends AbstractOptions<CreateFederatedTopicZnodesOptions> {
+    private boolean retryOnQuotaViolation = true;
+
+    /**
+     * Set the timeout in milliseconds for this operation or {@code null} if the default api timeout for the
+     * AdminClient should be used.
+     *
+     */
+    // This method is retained to keep binary compatibility with 0.11
+    public CreateFederatedTopicZnodesOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * Set to true if quota violation should be automatically retried.
+     */
+    public CreateFederatedTopicZnodesOptions retryOnQuotaViolation(boolean retryOnQuotaViolation) {
+        this.retryOnQuotaViolation = retryOnQuotaViolation;
+        return this;
+    }
+
+    /**
+     * Returns true if quota violation should be automatically retried.
+     */
+    public boolean shouldRetryOnQuotaViolation() {
+        return retryOnQuotaViolation;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateOrDeleteFederatedTopicZnodesResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateOrDeleteFederatedTopicZnodesResult.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link Admin#createFederatedTopicZnodes(Map)} or
+ * {@link Admin#deleteFederatedTopicZnodes(Map)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class CreateOrDeleteFederatedTopicZnodesResult {
+    private final Map<String, KafkaFuture<Void>> future;
+
+    CreateOrDeleteFederatedTopicZnodesResult(Map<String, KafkaFuture<Void>> future) {
+        this.future = future;
+    }
+
+    public Map<String, KafkaFuture<Void>> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteFederatedTopicZnodesOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteFederatedTopicZnodesOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.Map;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * Options for {@link Admin#deleteFederatedTopicZnodes(Map, DeleteFederatedTopicZnodesOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DeleteFederatedTopicZnodesOptions extends AbstractOptions<DeleteFederatedTopicZnodesOptions> {
+    private boolean retryOnQuotaViolation = true;
+
+    /**
+     * Set the timeout in milliseconds for this operation or {@code null} if the default api timeout for the
+     * AdminClient should be used.
+     *
+     */
+    // This method is retained to keep binary compatibility with 0.11
+    public DeleteFederatedTopicZnodesOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * Set to true if quota violation should be automatically retried.
+     */
+    public DeleteFederatedTopicZnodesOptions retryOnQuotaViolation(boolean retryOnQuotaViolation) {
+        this.retryOnQuotaViolation = retryOnQuotaViolation;
+        return this;
+    }
+
+    /**
+     * Returns true if quota violation should be automatically retried.
+     */
+    public boolean shouldRetryOnQuotaViolation() {
+        return retryOnQuotaViolation;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -63,6 +63,24 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public CreateOrDeleteFederatedTopicZnodesResult createFederatedTopicZnodes(
+        Map<String, String> federatedTopics, CreateFederatedTopicZnodesOptions options) {
+        return delegate.createFederatedTopicZnodes(federatedTopics, options);
+    }
+
+    @Override
+    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(
+        Map<String, String> federatedTopics, DeleteFederatedTopicZnodesOptions options) {
+        return delegate.deleteFederatedTopicZnodes(federatedTopics, options);
+    }
+
+    @Override
+    public ListFederatedTopicZnodesResult listFederatedTopicZnodes(
+        Map<String, String> federatedTopics, ListFederatedTopicZnodesOptions options) {
+        return delegate.listFederatedTopicZnodes(federatedTopics, options);
+    }
+
+    @Override
     public DeleteTopicsResult deleteTopics(TopicCollection topics, DeleteTopicsOptions options) {
         return delegate.deleteTopics(topics, options);
     }
@@ -194,6 +212,16 @@ public class ForwardingAdmin implements Admin {
     @Override
     public ElectLeadersResult electLeaders(ElectionType electionType, Set<TopicPartition> partitions, ElectLeadersOptions options) {
         return delegate.electLeaders(electionType, partitions, options);
+    }
+
+    @Override
+    public MoveControllerResult moveController(MoveControllerOptions options) {
+        return delegate.moveController(options);
+    }
+
+    @Override
+    public SkipShutdownSafetyCheckResult skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions options) {
+        return delegate.skipShutdownSafetyCheck(options);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -162,6 +162,11 @@ import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.UnregisterBrokerRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.message.UpdateFeaturesResponseData.UpdatableFeatureResult;
+import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData;
+import org.apache.kafka.common.message.LiCreateFederatedTopicZnodesRequestData;
+import org.apache.kafka.common.message.LiDeleteFederatedTopicZnodesRequestData;
+import org.apache.kafka.common.message.LiListFederatedTopicZnodesRequestData;
+import org.apache.kafka.common.message.LiMoveControllerRequestData;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -246,6 +251,16 @@ import org.apache.kafka.common.requests.UnregisterBrokerRequest;
 import org.apache.kafka.common.requests.UnregisterBrokerResponse;
 import org.apache.kafka.common.requests.UpdateFeaturesRequest;
 import org.apache.kafka.common.requests.UpdateFeaturesResponse;
+import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckRequest;
+import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckResponse;
+import org.apache.kafka.common.requests.LiCreateFederatedTopicZnodesRequest;
+import org.apache.kafka.common.requests.LiCreateFederatedTopicZnodesResponse;
+import org.apache.kafka.common.requests.LiDeleteFederatedTopicZnodesRequest;
+import org.apache.kafka.common.requests.LiDeleteFederatedTopicZnodesResponse;
+import org.apache.kafka.common.requests.LiListFederatedTopicZnodesRequest;
+import org.apache.kafka.common.requests.LiListFederatedTopicZnodesResponse;
+import org.apache.kafka.common.requests.LiMoveControllerRequest;
+import org.apache.kafka.common.requests.LiMoveControllerResponse;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.scram.internals.ScramFormatter;
 import org.apache.kafka.common.security.token.delegation.DelegationToken;
@@ -1801,6 +1816,44 @@ public class KafkaAdminClient extends AdminClient {
         return new CreateTopicsResult(new HashMap<>(topicFutures));
     }
 
+    @Override
+    public CreateOrDeleteFederatedTopicZnodesResult createFederatedTopicZnodes(
+            final Map<String, String> federatedTopics,
+            final CreateFederatedTopicZnodesOptions options) {
+        final Map<String, KafkaFutureImpl<Void>> futures = new HashMap<>(federatedTopics.size());
+        final List<LiCreateFederatedTopicZnodesRequestData.FederatedTopics> topics = new ArrayList<>();
+        federatedTopics.forEach((topic, namespace) -> {
+            topics.add(new LiCreateFederatedTopicZnodesRequestData.FederatedTopics()
+                    .setName(topic).setNamespace(namespace));
+            futures.put(topic, new KafkaFutureImpl<>());
+        });
+        final long now = time.milliseconds();
+        runnable.call(new Call("createFederatedTopicZnodes", calcDeadlineMs(now, options.timeoutMs()),
+                new ControllerNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new LiCreateFederatedTopicZnodesRequest.Builder(
+                        new LiCreateFederatedTopicZnodesRequestData().setTopics(topics).setTimeoutMs(timeoutMs),
+                        (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                handleNotControllerError(abstractResponse);
+                Errors error = Errors.forCode(((LiCreateFederatedTopicZnodesResponse) abstractResponse)
+                        .data().errorCode());
+                if (error == Errors.NONE) futures.values().forEach(future -> future.complete(null));
+                else completeAllExceptionally(futures.values(), error.exception());
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                completeAllExceptionally(futures.values(), throwable);
+            }
+        }, now);
+        return new CreateOrDeleteFederatedTopicZnodesResult(new HashMap<>(futures));
+    }
+
     private Call getCreateTopicsCall(final CreateTopicsOptions options,
                                      final Map<String, KafkaFutureImpl<TopicMetadataAndConfig>> futures,
                                      final CreatableTopicCollection topics,
@@ -1911,6 +1964,44 @@ public class KafkaAdminClient extends AdminClient {
             return DeleteTopicsResult.ofTopicNames(handleDeleteTopicsUsingNames(((TopicNameCollection) topics).topicNames(), options));
         else
             throw new IllegalArgumentException("The TopicCollection: " + topics + " provided did not match any supported classes for deleteTopics.");
+    }
+
+    @Override
+    public CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(
+            final Map<String, String> federatedTopics,
+            final DeleteFederatedTopicZnodesOptions options) {
+        final Map<String, KafkaFutureImpl<Void>> futures = new HashMap<>(federatedTopics.size());
+        final List<LiDeleteFederatedTopicZnodesRequestData.FederatedTopics> topics = new ArrayList<>();
+        federatedTopics.forEach((topic, namespace) -> {
+            topics.add(new LiDeleteFederatedTopicZnodesRequestData.FederatedTopics()
+                    .setName(topic).setNamespace(namespace));
+            futures.put(topic, new KafkaFutureImpl<>());
+        });
+        final long now = time.milliseconds();
+        runnable.call(new Call("deleteFederatedTopicZnodes", calcDeadlineMs(now, options.timeoutMs()),
+                new ControllerNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new LiDeleteFederatedTopicZnodesRequest.Builder(
+                        new LiDeleteFederatedTopicZnodesRequestData().setTopics(topics).setTimeoutMs(timeoutMs),
+                        (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                handleNotControllerError(abstractResponse);
+                Errors error = Errors.forCode(((LiDeleteFederatedTopicZnodesResponse) abstractResponse)
+                        .data().errorCode());
+                if (error == Errors.NONE) futures.values().forEach(future -> future.complete(null));
+                else completeAllExceptionally(futures.values(), error.exception());
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                completeAllExceptionally(futures.values(), throwable);
+            }
+        }, now);
+        return new CreateOrDeleteFederatedTopicZnodesResult(new HashMap<>(futures));
     }
 
     private Map<String, KafkaFuture<Void>> handleDeleteTopicsUsingNames(final Collection<String> topicNames,
@@ -2139,6 +2230,40 @@ public class KafkaAdminClient extends AdminClient {
             }
         }, now);
         return new ListTopicsResult(topicListingFuture);
+    }
+
+    @Override
+    public ListFederatedTopicZnodesResult listFederatedTopicZnodes(
+            final Map<String, String> federatedTopics,
+            final ListFederatedTopicZnodesOptions options) {
+        final KafkaFutureImpl<List<String>> future = new KafkaFutureImpl<>();
+        final List<LiListFederatedTopicZnodesRequestData.FederatedTopics> topics = new ArrayList<>();
+        federatedTopics.forEach((topic, namespace) -> topics.add(
+                new LiListFederatedTopicZnodesRequestData.FederatedTopics()
+                        .setName(topic).setNamespace(namespace)));
+        final long now = time.milliseconds();
+        runnable.call(new Call("listFederatedTopicZnodes", calcDeadlineMs(now, options.timeoutMs()),
+                new LeastLoadedNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new LiListFederatedTopicZnodesRequest.Builder(
+                        new LiListFederatedTopicZnodesRequestData().setTopics(topics), (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                LiListFederatedTopicZnodesResponse response = (LiListFederatedTopicZnodesResponse) abstractResponse;
+                Errors error = Errors.forCode(response.data().errorCode());
+                if (error == Errors.NONE) future.complete(new ArrayList<>(response.data().topics()));
+                else future.completeExceptionally(error.exception());
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        }, now);
+        return new ListFederatedTopicZnodesResult(future);
     }
 
     @Override
@@ -3685,6 +3810,63 @@ public class KafkaAdminClient extends AdminClient {
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
         return Collections.unmodifiableMap(this.metrics.metrics());
+    }
+
+    @Override
+    public SkipShutdownSafetyCheckResult skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        runnable.call(new Call("skipShutdownSafetyCheck", calcDeadlineMs(now, options.timeoutMs()),
+                new ControllerNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new LiControlledShutdownSkipSafetyCheckRequest.Builder(
+                        new LiControlledShutdownSkipSafetyCheckRequestData()
+                                .setBrokerId(options.brokerId()).setBrokerEpoch(options.brokerEpoch()),
+                        (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                handleNotControllerError(abstractResponse);
+                Errors error = Errors.forCode(((LiControlledShutdownSkipSafetyCheckResponse) abstractResponse)
+                        .data().errorCode());
+                if (error == Errors.NONE) future.complete(null);
+                else future.completeExceptionally(error.exception());
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        }, now);
+        return new SkipShutdownSafetyCheckResult(future);
+    }
+
+    @Override
+    public MoveControllerResult moveController(MoveControllerOptions options) {
+        final KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        final long now = time.milliseconds();
+        runnable.call(new Call("moveController", calcDeadlineMs(now, options.timeoutMs()),
+                new LeastLoadedNodeProvider()) {
+            @Override
+            AbstractRequest.Builder<?> createRequest(int timeoutMs) {
+                return new LiMoveControllerRequest.Builder(new LiMoveControllerRequestData(), (short) 0);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                Errors error = Errors.forCode(((LiMoveControllerResponse) abstractResponse).data().errorCode());
+                if (error == Errors.NONE) future.complete(null);
+                else future.completeExceptionally(error.exception());
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        }, now);
+        return new MoveControllerResult(future);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListFederatedTopicZnodesOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListFederatedTopicZnodesOptions.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * Options for {@link Admin#listFederatedTopicZnodes()}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class ListFederatedTopicZnodesOptions extends AbstractOptions<ListFederatedTopicZnodesOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListFederatedTopicZnodesResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListFederatedTopicZnodesResult.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import java.util.List;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+
+/**
+ * The result of the {@link Admin#listFederatedTopicZnodes()} call.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class ListFederatedTopicZnodesResult {
+    final KafkaFuture<List<String>> future;
+
+    ListFederatedTopicZnodesResult(KafkaFuture<List<String>> future) {
+        this.future = future;
+    }
+
+    /**
+    * Return a future which yields a list of federated topic names
+    */
+    public KafkaFuture<List<String>> topics() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerOptions.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#moveController(MoveControllerOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class MoveControllerOptions extends AbstractOptions<MoveControllerOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MoveControllerResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link Admin#moveController(MoveControllerOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class MoveControllerResult {
+    private final KafkaFuture<Void> future;
+
+    MoveControllerResult(KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/SkipShutdownSafetyCheckOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/SkipShutdownSafetyCheckOptions.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Options for {@link Admin#skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class SkipShutdownSafetyCheckOptions extends AbstractOptions<SkipShutdownSafetyCheckOptions> {
+    private int brokerId;
+    private long brokerEpoch;
+
+    public int brokerId() {
+        return brokerId;
+    }
+
+    public long brokerEpoch() {
+        return brokerEpoch;
+    }
+
+    public SkipShutdownSafetyCheckOptions brokerId(int brokerId) {
+        this.brokerId = brokerId;
+        return this;
+    }
+
+    public SkipShutdownSafetyCheckOptions brokerEpoch(long brokerEpoch) {
+        this.brokerEpoch = brokerEpoch;
+        return this;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/SkipShutdownSafetyCheckResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/SkipShutdownSafetyCheckResult.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * The result of {@link Admin#skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public final class SkipShutdownSafetyCheckResult {
+    private final KafkaFuture<Void> future;
+
+    SkipShutdownSafetyCheckResult(KafkaFuture<Void> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Void> all() {
+        return future;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/LiKafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/LiKafkaAdminClientTest.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.NodeApiVersions;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.message.LiListFederatedTopicZnodesResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckRequest;
+import org.apache.kafka.common.requests.LiControlledShutdownSkipSafetyCheckResponse;
+import org.apache.kafka.common.requests.LiCreateFederatedTopicZnodesRequest;
+import org.apache.kafka.common.requests.LiCreateFederatedTopicZnodesResponse;
+import org.apache.kafka.common.requests.LiDeleteFederatedTopicZnodesRequest;
+import org.apache.kafka.common.requests.LiDeleteFederatedTopicZnodesResponse;
+import org.apache.kafka.common.requests.LiListFederatedTopicZnodesRequest;
+import org.apache.kafka.common.requests.LiListFederatedTopicZnodesResponse;
+import org.apache.kafka.common.requests.LiMoveControllerRequest;
+import org.apache.kafka.common.requests.LiMoveControllerResponse;
+import org.apache.kafka.common.requests.RequestTestUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LiKafkaAdminClientTest {
+    private static final String TOPIC = "orders";
+    private static final String NAMESPACE = "west";
+
+    private static AdminClientUnitTestEnv clientEnv() {
+        Node controller = new Node(0, "localhost", 8121);
+        Node broker = new Node(1, "localhost", 8122);
+        Cluster cluster = new Cluster(
+            "bridge-test",
+            Arrays.asList(controller, broker),
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Collections.emptySet(),
+            controller
+        );
+        AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(cluster);
+        env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+        return env;
+    }
+
+    @Test
+    public void testSkipShutdownSafetyCheckBuildsRequestAndCompletesResult() throws Exception {
+        try (AdminClientUnitTestEnv env = clientEnv()) {
+            env.kafkaClient().prepareResponse(request -> {
+                if (!(request instanceof LiControlledShutdownSkipSafetyCheckRequest)) {
+                    return false;
+                }
+                LiControlledShutdownSkipSafetyCheckRequest bridgeRequest =
+                    (LiControlledShutdownSkipSafetyCheckRequest) request;
+                assertEquals(7, bridgeRequest.data().brokerId());
+                assertEquals(19L, bridgeRequest.data().brokerEpoch());
+                return true;
+            }, LiControlledShutdownSkipSafetyCheckResponse.prepareResponse(Errors.NONE));
+
+            env.adminClient().skipShutdownSafetyCheck(
+                new SkipShutdownSafetyCheckOptions().brokerId(7).brokerEpoch(19L).timeoutMs(5_000)
+            ).all().get();
+        }
+    }
+
+    @Test
+    public void testMoveControllerBuildsRequestAndCompletesResult() throws Exception {
+        try (AdminClientUnitTestEnv env = clientEnv()) {
+            env.kafkaClient().prepareResponse(
+                request -> request instanceof LiMoveControllerRequest,
+                LiMoveControllerResponse.prepareResponse(Errors.NONE, (short) 0)
+            );
+
+            env.adminClient().moveController(new MoveControllerOptions().timeoutMs(5_000)).all().get();
+        }
+    }
+
+    @Test
+    public void testCreateAndDeleteFederatedTopicBuildRequests() throws Exception {
+        Map<String, String> topics = Collections.singletonMap(TOPIC, NAMESPACE);
+        try (AdminClientUnitTestEnv env = clientEnv()) {
+            env.kafkaClient().prepareResponse(request -> {
+                if (!(request instanceof LiCreateFederatedTopicZnodesRequest)) {
+                    return false;
+                }
+                LiCreateFederatedTopicZnodesRequest bridgeRequest = (LiCreateFederatedTopicZnodesRequest) request;
+                assertEquals(TOPIC, bridgeRequest.data().topics().get(0).name());
+                assertEquals(NAMESPACE, bridgeRequest.data().topics().get(0).namespace());
+                assertTrue(bridgeRequest.data().timeoutMs() > 0);
+                return true;
+            }, LiCreateFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, 0, (short) 0));
+
+            env.adminClient().createFederatedTopicZnodes(
+                topics, new CreateFederatedTopicZnodesOptions().timeoutMs(5_000)
+            ).all().get(TOPIC).get();
+
+            env.kafkaClient().prepareResponse(request -> {
+                if (!(request instanceof LiDeleteFederatedTopicZnodesRequest)) {
+                    return false;
+                }
+                LiDeleteFederatedTopicZnodesRequest bridgeRequest = (LiDeleteFederatedTopicZnodesRequest) request;
+                assertEquals(TOPIC, bridgeRequest.data().topics().get(0).name());
+                assertEquals(NAMESPACE, bridgeRequest.data().topics().get(0).namespace());
+                assertTrue(bridgeRequest.data().timeoutMs() > 0);
+                return true;
+            }, LiDeleteFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, 0, (short) 0));
+
+            env.adminClient().deleteFederatedTopicZnodes(
+                topics, new DeleteFederatedTopicZnodesOptions().timeoutMs(5_000)
+            ).all().get(TOPIC).get();
+        }
+    }
+
+    @Test
+    public void testListFederatedTopicsReturnsResponseNames() throws Exception {
+        try (AdminClientUnitTestEnv env = clientEnv()) {
+            env.kafkaClient().prepareResponse(request -> {
+                if (!(request instanceof LiListFederatedTopicZnodesRequest)) {
+                    return false;
+                }
+                LiListFederatedTopicZnodesRequest bridgeRequest = (LiListFederatedTopicZnodesRequest) request;
+                assertEquals(TOPIC, bridgeRequest.data().topics().get(0).name());
+                assertEquals(NAMESPACE, bridgeRequest.data().topics().get(0).namespace());
+                return true;
+            }, new LiListFederatedTopicZnodesResponse(
+                new LiListFederatedTopicZnodesResponseData()
+                    .setErrorCode(Errors.NONE.code())
+                    .setTopics(Collections.singletonList("orders/west")),
+                (short) 0
+            ));
+
+            List<String> topics = env.adminClient().listFederatedTopicZnodes(
+                Collections.singletonMap(TOPIC, NAMESPACE),
+                new ListFederatedTopicZnodesOptions().timeoutMs(5_000)
+            ).topics().get();
+            assertEquals(Collections.singletonList("orders/west"), topics);
+        }
+    }
+
+    @Test
+    public void testShutdownSafetyOverrideRetriesAfterControllerChange() throws Exception {
+        try (AdminClientUnitTestEnv env = clientEnv()) {
+            env.kafkaClient().prepareResponseFrom(
+                LiControlledShutdownSkipSafetyCheckResponse.prepareResponse(Errors.NOT_CONTROLLER),
+                env.cluster().nodeById(0)
+            );
+            env.kafkaClient().prepareResponse(RequestTestUtils.metadataResponse(
+                env.cluster().nodes(), env.cluster().clusterResource().clusterId(), 1, Collections.emptyList()
+            ));
+            env.kafkaClient().prepareResponseFrom(
+                LiControlledShutdownSkipSafetyCheckResponse.prepareResponse(Errors.NONE),
+                env.cluster().nodeById(1)
+            );
+
+            env.adminClient().skipShutdownSafetyCheck(
+                new SkipShutdownSafetyCheckOptions().brokerId(7).brokerEpoch(19L).timeoutMs(5_000)
+            ).all().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void testCreateFederatedTopicRetriesAfterControllerChange() throws Exception {
+        try (AdminClientUnitTestEnv env = clientEnv()) {
+            env.kafkaClient().prepareResponseFrom(
+                LiCreateFederatedTopicZnodesResponse.prepareResponse(Errors.NOT_CONTROLLER, 0, (short) 0),
+                env.cluster().nodeById(0)
+            );
+            env.kafkaClient().prepareResponse(RequestTestUtils.metadataResponse(
+                env.cluster().nodes(), env.cluster().clusterResource().clusterId(), 1, Collections.emptyList()
+            ));
+            env.kafkaClient().prepareResponseFrom(
+                LiCreateFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, 0, (short) 0),
+                env.cluster().nodeById(1)
+            );
+
+            env.adminClient().createFederatedTopicZnodes(
+                Collections.singletonMap(TOPIC, NAMESPACE),
+                new CreateFederatedTopicZnodesOptions().timeoutMs(5_000)
+            ).all().get(TOPIC).get();
+        }
+    }
+
+    @Test
+    public void testDeleteFederatedTopicRetriesAfterControllerChange() throws Exception {
+        try (AdminClientUnitTestEnv env = clientEnv()) {
+            env.kafkaClient().prepareResponseFrom(
+                LiDeleteFederatedTopicZnodesResponse.prepareResponse(Errors.NOT_CONTROLLER, 0, (short) 0),
+                env.cluster().nodeById(0)
+            );
+            env.kafkaClient().prepareResponse(RequestTestUtils.metadataResponse(
+                env.cluster().nodes(), env.cluster().clusterResource().clusterId(), 1, Collections.emptyList()
+            ));
+            env.kafkaClient().prepareResponseFrom(
+                LiDeleteFederatedTopicZnodesResponse.prepareResponse(Errors.NONE, 0, (short) 0),
+                env.cluster().nodeById(1)
+            );
+
+            env.adminClient().deleteFederatedTopicZnodes(
+                Collections.singletonMap(TOPIC, NAMESPACE),
+                new DeleteFederatedTopicZnodesOptions().timeoutMs(5_000)
+            ).all().get(TOPIC).get();
+        }
+    }
+
+    @Test
+    public void testFederatedTopicErrorCompletesEachTopicFuture() throws Exception {
+        try (AdminClientUnitTestEnv env = clientEnv()) {
+            env.kafkaClient().prepareResponse(
+                request -> request instanceof LiCreateFederatedTopicZnodesRequest,
+                LiCreateFederatedTopicZnodesResponse.prepareResponse(Errors.REQUEST_TIMED_OUT, 0, (short) 0)
+            );
+
+            ExecutionException exception = org.junit.jupiter.api.Assertions.assertThrows(
+                ExecutionException.class,
+                () -> env.adminClient().createFederatedTopicZnodes(
+                    Collections.singletonMap(TOPIC, NAMESPACE),
+                    new CreateFederatedTopicZnodesOptions().timeoutMs(5_000)
+                ).all().get(TOPIC).get()
+            );
+            assertInstanceOf(TimeoutException.class, exception.getCause());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -416,6 +416,24 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public synchronized CreateOrDeleteFederatedTopicZnodesResult createFederatedTopicZnodes(
+            Map<String, String> federatedTopics, CreateFederatedTopicZnodesOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public synchronized CreateOrDeleteFederatedTopicZnodesResult deleteFederatedTopicZnodes(
+            Map<String, String> federatedTopics, DeleteFederatedTopicZnodesOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public synchronized ListFederatedTopicZnodesResult listFederatedTopicZnodes(
+            Map<String, String> federatedTopics, ListFederatedTopicZnodesOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public synchronized ListTopicsResult listTopics(ListTopicsOptions options) {
         Map<String, TopicListing> topicListings = new HashMap<>();
 
@@ -738,6 +756,16 @@ public class MockAdminClient extends AdminClient {
 
     @Override
     public synchronized DeleteConsumerGroupOffsetsResult deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions, DeleteConsumerGroupOffsetsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public synchronized MoveControllerResult moveController(MoveControllerOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public synchronized SkipShutdownSafetyCheckResult skipShutdownSafetyCheck(SkipShutdownSafetyCheckOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 


### PR DESCRIPTION
Restore the LinkedIn Admin options, results, and methods for shutdown override, controller movement, and federated-topic operations. Preserve the 3.0-li method signatures and futures.

Shutdown override and federated-topic create/delete refresh controller metadata and retry NOT_CONTROLLER responses. Tests cover request fields, successful results, timeout errors, per-topic futures, and controller-change retries.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.