### PR TITLE
kafka: restore LinkedIn ZooKeeper operational behavior

### DIFF
--- a/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
@@ -29,6 +29,7 @@ import kafka.server.DelayedOperationPurgatory;
 import kafka.server.DelayedProduce;
 import kafka.server.DelayedRemoteFetch;
 import kafka.server.KafkaConfig;
+import kafka.server.LeaderTransferManager;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory.QuotaManagers;
 import kafka.server.ReplicaManager;
@@ -70,6 +71,7 @@ public class ReplicaManagerBuilder {
     private Long brokerEpoch = -1L;
     private Optional<AddPartitionsToTxnManager> addPartitionsToTxnManager = Optional.empty();
     private DirectoryEventHandler directoryEventHandler = DirectoryEventHandler.NOOP;
+    private LeaderTransferManager leaderTransferManager = LeaderTransferManager.noOp();
 
     public ReplicaManagerBuilder setConfig(KafkaConfig config) {
         this.config = config;
@@ -181,6 +183,11 @@ public class ReplicaManagerBuilder {
         return this;
     }
 
+    public ReplicaManagerBuilder setLeaderTransferManager(LeaderTransferManager leaderTransferManager) {
+        this.leaderTransferManager = leaderTransferManager;
+        return this;
+    }
+
     public ReplicaManager build() {
         if (config == null) config = new KafkaConfig(Collections.emptyMap());
         if (logManager == null) throw new RuntimeException("You must set logManager");
@@ -213,6 +220,7 @@ public class ReplicaManagerBuilder {
                              OptionConverters.toScala(threadNamePrefix),
                              () -> brokerEpoch,
                              OptionConverters.toScala(addPartitionsToTxnManager),
-                             directoryEventHandler);
+                             directoryEventHandler,
+                             leaderTransferManager);
     }
 }

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -147,7 +147,9 @@ object Partition {
       delayedOperations = delayedOperations,
       metadataCache = replicaManager.metadataCache,
       logManager = replicaManager.logManager,
-      alterIsrManager = replicaManager.alterPartitionManager)
+      alterIsrManager = replicaManager.alterPartitionManager,
+      leaderTransferEnabled = replicaManager.config.liProtocolBridgeLeaderTransferActive,
+      leaderTransferManager = replicaManager.leaderTransferManager)
   }
 
   def removeMetrics(topicPartition: TopicPartition): Unit = {
@@ -301,8 +303,26 @@ class Partition(val topicPartition: TopicPartition,
                 metadataCache: MetadataCache,
                 logManager: LogManager,
                 alterIsrManager: AlterPartitionManager,
-                @volatile private var _topicId: Option[Uuid] = None // TODO: merge topicPartition and _topicId into TopicIdPartition once TopicId persist in most of the code by KAFKA-16212
+                @volatile private var _topicId: Option[Uuid] = None, // TODO: merge topicPartition and _topicId into TopicIdPartition once TopicId persist in most of the code by KAFKA-16212
+                leaderTransferEnabled: Boolean = false,
+                leaderTransferManager: LeaderTransferManager = LeaderTransferManager.NoOp
                ) extends Logging {
+
+  def this(topicPartition: TopicPartition,
+           replicaLagTimeMaxMs: Long,
+           interBrokerProtocolVersion: MetadataVersion,
+           localBrokerId: Int,
+           localBrokerEpochSupplier: () => Long,
+           time: Time,
+           alterPartitionListener: AlterPartitionListener,
+           delayedOperations: DelayedOperations,
+           metadataCache: MetadataCache,
+           logManager: LogManager,
+           alterIsrManager: AlterPartitionManager,
+           topicId: Option[Uuid]) =
+    this(topicPartition, replicaLagTimeMaxMs, interBrokerProtocolVersion, localBrokerId,
+      localBrokerEpochSupplier, time, alterPartitionListener, delayedOperations, metadataCache,
+      logManager, alterIsrManager, topicId, false, LeaderTransferManager.NoOp)
 
   import Partition.metricsGroup
   def topic: String = topicPartition.topic
@@ -1281,7 +1301,27 @@ class Partition(val topicPartition: TopicPartition,
   }
 
   private def needsShrinkIsr(): Boolean = {
-    leaderLogIfLocal.exists { _ => getOutOfSyncReplicas(replicaLagTimeMaxMs).nonEmpty }
+    leaderLogIfLocal.exists { leaderLog =>
+      val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
+      outOfSyncReplicaIds.nonEmpty &&
+        (!leaderTransferEnabled ||
+          (partitionState.isr -- outOfSyncReplicaIds).size >= leaderLog.config.minInSyncReplicas)
+    }
+  }
+
+  def maybeTransferToNewLeader(): Unit = {
+    if (!leaderTransferEnabled)
+      return
+    val recommendedLeader = inReadLock(leaderIsrUpdateLock) {
+      leaderLogIfLocal.flatMap { leaderLog =>
+        val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
+        if (outOfSyncReplicaIds.nonEmpty &&
+          (partitionState.isr -- outOfSyncReplicaIds).size < leaderLog.config.minInSyncReplicas)
+          (partitionState.isr -- outOfSyncReplicaIds - localBrokerId).toSeq.sorted.headOption
+        else None
+      }
+    }
+    recommendedLeader.foreach(leaderTransferManager.submit(topicPartition, _))
   }
 
   private def isFollowerOutOfSync(replicaId: Int,

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -18,11 +18,11 @@ package kafka.controller
 
 import com.yammer.metrics.core.{Meter, Timer}
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{CompletableFuture, CompletionException, Executors, TimeUnit}
 import kafka.api._
 import kafka.common._
 import kafka.cluster.Broker
-import kafka.controller.KafkaController.{ActiveBrokerCountMetricName, ActiveControllerCountMetricName, ActivePreferredControllerCountMetricName, AlterReassignmentsCallback, ControllerStateMetricName, ElectLeadersCallback, FencedBrokerCountMetricName, GlobalPartitionCountMetricName, GlobalTopicCountMetricName, ListReassignmentsCallback, OfflinePartitionsCountMetricName, PreferredReplicaImbalanceCountMetricName, ReplicasIneligibleToDeleteCountMetricName, ReplicasToDeleteCountMetricName, TopicsIneligibleToDeleteCountMetricName, TopicsToDeleteCountMetricName, UpdateFeaturesCallback, ZkMigrationStateMetricName, StandbyPreferredControllerCountMetricName}
+import kafka.controller.KafkaController.{ActiveBrokerCountMetricName, ActiveControllerCountMetricName, ActivePreferredControllerCountMetricName, AlterReassignmentsCallback, ControllerStateMetricName, ElectLeadersCallback, FencedBrokerCountMetricName, GlobalPartitionCountMetricName, GlobalTopicCountMetricName, ListReassignmentsCallback, MaintenanceBrokerCountMetricName, OfflinePartitionsCountMetricName, PreferredReplicaImbalanceCountMetricName, ReplicasIneligibleToDeleteCountMetricName, ReplicasToDeleteCountMetricName, TopicsIneligibleToDeleteCountMetricName, TopicsToDeleteCountMetricName, UpdateFeaturesCallback, ZkMigrationStateMetricName, StandbyPreferredControllerCountMetricName}
 import kafka.coordinator.transaction.ZkProducerIdManager
 import kafka.server._
 import kafka.server.metadata.ZkFinalizedFeatureCache
@@ -42,7 +42,7 @@ import org.apache.kafka.common.message.{AllocateProducerIdsRequestData, Allocate
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractControlRequest, ApiError, LeaderAndIsrResponse, UpdateFeaturesRequest, UpdateMetadataResponse}
-import org.apache.kafka.common.utils.{Time, Utils}
+import org.apache.kafka.common.utils.{ThreadUtils, Time, Utils}
 import org.apache.kafka.metadata.LeaderRecoveryState
 import org.apache.kafka.metadata.migration.ZkMigrationState
 import org.apache.kafka.server.common.{AdminOperationException, ProducerIdsBlock}
@@ -84,6 +84,7 @@ object KafkaController extends Logging {
   private val TopicsIneligibleToDeleteCountMetricName = "TopicsIneligibleToDeleteCount"
   private val ReplicasIneligibleToDeleteCountMetricName = "ReplicasIneligibleToDeleteCount"
   private val ActiveBrokerCountMetricName = "ActiveBrokerCount"
+  private val MaintenanceBrokerCountMetricName = "MaintenanceBrokerCount"
   private val FencedBrokerCountMetricName = "FencedBrokerCount"
   private val ZkMigrationStateMetricName = "ZkMigrationState"
 
@@ -103,8 +104,22 @@ object KafkaController extends Logging {
     TopicsIneligibleToDeleteCountMetricName,
     ReplicasIneligibleToDeleteCountMetricName,
     ActiveBrokerCountMetricName,
+    MaintenanceBrokerCountMetricName,
     FencedBrokerCountMetricName
   )
+
+  private[controller] def validateReassignmentCancellation(
+    originalReplicas: Seq[Int],
+    liveBrokerIds: Set[Int],
+    minimumAliveReplicas: Int
+  ): Option[ApiError] = {
+    val originalReplicaSet = originalReplicas.toSet
+    val aliveOriginalReplicas = originalReplicaSet.intersect(liveBrokerIds)
+    if (originalReplicaSet.subsetOf(liveBrokerIds) || aliveOriginalReplicas.size >= minimumAliveReplicas) None
+    else Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+      s"Replica assignment cancellation requires at least $minimumAliveReplicas live original replicas. " +
+        s"Original replicas: $originalReplicas; live brokers: $liveBrokerIds"))
+  }
 }
 
 class KafkaController(val config: KafkaConfig,
@@ -116,12 +131,29 @@ class KafkaController(val config: KafkaConfig,
                       tokenManager: DelegationTokenManager,
                       brokerFeatures: BrokerFeatures,
                       featureCache: ZkFinalizedFeatureCache,
-                      threadNamePrefix: Option[String] = None)
+                      threadNamePrefix: Option[String] = None,
+                      additionalZkClients: Seq[KafkaZkClient] = Seq.empty)
   extends ControllerEventProcessor with Logging {
 
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
   this.logIdent = s"[Controller id=${config.brokerId}] "
+
+  private val controllerInitZkClients = zkClient +: additionalZkClients
+  private val controllerInitExecutor = if (controllerInitZkClients.size > 1) {
+    Some(Executors.newFixedThreadPool(
+      controllerInitZkClients.size,
+      ThreadUtils.createThreadFactory(s"controller-${config.brokerId}-metadata-loader-%d", true)))
+  } else {
+    None
+  }
+
+  private def joinControllerInit[T](future: CompletableFuture[T]): T = {
+    try future.join()
+    catch {
+      case error: CompletionException if error.getCause != null => throw error.getCause
+    }
+  }
 
   @volatile private var brokerInfo = initialBrokerInfo
   @volatile private var _brokerEpoch = initialBrokerEpoch
@@ -152,6 +184,8 @@ class KafkaController(val config: KafkaConfig,
     new ControllerBrokerRequestBatch(config, controllerChannelManager, eventManager, controllerContext, stateChangeLogger))
   val partitionStateMachine: PartitionStateMachine = new ZkPartitionStateMachine(config, stateChangeLogger, controllerContext, zkClient,
     new ControllerBrokerRequestBatch(config, controllerChannelManager, eventManager, controllerContext, stateChangeLogger))
+  def isTopicDeletionEnabled: Boolean = topicDeletionManager.isDeleteTopicEnabled
+
   private val topicDeletionManager = new TopicDeletionManager(config, controllerContext, replicaStateMachine,
     partitionStateMachine, new ControllerDeletionClient(this, zkClient))
 
@@ -166,6 +200,7 @@ class KafkaController(val config: KafkaConfig,
   private val preferredReplicaElectionHandler = new PreferredReplicaElectionHandler(eventManager)
   private val isrChangeNotificationHandler = new IsrChangeNotificationHandler(eventManager)
   private val logDirEventNotificationHandler = new LogDirEventNotificationHandler(eventManager)
+  private val topicDeletionFlagHandler = new TopicDeletionFlagHandler(eventManager)
 
   @volatile var activeControllerId = -1
   @volatile private var offlinePartitionCount = 0
@@ -197,6 +232,8 @@ class KafkaController(val config: KafkaConfig,
   metricsGroup.newGauge(TopicsIneligibleToDeleteCountMetricName, () => ineligibleTopicsToDeleteCount)
   metricsGroup.newGauge(ReplicasIneligibleToDeleteCountMetricName, () => ineligibleReplicasToDeleteCount)
   metricsGroup.newGauge(ActiveBrokerCountMetricName, () => activeBrokerCount)
+  metricsGroup.newGauge(MaintenanceBrokerCountMetricName,
+    () => if (isActive) config.maintenanceBrokerList.size else 0)
   // FencedBrokerCount metric is always 0 in the ZK controller.
   metricsGroup.newGauge(FencedBrokerCountMetricName, () => 0)
 
@@ -242,6 +279,7 @@ class KafkaController(val config: KafkaConfig,
       eventManager.close()
       onControllerResignation()
     } finally {
+      controllerInitExecutor.foreach(_.shutdownNow())
       removeMetrics()
     }
   }
@@ -316,6 +354,8 @@ class KafkaController(val config: KafkaConfig,
     zkClient.deleteIsrChangeNotifications(controllerContext.epochZkVersion)
     info("Initializing controller context")
     initializeControllerContext()
+    if (config.liProtocolBridgeDynamicTopicDeletionActive)
+      processTopicDeletionFlagChange(initializing = true)
     info("Fetching topic deletions in progress")
     val (topicsToBeDeleted, topicsIneligibleForDeletion) = fetchTopicDeletionsInProgress()
     info("Initializing topic deletion manager")
@@ -527,6 +567,7 @@ class KafkaController(val config: KafkaConfig,
     zkClient.unregisterZNodeChildChangeHandler(isrChangeNotificationHandler.path)
     zkClient.unregisterZNodeChangeHandler(partitionReassignmentHandler.path)
     zkClient.unregisterZNodeChangeHandler(preferredReplicaElectionHandler.path)
+    zkClient.unregisterZNodeChangeHandler(topicDeletionFlagHandler.path)
     zkClient.unregisterZNodeChildChangeHandler(logDirEventNotificationHandler.path)
     unregisterBrokerModificationsHandler(brokerModificationsHandlers.keySet)
 
@@ -980,7 +1021,7 @@ class KafkaController(val config: KafkaConfig,
     info(s"Initialized broker epochs cache: ${controllerContext.liveBrokerIdAndEpochs}")
     controllerContext.setAllTopics(zkClient.getAllTopicsInCluster(true))
     registerPartitionModificationsHandlers(controllerContext.allTopics.toSeq)
-    val replicaAssignmentAndTopicIds = zkClient.getReplicaAssignmentAndTopicIdForTopics(controllerContext.allTopics.toSet)
+    val replicaAssignmentAndTopicIds = loadReplicaAssignments(controllerContext.allTopics.toSet)
     processTopicIds(replicaAssignmentAndTopicIds)
 
     replicaAssignmentAndTopicIds.foreach { case TopicIdReplicaAssignment(_, _, assignments) =>
@@ -1001,6 +1042,22 @@ class KafkaController(val config: KafkaConfig,
     info(s"Currently active brokers in the cluster: ${controllerContext.liveBrokerIds}")
     info(s"Currently shutting brokers in the cluster: ${controllerContext.shuttingDownBrokerIds}")
     info(s"Current list of topics in the cluster: ${controllerContext.allTopics}")
+  }
+
+  private[controller] def loadReplicaAssignments(
+    topics: scala.collection.immutable.Set[String]
+  ): scala.collection.immutable.Set[TopicIdReplicaAssignment] = {
+    if (controllerInitZkClients.size <= 1 || topics.size <= 1) {
+      zkClient.getReplicaAssignmentAndTopicIdForTopics(topics)
+    } else {
+      val chunkSize = math.max(1, math.ceil(topics.size.toDouble / controllerInitZkClients.size).toInt)
+      val futures = topics.grouped(chunkSize).zipWithIndex.map { case (topicChunk, index) =>
+        CompletableFuture.supplyAsync(
+          () => controllerInitZkClients(index).getReplicaAssignmentAndTopicIdForTopics(topicChunk.toSet),
+          controllerInitExecutor.get)
+      }.toSeq
+      futures.flatMap(joinControllerInit).toSet
+    }
   }
 
   private def fetchPendingPreferredReplicaElections(): Set[TopicPartition] = {
@@ -1050,9 +1107,25 @@ class KafkaController(val config: KafkaConfig,
   }
 
   private def updateLeaderAndIsrCache(partitions: Seq[TopicPartition] = controllerContext.allPartitions.toSeq): Unit = {
-    val leaderIsrAndControllerEpochs = zkClient.getTopicPartitionStates(partitions)
+    val leaderIsrAndControllerEpochs = loadPartitionStates(partitions)
     leaderIsrAndControllerEpochs.forKeyValue { (partition, leaderIsrAndControllerEpoch) =>
       controllerContext.putPartitionLeadershipInfo(partition, leaderIsrAndControllerEpoch)
+    }
+  }
+
+  private[controller] def loadPartitionStates(
+    partitions: Seq[TopicPartition]
+  ): scala.collection.immutable.Map[TopicPartition, LeaderIsrAndControllerEpoch] = {
+    if (controllerInitZkClients.size <= 1 || partitions.size <= 1) {
+      zkClient.getTopicPartitionStates(partitions).toMap
+    } else {
+      val chunkSize = math.max(1, math.ceil(partitions.size.toDouble / controllerInitZkClients.size).toInt)
+      val futures = partitions.grouped(chunkSize).zipWithIndex.map { case (partitionChunk, index) =>
+        CompletableFuture.supplyAsync(
+          () => controllerInitZkClients(index).getTopicPartitionStates(partitionChunk),
+          controllerInitExecutor.get)
+      }.toSeq
+      futures.flatMap(joinControllerInit).toMap
     }
   }
 
@@ -1887,7 +1960,7 @@ class KafkaController(val config: KafkaConfig,
       zkClient.deleteTopicDeletions(nonExistentTopics.toSeq, controllerContext.epochZkVersion)
     }
     topicsToBeDeleted --= nonExistentTopics
-    if (config.deleteTopicEnable) {
+    if (isTopicDeletionEnabled) {
       if (topicsToBeDeleted.nonEmpty) {
         info(s"Starting topic deletion for topics ${topicsToBeDeleted.mkString(",")}")
         // mark topic ineligible for deletion if other state changes are in progress
@@ -1905,6 +1978,28 @@ class KafkaController(val config: KafkaConfig,
       // If delete topic is disabled remove entries under zookeeper path : /admin/delete_topics
       info(s"Removing $topicsToBeDeleted since delete topic is disabled")
       zkClient.deleteTopicDeletions(topicsToBeDeleted.toSeq, controllerContext.epochZkVersion)
+    }
+  }
+
+  private def processTopicDeletionFlagChange(initializing: Boolean = false): Unit = {
+    if (!isActive || !config.liProtocolBridgeDynamicTopicDeletionActive)
+      return
+
+    // ZooKeeper watches are one-shot. An exists watch also covers deletion followed by recreation.
+    if (zkClient.registerZNodeChangeHandlerAndCheckExistence(topicDeletionFlagHandler)) {
+      zkClient.getTopicDeletionFlag match {
+        case Some(enabled) => topicDeletionManager.isDeleteTopicEnabled = enabled
+        case None => warn(s"Invalid or missing topic deletion flag. Keeping delete.topic.enable=$isTopicDeletionEnabled")
+      }
+    } else {
+      topicDeletionManager.resetDeleteTopicEnabled()
+      if (initializing)
+        zkClient.setTopicDeletionFlag(isTopicDeletionEnabled)
+    }
+
+    if (!initializing && isTopicDeletionEnabled) {
+      processTopicDeletion()
+      topicDeletionManager.tryTopicDeletion()
     }
   }
 
@@ -1953,7 +2048,12 @@ class KafkaController(val config: KafkaConfig,
       val partitionsToReassign = mutable.Map.empty[TopicPartition, ReplicaAssignment]
 
       reassignments.forKeyValue { (tp, targetReplicas) =>
-        val maybeApiError = targetReplicas.flatMap(validateReplicas(tp, _))
+        val maybeApiError = targetReplicas match {
+          case Some(replicas) => validateReplicas(tp, replicas)
+          case None if config.liProtocolBridgeReassignmentCancellationSafetyActive =>
+            validateReassignmentCancellation(tp)
+          case None => None
+        }
         maybeApiError match {
           case None =>
             maybeBuildReassignment(tp, targetReplicas) match {
@@ -1972,6 +2072,13 @@ class KafkaController(val config: KafkaConfig,
       reassignmentResults ++= maybeTriggerPartitionReassignment(partitionsToReassign)
       callback(Left(reassignmentResults))
     }
+  }
+
+  private def validateReassignmentCancellation(topicPartition: TopicPartition): Option[ApiError] = {
+    val assignment = controllerContext.partitionFullReplicaAssignment(topicPartition)
+    if (!assignment.isBeingReassigned) None
+    else KafkaController.validateReassignmentCancellation(
+      assignment.originReplicas, controllerContext.liveBrokerIds, config.liMinOriginalAliveReplicas)
   }
 
   private def validateReplicas(topicPartition: TopicPartition, replicas: Seq[Int]): Option[ApiError] = {
@@ -2754,6 +2861,8 @@ class KafkaController(val config: KafkaConfig,
           processPartitionModifications(topic)
         case TopicDeletion =>
           processTopicDeletion()
+        case TopicDeletionFlagChange =>
+          processTopicDeletionFlagChange()
         case ApiPartitionReassignment(reassignments, callback) =>
           processApiPartitionReassignment(reassignments, callback)
         case ZkPartitionReassignment =>
@@ -2836,6 +2945,13 @@ class TopicDeletionHandler(eventManager: ControllerEventManager) extends ZNodeCh
   override val path: String = DeleteTopicsZNode.path
 
   override def handleChildChange(): Unit = eventManager.put(TopicDeletion)
+}
+
+class TopicDeletionFlagHandler(eventManager: ControllerEventManager) extends ZNodeChangeHandler {
+  override val path: String = DeleteTopicFlagZNode.path
+  override def handleCreation(): Unit = eventManager.put(TopicDeletionFlagChange)
+  override def handleDataChange(): Unit = eventManager.put(TopicDeletionFlagChange)
+  override def handleDeletion(): Unit = eventManager.put(TopicDeletionFlagChange)
 }
 
 class PartitionReassignmentHandler(eventManager: ControllerEventManager) extends ZNodeChangeHandler {
@@ -3027,6 +3143,11 @@ case class PartitionModifications(topic: String) extends ControllerEvent {
 }
 
 case object TopicDeletion extends ControllerEvent {
+  override def state: ControllerState = ControllerState.TopicDeletion
+  override def preempt(): Unit = {}
+}
+
+case object TopicDeletionFlagChange extends ControllerEvent {
   override def state: ControllerState = ControllerState.TopicDeletion
   override def preempt(): Unit = {}
 }

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -89,7 +89,11 @@ class TopicDeletionManager(config: KafkaConfig,
                            partitionStateMachine: PartitionStateMachine,
                            client: DeletionClient) extends Logging {
   this.logIdent = s"[Topic Deletion Manager ${config.brokerId}] "
-  val isDeleteTopicEnabled: Boolean = config.deleteTopicEnable
+  @volatile var isDeleteTopicEnabled: Boolean = config.deleteTopicEnable
+
+  def resetDeleteTopicEnabled(): Unit = {
+    isDeleteTopicEnabled = config.deleteTopicEnable
+  }
 
   def init(initialTopicsToBeDeleted: Set[String], initialTopicsIneligibleForDeletion: Set[String]): Unit = {
     info(s"Initializing manager with initial deletions: $initialTopicsToBeDeleted, " +
@@ -148,15 +152,15 @@ class TopicDeletionManager(config: KafkaConfig,
    * @param replicas Replicas for which deletion has failed
    */
   def failReplicaDeletion(replicas: Set[PartitionAndReplica]): Unit = {
-    if (isDeleteTopicEnabled) {
-      val replicasThatFailedToDelete = replicas.filter(r => isTopicQueuedUpForDeletion(r.topic))
-      if (replicasThatFailedToDelete.nonEmpty) {
-        val topics = replicasThatFailedToDelete.map(_.topic)
-        debug(s"Deletion failed for replicas ${replicasThatFailedToDelete.mkString(",")}. Halting deletion for topics $topics")
-        replicaStateMachine.handleStateChanges(replicasThatFailedToDelete.toSeq, ReplicaDeletionIneligible)
-        markTopicIneligibleForDeletion(topics, reason = "replica deletion failure")
+    // Requests sent before a pause can still finish. Keep their results for the next resume.
+    val replicasThatFailedToDelete = replicas.filter(r => controllerContext.isTopicQueuedUpForDeletion(r.topic))
+    if (replicasThatFailedToDelete.nonEmpty) {
+      val topics = replicasThatFailedToDelete.map(_.topic)
+      debug(s"Deletion failed for replicas ${replicasThatFailedToDelete.mkString(",")}. Halting deletion for topics $topics")
+      replicaStateMachine.handleStateChanges(replicasThatFailedToDelete.toSeq, ReplicaDeletionIneligible)
+      markTopicIneligibleForDeletion(topics, reason = "replica deletion failure")
+      if (isDeleteTopicEnabled)
         resumeDeletions()
-      }
     }
   }
 
@@ -203,10 +207,11 @@ class TopicDeletionManager(config: KafkaConfig,
    * @param replicas Replicas that were successfully deleted by the broker
    */
   def completeReplicaDeletion(replicas: Set[PartitionAndReplica]): Unit = {
-    val successfullyDeletedReplicas = replicas.filter(r => isTopicQueuedUpForDeletion(r.topic))
+    val successfullyDeletedReplicas = replicas.filter(r => controllerContext.isTopicQueuedUpForDeletion(r.topic))
     debug(s"Deletion successfully completed for replicas ${successfullyDeletedReplicas.mkString(",")}")
     replicaStateMachine.handleStateChanges(successfullyDeletedReplicas.toSeq, ReplicaDeletionSuccessful)
-    resumeDeletions()
+    if (isDeleteTopicEnabled)
+      resumeDeletions()
   }
 
   /**

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -101,7 +101,9 @@ object DynamicBrokerConfig {
       KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
       KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
       KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp,
-      KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp
+      KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp,
+      KafkaConfig.LiProtocolBridgeReassignmentCancellationSafetyEnableProp,
+      KafkaConfig.MaintenanceBrokerListProp
     ) ++
     DynamicListenerConfig.ReconfigurableConfigs ++
     SocketServer.ReconfigurableConfigs ++
@@ -116,7 +118,9 @@ object DynamicBrokerConfig {
     KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
     KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
     KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp,
-    KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp
+    KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp,
+    KafkaConfig.LiProtocolBridgeReassignmentCancellationSafetyEnableProp,
+    KafkaConfig.MaintenanceBrokerListProp
   )
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(
     ClusterLevelListenerConfigs)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2223,7 +2223,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           .setErrorCode(Errors.NOT_CONTROLLER.code))
       }
       sendResponseCallback(results)
-    } else if (!config.deleteTopicEnable) {
+    } else if (!zkSupport.controller.isTopicDeletionEnabled) {
       val error = if (request.context.apiVersion < 3) Errors.INVALID_REQUEST else Errors.TOPIC_DELETION_DISABLED
       deleteTopicRequest.topics().forEach { topic =>
         results.add(new DeletableTopicResult()

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -73,6 +73,12 @@ object KafkaConfig {
     "li.protocol.bridge.federated.topics.enable"
   val LiProtocolBridgeRackIdMapperEnableProp =
     "li.protocol.bridge.rack.id.mapper.enable"
+  val LiProtocolBridgeDynamicTopicDeletionEnableProp =
+    "li.protocol.bridge.dynamic.topic.deletion.enable"
+  val LiProtocolBridgeReassignmentCancellationSafetyEnableProp =
+    "li.protocol.bridge.reassignment.cancellation.safety.enable"
+  val LiProtocolBridgeLeaderTransferEnableProp =
+    "li.protocol.bridge.leader.transfer.on.isr.shrink.enable"
 
   // 3.0-li operational settings consumed by the LinkedIn server wrapper.
   val ListenersProp: String = SocketServerConfigs.LISTENERS_CONFIG
@@ -88,6 +94,7 @@ object KafkaConfig {
     "controlled.shutdown.safety.check.redundancy.factor"
   val ObserverClassNameProp = "observer.class.name"
   val ObserverShutdownTimeoutMsProp = "observer.shutdown.timeout"
+  val MaintenanceBrokerListProp = "maintenance.broker.list"
 
   // Source-compatible names used by the LinkedIn KafkaServer wrapper. Apache 3.9 moved most of
   // these definitions into Java config classes, but the wrapper still calls KafkaConfig.*Prop().
@@ -117,8 +124,6 @@ object KafkaConfig {
   val ZkSslTrustStorePasswordProp = "zookeeper.ssl.truststore.password"
   val ZkSslTrustStoreTypeProp = "zookeeper.ssl.truststore.type"
 
-  val LiDropCorruptedFilesEnableProp = "li.drop.corrupted.files.enable"
-  val LiLeaderElectionOnCorruptionWaitMsProp = "li.leader.election.on.corruption.wait.ms"
   val LiLongTailProduceRequestLogRatioProp = "li.instrumentation.requests.produce.long.tail.log.ratio"
   val LiLongTailProduceRequestLogThresholdMsProp = "li.instrumentation.requests.produce.long.tail.log.threshold.ms"
   val LiMinOriginalAliveReplicasProp = "li.min.original.alive.replicas"
@@ -148,6 +153,12 @@ object KafkaConfig {
     "Enable the 3.0-li federated-topic APIs and ZooKeeper metadata used by the LinkedIn authorizer."
   val LiProtocolBridgeRackIdMapperEnableDoc =
     "Apply the configured 3.0-li rack ID mapper during automatic replica assignment."
+  val LiProtocolBridgeDynamicTopicDeletionEnableDoc =
+    "Read delete.topic.enable dynamically from the 3.0-li /topic_deletion_flag ZooKeeper path."
+  val LiProtocolBridgeReassignmentCancellationSafetyEnableDoc =
+    "Require enough original replicas to be alive before cancelling a reassignment."
+  val LiProtocolBridgeLeaderTransferEnableDoc =
+    "Transfer leadership instead of shrinking an ISR below min.insync.replicas. Requires a broker restart."
   val PreferredControllerDoc = "Whether this broker is eligible for preferred-controller placement."
   val AllowPreferredControllerFallbackDoc =
     "Allow a non-preferred broker to become controller when no preferred controller is available."
@@ -159,6 +170,7 @@ object KafkaConfig {
     "Additional live ISR replicas required by the controlled shutdown safety check."
   val ObserverClassNameDoc = "Broker request observer implementation class."
   val ObserverShutdownTimeoutMsDoc = "Maximum time in milliseconds allowed to close the request observer."
+  val MaintenanceBrokerListDoc = "Comma-separated broker IDs excluded from automatic replica assignment."
 
   def main(args: Array[String]): Unit = {
     System.out.println(configDef.toHtml(4, (config: String) => "brokerconfigs_" + config,
@@ -208,6 +220,12 @@ object KafkaConfig {
       ConfigDef.Importance.HIGH, LiProtocolBridgeFederatedTopicsEnableDoc)
     .define(LiProtocolBridgeRackIdMapperEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeRackIdMapperEnableDoc)
+    .define(LiProtocolBridgeDynamicTopicDeletionEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeDynamicTopicDeletionEnableDoc)
+    .define(LiProtocolBridgeReassignmentCancellationSafetyEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeReassignmentCancellationSafetyEnableDoc)
+    .define(LiProtocolBridgeLeaderTransferEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeLeaderTransferEnableDoc)
     .define(PreferredControllerProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, PreferredControllerDoc)
     .define(AllowPreferredControllerFallbackProp, ConfigDef.Type.BOOLEAN, true,
@@ -222,8 +240,16 @@ object KafkaConfig {
       ConfigDef.Importance.MEDIUM, ObserverClassNameDoc)
     .define(ObserverShutdownTimeoutMsProp, ConfigDef.Type.LONG, 60000L, ConfigDef.Range.atLeast(1),
       ConfigDef.Importance.MEDIUM, ObserverShutdownTimeoutMsDoc)
+    .define(MaintenanceBrokerListProp, ConfigDef.Type.STRING, "",
+      ConfigDef.Importance.HIGH, MaintenanceBrokerListDoc)
     .define(LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp, ConfigDef.Type.STRING, "",
       ConfigDef.Importance.HIGH, "Rack ID mapper class used for automatic replica assignment.")
+    .define(LiZookeeperPaginationEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, "Use paginated reads for ZooKeeper paths that may exceed the response limit.")
+    .define(LiNumControllerInitThreadsProp, ConfigDef.Type.INT, 1, ConfigDef.Range.atLeast(1),
+      ConfigDef.Importance.HIGH, "Number of ZooKeeper clients used to load controller state in parallel.")
+    .define(LiMinOriginalAliveReplicasProp, ConfigDef.Type.INT, 2, ConfigDef.Range.atLeast(1),
+      ConfigDef.Importance.HIGH, "Minimum live original replicas required to cancel a reassignment.")
 
   def configNames: Seq[String] = configDef.names.asScala.toBuffer.sorted
   private[server] def defaultValues: Map[String, _] = configDef.defaultValues.asScala
@@ -339,6 +365,12 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     getBoolean(KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp)
   def liProtocolBridgeRackIdMapperEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgeRackIdMapperEnableProp)
+  def liProtocolBridgeDynamicTopicDeletionEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeDynamicTopicDeletionEnableProp)
+  def liProtocolBridgeReassignmentCancellationSafetyEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeReassignmentCancellationSafetyEnableProp)
+  def liProtocolBridgeLeaderTransferEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeLeaderTransferEnableProp)
 
   def liProtocolBridgeModeActive: Boolean = processRoles.isEmpty && liProtocolBridgeModeEnable
   def liProtocolBridgeFollowerRecoveryActive: Boolean =
@@ -357,6 +389,12 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     processRoles.isEmpty && liProtocolBridgeFederatedTopicsEnable
   def liProtocolBridgeRackIdMapperActive: Boolean =
     processRoles.isEmpty && liProtocolBridgeRackIdMapperEnable
+  def liProtocolBridgeDynamicTopicDeletionActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeDynamicTopicDeletionEnable
+  def liProtocolBridgeReassignmentCancellationSafetyActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeReassignmentCancellationSafetyEnable
+  def liProtocolBridgeLeaderTransferActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeLeaderTransferEnable
 
   lazy val rackIdMapperForReplicaAssignment: RackAwareReplicaAssignmentRackIdMapper = {
     val className = getString(KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp)
@@ -375,6 +413,18 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     getInt(KafkaConfig.ControlledShutdownSafetyCheckRedundancyFactorProp)
   def observerClassName: String = getString(KafkaConfig.ObserverClassNameProp)
   def observerShutdownTimeoutMs: Long = getLong(KafkaConfig.ObserverShutdownTimeoutMsProp)
+  def liZookeeperPaginationEnable: Boolean = getBoolean(KafkaConfig.LiZookeeperPaginationEnableProp)
+  def liNumControllerInitThreads: Int = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
+  def liMinOriginalAliveReplicas: Int = getInt(KafkaConfig.LiMinOriginalAliveReplicasProp)
+  def maintenanceBrokerList: Set[Int] = {
+    val value = getString(KafkaConfig.MaintenanceBrokerListProp)
+    try value.split(',').iterator.map(_.trim).filter(_.nonEmpty).map(_.toInt).toSet
+    catch {
+      case _: NumberFormatException =>
+        throw new ConfigException(KafkaConfig.MaintenanceBrokerListProp, value,
+          "must be a comma-separated list of broker IDs")
+    }
+  }
 
   private[server] val dynamicConfig = new DynamicBrokerConfig(this)
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -29,7 +29,7 @@ import kafka.network.{ControlPlaneAcceptor, DataPlaneAcceptor, RequestChannel, S
 import kafka.raft.KafkaRaftManager
 import kafka.server.metadata.{OffsetTrackingListener, ZkConfigRepository, ZkMetadataCache}
 import kafka.utils._
-import kafka.zk.{AdminZkClient, BrokerInfo, KafkaZkClient}
+import kafka.zk.{AdminZkClient, BrokerInfo, FederatedTopicsZNode, KafkaZkClient, PreferredControllersZNode}
 import org.apache.kafka.clients.{ApiVersions, ManualMetadataUpdater, MetadataRecoveryStrategy, NetworkClient, NetworkClientUtils}
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.internals.Topic
@@ -100,6 +100,12 @@ object KafkaServer {
     // The zk sasl is enabled by default so it can produce false error when broker does not intend to use SASL.
     if (!JaasUtils.isZkSaslEnabled) clientConfig.setProperty(JaasUtils.ZK_SASL_CLIENT, "false")
     clientConfig
+  }
+
+  private[server] def compatibilityZkPaths(config: KafkaConfig): Seq[String] = {
+    val preferred = if (config.liProtocolBridgePreferredControllerActive) Seq(PreferredControllersZNode.path) else Seq.empty
+    val federated = if (config.liProtocolBridgeFederatedTopicsActive) Seq(FederatedTopicsZNode.path) else Seq.empty
+    preferred ++ federated
   }
 
   val MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS: Long = 120000
@@ -189,6 +195,7 @@ class KafkaServer(
   var clientToControllerChannelManager: NodeToControllerChannelManager = _
 
   var alterPartitionManager: AlterPartitionManager = _
+  var leaderTransferManager: LeaderTransferManager = LeaderTransferManager.NoOp
 
   var kafkaScheduler: KafkaScheduler = _
 
@@ -200,6 +207,7 @@ class KafkaServer(
 
   val zkClientConfig: ZKClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(config)
   private var _zkClient: KafkaZkClient = _
+  private var additionalControllerZkClients: Seq[KafkaZkClient] = Seq.empty
   private var configRepository: ZkConfigRepository = _
 
   val correlationId: AtomicInteger = new AtomicInteger(0)
@@ -427,6 +435,13 @@ class KafkaServer(
         }
         alterPartitionManager.start()
 
+        leaderTransferManager = if (config.liProtocolBridgeLeaderTransferActive)
+          LeaderTransferManager(config, controllerNodeProvider, kafkaScheduler, time, metrics,
+            s"zk-broker-${config.nodeId}-", brokerEpochSupplier)
+        else
+          LeaderTransferManager.NoOp
+        leaderTransferManager.start()
+
         // Start replica manager
         _replicaManager = createReplicaManager(isShuttingDown)
         replicaManager.startup()
@@ -441,7 +456,11 @@ class KafkaServer(
         tokenManager.startup()
 
         /* start kafka controller */
-        _kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch, tokenManager, brokerFeatures, metadataCache, threadNamePrefix)
+        additionalControllerZkClients = (1 until config.liNumControllerInitThreads).map { index =>
+          KafkaZkClient.createZkClient(s"Kafka controller init ${index + 1}", time, config, zkClientConfig)
+        }
+        _kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch,
+          tokenManager, brokerFeatures, metadataCache, threadNamePrefix, additionalControllerZkClients)
         kafkaController.startup()
 
         if (config.migrationEnabled) {
@@ -776,13 +795,16 @@ class KafkaServer(
       delayedRemoteFetchPurgatoryParam = None,
       threadNamePrefix = threadNamePrefix,
       brokerEpochSupplier = brokerEpochSupplier,
-      addPartitionsToTxnManager = Some(addPartitionsToTxnManager))
+      addPartitionsToTxnManager = Some(addPartitionsToTxnManager),
+      leaderTransferManager = leaderTransferManager)
   }
 
   private def initZkClient(time: Time): Unit = {
     info(s"Connecting to zookeeper on ${config.zkConnect}")
     _zkClient = KafkaZkClient.createZkClient("Kafka server", time, config, zkClientConfig)
     _zkClient.createTopLevelPaths()
+    KafkaServer.compatibilityZkPaths(config).foreach(path =>
+      _zkClient.createRecursive(path, throwIfPathExists = false))
   }
 
   private def getOrGenerateClusterId(zkClient: KafkaZkClient): String = {
@@ -1068,6 +1090,8 @@ class KafkaServer(
         if (replicaManager != null)
           CoreUtils.swallow(replicaManager.shutdown(), this)
 
+        if (leaderTransferManager != null)
+          CoreUtils.swallow(leaderTransferManager.shutdown(), this)
         if (alterPartitionManager != null)
           CoreUtils.swallow(alterPartitionManager.shutdown(), this)
 
@@ -1091,6 +1115,8 @@ class KafkaServer(
         if (featureChangeListener != null)
           CoreUtils.swallow(featureChangeListener.close(), this)
 
+        additionalControllerZkClients.foreach(client => CoreUtils.swallow(client.close(), this))
+        additionalControllerZkClients = Seq.empty
         if (zkClient != null)
           CoreUtils.swallow(zkClient.close(), this)
 

--- a/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
+++ b/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
@@ -30,10 +30,16 @@ object LiProtocolBridgeMetrics {
   val PreferredControllerEnabled = "PreferredControllerEnabled"
   val FederatedTopicsEnabled = "FederatedTopicsEnabled"
   val RackIdMapperEnabled = "RackIdMapperEnabled"
+  val ZookeeperPaginationEnabled = "ZookeeperPaginationEnabled"
+  val DynamicTopicDeletionEnabled = "DynamicTopicDeletionEnabled"
+  val ReassignmentCancellationSafetyEnabled = "ReassignmentCancellationSafetyEnabled"
+  val LeaderTransferEnabled = "LeaderTransferEnabled"
+  val ControllerInitializationThreads = "ControllerInitializationThreads"
   val MetricNames: Seq[String] = Seq(ModeEnabled, FollowerRecoveryEnabled,
     RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled, MoveControllerEnabled,
     ShutdownSafetyOverrideEnabled, PreferredControllerEnabled, FederatedTopicsEnabled,
-    RackIdMapperEnabled)
+    RackIdMapperEnabled, ZookeeperPaginationEnabled, DynamicTopicDeletionEnabled,
+    ReassignmentCancellationSafetyEnabled, LeaderTransferEnabled, ControllerInitializationThreads)
 }
 
 /** Exposes the effective value of every 3.0-li compatibility flag on each ZooKeeper broker. */
@@ -60,6 +66,16 @@ class LiProtocolBridgeMetrics(config: KafkaConfig) extends AutoCloseable {
     () => enabled(config.liProtocolBridgeFederatedTopicsActive), tags)
   metricsGroup.newGauge(RackIdMapperEnabled,
     () => enabled(config.liProtocolBridgeRackIdMapperActive), tags)
+  metricsGroup.newGauge(ZookeeperPaginationEnabled,
+    () => enabled(config.liZookeeperPaginationEnable), tags)
+  metricsGroup.newGauge(DynamicTopicDeletionEnabled,
+    () => enabled(config.liProtocolBridgeDynamicTopicDeletionActive), tags)
+  metricsGroup.newGauge(ReassignmentCancellationSafetyEnabled,
+    () => enabled(config.liProtocolBridgeReassignmentCancellationSafetyActive), tags)
+  metricsGroup.newGauge(LeaderTransferEnabled,
+    () => enabled(config.liProtocolBridgeLeaderTransferActive), tags)
+  metricsGroup.newGauge(ControllerInitializationThreads,
+    () => config.liNumControllerInitThreads, tags)
 
   private def enabled(value: Boolean): Int = if (value) 1 else 0
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -272,7 +272,8 @@ class ReplicaManager(val config: KafkaConfig,
                      threadNamePrefix: Option[String] = None,
                      val brokerEpochSupplier: () => Long = () => -1,
                      addPartitionsToTxnManager: Option[AddPartitionsToTxnManager] = None,
-                     val directoryEventHandler: DirectoryEventHandler = DirectoryEventHandler.NOOP
+                     val directoryEventHandler: DirectoryEventHandler = DirectoryEventHandler.NOOP,
+                     val leaderTransferManager: LeaderTransferManager = LeaderTransferManager.NoOp
                      ) extends Logging {
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 
@@ -2418,6 +2419,11 @@ class ReplicaManager(val config: KafkaConfig,
     // Shrink ISRs for non offline partitions
     allPartitions.keys.foreach { topicPartition =>
       onlinePartition(topicPartition).foreach(_.maybeShrinkIsr())
+    }
+    if (config.liProtocolBridgeLeaderTransferActive) {
+      allPartitions.keys.foreach { topicPartition =>
+        onlinePartition(topicPartition).foreach(_.maybeTransferToNewLeader())
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/server/ZkAdminManager.scala
+++ b/core/src/main/scala/kafka/server/ZkAdminManager.scala
@@ -180,7 +180,8 @@ class ZkAdminManager(val config: KafkaConfig,
       zkClient.getPreferredControllerList.toSet
     else
       Set.empty[Int]
-    val brokers = mapRackIds(liveBrokers.filterNot(broker => preferredControllerIds.contains(broker.id)))
+    val excludedBrokerIds = preferredControllerIds ++ config.maintenanceBrokerList
+    val brokers = mapRackIds(liveBrokers.filterNot(broker => excludedBrokerIds.contains(broker.id)))
     val metadata = toCreate.values.map(topic =>
       try {
         if (metadataCache.contains(topic.name))
@@ -330,7 +331,8 @@ class ZkAdminManager(val config: KafkaConfig,
       zkClient.getPreferredControllerList.toSet
     else
       Set.empty[Int]
-    val allBrokers = mapRackIds(brokerMetadatas.filterNot(broker => preferredControllerIds.contains(broker.id)))
+    val excludedBrokerIds = preferredControllerIds ++ config.maintenanceBrokerList
+    val allBrokers = mapRackIds(brokerMetadatas.filterNot(broker => excludedBrokerIds.contains(broker.id)))
     val allBrokerIds = allBrokers.map(_.id)
 
     // 1. map over topics creating assignment and calling AdminUtils

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -59,8 +59,11 @@ class AdminZkClient(zkClient: KafkaZkClient,
                   topicConfig: Properties = new Properties,
                   rackAwareMode: RackAwareMode = RackAwareMode.Enforced,
                   usesTopicId: Boolean = false): Unit = {
-    val brokerMetadatas = getBrokerMetadatas(rackAwareMode).asJava
-    val replicaAssignment = CoreUtils.replicaToBrokerAssignmentAsScala(AdminUtils.assignReplicasToBrokers(brokerMetadatas, partitions, replicationFactor))
+    val excludedBrokerIds = getAssignmentExcludedBrokerIds()
+    val brokerMetadatas = getBrokerMetadatas(rackAwareMode)
+      .filterNot(metadata => excludedBrokerIds.contains(metadata.id)).asJava
+    val replicaAssignment = CoreUtils.replicaToBrokerAssignmentAsScala(
+      AdminUtils.assignReplicasToBrokers(brokerMetadatas, partitions, replicationFactor))
     createTopicWithAssignment(topic, topicConfig, replicaAssignment, usesTopicId = usesTopicId)
   }
 
@@ -88,6 +91,21 @@ class AdminZkClient(zkClient: KafkaZkClient,
     }
     brokerMetadatas.sortBy(_.id)
   }
+
+  /** Return broker IDs excluded from automatic assignment by the cluster-level maintenance setting. */
+  def getMaintenanceBrokerList(): Set[Int] = {
+    val value = fetchEntityConfig(ConfigType.BROKER, "<default>")
+      .getProperty(KafkaConfig.MaintenanceBrokerListProp, "")
+    try value.split(',').iterator.map(_.trim).filter(_.nonEmpty).map(_.toInt).toSet
+    catch {
+      case _: NumberFormatException =>
+        throw new AdminOperationException(
+          s"${KafkaConfig.MaintenanceBrokerListProp} must be a comma-separated list of broker IDs: $value")
+    }
+  }
+
+  private def getAssignmentExcludedBrokerIds(): Set[Int] =
+    getMaintenanceBrokerList() ++ zkClient.getPreferredControllerList
 
   /**
    * Create topic and optionally validate its parameters. Note that this method is used by the
@@ -223,10 +241,15 @@ class AdminZkClient(zkClient: KafkaZkClient,
                     replicaAssignment: Option[Map[Int, Seq[Int]]] = None,
                     validateOnly: Boolean = false): Map[Int, Seq[Int]] = {
 
+    val assignmentBrokers = if (replicaAssignment.isDefined) allBrokers
+    else {
+      val excludedBrokerIds = getAssignmentExcludedBrokerIds()
+      allBrokers.filterNot(metadata => excludedBrokerIds.contains(metadata.id))
+    }
     val proposedAssignmentForNewPartitions = createNewPartitionsAssignment(
       topic,
       existingAssignment,
-      allBrokers,
+      assignmentBrokers,
       numPartitions,
       replicaAssignment
     )

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -64,8 +64,13 @@ class KafkaZkClient private[zk] (
   zooKeeperClient: ZooKeeperClient,
   isSecure: Boolean,
   time: Time,
-  enableEntityConfigControllerCheck: Boolean
+  enableEntityConfigControllerCheck: Boolean,
+  paginateTopics: Boolean = false
 ) extends AutoCloseable with Logging {
+
+  def this(zooKeeperClient: ZooKeeperClient, isSecure: Boolean, time: Time,
+           enableEntityConfigControllerCheck: Boolean) =
+    this(zooKeeperClient, isSecure, time, enableEntityConfigControllerCheck, false)
 
   private val metricsGroup: KafkaMetricsGroup = new KafkaMetricsGroup(this.getClass) {
     override def metricName(name: String, metricTags: util.Map[String, String]): MetricName = {
@@ -133,8 +138,12 @@ class KafkaZkClient private[zk] (
   }
 
   def getAllFederatedTopicsInNamespace(namespace: String, registerWatch: Boolean = false): Set[String] = {
-    val response = retryRequestUntilConnected(
-      GetChildrenRequest(FederatedTopicZNode.namespacePath(namespace), registerWatch))
+    val path = FederatedTopicZNode.namespacePath(namespace)
+    val request = if (paginateTopics)
+      GetChildrenPaginatedRequest(path, registerWatch)
+    else
+      GetChildrenRequest(path, registerWatch)
+    val response = retryRequestUntilConnected(request)
     response.resultCode match {
       case Code.OK => response.children.toSet
       case Code.NONODE => Set.empty
@@ -576,7 +585,13 @@ class KafkaZkClient private[zk] (
    * @return List of all entity names
    */
   def getAllEntitiesWithConfig(entityType: String): Seq[String] = {
-    getChildren(ConfigEntityTypeZNode.path(entityType))
+    val path = ConfigEntityTypeZNode.path(entityType)
+    if (paginateTopics && entityType == ConfigType.TOPIC) {
+      val response = retryRequestUntilConnected(GetChildrenPaginatedRequest(path, registerWatch = false))
+      response.maybeThrow()
+      response.children
+    } else
+      getChildren(path)
   }
 
   /**
@@ -656,8 +671,11 @@ class KafkaZkClient private[zk] (
    * @return sequence of topics in the cluster.
    */
   def getAllTopicsInCluster(registerWatch: Boolean = false): Set[String] = {
-    val getChildrenResponse = retryRequestUntilConnected(
-      GetChildrenRequest(TopicsZNode.path, registerWatch))
+    val request = if (paginateTopics)
+      GetChildrenPaginatedRequest(TopicsZNode.path, registerWatch)
+    else
+      GetChildrenRequest(TopicsZNode.path, registerWatch)
+    val getChildrenResponse = retryRequestUntilConnected(request)
     getChildrenResponse.resultCode match {
       case Code.OK => getChildrenResponse.children.toSet
       case Code.NONODE => Set.empty
@@ -1323,6 +1341,28 @@ class KafkaZkClient private[zk] (
   def deleteController(expectedControllerEpochZkVersion: Int): Unit = {
     val deleteRequest = DeleteRequest(ControllerZNode.path, ZkVersion.MatchAnyVersion)
     retryRequestUntilConnected(deleteRequest, expectedControllerEpochZkVersion)
+  }
+
+  def getTopicDeletionFlag: Option[Boolean] = {
+    val response = retryRequestUntilConnected(GetDataRequest(DeleteTopicFlagZNode.path))
+    response.resultCode match {
+      case Code.OK => DeleteTopicFlagZNode.decode(response.data)
+      case Code.NONODE => None
+      case _ => throw response.resultException.get
+    }
+  }
+
+  def setTopicDeletionFlag(enabled: Boolean): Unit = {
+    val data = DeleteTopicFlagZNode.encode(enabled)
+    val response = retryRequestUntilConnected(
+      SetDataRequest(DeleteTopicFlagZNode.path, data, ZkVersion.MatchAnyVersion))
+    response.resultCode match {
+      case Code.NONODE =>
+        createRecursive(DeleteTopicFlagZNode.path, data, throwIfPathExists = false)
+        retryRequestUntilConnected(
+          SetDataRequest(DeleteTopicFlagZNode.path, data, ZkVersion.MatchAnyVersion)).maybeThrow()
+      case _ => response.maybeThrow()
+    }
   }
 
   def createFederatedTopicZNode(topic: String, namespace: String): Unit =
@@ -2330,7 +2370,8 @@ object KafkaZkClient {
             metricGroup: String = "kafka.server",
             metricType: String = "SessionExpireListener",
             createChrootIfNecessary: Boolean = false,
-            enableEntityConfigControllerCheck: Boolean = true
+            enableEntityConfigControllerCheck: Boolean = true,
+            paginateTopics: Boolean = false
   ): KafkaZkClient = {
 
     /* ZooKeeper 3.6.0 changed the default configuration for JUTE_MAXBUFFER from 4 MB to 1 MB.
@@ -2365,7 +2406,7 @@ object KafkaZkClient {
     }
     val zooKeeperClient = new ZooKeeperClient(connectString, sessionTimeoutMs, connectionTimeoutMs, maxInFlightRequests,
       time, metricGroup, metricType, zkClientConfig, name)
-    new KafkaZkClient(zooKeeperClient, isSecure, time, enableEntityConfigControllerCheck)
+    new KafkaZkClient(zooKeeperClient, isSecure, time, enableEntityConfigControllerCheck, paginateTopics)
   }
 
   // A helper function to transform a regular request into a MultiRequest
@@ -2456,6 +2497,6 @@ object KafkaZkClient {
 
     KafkaZkClient(config.zkConnect, secureAclsEnabled, config.zkSessionTimeoutMs, config.zkConnectionTimeoutMs,
       config.zkMaxInFlightRequests, time, name = name, zkClientConfig = zkClientConfig,
-      createChrootIfNecessary = true)
+      createChrootIfNecessary = true, paginateTopics = config.liZookeeperPaginationEnable)
   }
 }

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -92,6 +92,19 @@ object ConfigZNode {
   def path = "/config"
 }
 
+object DeleteTopicFlagZNode {
+  def path = "/topic_deletion_flag"
+  def encode(value: Boolean): Array[Byte] = value.toString.getBytes(UTF_8)
+  def decode(bytes: Array[Byte]): Option[Boolean] =
+    Option(bytes).flatMap { value =>
+      new String(value, UTF_8).trim.toLowerCase match {
+        case "true" => Some(true)
+        case "false" => Some(false)
+        case _ => None
+      }
+    }
+}
+
 object BrokersZNode {
   def path = "/brokers"
 }
@@ -1124,8 +1137,6 @@ object ZkData {
   val PersistentZkPaths: Seq[String] = Seq(
     ConsumerPathZNode.path, // old consumer path
     BrokerIdsZNode.path,
-    FederatedTopicsZNode.path,
-    PreferredControllersZNode.path,
     TopicsZNode.path,
     ConfigEntityChangeNotificationZNode.path,
     DeleteTopicsZNode.path,

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -25,7 +25,7 @@ import com.yammer.metrics.core.MetricName
 import kafka.utils.CoreUtils.{inLock, inReadLock, inWriteLock}
 import kafka.utils.Logging
 import kafka.zookeeper.ZooKeeperClient._
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{ThreadUtils, Time}
 import org.apache.kafka.server.util.KafkaScheduler
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.zookeeper.AsyncCallback.{Children2Callback, DataCallback, StatCallback}
@@ -80,6 +80,8 @@ class ZooKeeperClient(connectString: String,
   private val inFlightRequests = new Semaphore(maxInFlightRequests)
   private val stateChangeHandlers = new ConcurrentHashMap[String, StateChangeHandler]().asScala
   private[zookeeper] val reinitializeScheduler = new KafkaScheduler(1, true, s"zk-client-${threadPrefix}reinit-")
+  private val paginationExecutor = Executors.newSingleThreadExecutor(
+    ThreadUtils.createThreadFactory(s"zk-client-${threadPrefix}pagination", true))
   private var isFirstConnectionEstablished = false
 
   private val metricNames = mutable.Set[String]()
@@ -201,6 +203,34 @@ class ZooKeeperClient(connectString: String,
             callback(GetChildrenResponse(Code.get(rc), path, Option(ctx), Option(children).map(_.asScala).getOrElse(Seq.empty),
               stat, responseMetadata(sendTimeMs)))
         }, ctx.orNull)
+      case GetChildrenPaginatedRequest(path, _, ctx) =>
+        def systemError(error: Throwable): GetChildrenResponse = {
+          this.error("ZooKeeper pagination failed. The client must provide getAllChildrenPaginated when " +
+            "li.zookeeper.pagination.enable is true.", error)
+          GetChildrenResponse(Code.SYSTEMERROR, path, ctx, Seq.empty, new Stat, responseMetadata(sendTimeMs))
+        }
+
+        try {
+          paginationExecutor.execute(() => {
+            val response = try {
+              inReadLock(initializationLock) {
+                val method = zooKeeper.getClass.getMethod(
+                  "getAllChildrenPaginated", classOf[String], java.lang.Boolean.TYPE)
+                val children = method.invoke(zooKeeper, path, Boolean.box(shouldWatch(request)))
+                  .asInstanceOf[JList[String]].asScala.toSeq
+                GetChildrenResponse(Code.OK, path, ctx, children, new Stat, responseMetadata(sendTimeMs))
+              }
+            } catch {
+              case e: java.lang.reflect.InvocationTargetException if e.getCause.isInstanceOf[KeeperException] =>
+                GetChildrenResponse(e.getCause.asInstanceOf[KeeperException].code, path, ctx, Seq.empty,
+                  new Stat, responseMetadata(sendTimeMs))
+              case e: Throwable => systemError(e)
+            }
+            callback(response)
+          })
+        } catch {
+          case e: RejectedExecutionException => callback(systemError(e))
+        }
       case CreateRequest(path, data, acl, createMode, ctx) =>
         zooKeeper.create(path, data, acl.asJava, createMode,
           (rc, path, ctx, name) =>
@@ -273,6 +303,8 @@ class ZooKeeperClient(connectString: String,
   // may need to be updated.
   private def shouldWatch(request: AsyncRequest): Boolean = request match {
     case GetChildrenRequest(_, registerWatch, _) => registerWatch && zNodeChildChangeHandlers.contains(request.path)
+    case GetChildrenPaginatedRequest(_, registerWatch, _) =>
+      registerWatch && zNodeChildChangeHandlers.contains(request.path)
     case _: ExistsRequest | _: GetDataRequest => zNodeChangeHandlers.contains(request.path)
     case _ => throw new IllegalArgumentException(s"Request $request is not watchable")
   }
@@ -341,6 +373,7 @@ class ZooKeeperClient(connectString: String,
     // is waiting for lock to process session expiry. Close expiry thread
     // first to ensure that new clients are not created during close().
     reinitializeScheduler.shutdown()
+    ThreadUtils.shutdownExecutorServiceQuietly(paginationExecutor, 10, TimeUnit.SECONDS)
 
     inWriteLock(initializationLock) {
       zNodeChangeHandlers.clear()
@@ -542,6 +575,11 @@ case class SetAclRequest(path: String, acl: Seq[ACL], version: Int, ctx: Option[
 }
 
 case class GetChildrenRequest(path: String, registerWatch: Boolean, ctx: Option[Any] = None) extends AsyncRequest {
+  type Response = GetChildrenResponse
+}
+
+case class GetChildrenPaginatedRequest(path: String, registerWatch: Boolean, ctx: Option[Any] = None)
+  extends AsyncRequest {
   type Response = GetChildrenResponse
 }
 

--- a/core/src/test/scala/integration/kafka/server/LiDynamicTopicDeletionTest.scala
+++ b/core/src/test/scala/integration/kafka/server/LiDynamicTopicDeletionTest.scala
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.{Collections, Properties}
+import java.util.concurrent.{ExecutionException, TimeUnit}
+import kafka.utils.TestUtils
+import kafka.zk.DeleteTopicFlagZNode
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, DeleteTopicsOptions}
+import org.apache.kafka.common.errors.TopicDeletionDisabledException
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{AfterEach, Test}
+
+import scala.collection.Seq
+import scala.concurrent.{Await, Promise}
+import scala.concurrent.duration._
+
+class LiDynamicTopicDeletionTest extends QuorumTestHarness {
+  private var brokers = Seq.empty[KafkaServer]
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    TestUtils.shutdownServers(brokers)
+    brokers = Seq.empty
+    super.tearDown()
+  }
+
+  private def startBroker(deleteEnabled: Boolean = true, bridgeEnabled: Boolean = true): KafkaServer = {
+    val props = TestUtils.createBrokerConfig(0, zkConnect)
+    props.put("delete.topic.enable", deleteEnabled.toString)
+    props.put(KafkaConfig.LiProtocolBridgeDynamicTopicDeletionEnableProp, bridgeEnabled.toString)
+    val broker = createBroker(KafkaConfig.fromProps(props)).asInstanceOf[KafkaServer]
+    brokers :+= broker
+    TestUtils.waitUntilTrue(() => broker.kafkaController.isActive, "Controller was not elected")
+    awaitControllerEvents(broker)
+    broker
+  }
+
+  private def awaitControllerEvents(broker: KafkaServer): Unit = {
+    val ready = Promise[Unit]()
+    broker.kafkaController.listPartitionReassignments(None, _ => ready.success(()))
+    Await.result(ready.future, 10.seconds)
+  }
+
+  private def awaitDeletionEnabled(broker: KafkaServer, enabled: Boolean): Unit =
+    TestUtils.waitUntilTrue(() => broker.kafkaController.isTopicDeletionEnabled == enabled,
+      s"Topic deletion did not become $enabled")
+
+  @Test
+  def testNewFlagRemainsWatchedAndControlsDeleteApi(): Unit = {
+    val broker = startBroker()
+    assertEquals(Some(true), zkClient.getTopicDeletionFlag)
+    TestUtils.createTopic(zkClient, "deletion-toggle", 1, 1, brokers)
+    val props = new Properties
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
+      s"localhost:${broker.boundPort(broker.config.interBrokerListenerName)}")
+    val admin = Admin.create(props)
+    try {
+      zkClient.setTopicDeletionFlag(false)
+      awaitDeletionEnabled(broker, enabled = false)
+      val error = assertThrows(classOf[ExecutionException], () => admin.deleteTopics(
+        Collections.singletonList("deletion-toggle"), new DeleteTopicsOptions().timeoutMs(5000))
+        .all().get(10, TimeUnit.SECONDS))
+      assertInstanceOf(classOf[TopicDeletionDisabledException], error.getCause)
+      assertTrue(zkClient.topicExists("deletion-toggle"))
+      assertTrue(zkClient.getTopicDeletions.isEmpty)
+
+      zkClient.setTopicDeletionFlag(true)
+      awaitDeletionEnabled(broker, enabled = true)
+      admin.deleteTopics(Collections.singletonList("deletion-toggle"))
+        .all().get(10, TimeUnit.SECONDS)
+    } finally admin.close()
+  }
+
+  @Test
+  def testDeletionAndRecreationRearmWatch(): Unit = {
+    zkClient.setTopicDeletionFlag(false)
+    val broker = startBroker()
+    assertFalse(broker.kafkaController.isTopicDeletionEnabled)
+    zkClient.deletePath(DeleteTopicFlagZNode.path)
+    awaitDeletionEnabled(broker, enabled = true)
+    zkClient.setTopicDeletionFlag(false)
+    awaitDeletionEnabled(broker, enabled = false)
+    zkClient.setTopicDeletionFlag(true)
+    awaitDeletionEnabled(broker, enabled = true)
+  }
+
+  @Test
+  def testFlagCanEnableDeletionWhenStaticDefaultIsFalse(): Unit = {
+    zkClient.setTopicDeletionFlag(true)
+    val broker = startBroker(deleteEnabled = false)
+    assertTrue(broker.kafkaController.isTopicDeletionEnabled)
+    TestUtils.createTopic(zkClient, "enabled-by-zookeeper", 1, 1, brokers)
+    zkClient.createDeleteTopicPath("enabled-by-zookeeper")
+    TestUtils.waitUntilTrue(() => !zkClient.topicExists("enabled-by-zookeeper"),
+      "The controller did not use the effective deletion flag")
+  }
+
+  @Test
+  def testInvalidFlagKeepsLastValidValue(): Unit = {
+    zkClient.setTopicDeletionFlag(false)
+    val broker = startBroker()
+    zkClient.currentZooKeeper.setData(DeleteTopicFlagZNode.path, "invalid".getBytes(UTF_8), -1)
+    // A following valid write proves that the watch survives invalid input.
+    zkClient.setTopicDeletionFlag(false)
+    awaitControllerEvents(broker)
+    assertFalse(broker.kafkaController.isTopicDeletionEnabled)
+    zkClient.setTopicDeletionFlag(true)
+    awaitDeletionEnabled(broker, enabled = true)
+  }
+
+  @Test
+  def testDisabledBridgeUsesStaticConfig(): Unit = {
+    zkClient.setTopicDeletionFlag(false)
+    val broker = startBroker(bridgeEnabled = false)
+    assertTrue(broker.kafkaController.isTopicDeletionEnabled)
+  }
+}

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -2148,6 +2148,53 @@ class PartitionTest extends AbstractPartitionTest {
   }
 
   @Test
+  def testLeaderTransferSelectsLowestInSyncFollower(): Unit = {
+    configRepository.setTopicConfig(topicPartition.topic, TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "4")
+    val log = logManager.getOrCreateLog(topicPartition, topicId = None)
+    seedLogData(log, numRecords = 10, leaderEpoch = 4)
+
+    val lowestInSyncFollower = brokerId + 1
+    val otherInSyncFollower = brokerId + 2
+    val outOfSyncFollower = brokerId + 3
+    val replicas = Seq(brokerId, otherInSyncFollower, lowestInSyncFollower, outOfSyncFollower)
+    val leaderTransferManager = mock(classOf[LeaderTransferManager])
+    val transferPartition = new Partition(
+      topicPartition,
+      replicaLagTimeMaxMs = ReplicationConfigs.REPLICA_LAG_TIME_MAX_MS_DEFAULT,
+      interBrokerProtocolVersion = MetadataVersion.latestTesting,
+      localBrokerId = brokerId,
+      () => defaultBrokerEpoch(brokerId),
+      time,
+      alterPartitionListener,
+      delayedOperations,
+      metadataCache,
+      logManager,
+      alterPartitionManager,
+      leaderTransferEnabled = true,
+      leaderTransferManager = leaderTransferManager)
+    transferPartition.createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
+    assertTrue(transferPartition.makeLeader(
+      new LeaderAndIsrPartitionState()
+        .setControllerEpoch(0)
+        .setLeader(brokerId)
+        .setLeaderEpoch(5)
+        .setIsr(replicas.map(Int.box).asJava)
+        .setPartitionEpoch(1)
+        .setReplicas(replicas.map(Int.box).asJava)
+        .setIsNew(true),
+      offsetCheckpoints,
+      None))
+
+    fetchFollower(transferPartition, replicaId = otherInSyncFollower, fetchOffset = log.logEndOffset)
+    fetchFollower(transferPartition, replicaId = lowestInSyncFollower, fetchOffset = log.logEndOffset)
+    time.sleep(transferPartition.replicaLagTimeMaxMs + 1)
+    transferPartition.maybeTransferToNewLeader()
+
+    verify(leaderTransferManager).submit(topicPartition, lowestInSyncFollower)
+    verifyNoMoreInteractions(leaderTransferManager)
+  }
+
+  @Test
   def testMaybeShrinkIsr(): Unit = {
     val log = logManager.getOrCreateLog(topicPartition, topicId = None)
     seedLogData(log, numRecords = 10, leaderEpoch = 4)

--- a/core/src/test/scala/unit/kafka/controller/KafkaControllerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/KafkaControllerTest.scala
@@ -17,17 +17,20 @@
 
 package kafka.controller
 
+import kafka.api.LeaderAndIsr
 import kafka.server.metadata.ZkMetadataCache
 import kafka.server.{BrokerFeatures, DelegationTokenManager, KafkaConfig}
 import kafka.utils.TestUtils
 import kafka.zk.{BrokerInfo, KafkaZkClient}
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.MockTime
+import org.junit.jupiter.api.Assertions.{assertEquals, assertSame, assertThrows, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.{mock, mockConstruction, times, verify, verifyNoMoreInteractions}
+import org.mockito.Mockito.{mock, mockConstruction, times, verify, verifyNoMoreInteractions, when}
 
 class KafkaControllerTest {
   var config: KafkaConfig = _
@@ -70,6 +73,57 @@ class KafkaControllerTest {
     } finally {
       mockMetricsGroupCtor.close()
     }
+  }
+
+  @Test
+  def testParallelControllerInitializationLoadsPartitionStatesFromEveryClient(): Unit = {
+    val firstClient = mock(classOf[KafkaZkClient])
+    val secondClient = mock(classOf[KafkaZkClient])
+    val firstPartition = new TopicPartition("topic", 0)
+    val secondPartition = new TopicPartition("topic", 1)
+    val firstState = LeaderIsrAndControllerEpoch(LeaderAndIsr(1, List(1)), 1)
+    val secondState = LeaderIsrAndControllerEpoch(LeaderAndIsr(2, List(2)), 1)
+    when(firstClient.getTopicPartitionStates(Seq(firstPartition))).thenReturn(Map(firstPartition -> firstState))
+    when(secondClient.getTopicPartitionStates(Seq(secondPartition))).thenReturn(Map(secondPartition -> secondState))
+
+    val controller = new KafkaController(config, firstClient, new MockTime(), mock(classOf[Metrics]),
+      mock(classOf[BrokerInfo]), 0L, mock(classOf[DelegationTokenManager]), mock(classOf[BrokerFeatures]),
+      mock(classOf[ZkMetadataCache]), additionalZkClients = Seq(secondClient))
+    try {
+      assertEquals(Map(firstPartition -> firstState, secondPartition -> secondState),
+        controller.loadPartitionStates(Seq(firstPartition, secondPartition)))
+    } finally controller.shutdown()
+  }
+
+  @Test
+  def testParallelControllerInitializationPreservesFailureCause(): Unit = {
+    val firstClient = mock(classOf[KafkaZkClient])
+    val secondClient = mock(classOf[KafkaZkClient])
+    val firstPartition = new TopicPartition("topic", 0)
+    val secondPartition = new TopicPartition("topic", 1)
+    val firstState = LeaderIsrAndControllerEpoch(LeaderAndIsr(1, List(1)), 1)
+    val failure = new IllegalStateException("ZooKeeper read failed")
+    when(firstClient.getTopicPartitionStates(Seq(firstPartition))).thenReturn(Map(firstPartition -> firstState))
+    when(secondClient.getTopicPartitionStates(Seq(secondPartition))).thenThrow(failure)
+
+    val controller = new KafkaController(config, firstClient, new MockTime(), mock(classOf[Metrics]),
+      mock(classOf[BrokerInfo]), 0L, mock(classOf[DelegationTokenManager]), mock(classOf[BrokerFeatures]),
+      mock(classOf[ZkMetadataCache]), additionalZkClients = Seq(secondClient))
+    try {
+      val thrown = assertThrows(classOf[IllegalStateException],
+        () => controller.loadPartitionStates(Seq(firstPartition, secondPartition)))
+      assertSame(failure, thrown)
+    } finally controller.shutdown()
+  }
+
+  @Test
+  def testReassignmentCancellationRequiresEnoughLiveOriginalReplicas(): Unit = {
+    assertTrue(KafkaController.validateReassignmentCancellation(
+      Seq(1, 2, 3), Set(1, 4), minimumAliveReplicas = 2).isDefined)
+    assertEquals(None, KafkaController.validateReassignmentCancellation(
+      Seq(1, 2, 3), Set(1, 2, 4), minimumAliveReplicas = 2))
+    assertEquals(None, KafkaController.validateReassignmentCancellation(
+      Seq(1), Set(1, 4), minimumAliveReplicas = 2))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -24,9 +24,26 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito._
 
 class TopicDeletionManagerTest {
+
+  @Test
+  def testDynamicDeleteTopicFlagCanBeResetToBrokerConfig(): Unit = {
+    val disabledProps = TestUtils.createBrokerConfig(1, "zkConnect")
+    disabledProps.put("delete.topic.enable", "false")
+    val disabledConfig = KafkaConfig.fromProps(disabledProps)
+    val manager = new TopicDeletionManager(disabledConfig, new ControllerContext,
+      mock(classOf[ReplicaStateMachine]), mock(classOf[PartitionStateMachine]), deletionClient)
+
+    assertFalse(manager.isDeleteTopicEnabled)
+    manager.isDeleteTopicEnabled = true
+    assertTrue(manager.isDeleteTopicEnabled)
+    manager.resetDeleteTopicEnabled()
+    assertFalse(manager.isDeleteTopicEnabled)
+  }
 
   private val brokerId = 1
   private val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(brokerId, "zkConnect"))
@@ -58,6 +75,40 @@ class TopicDeletionManagerTest {
 
     assertEquals(Set("foo", "bar"), controllerContext.topicsToBeDeleted.toSet)
     assertEquals(Set("bar"), controllerContext.topicsIneligibleForDeletion.toSet)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testDeletionCallbacksAreRecordedWhilePaused(withFailure: Boolean): Unit = {
+    val context = initContext(Seq(1, 2, 3), Set("foo"), numPartitions = 1, replicationFactor = 3)
+    val replicaStateMachine = new MockReplicaStateMachine(context)
+    replicaStateMachine.startup()
+    val partitionStateMachine = new MockPartitionStateMachine(context,
+      uncleanLeaderElectionEnabled = false, isLeaderRecoverySupported = true)
+    partitionStateMachine.startup()
+    val manager = new TopicDeletionManager(config, context, replicaStateMachine,
+      partitionStateMachine, deletionClient)
+    manager.init(Set.empty, Set.empty)
+    manager.enqueueTopicsForDeletion(Set("foo"))
+    val replicas = context.replicasForTopic("foo")
+    val (failed, successful) = replicas.partition(replica => withFailure && replica.replica == 1)
+
+    manager.isDeleteTopicEnabled = false
+    manager.completeReplicaDeletion(successful)
+    manager.failReplicaDeletion(failed)
+    assertEquals(successful, context.replicasInState("foo", ReplicaDeletionSuccessful))
+    assertEquals(failed, context.replicasInState("foo", ReplicaDeletionIneligible))
+    assertTrue(context.topicsToBeDeleted.contains("foo"))
+    verify(deletionClient, never()).deleteTopic("foo", context.epochZkVersion)
+
+    manager.isDeleteTopicEnabled = true
+    manager.tryTopicDeletion()
+    if (withFailure) {
+      assertEquals(failed, context.replicasInState("foo", ReplicaDeletionStarted))
+      manager.completeReplicaDeletion(failed)
+    }
+    assertFalse(context.topicsToBeDeleted.contains("foo"))
+    verify(deletionClient).deleteTopic("foo", context.epochZkVersion)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -300,28 +300,35 @@ class DynamicBrokerConfigTest {
   }
 
   @Test
-  def testProtocolBridgeFlagsAreDisabledByDefaultAndClusterWide(): Unit = {
+  def testProtocolBridgeFlagDefaultsAndDynamicScope(): Unit = {
     val brokerProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     brokerProps.put(ReplicationConfigs.INTER_BROKER_PROTOCOL_VERSION_CONFIG, "3.0")
     val config = KafkaConfig(brokerProps)
     config.dynamicConfig.initialize(None, None)
-    val bridgeFlags = Seq(
+    val dynamicBridgeFlags = Seq(
       KafkaConfig.LiProtocolBridgeModeEnableProp,
       KafkaConfig.LiProtocolBridgeFollowerRecoveryEnableProp,
       KafkaConfig.LiProtocolBridgeRecommendedElectionEnableProp,
       KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
       KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
       KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp,
-      KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp
+      KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp,
+      KafkaConfig.LiProtocolBridgeReassignmentCancellationSafetyEnableProp
     )
-    bridgeFlags.foreach(flag => assertFalse(config.getBoolean(flag), s"$flag should be disabled by default"))
+    val allBridgeFlags = dynamicBridgeFlags :+ KafkaConfig.LiProtocolBridgeLeaderTransferEnableProp
+    allBridgeFlags.foreach(flag => assertFalse(config.getBoolean(flag), s"$flag should be disabled by default"))
 
-    val props = new Properties
-    bridgeFlags.foreach(props.put(_, "true"))
-    config.dynamicConfig.validate(props, perBrokerConfig = false)
-    config.dynamicConfig.updateDefaultConfig(props)
-    bridgeFlags.foreach(flag => assertTrue(config.getBoolean(flag), s"$flag should be enabled dynamically"))
-    assertThrows(classOf[ConfigException], () => config.dynamicConfig.validate(props, perBrokerConfig = true))
+    val dynamicProps = new Properties
+    dynamicBridgeFlags.foreach(dynamicProps.put(_, "true"))
+    config.dynamicConfig.validate(dynamicProps, perBrokerConfig = false)
+    config.dynamicConfig.updateDefaultConfig(dynamicProps)
+    dynamicBridgeFlags.foreach(flag => assertTrue(config.getBoolean(flag), s"$flag should be enabled dynamically"))
+    assertThrows(classOf[ConfigException], () => config.dynamicConfig.validate(dynamicProps, perBrokerConfig = true))
+
+    val startupOnlyProps = new Properties
+    startupOnlyProps.put(KafkaConfig.LiProtocolBridgeLeaderTransferEnableProp, "true")
+    assertThrows(classOf[ConfigException],
+      () => config.dynamicConfig.validate(startupOnlyProps, perBrokerConfig = false))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -6854,6 +6854,7 @@ class KafkaApisTest extends Logging {
       anyShort
     )).thenReturn(UnboundedControllerMutationQuota)
     when(controller.isActive).thenReturn(true)
+    when(controller.isTopicDeletionEnabled).thenReturn(true)
     when(controller.controllerContext).thenReturn(controllerContext)
 
     val topicResults = Map(
@@ -6933,6 +6934,7 @@ class KafkaApisTest extends Logging {
       anyShort
     )).thenReturn(UnboundedControllerMutationQuota)
     when(controller.isActive).thenReturn(true)
+    when(controller.isTopicDeletionEnabled).thenReturn(true)
 
     // Try to delete three topics:
     // 1. One without describe permission

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -54,6 +54,14 @@ import scala.jdk.CollectionConverters._
 class KafkaConfigTest {
 
   @Test
+  def testInvalidMaintenanceBrokerList(): Unit = {
+    val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
+    props.setProperty(KafkaConfig.MaintenanceBrokerListProp, "1,not-a-broker")
+    val config = KafkaConfig.fromProps(props)
+    assertThrows(classOf[ConfigException], () => config.maintenanceBrokerList)
+  }
+
+  @Test
   def testLogRetentionTimeHoursProvided(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     props.setProperty(ServerLogConfigs.LOG_RETENTION_TIME_HOURS_CONFIG, "1")
@@ -1147,6 +1155,7 @@ class KafkaConfigTest {
         case GroupCoordinatorConfig.SHARE_GROUP_MAX_SIZE_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
 
         case KafkaConfig.ObserverClassNameProp |
+             KafkaConfig.MaintenanceBrokerListProp |
              KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp => // ignore string values
 
         case _ => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1")

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import kafka.utils.{CoreUtils, TestUtils}
+import kafka.zk.{FederatedTopicsZNode, PreferredControllersZNode}
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.network.SocketServerConfigs
 import org.apache.kafka.server.common.MetadataVersion
@@ -31,6 +32,20 @@ import java.util.Properties
 import scala.jdk.CollectionConverters._
 
 class KafkaServerTest extends QuorumTestHarness {
+
+  @Test
+  def testCompatibilityZkPathsRequireFeatureFlags(): Unit = {
+    val defaultProps = new Properties
+    defaultProps.put(ZkConfigs.ZK_CONNECT_CONFIG, TestUtils.MockZkConnect)
+    assertEquals(Seq.empty, KafkaServer.compatibilityZkPaths(KafkaConfig.fromProps(defaultProps)))
+
+    val props = new Properties
+    props.put(ZkConfigs.ZK_CONNECT_CONFIG, TestUtils.MockZkConnect)
+    props.put(KafkaConfig.LiProtocolBridgePreferredControllerEnableProp, "true")
+    props.put(KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp, "true")
+    assertEquals(Set(PreferredControllersZNode.path, FederatedTopicsZNode.path),
+      KafkaServer.compatibilityZkPaths(KafkaConfig.fromProps(props)).toSet)
+  }
 
   @Test
   def testAlreadyRegisteredAdvertisedListeners(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/LegacyBrokerConstructorTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LegacyBrokerConstructorTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.cluster.{AlterPartitionListener, DelayedOperations, Partition}
+import kafka.log.LogManager
+import kafka.zk.KafkaZkClient
+import kafka.zookeeper.ZooKeeperClient
+import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.server.common.MetadataVersion
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class LegacyBrokerConstructorTest {
+  @Test
+  def testPartitionConstructorKeepsItsJvmSignature(): Unit = {
+    assertNotNull(classOf[Partition].getConstructor(
+      classOf[TopicPartition], java.lang.Long.TYPE, classOf[MetadataVersion], Integer.TYPE,
+      classOf[Function0[Long]], classOf[Time], classOf[AlterPartitionListener], classOf[DelayedOperations],
+      classOf[MetadataCache], classOf[LogManager], classOf[AlterPartitionManager], classOf[Option[Uuid]]))
+  }
+
+  @Test
+  def testZooKeeperClientConstructorKeepsItsJvmSignature(): Unit = {
+    assertNotNull(classOf[KafkaZkClient].getConstructor(classOf[ZooKeeperClient],
+      java.lang.Boolean.TYPE, classOf[Time], java.lang.Boolean.TYPE))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
@@ -38,7 +38,10 @@ class LiProtocolBridgeMetricsTest {
     val metrics = new LiProtocolBridgeMetrics(config)
 
     try {
-      assertTrue(metricValues(brokerId).values.forall(_ == 0))
+      val initialValues = metricValues(brokerId)
+      assertEquals(1, initialValues(LiProtocolBridgeMetrics.ControllerInitializationThreads))
+      assertTrue(initialValues.filterNot(_._1 == LiProtocolBridgeMetrics.ControllerInitializationThreads)
+        .values.forall(_ == 0))
 
       val props = new Properties
       Seq(
@@ -48,16 +51,22 @@ class LiProtocolBridgeMetricsTest {
         KafkaConfig.LiProtocolBridgeExcludePartitionsEnableProp,
         KafkaConfig.LiProtocolBridgeMoveControllerEnableProp,
         KafkaConfig.LiProtocolBridgeShutdownSafetyOverrideEnableProp,
-        KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp
+        KafkaConfig.LiProtocolBridgeFederatedTopicsEnableProp,
+        KafkaConfig.LiProtocolBridgeReassignmentCancellationSafetyEnableProp
       ).foreach(props.put(_, "true"))
       config.dynamicConfig.updateDefaultConfig(props)
 
       val updatedValues = metricValues(brokerId)
       assertEquals(LiProtocolBridgeMetrics.MetricNames.toSet, updatedValues.keySet)
       val staticMetrics = Set(LiProtocolBridgeMetrics.PreferredControllerEnabled,
-        LiProtocolBridgeMetrics.RackIdMapperEnabled)
+        LiProtocolBridgeMetrics.RackIdMapperEnabled, LiProtocolBridgeMetrics.ZookeeperPaginationEnabled,
+        LiProtocolBridgeMetrics.DynamicTopicDeletionEnabled,
+        LiProtocolBridgeMetrics.LeaderTransferEnabled)
+      assertEquals(1, updatedValues(LiProtocolBridgeMetrics.ControllerInitializationThreads))
       staticMetrics.foreach(name => assertEquals(0, updatedValues(name)))
-      assertTrue(updatedValues.filterNot { case (name, _) => staticMetrics.contains(name) }.values.forall(_ == 1))
+      assertTrue(updatedValues.filterNot { case (name, _) =>
+        staticMetrics.contains(name) || name == LiProtocolBridgeMetrics.ControllerInitializationThreads
+      }.values.forall(_ == 1))
     } finally {
       metrics.close()
     }

--- a/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
@@ -58,6 +58,31 @@ class AdminZkClientTest extends QuorumTestHarness with Logging with RackAwareTes
   }
 
   @Test
+  def testAutomaticAssignmentExcludesMaintenanceBrokers(): Unit = {
+    createBrokersInZk(zkClient, Seq(0, 1, 2, 3))
+    val props = new Properties
+    props.put(KafkaConfig.MaintenanceBrokerListProp, "1")
+    adminZkClient.changeBrokerConfig(None, props)
+    zkClient.createRecursive(PreferredControllersZNode.path)
+    zkClient.registerPreferredControllerId(2)
+
+    adminZkClient.createTopic("maintenance-test", partitions = 4, replicationFactor = 2)
+    val assignment = zkClient.getReplicaAssignmentForTopics(Set("maintenance-test"))
+    assertTrue(assignment.values.forall(replicas => !replicas.contains(1) && !replicas.contains(2)))
+  }
+
+  @Test
+  def testInvalidMaintenanceBrokerListHasAdminError(): Unit = {
+    val props = new Properties
+    props.put(KafkaConfig.MaintenanceBrokerListProp, "1,not-a-broker")
+    adminZkClient.changeBrokerConfig(None, props)
+
+    val error = assertThrows(classOf[AdminOperationException],
+      () => adminZkClient.getMaintenanceBrokerList())
+    assertTrue(error.getMessage.contains(KafkaConfig.MaintenanceBrokerListProp))
+  }
+
+  @Test
   def testManualReplicaAssignment(): Unit = {
     val brokers = List(0, 1, 2, 3, 4)
     createBrokersInZk(zkClient, brokers)

--- a/core/src/test/scala/unit/kafka/zk/DeleteTopicFlagZNodeTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/DeleteTopicFlagZNodeTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.zk
+
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+class DeleteTopicFlagZNodeTest {
+  @Test
+  def testEncodingAndStrictDecoding(): Unit = {
+    assertEquals(Some(true), DeleteTopicFlagZNode.decode(DeleteTopicFlagZNode.encode(true)))
+    assertEquals(Some(false), DeleteTopicFlagZNode.decode(" FALSE ".getBytes(UTF_8)))
+    assertTrue(DeleteTopicFlagZNode.decode("enabled".getBytes(UTF_8)).isEmpty)
+    assertTrue(DeleteTopicFlagZNode.decode(null).isEmpty)
+  }
+}

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -47,6 +47,7 @@ import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.config.{ConfigType, ReplicationConfigs, ZkConfigs}
 import org.apache.kafka.storage.internals.log.LogConfig
+import org.apache.zookeeper.KeeperException
 import org.apache.zookeeper.KeeperException.{Code, NoAuthException, NoNodeException, NodeExistsException}
 import org.apache.zookeeper.{CreateMode, ZooDefs}
 import org.apache.zookeeper.client.ZKClientConfig
@@ -112,6 +113,35 @@ class KafkaZkClientTest extends QuorumTestHarness {
 
     zkClient.deleteFederatedTopicZNode("orders", "west")
     assertEquals(Set("/east/payments"), zkClient.getAllFederatedTopics())
+  }
+
+  @Test
+  def testSetTopicDeletionFlagCreatesMissingZnode(): Unit = {
+    assertEquals(None, zkClient.getTopicDeletionFlag)
+    zkClient.setTopicDeletionFlag(enabled = false)
+    assertEquals(Some(false), zkClient.getTopicDeletionFlag)
+    zkClient.setTopicDeletionFlag(enabled = true)
+    assertEquals(Some(true), zkClient.getTopicDeletionFlag)
+  }
+
+  @Test
+  def testPaginatedConfigReadPropagatesClientFailure(): Unit = {
+    val paginatedClient = KafkaZkClient(zkConnect,
+      zkAclsEnabled.getOrElse(JaasUtils.isZkSaslEnabled),
+      zkSessionTimeout,
+      zkConnectionTimeout,
+      zkMaxInFlightRequests,
+      Time.SYSTEM,
+      name = "KafkaZkClientPaginationFailureTest",
+      zkClientConfig = new ZKClientConfig,
+      enableEntityConfigControllerCheck = false,
+      paginateTopics = true)
+    try {
+      assertThrows(classOf[KeeperException],
+        () => paginatedClient.getAllEntitiesWithConfig(ConfigType.TOPIC))
+    } finally {
+      paginatedClient.close()
+    }
   }
 
   @Test


### PR DESCRIPTION
Restore ZooKeeper operational behavior behind explicit settings.

- Keep the topic-deletion flag watched through creation, deletion, and recreation. Use its value in the delete API and controller. Record in-flight callbacks during a pause so deletion can resume.
- Check live original replicas before cancelling reassignment. Exclude maintenance and preferred-controller brokers from automatic assignment.
- Load controller state through reusable parallel ZooKeeper clients and propagate read failures. Add optional paginated topic and config reads.
- Wire ISR leader transfer to the lowest-ID in-sync follower. The setting requires a broker restart.
- Preserve the existing Partition and KafkaZkClient JVM constructors.

Include focused configuration, assignment, deletion, pagination, parallel-read, constructor, and leader-selection tests.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.