### PR TITLE
kafka: restore LinkedIn server extension points

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -96,6 +96,16 @@ public class FetchResponse extends AbstractResponse {
         return Errors.forCode(data.errorCode());
     }
 
+    /**
+     * Return response partitions for name-based fetch protocol versions.
+     *
+     * This overload preserves the 3.0-li observer API. Callers handling Fetch v13 or newer must use
+     * {@link #responseData(Map, short)} so topic IDs can be resolved to names.
+     */
+    public LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseData() {
+        return responseData(Collections.emptyMap(), (short) 12);
+    }
+
     public LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseData(Map<Uuid, String> topicNames, short version) {
         final LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> responseData = new LinkedHashMap<>();
         data.responses().forEach(topicResponse -> {

--- a/core/src/main/java/kafka/admin/RackAwareReplicaAssignmentRackIdMapper.java
+++ b/core/src/main/java/kafka/admin/RackAwareReplicaAssignmentRackIdMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.admin;
+
+/** Maps deployment rack IDs to the fault-domain IDs used for automatic replica assignment. */
+@FunctionalInterface
+public interface RackAwareReplicaAssignmentRackIdMapper {
+    String apply(String rackId);
+}

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.scalalogging.Logger
 import com.yammer.metrics.core.{Histogram, Meter}
 import kafka.network
-import kafka.server.{KafkaConfig, RequestLocal}
+import kafka.server.{KafkaConfig, NoOpObserver, Observer, RequestLocal}
 import kafka.utils.{Logging, Pool}
 import kafka.utils.Implicits._
 import org.apache.kafka.common.config.ConfigResource
@@ -41,6 +41,7 @@ import java.util
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 
 object RequestChannel extends Logging {
   private val requestLogger = Logger("kafka.request.logger")
@@ -358,7 +359,11 @@ object RequestChannel extends Logging {
 class RequestChannel(val queueSize: Int,
                      val metricNamePrefix: String,
                      time: Time,
-                     val metrics: RequestChannel.Metrics) {
+                     val metrics: RequestChannel.Metrics,
+                     val observer: Observer = new NoOpObserver) {
+  def this(queueSize: Int, metricNamePrefix: String, time: Time, metrics: RequestChannel.Metrics) =
+    this(queueSize, metricNamePrefix, time, metrics, new NoOpObserver)
+
   import RequestChannel._
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
@@ -410,6 +415,10 @@ class RequestChannel(val queueSize: Int,
     response: AbstractResponse,
     onComplete: Option[Send => Unit]
   ): Unit = {
+    try observer.observe(request.context, request.body[AbstractRequest], response)
+    catch {
+      case NonFatal(e) => warn("Request observer failed while observing a response", e)
+    }
     updateErrorMetrics(request.header.apiKey, response.errorCounts.asScala)
     sendResponse(new RequestChannel.SendResponse(
       request,

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -29,7 +29,7 @@ import kafka.cluster.{BrokerEndPoint, EndPoint}
 import kafka.network.Processor._
 import kafka.network.RequestChannel.{CloseConnectionResponse, EndThrottlingResponse, NoOpResponse, SendResponse, StartThrottlingResponse}
 import kafka.network.SocketServer._
-import kafka.server.{ApiVersionManager, BrokerReconfigurable, KafkaConfig}
+import kafka.server.{ApiVersionManager, BrokerReconfigurable, KafkaConfig, NoOpObserver, Observer}
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import kafka.utils._
 import org.apache.kafka.common.config.ConfigException
@@ -78,8 +78,16 @@ class SocketServer(val config: KafkaConfig,
                    val metrics: Metrics,
                    val time: Time,
                    val credentialProvider: CredentialProvider,
-                   val apiVersionManager: ApiVersionManager)
+                   val apiVersionManager: ApiVersionManager,
+                   val observer: Observer = new NoOpObserver)
   extends Logging with BrokerReconfigurable {
+
+  def this(config: KafkaConfig,
+           metrics: Metrics,
+           time: Time,
+           credentialProvider: CredentialProvider,
+           apiVersionManager: ApiVersionManager) =
+    this(config, metrics, time, credentialProvider, apiVersionManager, new NoOpObserver)
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
@@ -98,11 +106,12 @@ class SocketServer(val config: KafkaConfig,
   private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolSensor) else MemoryPool.NONE
   // data-plane
   private[network] val dataPlaneAcceptors = new ConcurrentHashMap[EndPoint, DataPlaneAcceptor]()
-  val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneAcceptor.MetricPrefix, time, apiVersionManager.newRequestMetrics)
+  val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneAcceptor.MetricPrefix, time,
+    apiVersionManager.newRequestMetrics, observer)
   // control-plane
   private[network] var controlPlaneAcceptorOpt: Option[ControlPlaneAcceptor] = None
   val controlPlaneRequestChannelOpt: Option[RequestChannel] = config.controlPlaneListenerName.map(_ =>
-    new RequestChannel(20, ControlPlaneAcceptor.MetricPrefix, time, apiVersionManager.newRequestMetrics))
+    new RequestChannel(20, ControlPlaneAcceptor.MetricPrefix, time, apiVersionManager.newRequestMetrics, observer))
 
   private[this] val nextProcessorId: AtomicInteger = new AtomicInteger(0)
   val connectionQuotas = new ConnectionQuotas(config, time, metrics)

--- a/core/src/main/scala/kafka/server/KafkaActions.scala
+++ b/core/src/main/scala/kafka/server/KafkaActions.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import org.apache.kafka.common.requests.ControlledShutdownResponse
+
+/** Lets the LinkedIn wrapper react to environment-specific broker lifecycle events. */
+trait KafkaActions {
+  def notifyControlledShutdownStatus(safeToShutdown: Boolean,
+                                     controlledShutdownResponse: ControlledShutdownResponse,
+                                     remainingRetries: Long): Unit
+}
+
+object NoOpKafkaActions extends KafkaActions {
+  override def notifyControlledShutdownStatus(safeToShutdown: Boolean,
+                                              controlledShutdownResponse: ControlledShutdownResponse,
+                                              remainingRetries: Long): Unit = ()
+}

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -81,11 +81,12 @@ import java.time.Duration
 import java.util
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
-import java.util.{Collections, Optional, OptionalInt}
+import java.util.{Collections, Locale, Optional, OptionalInt}
 import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Map, Seq, Set, immutable, mutable}
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -610,6 +611,10 @@ class KafkaApis(val requestChannel: RequestChannel,
    */
   def handleProduceRequest(request: RequestChannel.Request, requestLocal: RequestLocal): Unit = {
     val produceRequest = request.body[ProduceRequest]
+    try requestChannel.observer.observeProduceRequest(request.context, produceRequest)
+    catch {
+      case NonFatal(e) => warn("Request observer failed while observing a Produce request", e)
+    }
 
     if (RequestUtils.hasTransactionalRecords(produceRequest)) {
       val isAuthorizedTransactional = produceRequest.transactionalId != null &&
@@ -2018,6 +2023,15 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleApiVersionsRequest(request: RequestChannel.Request): Unit = {
+    val clientSoftwareName = request.body[ApiVersionsRequest].data.clientSoftwareName
+    try {
+      requestChannel.observer.trackClientLibrary(
+        clientSoftwareName != null && clientSoftwareName.toLowerCase(Locale.ROOT).contains("xinfra"),
+        request.context.clientId)
+    } catch {
+      case NonFatal(e) => warn("Request observer failed while tracking a client library", e)
+    }
+
     // Note that broker returns its full list of supported ApiKeys and versions regardless of current
     // authentication state (e.g., before SASL authentication on an SASL listener, do note that no
     // Kafka protocol requests may take place on an SSL listener before the SSL handshake is finished).

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -20,6 +20,7 @@ package kafka.server
 import java.util
 import java.util.concurrent.TimeUnit
 import java.util.Properties
+import kafka.admin.RackAwareReplicaAssignmentRackIdMapper
 import kafka.cluster.EndPoint
 import kafka.utils.{CoreUtils, Logging}
 import kafka.utils.Implicits._
@@ -70,14 +71,63 @@ object KafkaConfig {
     "li.protocol.bridge.preferred.controller.enable"
   val LiProtocolBridgeFederatedTopicsEnableProp =
     "li.protocol.bridge.federated.topics.enable"
+  val LiProtocolBridgeRackIdMapperEnableProp =
+    "li.protocol.bridge.rack.id.mapper.enable"
 
   // 3.0-li operational settings consumed by the LinkedIn server wrapper.
+  val ListenersProp: String = SocketServerConfigs.LISTENERS_CONFIG
+  val ZkConnectProp: String = ZkConfigs.ZK_CONNECT_CONFIG
+  val ZkSessionTimeoutMsProp: String = ZkConfigs.ZK_SESSION_TIMEOUT_MS_CONFIG
+  val ZkConnectionTimeoutMsProp: String = ZkConfigs.ZK_CONNECTION_TIMEOUT_MS_CONFIG
+  val LogMessageFormatVersionProp: String = ServerLogConfigs.LOG_MESSAGE_FORMAT_VERSION_CONFIG
   val PreferredControllerProp = "preferred.controller"
   val AllowPreferredControllerFallbackProp = "allow.preferred.controller.fallback"
   val LiMinPreferredControllerCountProp = "li.min.preferred.controller.count"
   val ControlledShutdownSafetyCheckEnableProp = "controlled.shutdown.safety.check.enable"
   val ControlledShutdownSafetyCheckRedundancyFactorProp =
     "controlled.shutdown.safety.check.redundancy.factor"
+  val ObserverClassNameProp = "observer.class.name"
+  val ObserverShutdownTimeoutMsProp = "observer.shutdown.timeout"
+
+  // Source-compatible names used by the LinkedIn KafkaServer wrapper. Apache 3.9 moved most of
+  // these definitions into Java config classes, but the wrapper still calls KafkaConfig.*Prop().
+  val BrokerIdProp = "broker.id"
+  val ConsumerQuotaBytesPerSecondDefaultProp = "quota.consumer.default"
+  val DefaultReplicationFactorProp = "default.replication.factor"
+  val DeleteTopicEnableProp = "delete.topic.enable"
+  val LogRetentionTimeHoursProp = "log.retention.hours"
+  val LogRetentionTimeMillisProp = "log.retention.ms"
+  val LogRetentionTimeMinutesProp = "log.retention.minutes"
+  val LogRollTimeHoursProp = "log.roll.hours"
+  val LogRollTimeJitterHoursProp = "log.roll.jitter.hours"
+  val LogRollTimeJitterMillisProp = "log.roll.jitter.ms"
+  val LogRollTimeMillisProp = "log.roll.ms"
+  val NumPartitionsProp = "num.partitions"
+  val ProducerQuotaBytesPerSecondDefaultProp = "quota.producer.default"
+  val ListenerSecurityProtocolMapProp = "listener.security.protocol.map"
+  val MetricReplaceOnDuplicateProp = "metrics.replace.on.duplicate"
+  val ReplicaRequestTimeoutMsProp = "replica.request.timeout.ms"
+  val ZkClientCnxnSocketProp = "zookeeper.clientCnxnSocket"
+  val ZkEnableSecureAclsProp = "zookeeper.set.acl"
+  val ZkSslClientEnableProp = "zookeeper.ssl.client.enable"
+  val ZkSslEndpointIdentificationAlgorithmProp = "zookeeper.ssl.endpoint.identification.algorithm"
+  val ZkSslKeyStoreLocationProp = "zookeeper.ssl.keystore.location"
+  val ZkSslKeyStorePasswordProp = "zookeeper.ssl.keystore.password"
+  val ZkSslTrustStoreLocationProp = "zookeeper.ssl.truststore.location"
+  val ZkSslTrustStorePasswordProp = "zookeeper.ssl.truststore.password"
+  val ZkSslTrustStoreTypeProp = "zookeeper.ssl.truststore.type"
+
+  val LiDropCorruptedFilesEnableProp = "li.drop.corrupted.files.enable"
+  val LiLeaderElectionOnCorruptionWaitMsProp = "li.leader.election.on.corruption.wait.ms"
+  val LiLongTailProduceRequestLogRatioProp = "li.instrumentation.requests.produce.long.tail.log.ratio"
+  val LiLongTailProduceRequestLogThresholdMsProp = "li.instrumentation.requests.produce.long.tail.log.threshold.ms"
+  val LiMinOriginalAliveReplicasProp = "li.min.original.alive.replicas"
+  val LiNumControllerInitThreadsProp = "li.num.controller.init.threads"
+  val LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp =
+    "li.rack.aware.assignment.rack.id.mapper.class"
+  val LiZookeeperPaginationEnableProp = "li.zookeeper.pagination.enable"
+  val RequestMetricsSizeBucketsProp = "request.metrics.size.buckets"
+  val RequestMetricsTotalTimeBucketsProp = "request.metrics.total.time.buckets"
 
   val LiProtocolBridgeModeEnableDoc =
     "Enable the temporary protocol bridge used while 3.0-li and upstream-based brokers coexist. " +
@@ -96,6 +146,8 @@ object KafkaConfig {
     "Enable 3.0-li preferred-controller election and shutdown behavior on ZooKeeper brokers."
   val LiProtocolBridgeFederatedTopicsEnableDoc =
     "Enable the 3.0-li federated-topic APIs and ZooKeeper metadata used by the LinkedIn authorizer."
+  val LiProtocolBridgeRackIdMapperEnableDoc =
+    "Apply the configured 3.0-li rack ID mapper during automatic replica assignment."
   val PreferredControllerDoc = "Whether this broker is eligible for preferred-controller placement."
   val AllowPreferredControllerFallbackDoc =
     "Allow a non-preferred broker to become controller when no preferred controller is available."
@@ -105,6 +157,8 @@ object KafkaConfig {
     "Reject controlled shutdown when the remaining live ISR would be below min ISR plus the configured redundancy."
   val ControlledShutdownSafetyCheckRedundancyFactorDoc =
     "Additional live ISR replicas required by the controlled shutdown safety check."
+  val ObserverClassNameDoc = "Broker request observer implementation class."
+  val ObserverShutdownTimeoutMsDoc = "Maximum time in milliseconds allowed to close the request observer."
 
   def main(args: Array[String]): Unit = {
     System.out.println(configDef.toHtml(4, (config: String) => "brokerconfigs_" + config,
@@ -152,6 +206,8 @@ object KafkaConfig {
       ConfigDef.Importance.HIGH, LiProtocolBridgePreferredControllerEnableDoc)
     .define(LiProtocolBridgeFederatedTopicsEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeFederatedTopicsEnableDoc)
+    .define(LiProtocolBridgeRackIdMapperEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeRackIdMapperEnableDoc)
     .define(PreferredControllerProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, PreferredControllerDoc)
     .define(AllowPreferredControllerFallbackProp, ConfigDef.Type.BOOLEAN, true,
@@ -162,6 +218,12 @@ object KafkaConfig {
       ConfigDef.Importance.HIGH, ControlledShutdownSafetyCheckEnableDoc)
     .define(ControlledShutdownSafetyCheckRedundancyFactorProp, ConfigDef.Type.INT, 0,
       ConfigDef.Range.atLeast(0), ConfigDef.Importance.HIGH, ControlledShutdownSafetyCheckRedundancyFactorDoc)
+    .define(ObserverClassNameProp, ConfigDef.Type.STRING, "kafka.server.NoOpObserver",
+      ConfigDef.Importance.MEDIUM, ObserverClassNameDoc)
+    .define(ObserverShutdownTimeoutMsProp, ConfigDef.Type.LONG, 60000L, ConfigDef.Range.atLeast(1),
+      ConfigDef.Importance.MEDIUM, ObserverShutdownTimeoutMsDoc)
+    .define(LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp, ConfigDef.Type.STRING, "",
+      ConfigDef.Importance.HIGH, "Rack ID mapper class used for automatic replica assignment.")
 
   def configNames: Seq[String] = configDef.names.asScala.toBuffer.sorted
   private[server] def defaultValues: Map[String, _] = configDef.defaultValues.asScala
@@ -275,6 +337,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     getBoolean(KafkaConfig.LiProtocolBridgePreferredControllerEnableProp)
   def liProtocolBridgeFederatedTopicsEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp)
+  def liProtocolBridgeRackIdMapperEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeRackIdMapperEnableProp)
 
   def liProtocolBridgeModeActive: Boolean = processRoles.isEmpty && liProtocolBridgeModeEnable
   def liProtocolBridgeFollowerRecoveryActive: Boolean =
@@ -291,6 +355,16 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     processRoles.isEmpty && liProtocolBridgePreferredControllerEnable
   def liProtocolBridgeFederatedTopicsActive: Boolean =
     processRoles.isEmpty && liProtocolBridgeFederatedTopicsEnable
+  def liProtocolBridgeRackIdMapperActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeRackIdMapperEnable
+
+  lazy val rackIdMapperForReplicaAssignment: RackAwareReplicaAssignmentRackIdMapper = {
+    val className = getString(KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp)
+    if (liProtocolBridgeRackIdMapperActive && className.nonEmpty)
+      CoreUtils.createObject[RackAwareReplicaAssignmentRackIdMapper](className)
+    else
+      rackId => rackId
+  }
 
   def preferredController: Boolean = getBoolean(KafkaConfig.PreferredControllerProp)
   def allowPreferredControllerFallback: Boolean = getBoolean(KafkaConfig.AllowPreferredControllerFallbackProp)
@@ -299,6 +373,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     getBoolean(KafkaConfig.ControlledShutdownSafetyCheckEnableProp)
   def controlledShutdownSafetyCheckRedundancyFactor: Int =
     getInt(KafkaConfig.ControlledShutdownSafetyCheckRedundancyFactorProp)
+  def observerClassName: String = getString(KafkaConfig.ObserverClassNameProp)
+  def observerShutdownTimeoutMs: Long = getLong(KafkaConfig.ObserverShutdownTimeoutMsProp)
 
   private[server] val dynamicConfig = new DynamicBrokerConfig(this)
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -113,8 +113,33 @@ class KafkaServer(
   val config: KafkaConfig,
   time: Time = Time.SYSTEM,
   threadNamePrefix: Option[String] = None,
-  enableForwarding: Boolean = false
+  enableForwarding: Boolean = false,
+  kafkaActions: KafkaActions = NoOpKafkaActions
 ) extends KafkaBroker with Server {
+
+  def this(config: KafkaConfig,
+           time: Time,
+           threadNamePrefix: Option[String],
+           enableForwarding: Boolean) =
+    this(config, time, threadNamePrefix, enableForwarding, NoOpKafkaActions)
+
+  // Binary-compatible constructors preserved for LinkedIn client test harnesses built against
+  // 3.0-li. The reporter argument was already ignored by the old implementation, which creates
+  // reporters from KafkaConfig below.
+  @deprecated("Use the primary KafkaServer constructor", "3.9-li")
+  def this(config: KafkaConfig,
+           time: Time,
+           threadNamePrefix: Option[String],
+           kafkaMetricsReporters: Seq[KafkaMetricsReporter],
+           kafkaActions: KafkaActions) =
+    this(config, time, threadNamePrefix, enableForwarding = false, kafkaActions = kafkaActions)
+
+  @deprecated("Use the primary KafkaServer constructor", "3.9-li")
+  def this(config: KafkaConfig,
+           time: Time,
+           threadNamePrefix: Option[String],
+           kafkaMetricsReporters: Seq[KafkaMetricsReporter]) =
+    this(config, time, threadNamePrefix, enableForwarding = false, kafkaActions = NoOpKafkaActions)
 
   private val startupComplete = new AtomicBoolean(false)
   private val isShuttingDown = new AtomicBoolean(false)
@@ -133,6 +158,7 @@ class KafkaServer(
   private var controlPlaneRequestProcessor: KafkaApis = _
 
   var authorizer: Option[Authorizer] = None
+  private var observer: Observer = _
   @volatile var socketServer: SocketServer = _
   var dataPlaneRequestHandlerPool: KafkaRequestHandlerPool = _
   private var controlPlaneRequestHandlerPool: KafkaRequestHandlerPool = _
@@ -374,13 +400,15 @@ class KafkaServer(
           None
         )
 
+        observer = Observer(config)
+
         // Create and start the socket server acceptor threads so that the bound port is known.
         // Delay starting processors until the end of the initialization sequence to ensure
         // that credentials have been loaded before processing authentications.
         //
         // Note that we allow the use of KRaft mode controller APIs when forwarding is enabled
         // so that the Envelope request is exposed. This is only used in testing currently.
-        socketServer = new SocketServer(config, metrics, time, credentialProvider, apiVersionManager)
+        socketServer = new SocketServer(config, metrics, time, credentialProvider, apiVersionManager, observer)
 
         // Start alter partition manager based on the IBP version
         alterPartitionManager = if (config.interBrokerProtocolVersion.isAlterPartitionSupported) {
@@ -855,6 +883,7 @@ class KafkaServer(
 
         while (!shutdownSucceeded && remainingRetries > 0) {
           remainingRetries = remainingRetries - 1
+          var shutdownResponse: ControlledShutdownResponse = null
 
           // 1. Find the controller and establish a connection to it.
           // If the controller id or the broker registration are missing, we sleep and retry (if there are remaining retries)
@@ -904,7 +933,7 @@ class KafkaServer(
                 time.milliseconds(), true)
               val clientResponse = NetworkClientUtils.sendAndReceive(networkClient, request, time)
 
-              val shutdownResponse = clientResponse.responseBody.asInstanceOf[ControlledShutdownResponse]
+              shutdownResponse = clientResponse.responseBody.asInstanceOf[ControlledShutdownResponse]
               if (shutdownResponse.error != Errors.NONE) {
                 info(s"Controlled shutdown request returned after ${clientResponse.requestLatencyMs}ms " +
                   s"with error ${shutdownResponse.error}")
@@ -929,6 +958,9 @@ class KafkaServer(
                   s"configured controller.socket.timeout.ms and/or request.timeout.ms: ${ioe.getMessage}")
                 // ignore and try again
             }
+          }
+          if (shutdownResponse != null) {
+            kafkaActions.notifyControlledShutdownStatus(shutdownSucceeded, shutdownResponse, remainingRetries)
           }
           if (!shutdownSucceeded && remainingRetries > 0) {
             Thread.sleep(config.controlledShutdownRetryBackoffMs)
@@ -1020,6 +1052,8 @@ class KafkaServer(
         if (controlPlaneRequestProcessor != null)
           CoreUtils.swallow(controlPlaneRequestProcessor.close(), this)
         CoreUtils.swallow(authorizer.foreach(_.close()), this)
+        if (observer != null)
+          CoreUtils.swallow(observer.close(config.observerShutdownTimeoutMs, TimeUnit.MILLISECONDS), this)
         if (adminManager != null)
           CoreUtils.swallow(adminManager.shutdown(), this)
 

--- a/core/src/main/scala/kafka/server/LiCreateTopicPolicy.scala
+++ b/core/src/main/scala/kafka/server/LiCreateTopicPolicy.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import org.apache.kafka.common.errors.PolicyViolationException
+import org.apache.kafka.server.config.ReplicationConfigs
+import org.apache.kafka.server.policy.CreateTopicPolicy
+
+import scala.jdk.CollectionConverters._
+
+/** Enforces the deployment's default replication factor as the minimum for newly created topics. */
+class LiCreateTopicPolicy extends CreateTopicPolicy {
+  private var minimumReplicationFactor = 0
+
+  override def validate(metadata: CreateTopicPolicy.RequestMetadata): Unit = {
+    val assignments = metadata.replicasAssignments()
+    val replicationFactor = metadata.replicationFactor()
+    if (assignments == null && replicationFactor == null)
+      throw new PolicyViolationException(
+        s"Topic ${metadata.topic()} is missing both replica assignment and replication factor")
+
+    if (assignments != null) {
+      assignments.asScala.foreach { case (partition, replicas) =>
+        if (replicas.size < minimumReplicationFactor)
+          throw new PolicyViolationException(
+            s"Topic ${metadata.topic()} partition $partition has replication factor ${replicas.size}; " +
+              s"minimum is $minimumReplicationFactor")
+      }
+    } else if (replicationFactor < minimumReplicationFactor) {
+      throw new PolicyViolationException(
+        s"Topic ${metadata.topic()} has replication factor $replicationFactor; minimum is $minimumReplicationFactor")
+    }
+  }
+
+  override def configure(configs: java.util.Map[String, _]): Unit = {
+    minimumReplicationFactor = Option(configs.get(KafkaConfig.DefaultReplicationFactorProp))
+      .map(_.toString.toInt)
+      .getOrElse(ReplicationConfigs.REPLICATION_FACTOR_DEFAULT)
+  }
+
+  override def close(): Unit = ()
+}

--- a/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
+++ b/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
@@ -29,9 +29,11 @@ object LiProtocolBridgeMetrics {
   val ShutdownSafetyOverrideEnabled = "ShutdownSafetyOverrideEnabled"
   val PreferredControllerEnabled = "PreferredControllerEnabled"
   val FederatedTopicsEnabled = "FederatedTopicsEnabled"
+  val RackIdMapperEnabled = "RackIdMapperEnabled"
   val MetricNames: Seq[String] = Seq(ModeEnabled, FollowerRecoveryEnabled,
     RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled, MoveControllerEnabled,
-    ShutdownSafetyOverrideEnabled, PreferredControllerEnabled, FederatedTopicsEnabled)
+    ShutdownSafetyOverrideEnabled, PreferredControllerEnabled, FederatedTopicsEnabled,
+    RackIdMapperEnabled)
 }
 
 /** Exposes the effective value of every 3.0-li compatibility flag on each ZooKeeper broker. */
@@ -56,6 +58,8 @@ class LiProtocolBridgeMetrics(config: KafkaConfig) extends AutoCloseable {
     () => enabled(config.liProtocolBridgePreferredControllerActive), tags)
   metricsGroup.newGauge(FederatedTopicsEnabled,
     () => enabled(config.liProtocolBridgeFederatedTopicsActive), tags)
+  metricsGroup.newGauge(RackIdMapperEnabled,
+    () => enabled(config.liProtocolBridgeRackIdMapperActive), tags)
 
   private def enabled(value: Boolean): Int = if (value) 1 else 0
 

--- a/core/src/main/scala/kafka/server/NoOpObserver.scala
+++ b/core/src/main/scala/kafka/server/NoOpObserver.scala
@@ -1,0 +1,51 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import java.util.Map
+import java.util.concurrent.TimeUnit
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ProduceRequest, RequestContext}
+
+/**
+  * An observer implementation that has no operation and serves as a place holder.
+  */
+class NoOpObserver extends Observer {
+
+  def configure(configs: Map[String, _]): Unit = {}
+
+  /**
+    * Observe a request and its corresponding response.
+    */
+  def observe(requestContext: RequestContext, request: AbstractRequest, response: AbstractResponse): Unit = {}
+
+  /**
+    * Observe a produce request
+    */
+  def observeProduceRequest(requestContext: RequestContext, produceRequest: ProduceRequest): Unit = {}
+
+  /**
+    * Close the observer with timeout.
+    */
+  def close(timeout: Long, unit: TimeUnit): Unit = {}
+
+  /**
+   * track the client library.
+   */
+  def trackClientLibrary(isXinfraClient: Boolean, clientId: String): Unit = {}
+
+}

--- a/core/src/main/scala/kafka/server/Observer.scala
+++ b/core/src/main/scala/kafka/server/Observer.scala
@@ -1,0 +1,140 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import java.util.concurrent.TimeUnit
+import kafka.network.RequestChannel
+import kafka.utils.{CoreUtils, Logging}
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ProduceRequest, RequestContext}
+import org.apache.kafka.common.Configurable
+
+/**
+  * Top-level interface that every pluggable observer must implement. Kafka reads the `observer.class.name` setting
+  * at startup, creates an instance of the specified class using its default constructor, and calls `configure`.
+  *
+  * Kafka routes request and response pairs to `observe`, Produce requests to `observeProduceRequest`, and client
+  * library information to `trackClientLibrary`.
+  *
+  * If `observer.class.name` is empty or the specified class cannot be loaded, Kafka uses `NoOpObserver`.
+  */
+trait Observer extends Configurable {
+
+  /**
+    * Observe a request and its corresponding response
+    *
+    * @param requestContext the context information about the request
+    * @param request  the request being observed for a various purpose(s)
+    * @param response the response to the request
+    */
+  def observe(requestContext: RequestContext, request: AbstractRequest, response: AbstractResponse): Unit
+
+  /**
+    * Observe a produce request. This method handles only the produce request since produce request is special in
+    * two ways. Firstly, if ACK is set to be 0, there is no produce response associated with the produce request.
+    * Secondly, the lifecycle of some inner fields in a ProduceRequest is shorter than the lifecycle of the produce
+    * request itself. That means in some situations, when <code>observe</code> is called on a produce request and
+    * response pair, some fields in the produce request has been null-ed already so that the produce request and
+    * response is not observable (or no useful information). Therefore this method exists for the purpose of allowing
+    * users to observe on the produce request before its corresponding response is created.
+    *
+    * @param requestContext the context information about the request
+    * @param produceRequest  the produce request being observed for a various purpose(s)
+    */
+  def observeProduceRequest(requestContext: RequestContext, produceRequest: ProduceRequest): Unit
+
+  /**
+    * Hook to track the client library type so different client types can be compared. This function is in the hot path
+    * of request-handling so all computations that are added to it need to be light
+    *
+    * @param isXinfraClient  is this clientId a xinfra client
+    * @param clientId The clientId for this specific request
+    */
+  def trackClientLibrary(isXinfraClient: Boolean, clientId: String): Unit
+
+  /**
+    * Close the observer with timeout.
+    *
+    * @param timeout the maximum time to wait to close the observer.
+    * @param unit    the time unit.
+    */
+  def close(timeout: Long, unit: TimeUnit): Unit
+}
+
+object Observer extends Logging {
+
+  /**
+   * Create a new observer from the given Kafka config.
+   * @param config the Kafka configuration defining observer properties.
+   * @return A configured instance of Observer.
+   */
+  def apply(config: KafkaConfig): Observer = {
+    val className = config.observerClassName.trim
+    val observer = if (className.isEmpty) {
+      new NoOpObserver
+    } else {
+      try {
+        CoreUtils.createObject[Observer](className)
+      } catch {
+        case e: Exception =>
+          error(s"Creating observer instance from the given class name $className failed.", e)
+          new NoOpObserver
+        case e: LinkageError =>
+          error(s"Linking observer class $className failed.", e)
+          new NoOpObserver
+      }
+    }
+    observer.configure(config.originals())
+    observer
+  }
+
+  /**
+    * Generates a description of the given request and response. It could be used mostly for debugging purpose.
+    *
+    * @param request  the request being described
+    * @param response the response to the request
+    */
+  def describeRequestAndResponse(request: RequestChannel.Request, response: AbstractResponse): String = {
+    var requestDesc = "Request"
+    var responseDesc = "Response"
+    try {
+      if (request == null) {
+        requestDesc += " null"
+      } else {
+        requestDesc += (" header: " + request.header)
+        requestDesc += (" connection ID: " + request.context.connectionId)
+        requestDesc += (" from service with principal: " +
+          request.session.sanitizedUser +
+          " IP address: " + request.session.clientAddress)
+      }
+      requestDesc += " | " // Separate the response description from the request description
+
+      if (response == null) {
+        responseDesc += " null"
+      } else {
+        responseDesc += (if (response.errorCounts == null || response.errorCounts.size == 0) {
+          " with no error"
+        } else {
+          " with errors: " + response.errorCounts
+        })
+      }
+    } catch {
+      case e: Exception => return e.toString // If describing fails, return the exception message directly
+    }
+    requestDesc + responseDesc
+  }
+}

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -24,7 +24,7 @@ import kafka.server.metadata.ZkConfigRepository
 import kafka.utils._
 import kafka.utils.Implicits._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
-import org.apache.kafka.admin.AdminUtils
+import org.apache.kafka.admin.{AdminUtils, BrokerMetadata}
 import org.apache.kafka.clients.admin.{AlterConfigOp, ScramMechanism}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.config.{ConfigDef, ConfigException, ConfigResource}
@@ -124,6 +124,16 @@ class ZkAdminManager(val config: KafkaConfig,
     }
   }
 
+  private def mapRackIds(brokers: Iterable[BrokerMetadata]): Seq[BrokerMetadata] = {
+    if (config.liProtocolBridgeRackIdMapperActive) {
+      brokers.map { broker =>
+        new BrokerMetadata(broker.id, broker.rack.map(config.rackIdMapperForReplicaAssignment.apply))
+      }.toSeq
+    } else {
+      brokers.toSeq
+    }
+  }
+
   private def maybePopulateMetadataAndConfigs(metadataAndConfigs: Map[String, CreatableTopicResult],
                                               topicName: String,
                                               configs: Properties,
@@ -170,7 +180,7 @@ class ZkAdminManager(val config: KafkaConfig,
       zkClient.getPreferredControllerList.toSet
     else
       Set.empty[Int]
-    val brokers = liveBrokers.filterNot(broker => preferredControllerIds.contains(broker.id))
+    val brokers = mapRackIds(liveBrokers.filterNot(broker => preferredControllerIds.contains(broker.id)))
     val metadata = toCreate.values.map(topic =>
       try {
         if (metadataCache.contains(topic.name))
@@ -320,7 +330,7 @@ class ZkAdminManager(val config: KafkaConfig,
       zkClient.getPreferredControllerList.toSet
     else
       Set.empty[Int]
-    val allBrokers = brokerMetadatas.filterNot(broker => preferredControllerIds.contains(broker.id))
+    val allBrokers = mapRackIds(brokerMetadatas.filterNot(broker => preferredControllerIds.contains(broker.id)))
     val allBrokerIds = allBrokers.map(_.id)
 
     // 1. map over topics creating assignment and calling AdminUtils

--- a/core/src/test/scala/integration/kafka/server/KafkaActionsTest.scala
+++ b/core/src/test/scala/integration/kafka/server/KafkaActionsTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.utils.TestUtils
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.ControlledShutdownResponse
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.server.config.ServerConfigs
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.{AfterEach, Test}
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.Seq
+import scala.jdk.CollectionConverters._
+
+class KafkaActionsTest extends QuorumTestHarness {
+  private var brokers = Seq.empty[KafkaServer]
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    TestUtils.shutdownServers(brokers)
+    brokers = Seq.empty
+    super.tearDown()
+  }
+
+  @Test
+  def testControlledShutdownReportsResultBeforeReturning(): Unit = {
+    val controllerConfig = brokerConfig(0)
+    val controller = createBroker(controllerConfig).asInstanceOf[KafkaServer]
+    brokers :+= controller
+    assertEquals(0, TestUtils.waitUntilControllerElected(zkClient))
+
+    val actions = new RecordingKafkaActions
+    val target = new KafkaServer(brokerConfig(1), Time.SYSTEM, None,
+      enableForwarding = false, kafkaActions = actions)
+    brokers :+= target
+    target.startup()
+    TestUtils.waitUntilBrokerMetadataIsPropagated(brokers)
+    TestUtils.createTopic(zkClient, "kafka-actions", 1, 2, brokers)
+
+    target.shutdown()
+
+    val results = actions.results.asScala.toSeq
+    assertEquals(1, results.size)
+    assertTrue(results.head.safeToShutdown)
+    assertEquals(Errors.NONE, results.head.response.error())
+    assertTrue(results.head.remainingRetries >= 0)
+  }
+
+  private def brokerConfig(brokerId: Int): KafkaConfig = {
+    val props = TestUtils.createBrokerConfig(brokerId, zkConnect)
+    props.put(ServerConfigs.CONTROLLED_SHUTDOWN_ENABLE_CONFIG, "true")
+    KafkaConfig.fromProps(props)
+  }
+}
+
+case class ControlledShutdownResult(safeToShutdown: Boolean,
+                                    response: ControlledShutdownResponse,
+                                    remainingRetries: Long)
+
+class RecordingKafkaActions extends KafkaActions {
+  val results = new ConcurrentLinkedQueue[ControlledShutdownResult]
+
+  override def notifyControlledShutdownStatus(safeToShutdown: Boolean,
+                                              controlledShutdownResponse: ControlledShutdownResponse,
+                                              remainingRetries: Long): Unit = {
+    results.add(ControlledShutdownResult(safeToShutdown, controlledShutdownResponse, remainingRetries))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -204,6 +204,7 @@ class KafkaApisTest extends Logging {
       () => new FinalizedFeatures(MetadataVersion.latestTesting(), Collections.emptyMap[String, java.lang.Short], 0, raftSupport))
 
     val clientMetricsManagerOpt = if (raftSupport) Some(clientMetricsManager) else None
+    when(requestChannel.observer).thenReturn(new NoOpObserver)
 
     new KafkaApis(
       requestChannel = requestChannel,

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1146,6 +1146,8 @@ class KafkaConfigTest {
         case ShareGroupConfig.SHARE_GROUP_MAX_GROUPS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case GroupCoordinatorConfig.SHARE_GROUP_MAX_SIZE_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
 
+        case KafkaConfig.ObserverClassNameProp |
+             KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp => // ignore string values
 
         case _ => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1")
       }

--- a/core/src/test/scala/unit/kafka/server/LiCreateTopicPolicyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiCreateTopicPolicyTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import org.apache.kafka.common.errors.PolicyViolationException
+import org.apache.kafka.server.policy.CreateTopicPolicy
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+import java.util.Collections
+
+class LiCreateTopicPolicyTest {
+  @Test
+  def testDefaultReplicationFactorIsUsedWhenConfigIsAbsent(): Unit = {
+    val policy = new LiCreateTopicPolicy
+    policy.configure(Collections.emptyMap[String, AnyRef]())
+    policy.validate(requestMetadata(replicationFactor = 1))
+  }
+
+  @Test
+  def testExplicitMinimumReplicationFactorIsEnforced(): Unit = {
+    val policy = new LiCreateTopicPolicy
+    policy.configure(Collections.singletonMap(KafkaConfig.DefaultReplicationFactorProp, "3"))
+    assertThrows(classOf[PolicyViolationException], () => policy.validate(requestMetadata(replicationFactor = 2)))
+  }
+
+  private def requestMetadata(replicationFactor: Short): CreateTopicPolicy.RequestMetadata =
+    new CreateTopicPolicy.RequestMetadata(
+      "test-topic",
+      1,
+      replicationFactor,
+      null,
+      Collections.emptyMap[String, String]())
+}

--- a/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
@@ -54,9 +54,10 @@ class LiProtocolBridgeMetricsTest {
 
       val updatedValues = metricValues(brokerId)
       assertEquals(LiProtocolBridgeMetrics.MetricNames.toSet, updatedValues.keySet)
-      assertEquals(0, updatedValues(LiProtocolBridgeMetrics.PreferredControllerEnabled))
-      assertTrue(updatedValues.filterNot(_._1 == LiProtocolBridgeMetrics.PreferredControllerEnabled)
-        .values.forall(_ == 1))
+      val staticMetrics = Set(LiProtocolBridgeMetrics.PreferredControllerEnabled,
+        LiProtocolBridgeMetrics.RackIdMapperEnabled)
+      staticMetrics.foreach(name => assertEquals(0, updatedValues(name)))
+      assertTrue(updatedValues.filterNot { case (name, _) => staticMetrics.contains(name) }.values.forall(_ == 1))
     } finally {
       metrics.close()
     }

--- a/core/src/test/scala/unit/kafka/server/ObserverTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ObserverTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.network.{RequestChannel, SocketServer}
+import kafka.utils.TestUtils
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.security.CredentialProvider
+import org.junit.jupiter.api.Assertions.{assertInstanceOf, assertNotNull}
+import org.junit.jupiter.api.Test
+
+class ObserverTest {
+  @Test
+  def testBlankObserverClassUsesNoOpObserver(): Unit = {
+    val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect)
+    props.put(KafkaConfig.ObserverClassNameProp, "  ")
+
+    val observer = Observer(KafkaConfig.fromProps(props))
+    assertInstanceOf(classOf[NoOpObserver], observer)
+  }
+
+  @Test
+  def testObserverParametersPreserveOldJvmConstructors(): Unit = {
+    assertNotNull(classOf[RequestChannel].getConstructor(
+      classOf[Int], classOf[String], classOf[Time], classOf[RequestChannel.Metrics]))
+    assertNotNull(classOf[SocketServer].getConstructor(
+      classOf[KafkaConfig], classOf[Metrics], classOf[Time], classOf[CredentialProvider],
+      classOf[ApiVersionManager]))
+    assertNotNull(classOf[KafkaServer].getConstructor(
+      classOf[KafkaConfig], classOf[Time], classOf[Option[_]], classOf[Boolean]))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/RackIdMapperTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RackIdMapperTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.admin.RackAwareReplicaAssignmentRackIdMapper
+import org.apache.kafka.server.config.ZkConfigs
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+import java.util.Properties
+
+class RackIdMapperTest {
+  @Test
+  def testMapperIsIdentityWhenCompatibilityIsDisabled(): Unit = {
+    val props = new Properties
+    props.put(ZkConfigs.ZK_CONNECT_CONFIG, "localhost:2181")
+    props.put(KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp,
+      classOf[TestRackIdMapper].getName)
+
+    val config = KafkaConfig.fromProps(props)
+    assertEquals("rack-a", config.rackIdMapperForReplicaAssignment.apply("rack-a"))
+  }
+
+  @Test
+  def testConfiguredMapperIsUsedWhenCompatibilityIsEnabled(): Unit = {
+    val props = new Properties
+    props.put(ZkConfigs.ZK_CONNECT_CONFIG, "localhost:2181")
+    props.put(KafkaConfig.LiProtocolBridgeRackIdMapperEnableProp, "true")
+    props.put(KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp,
+      classOf[TestRackIdMapper].getName)
+
+    val config = KafkaConfig.fromProps(props)
+    assertEquals("fault-domain-rack-a", config.rackIdMapperForReplicaAssignment.apply("rack-a"))
+  }
+}
+
+class TestRackIdMapper extends RackAwareReplicaAssignmentRackIdMapper {
+  override def apply(rackId: String): String = s"fault-domain-$rackId"
+}


### PR DESCRIPTION
This change adds the Kafka server interfaces used by LinkedIn's `kafka-server` package.

`KafkaActions` reports each controlled-shutdown attempt with its result, response, and remaining retry count. `Observer` and `NoOpObserver` receive request and response data from request handling. Observer callback failures are logged without interrupting request processing, observer class-loading failures fall back to `NoOpObserver`, and a blank observer class selects `NoOpObserver` without a startup error. Name-based `FetchResponse` access exposes the response data used by the observer.

The change also adds the topic-creation policy and rack-ID mapper interfaces. The topic policy uses Kafka's default replication factor when the setting is not present in the original configuration map.

`KafkaServer` includes the 3.0-li constructor signatures used by LinkedIn test harnesses. Auxiliary constructors preserve the pre-change JVM signatures of `KafkaServer`, `SocketServer`, and `RequestChannel`. Kafka continues to create metric reporters from `KafkaConfig`.

The interfaces compile with Scala 2.12 and Scala 2.13. The tests cover configuration parsing, server construction, JVM constructor compatibility, controlled-shutdown callback delivery, blank observer configuration, topic-policy defaults, default identity rack mapping, and configured non-identity rack mapping.


## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.