### PR TITLE
kafka: restore LinkedIn operational metrics and watchdog

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -410,6 +410,9 @@ class Partition(val topicPartition: TopicPartition,
    */
   def isAtMinIsr: Boolean = leaderLogIfLocal.exists { partitionState.isr.size == effectiveMinIsr(_) }
 
+  def isOneAboveMinIsr: Boolean =
+    leaderLogIfLocal.exists { partitionState.isr.size == effectiveMinIsr(_) + 1 }
+
   def isReassigning: Boolean = assignmentState.isInstanceOf[OngoingReassignmentState]
 
   def isAddingLocalReplica: Boolean = assignmentState.isAddingReplica(localBrokerId)

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -47,7 +47,6 @@ import scala.jdk.CollectionConverters._
 object ControllerChannelManager {
   private val QueueSizeMetricName = "QueueSize"
   private val RequestRateAndQueueTimeMetricName = "RequestRateAndQueueTimeMs"
-  private val ProtocolBridgeModeMetricName = "LiProtocolBridgeModeEnabled"
 
   // Commit 74dca03f5bf3561c3694605fd15dc7b7c6502de8 added MaxBrokerEpoch to LeaderAndIsr v3,
   // UpdateMetadata v6, and StopReplica v2 in 3.0-li. Apache later used those version numbers for
@@ -118,8 +117,6 @@ class ControllerChannelManager(controllerEpoch: () => Int,
       brokerStateInfo.values.iterator.map(_.messageQueue.size).sum
     }
   )
-  metricsGroup.newGauge(ProtocolBridgeModeMetricName,
-    () => if (config.liProtocolBridgeModeActive) 1 else 0)
 
   def startup(initialBrokers: Set[Broker]):Unit = {
     initialBrokers.foreach(addNewBroker)

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -86,6 +86,7 @@ class ControllerContext extends ControllerChannelContext {
   var epochZkVersion: Int = KafkaController.InitialControllerEpochZkVersion
 
   val allTopics = mutable.Set.empty[String]
+  @volatile private var topicNameLengthTotal = 0L
   var topicIds = mutable.Map.empty[String, Uuid]
   var topicNames = mutable.Map.empty[Uuid, String]
   val partitionAssignments = mutable.Map.empty[String, mutable.Map[Int, ReplicaAssignment]]
@@ -121,6 +122,7 @@ class ControllerContext extends ControllerChannelContext {
 
   private def clearTopicsState(): Unit = {
     allTopics.clear()
+    topicNameLengthTotal = 0L
     topicIds.clear()
     topicNames.clear()
     partitionAssignments.clear()
@@ -323,7 +325,10 @@ class ControllerContext extends ControllerChannelContext {
   def setAllTopics(topics: Set[String]): Unit = {
     allTopics.clear()
     allTopics ++= topics
+    topicNameLengthTotal = topics.iterator.map(_.length.toLong).sum
   }
+
+  def sumOfTopicNameLengths: Long = topicNameLengthTotal
 
   def removeTopic(topic: String): Unit = {
     // Metric is cleaned when the topic is queued up for deletion so
@@ -333,7 +338,8 @@ class ControllerContext extends ControllerChannelContext {
       cleanPreferredReplicaImbalanceMetric(topic)
     topicsToBeDeleted -= topic
     topicsWithDeletionStarted -= topic
-    allTopics -= topic
+    if (allTopics.remove(topic))
+      topicNameLengthTotal -= topic.length
     topicIds.remove(topic).foreach { topicId =>
       topicNames.remove(topicId)
     }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -87,6 +87,7 @@ object KafkaController extends Logging {
   private val MaintenanceBrokerCountMetricName = "MaintenanceBrokerCount"
   private val FencedBrokerCountMetricName = "FencedBrokerCount"
   private val ZkMigrationStateMetricName = "ZkMigrationState"
+  private val SumOfTopicNameLengthMetricName = "SumOfTopicNameLength"
 
   // package private for testing
   private[controller] val MetricNames = Set(
@@ -236,6 +237,9 @@ class KafkaController(val config: KafkaConfig,
     () => if (isActive) config.maintenanceBrokerList.size else 0)
   // FencedBrokerCount metric is always 0 in the ZK controller.
   metricsGroup.newGauge(FencedBrokerCountMetricName, () => 0)
+  if (config.liProtocolBridgeLegacyRequestMetricsActive)
+    metricsGroup.newGauge(KafkaController.SumOfTopicNameLengthMetricName,
+      () => controllerContext.sumOfTopicNameLengths)
 
   /**
    * Returns true if this broker is the current controller.
@@ -596,6 +600,8 @@ class KafkaController(val config: KafkaConfig,
 
   private def removeMetrics(): Unit = {
     KafkaController.MetricNames.foreach(metricsGroup.removeMetric)
+    if (config.liProtocolBridgeLegacyRequestMetricsActive)
+      metricsGroup.removeMetric(KafkaController.SumOfTopicNameLengthMetricName)
   }
 
   /*

--- a/core/src/main/scala/kafka/log/LogTruncationStats.scala
+++ b/core/src/main/scala/kafka/log/LogTruncationStats.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.log
+
+import org.apache.kafka.server.metrics.KafkaMetricsGroup
+
+import java.util.concurrent.TimeUnit
+
+/** Truncation-volume metrics consumed by the LinkedIn monitoring wrapper. */
+object LogTruncationStats {
+  private val metricsGroup = new KafkaMetricsGroup(this.getClass)
+  val logTruncatedBytesRate = metricsGroup.newMeter(
+    "LogTruncatedBytesPerSec", "log-truncation", TimeUnit.SECONDS)
+  val logTruncatedMessagesRate = metricsGroup.newMeter(
+    "LogTruncatedMessagesPerSec", "log-truncation", TimeUnit.SECONDS)
+}

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -1881,7 +1881,9 @@ class UnifiedLog(@volatile var logStartOffset: Long,
         false
       } else {
         info(s"Truncating to offset $targetOffset")
-        lock synchronized {
+        val (messagesTruncated, bytesTruncated) = lock synchronized {
+          val originalEndOffset = localLog.logEndOffset
+          val originalSize = size
           localLog.checkIfMemoryMappedBufferClosed()
           if (localLog.segments.firstSegmentBaseOffset.getAsLong > targetOffset) {
             truncateFullyAndStartAt(targetOffset)
@@ -1894,8 +1896,14 @@ class UnifiedLog(@volatile var logStartOffset: Long,
             if (highWatermark >= localLog.logEndOffset)
               updateHighWatermark(localLog.logEndOffsetMetadata)
           }
-          true
+          (math.max(0L, originalEndOffset - localLog.logEndOffset),
+            math.max(0L, originalSize - size))
         }
+        if (config.liLogTruncationMetricsEnable) {
+          LogTruncationStats.logTruncatedMessagesRate.mark(messagesTruncated)
+          LogTruncationStats.logTruncatedBytesRate.mark(bytesTruncated)
+        }
+        true
       }
     }
   }

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -21,11 +21,12 @@ import java.nio.ByteBuffer
 import java.util.concurrent._
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.scalalogging.Logger
-import com.yammer.metrics.core.{Histogram, Meter}
+import com.yammer.metrics.core.{Counter, Histogram, Meter}
 import kafka.network
-import kafka.server.{KafkaConfig, NoOpObserver, Observer, RequestLocal}
+import kafka.server.{BrokerMetadataStats, KafkaConfig, NoOpObserver, Observer, RequestLocal}
 import kafka.utils.{Logging, Pool}
 import kafka.utils.Implicits._
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
@@ -35,7 +36,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.network.Session
-import org.apache.kafka.server.metrics.KafkaMetricsGroup
+import org.apache.kafka.server.metrics.{KafkaMetricsGroup, KafkaYammerMetrics}
 
 import java.util
 import scala.collection.mutable
@@ -61,22 +62,55 @@ object RequestChannel extends Logging {
   case object ShutdownRequest extends BaseRequest
   case object WakeupRequest extends BaseRequest
 
-  class Metrics(enabledApis: Iterable[ApiKeys]) {
+  class Metrics(enabledApis: Iterable[ApiKeys], config: Option[KafkaConfig] = None) {
     def this(scope: ListenerType) = {
-      this(ApiKeys.apisForListener(scope).asScala)
+      this(ApiKeys.apisForListener(scope).asScala, None)
     }
 
     private val metricsMap = mutable.Map[String, RequestMetrics]()
+    private val bucketConfig = config.filter(_.liProtocolBridgeRequestMetricBucketsActive)
+    val legacyRequestMetricsEnabled: Boolean = config.exists(_.liProtocolBridgeLegacyRequestMetricsActive)
 
+    val produceRequestAcksSizeMetricNameMap: Map[Int, util.TreeMap[Int, String]] =
+      bucketConfig.map(_ => createProduceSizeMetricNames()).getOrElse(Map.empty)
+    val consumerFetchRequestSizeMetricNameMap: util.TreeMap[Int, String] =
+      bucketConfig.map(_ => createSizeMetricNames(RequestMetrics.consumerFetchMetricName))
+        .getOrElse(new util.TreeMap[Int, String])
+
+    private val additionalMetricNames =
+      produceRequestAcksSizeMetricNameMap.values.flatMap(_.values.asScala) ++
+        consumerFetchRequestSizeMetricNameMap.values.asScala
     (enabledApis.map(_.name) ++
-      Seq(RequestMetrics.consumerFetchMetricName, RequestMetrics.followFetchMetricName, RequestMetrics.verifyPartitionsInTxnMetricName)).foreach { name =>
-      metricsMap.put(name, new RequestMetrics(name))
+      Seq(RequestMetrics.consumerFetchMetricName, RequestMetrics.followFetchMetricName,
+        RequestMetrics.verifyPartitionsInTxnMetricName) ++ additionalMetricNames).foreach { name =>
+      metricsMap.put(name, new RequestMetrics(name, bucketConfig, legacyRequestMetricsEnabled))
     }
 
-    def apply(metricName: String): RequestMetrics = metricsMap(metricName)
+    private def createSizeMetricNames(requestType: String): util.TreeMap[Int, String] =
+      RequestMetrics.getBucketBoundaryObjectMap(bucketConfig.get.requestMetricsSizeBuckets,
+        requestType, "Mb", identity, addBinNumber = false)
 
-    def close(): Unit = {
-       metricsMap.values.foreach(_.removeMetrics())
+    private def createProduceSizeMetricNames(): Map[Int, util.TreeMap[Int, String]] = {
+      val baseNames = createSizeMetricNames(ApiKeys.PRODUCE.name)
+      Seq(0 -> "0", 1 -> "1", -1 -> "All").map { case (acks, suffix) =>
+        val names = new util.TreeMap[Int, String]
+        baseNames.asScala.foreach { case (boundary, name) => names.put(boundary, s"${name}Acks$suffix") }
+        acks -> names
+      }.toMap
+    }
+
+    def requestSizeBucketMetricName(names: util.TreeMap[Int, String], sizeBytes: Long): Option[String] =
+      if (names.isEmpty) None
+      else Some(RequestMetrics.getBucketObject(names, (sizeBytes / 1024 / 1024).toInt))
+
+    def apply(metricName: String): RequestMetrics = metricsMap.synchronized {
+      metricsMap.getOrElseUpdate(metricName,
+        new RequestMetrics(metricName, bucketConfig, legacyRequestMetricsEnabled))
+    }
+
+    def close(): Unit = metricsMap.synchronized {
+      metricsMap.values.foreach(_.removeMetrics())
+      metricsMap.clear()
     }
   }
 
@@ -243,18 +277,28 @@ object RequestChannel extends Logging {
       val totalTimeMs = nanosToMs(endTimeNanos - startTimeNanos)
       val overrideMetricNames =
         if (header.apiKey == ApiKeys.FETCH) {
+          val fetchRequest = body[FetchRequest]
           val specifiedMetricName =
-            if (body[FetchRequest].isFromFollower) RequestMetrics.followFetchMetricName
+            if (fetchRequest.isFromFollower) RequestMetrics.followFetchMetricName
             else RequestMetrics.consumerFetchMetricName
-          Seq(specifiedMetricName, header.apiKey.name)
+          val sizeMetricName =
+            if (fetchRequest.isFromFollower || fetchRequest.maxWait > ConsumerConfig.DEFAULT_FETCH_MAX_WAIT_MS) None
+            else metrics.requestSizeBucketMetricName(metrics.consumerFetchRequestSizeMetricNameMap, responseBytes)
+          Seq(specifiedMetricName, header.apiKey.name) ++ sizeMetricName
+        } else if (header.apiKey == ApiKeys.PRODUCE) {
+          val acks = body[ProduceRequest].acks.toInt
+          val names = metrics.produceRequestAcksSizeMetricNameMap.get(acks)
+            .orElse(metrics.produceRequestAcksSizeMetricNameMap.get(-1))
+          Seq(header.apiKey.name) ++ names.flatMap(metrics.requestSizeBucketMetricName(_, sizeOfBodyInBytes))
         } else if (header.apiKey == ApiKeys.ADD_PARTITIONS_TO_TXN && body[AddPartitionsToTxnRequest].allVerifyOnlyRequest) {
-            Seq(RequestMetrics.verifyPartitionsInTxnMetricName)
+          Seq(RequestMetrics.verifyPartitionsInTxnMetricName)
         } else {
           Seq(header.apiKey.name)
         }
       overrideMetricNames.foreach { metricName =>
         val m = metrics(metricName)
         m.requestRate(header.apiVersion).mark()
+        m.requestRateAcrossVersions.foreach(_.mark())
         m.deprecatedRequestRate(header.apiKey, header.apiVersion, context.clientInformation).foreach(_.mark())
         m.requestQueueTimeHist.update(Math.round(requestQueueTimeMs))
         m.localTimeHist.update(Math.round(apiLocalTimeMs))
@@ -263,7 +307,9 @@ object RequestChannel extends Logging {
         m.responseQueueTimeHist.update(Math.round(responseQueueTimeMs))
         m.responseSendTimeHist.update(Math.round(responseSendTimeMs))
         m.totalTimeHist.update(Math.round(totalTimeMs))
+        m.totalTimeBucketHist.foreach(_.update(totalTimeMs))
         m.requestBytesHist.update(sizeOfBodyInBytes)
+        m.responseBytesHist.foreach(_.update(responseBytes))
         m.messageConversionsTimeHist.foreach(_.update(Math.round(messageConversionsTimeMs)))
         m.tempMemoryBytesHist.foreach(_.update(temporaryMemoryBytes))
       }
@@ -361,9 +407,15 @@ class RequestChannel(val queueSize: Int,
                      val metricNamePrefix: String,
                      time: Time,
                      val metrics: RequestChannel.Metrics,
-                     val observer: Observer = new NoOpObserver) {
+                     val observer: Observer = new NoOpObserver,
+                     enableDequeueWatchdog: Boolean = false) {
   def this(queueSize: Int, metricNamePrefix: String, time: Time, metrics: RequestChannel.Metrics) =
-    this(queueSize, metricNamePrefix, time, metrics, new NoOpObserver)
+    this(queueSize, metricNamePrefix, time, metrics, new NoOpObserver, enableDequeueWatchdog = false)
+
+  def this(queueSize: Int, metricNamePrefix: String, time: Time, metrics: RequestChannel.Metrics,
+           observer: Observer) =
+    this(queueSize, metricNamePrefix, time, metrics, observer, enableDequeueWatchdog = false)
+
 
   import RequestChannel._
 
@@ -374,6 +426,12 @@ class RequestChannel(val queueSize: Int,
   private val requestQueueSizeMetricName = metricNamePrefix.concat(RequestQueueSizeMetric)
   private val responseQueueSizeMetricName = metricNamePrefix.concat(ResponseQueueSizeMetric)
   private val callbackQueue = new ArrayBlockingQueue[BaseRequest](queueSize)
+  @volatile var lastDequeueTimeMs: Long = Long.MaxValue
+  // SocketServer enables this only on the data-plane channel. The unprefixed name is part of the
+  // 3.0-li monitoring contract consumed by the kafka-server wrapper.
+  private val requestDequeuePollIntervalMs = if (enableDequeueWatchdog)
+    Some(metricsGroup.newHistogram("RequestDequeuePollIntervalMs"))
+  else None
 
   metricsGroup.newGauge(requestQueueSizeMetricName, () => requestQueue.size)
 
@@ -423,6 +481,8 @@ class RequestChannel(val queueSize: Int,
     updateErrorMetrics(request.header.apiKey, response.errorCounts.asScala)
     val responseSend = request.buildResponseSend(response)
     request.responseBytes = responseSend.size
+    if (metrics.legacyRequestMetricsEnabled && request.header.apiKey == ApiKeys.METADATA)
+      BrokerMetadataStats.outgoingBytesRate.mark(responseSend.size)
     sendResponse(new RequestChannel.SendResponse(
       request,
       responseSend,
@@ -489,6 +549,7 @@ class RequestChannel(val queueSize: Int,
    *  Check the callback queue and execute first if present since these
    *  requests have already waited in line. */
   def receiveRequest(timeout: Long): RequestChannel.BaseRequest = {
+    recordRequestDequeuePoll()
     val callbackRequest = callbackQueue.poll()
     if (callbackRequest != null)
       callbackRequest
@@ -502,8 +563,17 @@ class RequestChannel(val queueSize: Int,
   }
 
   /** Get the next request or block until there is one */
-  def receiveRequest(): RequestChannel.BaseRequest =
+  def receiveRequest(): RequestChannel.BaseRequest = {
+    recordRequestDequeuePoll()
     requestQueue.take()
+  }
+
+  private def recordRequestDequeuePoll(): Unit = {
+    val now = time.milliseconds()
+    if (lastDequeueTimeMs != Long.MaxValue)
+      requestDequeuePollIntervalMs.foreach(_.update(math.max(0L, now - lastDequeueTimeMs)))
+    lastDequeueTimeMs = now
+  }
 
   def updateErrorMetrics(apiKey: ApiKeys, errors: collection.Map[Errors, Integer]): Unit = {
     errors.forKeyValue { (error, count) =>
@@ -518,6 +588,7 @@ class RequestChannel(val queueSize: Int,
 
   def shutdown(): Unit = {
     clear()
+    requestDequeuePollIntervalMs.foreach(_ => metricsGroup.removeMetric("RequestDequeuePollIntervalMs"))
     metrics.close()
   }
 
@@ -538,23 +609,43 @@ object RequestMetrics {
   val verifyPartitionsInTxnMetricName: String = ApiKeys.ADD_PARTITIONS_TO_TXN.name + "Verification"
 
   val RequestsPerSec: String = "RequestsPerSec"
+  val RequestsPerSecAcrossVersions: String = "RequestsPerSecAcrossVersions"
   val DeprecatedRequestsPerSec: String = "DeprecatedRequestsPerSec"
-  private val RequestQueueTimeMs = "RequestQueueTimeMs"
-  private val LocalTimeMs = "LocalTimeMs"
-  private val RemoteTimeMs = "RemoteTimeMs"
-  private val ThrottleTimeMs = "ThrottleTimeMs"
-  private val ResponseQueueTimeMs = "ResponseQueueTimeMs"
-  private val ResponseSendTimeMs = "ResponseSendTimeMs"
-  private val TotalTimeMs = "TotalTimeMs"
-  private val RequestBytes = "RequestBytes"
+  val RequestQueueTimeMs = "RequestQueueTimeMs"
+  val LocalTimeMs = "LocalTimeMs"
+  val RemoteTimeMs = "RemoteTimeMs"
+  val ThrottleTimeMs = "ThrottleTimeMs"
+  val ResponseQueueTimeMs = "ResponseQueueTimeMs"
+  val ResponseSendTimeMs = "ResponseSendTimeMs"
+  val TotalTimeMs = "TotalTimeMs"
+  val RequestBytes = "RequestBytes"
+  val ResponseBytes = "ResponseBytes"
   val MessageConversionsTimeMs: String = "MessageConversionsTimeMs"
   val TemporaryMemoryBytes: String = "TemporaryMemoryBytes"
   val ErrorsPerSec: String = "ErrorsPerSec"
+
+  def getBucketBoundaryObjectMap[T](boundaries: Array[Int], prefix: String, postfix: String,
+                                    create: String => T, addBinNumber: Boolean): util.TreeMap[Int, T] = {
+    val result = new util.TreeMap[Int, T]
+    boundaries.indices.foreach { index =>
+      val left = boundaries(index)
+      val bin = if (addBinNumber) s"_Bin${index + 1}_" else ""
+      val name = if (index == boundaries.length - 1) s"$prefix$bin$left${postfix}Greater"
+      else s"$prefix$bin${left}To${boundaries(index + 1)}$postfix"
+      result.put(left, create(name))
+    }
+    result
+  }
+
+  def getBucketObject[T](objects: util.TreeMap[Int, T], value: Int): T =
+    if (value < objects.firstKey) objects.firstEntry.getValue else objects.floorEntry(value).getValue
 }
 
 private case class DeprecatedRequestRateKey(version: Short, clientInformation: ClientInformation)
 
-class RequestMetrics(name: String) {
+class RequestMetrics(name: String,
+                     bucketConfig: Option[KafkaConfig] = None,
+                     legacyRequestMetricsEnabled: Boolean = false) {
 
   import RequestMetrics._
 
@@ -562,6 +653,9 @@ class RequestMetrics(name: String) {
 
   val tags: util.Map[String, String] = Map("request" -> name).asJava
   private val requestRateInternal = new Pool[Short, Meter]()
+  val requestRateAcrossVersions: Option[Meter] = if (legacyRequestMetricsEnabled)
+    Some(metricsGroup.newMeter(RequestsPerSecAcrossVersions, "requests", TimeUnit.SECONDS, tags))
+  else None
   private val deprecatedRequestRateInternal = new Pool[DeprecatedRequestRateKey, Meter]()
   // time a request spent in a request queue
   val requestQueueTimeHist: Histogram = metricsGroup.newHistogram(RequestQueueTimeMs, true, tags)
@@ -577,8 +671,13 @@ class RequestMetrics(name: String) {
   // time to send the response to the requester
   val responseSendTimeHist: Histogram = metricsGroup.newHistogram(ResponseSendTimeMs, true, tags)
   val totalTimeHist: Histogram = metricsGroup.newHistogram(TotalTimeMs, true, tags)
-  // request size in bytes
+  // request and response sizes in bytes
   val requestBytesHist: Histogram = metricsGroup.newHistogram(RequestBytes, true, tags)
+  val responseBytesHist: Option[Histogram] = if (legacyRequestMetricsEnabled)
+    Some(metricsGroup.newHistogram(ResponseBytes, true, tags)) else None
+  val totalTimeBucketHist: Option[TotalTimeBuckets] = bucketConfig
+    .filter(_.totalTimeHistogramEnabledMetrics.exists(_.equalsIgnoreCase(name)))
+    .map(config => new TotalTimeBuckets(config.requestMetricsTotalTimeBuckets))
   // time for message conversions (only relevant to fetch and produce requests)
   val messageConversionsTimeHist: Option[Histogram] =
     if (name == ApiKeys.FETCH.name || name == ApiKeys.PRODUCE.name)
@@ -592,6 +691,22 @@ class RequestMetrics(name: String) {
       Some(metricsGroup.newHistogram(TemporaryMemoryBytes, true, tags))
     else
       None
+
+  final class TotalTimeBuckets(boundaries: Array[Int]) {
+    private val counters: util.TreeMap[Int, (String, Counter)] =
+      RequestMetrics.getBucketBoundaryObjectMap(boundaries, "TotalTime", "Ms", metricName =>
+        metricName -> KafkaYammerMetrics.defaultRegistry.newCounter(metricsGroup.metricName(metricName, tags)),
+        addBinNumber = true)
+
+    def update(value: Double): Unit = {
+      val bounded = math.min(Int.MaxValue.toLong, Math.round(value)).toInt
+      RequestMetrics.getBucketObject(counters, bounded)._2.inc()
+    }
+
+    def remove(): Unit = counters.values.asScala.foreach { case (metricName, _) =>
+      metricsGroup.removeMetric(metricName, tags)
+    }
+  }
 
   private val errorMeters = mutable.Map[Errors, ErrorMeter]()
   Errors.values.foreach(error => errorMeters.put(error, new ErrorMeter(name, error)))
@@ -661,11 +776,16 @@ class RequestMetrics(name: String) {
     metricsGroup.removeMetric(LocalTimeMs, tags)
     metricsGroup.removeMetric(RemoteTimeMs, tags)
     metricsGroup.removeMetric(RequestsPerSec, tags)
+    if (legacyRequestMetricsEnabled)
+      metricsGroup.removeMetric(RequestsPerSecAcrossVersions, tags)
     metricsGroup.removeMetric(ThrottleTimeMs, tags)
     metricsGroup.removeMetric(ResponseQueueTimeMs, tags)
     metricsGroup.removeMetric(TotalTimeMs, tags)
     metricsGroup.removeMetric(ResponseSendTimeMs, tags)
     metricsGroup.removeMetric(RequestBytes, tags)
+    if (legacyRequestMetricsEnabled)
+      metricsGroup.removeMetric(ResponseBytes, tags)
+    totalTimeBucketHist.foreach(_.remove())
     if (name == ApiKeys.FETCH.name || name == ApiKeys.PRODUCE.name) {
       metricsGroup.removeMetric(MessageConversionsTimeMs, tags)
       metricsGroup.removeMetric(TemporaryMemoryBytes, tags)

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -107,7 +107,7 @@ class SocketServer(val config: KafkaConfig,
   // data-plane
   private[network] val dataPlaneAcceptors = new ConcurrentHashMap[EndPoint, DataPlaneAcceptor]()
   val dataPlaneRequestChannel = new RequestChannel(maxQueuedRequests, DataPlaneAcceptor.MetricPrefix, time,
-    apiVersionManager.newRequestMetrics, observer)
+    apiVersionManager.newRequestMetrics, observer, config.liProtocolBridgeRequestChannelWatchdogActive)
   // control-plane
   private[network] var controlPlaneAcceptorOpt: Option[ControlPlaneAcceptor] = None
   val controlPlaneRequestChannelOpt: Option[RequestChannel] = config.controlPlaneListenerName.map(_ =>

--- a/core/src/main/scala/kafka/server/ApiVersionManager.scala
+++ b/core/src/main/scala/kafka/server/ApiVersionManager.scala
@@ -39,7 +39,9 @@ trait ApiVersionManager {
   def isApiEnabled(apiKey: ApiKeys, apiVersion: Short): Boolean = {
     apiKey != null && apiKey.inScope(listenerType) && apiKey.isVersionEnabled(apiVersion, enableUnstableLastVersion)
   }
-  def newRequestMetrics: RequestChannel.Metrics = new network.RequestChannel.Metrics(enabledApis)
+  protected def requestMetricsConfig: Option[KafkaConfig] = None
+  def newRequestMetrics: RequestChannel.Metrics =
+    new network.RequestChannel.Metrics(enabledApis, requestMetricsConfig)
 
   def features: FinalizedFeatures
 }
@@ -69,7 +71,8 @@ object ApiVersionManager {
              ApiKeys.LI_DELETE_FEDERATED_TOPIC_ZNODES |
              ApiKeys.LI_LIST_FEDERATED_TOPIC_ZNODES => config.liProtocolBridgeFederatedTopicsActive
         case _ => true
-      }
+      },
+      Some(config)
     )
   }
 }
@@ -152,14 +155,16 @@ class DefaultApiVersionManager(
   val enableUnstableLastVersion: Boolean,
   val zkMigrationEnabled: Boolean = false,
   val clientMetricsManager: Option[ClientMetricsManager] = None,
-  liApiEnabled: ApiKeys => Boolean = _ => false
+  liApiEnabled: ApiKeys => Boolean = _ => false,
+  override protected val requestMetricsConfig: Option[KafkaConfig] = None
 ) extends ApiVersionManager {
-
-  val enabledApis: mutable.Set[ApiKeys] = ApiKeys.apisForListener(listenerType).asScala
 
   private def isLiApiEnabled(apiKey: ApiKeys): Boolean = {
     if (apiKey == null || apiKey.id < 1000) true else liApiEnabled(apiKey)
   }
+
+  val enabledApis: mutable.Set[ApiKeys] =
+    ApiKeys.apisForListener(listenerType).asScala.filter(isLiApiEnabled)
 
   override def isApiEnabled(apiKey: ApiKeys, apiVersion: Short): Boolean =
     super.isApiEnabled(apiKey, apiVersion) && isLiApiEnabled(apiKey)

--- a/core/src/main/scala/kafka/server/BrokerMetadataStats.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataStats.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import org.apache.kafka.server.metrics.KafkaMetricsGroup
+
+import java.util.concurrent.TimeUnit
+
+/** Broker response-byte metric consumed by the LinkedIn monitoring wrapper. */
+object BrokerMetadataStats {
+  private val metricsGroup = new KafkaMetricsGroup(this.getClass)
+  val outgoingBytesRate = metricsGroup.newMeter(
+    "MetadataOutgoingBytesPerSec", "bytes", TimeUnit.SECONDS)
+}

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -75,14 +75,16 @@ object KafkaConfig {
     "li.protocol.bridge.rack.id.mapper.enable"
   val LiProtocolBridgeDynamicTopicDeletionEnableProp =
     "li.protocol.bridge.dynamic.topic.deletion.enable"
-  val LiProtocolBridgeReassignmentCancellationSafetyEnableProp =
-    "li.protocol.bridge.reassignment.cancellation.safety.enable"
-  val LiProtocolBridgeLeaderTransferEnableProp =
-    "li.protocol.bridge.leader.transfer.on.isr.shrink.enable"
   val LiProtocolBridgeProduceRequestInstrumentationEnableProp =
     "li.protocol.bridge.produce.request.instrumentation.enable"
+  val LiProtocolBridgeRequestMetricBucketsEnableProp =
+    "li.protocol.bridge.request.metric.buckets.enable"
+  val LiProtocolBridgeRequestChannelWatchdogEnableProp =
+    "li.protocol.bridge.request.channel.watchdog.enable"
   val LiProtocolBridgeMinimumLogRollEnableProp =
     "li.protocol.bridge.minimum.log.roll.enable"
+  val LiProtocolBridgeReassignmentCancellationSafetyEnableProp =
+    "li.protocol.bridge.reassignment.cancellation.safety.enable"
   val LiProtocolBridgeListOffsetsInstrumentationEnableProp =
     "li.protocol.bridge.list.offsets.instrumentation.enable"
   val LiProtocolBridgeStaticDefaultQuotasEnableProp =
@@ -91,7 +93,42 @@ object KafkaConfig {
     "li.protocol.bridge.replica.request.timeout.enable"
   val LiProtocolBridgeOffsetsTopicConfigEnableProp =
     "li.protocol.bridge.offsets.topic.config.enable"
+  val LiProtocolBridgeLeaderTransferEnableProp =
+    "li.protocol.bridge.leader.transfer.on.isr.shrink.enable"
+  val LiProtocolBridgeLegacyRequestMetricsEnableProp =
+    "li.protocol.bridge.legacy.request.metrics.enable"
+  val LiProtocolBridgeLogTruncationMetricsEnableProp =
+    "li.protocol.bridge.log.truncation.metrics.enable"
+
+  val LiProtocolBridgeEnableProps: Seq[String] = Seq(
+    LiProtocolBridgeModeEnableProp,
+    LiProtocolBridgeFollowerRecoveryEnableProp,
+    LiProtocolBridgeRecommendedElectionEnableProp,
+    LiProtocolBridgeExcludePartitionsEnableProp,
+    LiProtocolBridgeMoveControllerEnableProp,
+    LiProtocolBridgeShutdownSafetyOverrideEnableProp,
+    LiProtocolBridgePreferredControllerEnableProp,
+    LiProtocolBridgeFederatedTopicsEnableProp,
+    LiProtocolBridgeRackIdMapperEnableProp,
+    LiProtocolBridgeDynamicTopicDeletionEnableProp,
+    LiProtocolBridgeProduceRequestInstrumentationEnableProp,
+    LiProtocolBridgeRequestMetricBucketsEnableProp,
+    LiProtocolBridgeRequestChannelWatchdogEnableProp,
+    LiProtocolBridgeMinimumLogRollEnableProp,
+    LiProtocolBridgeReassignmentCancellationSafetyEnableProp,
+    LiProtocolBridgeListOffsetsInstrumentationEnableProp,
+    LiProtocolBridgeStaticDefaultQuotasEnableProp,
+    LiProtocolBridgeReplicaRequestTimeoutEnableProp,
+    LiProtocolBridgeOffsetsTopicConfigEnableProp,
+    LiProtocolBridgeLeaderTransferEnableProp,
+    LiProtocolBridgeLegacyRequestMetricsEnableProp,
+    LiProtocolBridgeLogTruncationMetricsEnableProp)
+
   val LiMinLogRollTimeMillisProp = "li.min.log.roll.ms"
+  val RequestMaxLocalTimeMsProp = "request.max.local.time.ms"
+  val HeapDumpFolderProp = "heap.dump.folder"
+  val HeapDumpTimeoutProp = "heap.dump.timeout"
+  val TotalTimeHistogramEnabledMetricsProp = "total.time.histogram.enabled.metrics"
 
   // 3.0-li operational settings consumed by the LinkedIn server wrapper.
   val ListenersProp: String = SocketServerConfigs.LISTENERS_CONFIG
@@ -171,14 +208,18 @@ object KafkaConfig {
     "Apply the configured 3.0-li rack ID mapper during automatic replica assignment."
   val LiProtocolBridgeDynamicTopicDeletionEnableDoc =
     "Read delete.topic.enable dynamically from the 3.0-li /topic_deletion_flag ZooKeeper path."
-  val LiProtocolBridgeReassignmentCancellationSafetyEnableDoc =
-    "Require enough original replicas to be alive before cancelling a reassignment."
   val LiProtocolBridgeLeaderTransferEnableDoc =
     "Transfer leadership instead of shrinking an ISR below min.insync.replicas. Requires a broker restart."
   val LiProtocolBridgeProduceRequestInstrumentationEnableDoc =
     "Log sampled stage timings for long-tail produce requests using the 3.0-li log format."
+  val LiProtocolBridgeRequestMetricBucketsEnableDoc =
+    "Expose 3.0-li request size groups and total-time bucket counters."
+  val LiProtocolBridgeRequestChannelWatchdogEnableDoc =
+    "Halt a ZooKeeper broker when request handlers stop polling the request channel."
   val LiProtocolBridgeMinimumLogRollEnableDoc =
     "Apply a lower bound to time-based log segment rolling."
+  val LiProtocolBridgeReassignmentCancellationSafetyEnableDoc =
+    "Require enough original replicas to be alive before cancelling a reassignment."
   val LiProtocolBridgeListOffsetsInstrumentationEnableDoc =
     "Track ListOffsets timestamp modes and callers using the 3.0-li metrics."
   val LiProtocolBridgeStaticDefaultQuotasEnableDoc =
@@ -187,6 +228,10 @@ object KafkaConfig {
     "Use replica.request.timeout.ms for replica fetcher network requests."
   val LiProtocolBridgeOffsetsTopicConfigEnableDoc =
     "Apply the 3.0-li max message, minimum ISR, and compaction lag settings when creating __consumer_offsets."
+  val LiProtocolBridgeLegacyRequestMetricsEnableDoc =
+    "Expose aggregate request rates and response-size histograms consumed by production monitoring."
+  val LiProtocolBridgeLogTruncationMetricsEnableDoc =
+    "Expose LinkedIn counters for messages and bytes removed by log truncation."
   val PreferredControllerDoc = "Whether this broker is eligible for preferred-controller placement."
   val AllowPreferredControllerFallbackDoc =
     "Allow a non-preferred broker to become controller when no preferred controller is available."
@@ -250,14 +295,16 @@ object KafkaConfig {
       ConfigDef.Importance.HIGH, LiProtocolBridgeRackIdMapperEnableDoc)
     .define(LiProtocolBridgeDynamicTopicDeletionEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeDynamicTopicDeletionEnableDoc)
-    .define(LiProtocolBridgeReassignmentCancellationSafetyEnableProp, ConfigDef.Type.BOOLEAN, false,
-      ConfigDef.Importance.HIGH, LiProtocolBridgeReassignmentCancellationSafetyEnableDoc)
-    .define(LiProtocolBridgeLeaderTransferEnableProp, ConfigDef.Type.BOOLEAN, false,
-      ConfigDef.Importance.HIGH, LiProtocolBridgeLeaderTransferEnableDoc)
     .define(LiProtocolBridgeProduceRequestInstrumentationEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeProduceRequestInstrumentationEnableDoc)
+    .define(LiProtocolBridgeRequestMetricBucketsEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeRequestMetricBucketsEnableDoc)
+    .define(LiProtocolBridgeRequestChannelWatchdogEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeRequestChannelWatchdogEnableDoc)
     .define(LiProtocolBridgeMinimumLogRollEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeMinimumLogRollEnableDoc)
+    .define(LiProtocolBridgeReassignmentCancellationSafetyEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeReassignmentCancellationSafetyEnableDoc)
     .define(LiProtocolBridgeListOffsetsInstrumentationEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeListOffsetsInstrumentationEnableDoc)
     .define(LiProtocolBridgeStaticDefaultQuotasEnableProp, ConfigDef.Type.BOOLEAN, false,
@@ -266,6 +313,12 @@ object KafkaConfig {
       ConfigDef.Importance.HIGH, LiProtocolBridgeReplicaRequestTimeoutEnableDoc)
     .define(LiProtocolBridgeOffsetsTopicConfigEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, LiProtocolBridgeOffsetsTopicConfigEnableDoc)
+    .define(LiProtocolBridgeLeaderTransferEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeLeaderTransferEnableDoc)
+    .define(LiProtocolBridgeLegacyRequestMetricsEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeLegacyRequestMetricsEnableDoc)
+    .define(LiProtocolBridgeLogTruncationMetricsEnableProp, ConfigDef.Type.BOOLEAN, false,
+      ConfigDef.Importance.HIGH, LiProtocolBridgeLogTruncationMetricsEnableDoc)
     .define(PreferredControllerProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, PreferredControllerDoc)
     .define(AllowPreferredControllerFallbackProp, ConfigDef.Type.BOOLEAN, true,
@@ -286,18 +339,31 @@ object KafkaConfig {
       ConfigDef.Importance.HIGH, "Rack ID mapper class used for automatic replica assignment.")
     .define(LiZookeeperPaginationEnableProp, ConfigDef.Type.BOOLEAN, false,
       ConfigDef.Importance.HIGH, "Use paginated reads for ZooKeeper paths that may exceed the response limit.")
-    .define(LiNumControllerInitThreadsProp, ConfigDef.Type.INT, 1, ConfigDef.Range.atLeast(1),
-      ConfigDef.Importance.HIGH, "Number of ZooKeeper clients used to load controller state in parallel.")
-    .define(LiMinOriginalAliveReplicasProp, ConfigDef.Type.INT, 2, ConfigDef.Range.atLeast(1),
-      ConfigDef.Importance.HIGH, "Minimum live original replicas required to cancel a reassignment.")
     .define(LiLongTailProduceRequestLogThresholdMsProp, ConfigDef.Type.LONG, 60000L,
       ConfigDef.Range.atLeast(0), ConfigDef.Importance.MEDIUM,
       "Do not log produce request instrumentation below this total-time threshold.")
     .define(LiLongTailProduceRequestLogRatioProp, ConfigDef.Type.DOUBLE, 0.0,
       ConfigDef.Range.between(0.0, 1.0), ConfigDef.Importance.MEDIUM,
       "Ratio of long-tail produce requests to log after applying the threshold.")
+    .define(RequestMetricsSizeBucketsProp, ConfigDef.Type.STRING, "0,1,10,50,100",
+      ConfigDef.Importance.LOW, "Request and response size bucket boundaries in MiB.")
+    .define(RequestMetricsTotalTimeBucketsProp, ConfigDef.Type.STRING,
+      "0,5,10,20,30,40,50,100,200,300,500,1000,5000,15000",
+      ConfigDef.Importance.LOW, "Request total-time bucket boundaries in milliseconds.")
+    .define(TotalTimeHistogramEnabledMetricsProp, ConfigDef.Type.LIST,
+      java.util.Arrays.asList("Produce0To1MbAcks1", "Produce0To1MbAcksAll", "FetchConsumer0To1Mb"),
+      ConfigDef.Importance.LOW, "Request metric groups that expose total-time bucket counters.")
+    .define(RequestMaxLocalTimeMsProp, ConfigDef.Type.LONG, Long.MaxValue,
+      ConfigDef.Range.atLeast(1), ConfigDef.Importance.HIGH,
+      "Maximum interval without a request-channel poll before the broker halts.")
+    .define(HeapDumpFolderProp, ConfigDef.Type.STRING, System.getProperty("java.io.tmpdir"),
+      ConfigDef.Importance.MEDIUM, "Directory used for a watchdog heap dump before halting.")
+    .define(HeapDumpTimeoutProp, ConfigDef.Type.LONG, 120000L, ConfigDef.Range.atLeast(0),
+      ConfigDef.Importance.MEDIUM, "Maximum time to wait for a watchdog heap dump.")
     .define(LiMinLogRollTimeMillisProp, ConfigDef.Type.LONG, 0L, ConfigDef.Range.atLeast(0),
       ConfigDef.Importance.MEDIUM, "Minimum interval before a time-based log segment roll.")
+    .define(LiMinOriginalAliveReplicasProp, ConfigDef.Type.INT, 2, ConfigDef.Range.atLeast(1),
+      ConfigDef.Importance.HIGH, "Minimum live original replicas required to cancel a reassignment.")
     .define(ProducerQuotaBytesPerSecondDefaultProp, ConfigDef.Type.LONG, Long.MaxValue,
       ConfigDef.Range.atLeast(1), ConfigDef.Importance.HIGH, "Static default producer quota in bytes per second.")
     .define(ConsumerQuotaBytesPerSecondDefaultProp, ConfigDef.Type.LONG, Long.MaxValue,
@@ -310,6 +376,8 @@ object KafkaConfig {
       ConfigDef.Range.atLeast(1), ConfigDef.Importance.HIGH, "Minimum ISR for __consumer_offsets.")
     .define(OffsetsTopicMinCompactionLagMsProp, ConfigDef.Type.LONG, 0L,
       ConfigDef.Range.atLeast(0), ConfigDef.Importance.HIGH, "Minimum compaction lag for __consumer_offsets.")
+    .define(LiNumControllerInitThreadsProp, ConfigDef.Type.INT, 1, ConfigDef.Range.atLeast(1),
+      ConfigDef.Importance.HIGH, "Number of ZooKeeper clients used to load controller state in parallel.")
 
   def configNames: Seq[String] = configDef.names.asScala.toBuffer.sorted
   private[server] def defaultValues: Map[String, _] = configDef.defaultValues.asScala
@@ -427,14 +495,16 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     getBoolean(KafkaConfig.LiProtocolBridgeRackIdMapperEnableProp)
   def liProtocolBridgeDynamicTopicDeletionEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgeDynamicTopicDeletionEnableProp)
-  def liProtocolBridgeReassignmentCancellationSafetyEnable: Boolean =
-    getBoolean(KafkaConfig.LiProtocolBridgeReassignmentCancellationSafetyEnableProp)
-  def liProtocolBridgeLeaderTransferEnable: Boolean =
-    getBoolean(KafkaConfig.LiProtocolBridgeLeaderTransferEnableProp)
   def liProtocolBridgeProduceRequestInstrumentationEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgeProduceRequestInstrumentationEnableProp)
+  def liProtocolBridgeRequestMetricBucketsEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeRequestMetricBucketsEnableProp)
+  def liProtocolBridgeRequestChannelWatchdogEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeRequestChannelWatchdogEnableProp)
   def liProtocolBridgeMinimumLogRollEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgeMinimumLogRollEnableProp)
+  def liProtocolBridgeReassignmentCancellationSafetyEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeReassignmentCancellationSafetyEnableProp)
   def liProtocolBridgeListOffsetsInstrumentationEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgeListOffsetsInstrumentationEnableProp)
   def liProtocolBridgeStaticDefaultQuotasEnable: Boolean =
@@ -443,6 +513,12 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     getBoolean(KafkaConfig.LiProtocolBridgeReplicaRequestTimeoutEnableProp)
   def liProtocolBridgeOffsetsTopicConfigEnable: Boolean =
     getBoolean(KafkaConfig.LiProtocolBridgeOffsetsTopicConfigEnableProp)
+  def liProtocolBridgeLeaderTransferEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeLeaderTransferEnableProp)
+  def liProtocolBridgeLegacyRequestMetricsEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeLegacyRequestMetricsEnableProp)
+  def liProtocolBridgeLogTruncationMetricsEnable: Boolean =
+    getBoolean(KafkaConfig.LiProtocolBridgeLogTruncationMetricsEnableProp)
 
   def liProtocolBridgeModeActive: Boolean = processRoles.isEmpty && liProtocolBridgeModeEnable
   def liProtocolBridgeFollowerRecoveryActive: Boolean =
@@ -463,14 +539,16 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     processRoles.isEmpty && liProtocolBridgeRackIdMapperEnable
   def liProtocolBridgeDynamicTopicDeletionActive: Boolean =
     processRoles.isEmpty && liProtocolBridgeDynamicTopicDeletionEnable
-  def liProtocolBridgeReassignmentCancellationSafetyActive: Boolean =
-    processRoles.isEmpty && liProtocolBridgeReassignmentCancellationSafetyEnable
-  def liProtocolBridgeLeaderTransferActive: Boolean =
-    processRoles.isEmpty && liProtocolBridgeLeaderTransferEnable
   def liProtocolBridgeProduceRequestInstrumentationActive: Boolean =
     processRoles.isEmpty && liProtocolBridgeProduceRequestInstrumentationEnable
+  def liProtocolBridgeRequestMetricBucketsActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeRequestMetricBucketsEnable
+  def liProtocolBridgeRequestChannelWatchdogActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeRequestChannelWatchdogEnable
   def liProtocolBridgeMinimumLogRollActive: Boolean =
     processRoles.isEmpty && liProtocolBridgeMinimumLogRollEnable
+  def liProtocolBridgeReassignmentCancellationSafetyActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeReassignmentCancellationSafetyEnable
   def liProtocolBridgeListOffsetsInstrumentationActive: Boolean =
     processRoles.isEmpty && liProtocolBridgeListOffsetsInstrumentationEnable
   def liProtocolBridgeStaticDefaultQuotasActive: Boolean =
@@ -479,6 +557,12 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     processRoles.isEmpty && liProtocolBridgeReplicaRequestTimeoutEnable
   def liProtocolBridgeOffsetsTopicConfigActive: Boolean =
     processRoles.isEmpty && liProtocolBridgeOffsetsTopicConfigEnable
+  def liProtocolBridgeLeaderTransferActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeLeaderTransferEnable
+  def liProtocolBridgeLegacyRequestMetricsActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeLegacyRequestMetricsEnable
+  def liProtocolBridgeLogTruncationMetricsActive: Boolean =
+    processRoles.isEmpty && liProtocolBridgeLogTruncationMetricsEnable
 
   lazy val rackIdMapperForReplicaAssignment: RackAwareReplicaAssignmentRackIdMapper = {
     val className = getString(KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp)
@@ -498,7 +582,18 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   def observerClassName: String = getString(KafkaConfig.ObserverClassNameProp)
   def observerShutdownTimeoutMs: Long = getLong(KafkaConfig.ObserverShutdownTimeoutMsProp)
   def liZookeeperPaginationEnable: Boolean = getBoolean(KafkaConfig.LiZookeeperPaginationEnableProp)
-  def liNumControllerInitThreads: Int = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
+  def longTailProduceRequestLogThresholdMs: Long =
+    getLong(KafkaConfig.LiLongTailProduceRequestLogThresholdMsProp)
+  def longTailProduceRequestLogRatio: Double =
+    getDouble(KafkaConfig.LiLongTailProduceRequestLogRatioProp)
+  def requestMetricsSizeBuckets: Array[Int] = parseIntArray(KafkaConfig.RequestMetricsSizeBucketsProp)
+  def requestMetricsTotalTimeBuckets: Array[Int] = parseIntArray(KafkaConfig.RequestMetricsTotalTimeBucketsProp)
+  def totalTimeHistogramEnabledMetrics: Seq[String] =
+    getList(KafkaConfig.TotalTimeHistogramEnabledMetricsProp).asScala.toSeq
+  def requestMaxLocalTimeMs: Long = getLong(KafkaConfig.RequestMaxLocalTimeMsProp)
+  def heapDumpFolder: java.io.File = new java.io.File(getString(KafkaConfig.HeapDumpFolderProp))
+  def heapDumpTimeout: Long = getLong(KafkaConfig.HeapDumpTimeoutProp)
+  def liMinLogRollTimeMillis: Long = getLong(KafkaConfig.LiMinLogRollTimeMillisProp)
   def liMinOriginalAliveReplicas: Int = getInt(KafkaConfig.LiMinOriginalAliveReplicasProp)
   def producerQuotaBytesPerSecondDefault: Long = getLong(KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp)
   def consumerQuotaBytesPerSecondDefault: Long = getLong(KafkaConfig.ConsumerQuotaBytesPerSecondDefaultProp)
@@ -508,11 +603,23 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   def offsetsTopicMaxMessageBytes: Int = getInt(KafkaConfig.OffsetsTopicMaxMessageBytesProp)
   def offsetsTopicMinInSyncReplicas: Int = getInt(KafkaConfig.OffsetsTopicMinInSyncReplicasProp)
   def offsetsTopicMinCompactionLagMs: Long = getLong(KafkaConfig.OffsetsTopicMinCompactionLagMsProp)
-  def longTailProduceRequestLogThresholdMs: Long =
-    getLong(KafkaConfig.LiLongTailProduceRequestLogThresholdMsProp)
-  def longTailProduceRequestLogRatio: Double =
-    getDouble(KafkaConfig.LiLongTailProduceRequestLogRatioProp)
-  def liMinLogRollTimeMillis: Long = getLong(KafkaConfig.LiMinLogRollTimeMillisProp)
+  private def parseIntArray(name: String): Array[Int] = {
+    val value = getString(name)
+    val entries = value.split(',').map(_.trim).filter(_.nonEmpty)
+    if (entries.isEmpty)
+      throw new ConfigException(name, value, "must contain at least one integer")
+    val boundaries = try entries.map(_.toInt)
+    catch {
+      case _: NumberFormatException =>
+        throw new ConfigException(name, value, "must be a comma-separated list of integers")
+    }
+    val notStrictlyIncreasing = boundaries.zip(boundaries.drop(1))
+      .exists { case (left, right) => left >= right }
+    if (boundaries.exists(_ < 0) || notStrictlyIncreasing)
+      throw new ConfigException(name, value, "must contain non-negative integers in strictly increasing order")
+    boundaries
+  }
+  def liNumControllerInitThreads: Int = getInt(KafkaConfig.LiNumControllerInitThreadsProp)
   def maintenanceBrokerList: Set[Int] = {
     val value = getString(KafkaConfig.MaintenanceBrokerListProp)
     try value.split(',').iterator.map(_.trim).filter(_.nonEmpty).map(_.toInt).toSet
@@ -1461,6 +1568,8 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
     logProps.put(TopicConfig.SEGMENT_JITTER_MS_CONFIG, logRollTimeJitterMillis)
     logProps.put(org.apache.kafka.storage.internals.log.LogConfig.LI_MIN_SEGMENT_MS_CONFIG,
       java.lang.Long.valueOf(if (liProtocolBridgeMinimumLogRollActive) liMinLogRollTimeMillis else 0L))
+    logProps.put(org.apache.kafka.storage.internals.log.LogConfig.LI_LOG_TRUNCATION_METRICS_CONFIG,
+      java.lang.Boolean.valueOf(liProtocolBridgeLogTruncationMetricsActive))
     logProps.put(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG, logIndexSizeMaxBytes)
     logProps.put(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG, logFlushIntervalMessages)
     logProps.put(TopicConfig.FLUSH_MS_CONFIG, logFlushIntervalMs)

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -245,11 +245,15 @@ class KafkaRequestHandlerPool(
   }
 }
 
-class BrokerTopicStats(remoteStorageEnabled: Boolean = false) extends Logging {
+class BrokerTopicStats(remoteStorageEnabled: Boolean = false,
+                       legacyMetricsEnabled: Boolean = false) extends Logging {
 
-  private val valueFactory = (k: String) => new BrokerTopicMetrics(k, remoteStorageEnabled)
+  def this() = this(false, false)
+  def this(remoteStorageEnabled: Boolean) = this(remoteStorageEnabled, false)
+
+  private val valueFactory = (k: String) => new BrokerTopicMetrics(k, remoteStorageEnabled, legacyMetricsEnabled)
   private val stats = new Pool[String, BrokerTopicMetrics](Some(valueFactory))
-  val allTopicsStats = new BrokerTopicMetrics(remoteStorageEnabled)
+  val allTopicsStats = new BrokerTopicMetrics(remoteStorageEnabled, legacyMetricsEnabled)
 
   def isTopicStatsExisted(topic: String): Boolean =
     stats.contains(topic)
@@ -286,7 +290,9 @@ class BrokerTopicStats(remoteStorageEnabled: Boolean = false) extends Logging {
     val topicMetrics = topicStats(topic)
     if (topicMetrics != null) {
       topicMetrics.closeMetric(BrokerTopicMetrics.MESSAGE_IN_PER_SEC)
+      topicMetrics.closeMetric(BrokerTopicMetrics.MESSAGES_IN_TOTAL)
       topicMetrics.closeMetric(BrokerTopicMetrics.BYTES_IN_PER_SEC)
+      topicMetrics.closeMetric(BrokerTopicMetrics.BYTES_IN_TOTAL)
       topicMetrics.closeMetric(BrokerTopicMetrics.BYTES_REJECTED_PER_SEC)
       topicMetrics.closeMetric(BrokerTopicMetrics.FAILED_PRODUCE_REQUESTS_PER_SEC)
       topicMetrics.closeMetric(BrokerTopicMetrics.TOTAL_PRODUCE_REQUESTS_PER_SEC)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -43,7 +43,7 @@ import org.apache.kafka.common.requests.{ControlledShutdownRequest, ControlledSh
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.security.{JaasContext, JaasUtils}
-import org.apache.kafka.common.utils.{AppInfoParser, LogContext, Time, Utils}
+import org.apache.kafka.common.utils.{AppInfoParser, LogContext, PoisonPill, Time, Utils}
 import org.apache.kafka.common.{Endpoint, Node, TopicPartition}
 import org.apache.kafka.coordinator.group.GroupCoordinator
 import org.apache.kafka.image.loader.metrics.MetadataLoaderMetrics
@@ -108,6 +108,9 @@ object KafkaServer {
     preferred ++ federated
   }
 
+  private[server] def requestChannelWatchdogIntervalMs(requestMaxLocalTimeMs: Long): Long =
+    math.max(1L, math.min(10000L, requestMaxLocalTimeMs / 2L))
+
   val MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS: Long = 120000
 }
 
@@ -148,6 +151,7 @@ class KafkaServer(
     this(config, time, threadNamePrefix, enableForwarding = false, kafkaActions = NoOpKafkaActions)
 
   private val startupComplete = new AtomicBoolean(false)
+  private val liProtocolBridgeMetrics = new LiProtocolBridgeMetrics(config)
   private val isShuttingDown = new AtomicBoolean(false)
   private val isStartingUp = new AtomicBoolean(false)
 
@@ -214,6 +218,8 @@ class KafkaServer(
 
   private var _clusterId: String = _
   @volatile private var _brokerTopicStats: BrokerTopicStats = _
+  private var requestChannelPoisonPill: PoisonPill = _
+  private var healthCheckScheduler: KafkaScheduler = _
 
   private var _featureChangeListener: FinalizedFeatureChangeListener = _
 
@@ -309,15 +315,20 @@ class KafkaServer(
         kafkaYammerMetrics = KafkaYammerMetrics.INSTANCE
         kafkaYammerMetrics.configure(config.originals)
         metrics = Server.initializeMetrics(config, time, clusterId)
+        if (config.liProtocolBridgeRequestChannelWatchdogActive)
+          requestChannelPoisonPill = new PoisonPill(metrics)
         createCurrentControllerIdMetric()
 
         /* register broker metrics */
-        _brokerTopicStats = new BrokerTopicStats(config.remoteLogManagerConfig.isRemoteStorageSystemEnabled())
+        _brokerTopicStats = new BrokerTopicStats(
+          config.remoteLogManagerConfig.isRemoteStorageSystemEnabled(),
+          config.liProtocolBridgeLegacyRequestMetricsActive)
 
         quotaManagers = QuotaFactory.instantiate(config, metrics, time, threadNamePrefix.getOrElse(""))
         KafkaBroker.notifyClusterListeners(clusterId, kafkaMetricsReporters ++ metrics.reporters.asScala)
 
-        logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)
+        logDirFailureChannel = new LogDirFailureChannel(
+          config.logDirs.size, config.liProtocolBridgeLegacyRequestMetricsActive)
 
         // Make sure all storage directories have meta.properties files.
         val metaPropsEnsemble = {
@@ -417,6 +428,22 @@ class KafkaServer(
         // Note that we allow the use of KRaft mode controller APIs when forwarding is enabled
         // so that the Envelope request is exposed. This is only used in testing currently.
         socketServer = new SocketServer(config, metrics, time, credentialProvider, apiVersionManager, observer)
+        if (config.liProtocolBridgeRequestChannelWatchdogActive) {
+          healthCheckScheduler = new KafkaScheduler(1, true, "kafka-healthcheck-scheduler-")
+          healthCheckScheduler.startup()
+          val watchdogIntervalMs = KafkaServer.requestChannelWatchdogIntervalMs(config.requestMaxLocalTimeMs)
+          healthCheckScheduler.schedule("halt-broker-if-request-channel-stalls", () => {
+            val lastDequeueMs = socketServer.dataPlaneRequestChannel.lastDequeueTimeMs
+            if (lastDequeueMs != Long.MaxValue) {
+              val elapsedMs = math.max(0L, time.milliseconds() - lastDequeueMs)
+              requestChannelPoisonPill.recordTimeSinceLastDequeue(elapsedMs)
+              if (elapsedMs > config.requestMaxLocalTimeMs) {
+                fatal(s"No request handler has polled the request channel for $elapsedMs ms; halting broker")
+                requestChannelPoisonPill.die(config.heapDumpFolder, config.heapDumpTimeout)
+              }
+            }
+          }, watchdogIntervalMs, watchdogIntervalMs)
+        }
 
         // Start alter partition manager based on the IBP version
         alterPartitionManager = if (config.interBrokerProtocolVersion.isAlterPartitionSupported) {
@@ -1066,6 +1093,8 @@ class KafkaServer(
          * not flush the remaining partitions or write the clean shutdown marker. Ultimately, the
          * broker would have to take hours to recover the log during restart.
          */
+        if (healthCheckScheduler != null)
+          CoreUtils.swallow(healthCheckScheduler.shutdown(), this)
         if (kafkaScheduler != null)
           CoreUtils.swallow(kafkaScheduler.shutdown(), this)
 
@@ -1103,6 +1132,8 @@ class KafkaServer(
 
         if (logManager != null)
           CoreUtils.swallow(logManager.shutdown(), this)
+        if (logDirFailureChannel != null)
+          CoreUtils.swallow(logDirFailureChannel.close(), this)
 
         if (kafkaController != null)
           CoreUtils.swallow(kafkaController.shutdown(), this)
@@ -1133,6 +1164,7 @@ class KafkaServer(
           CoreUtils.swallow(metrics.close(), this)
         if (brokerTopicStats != null)
           CoreUtils.swallow(brokerTopicStats.close(), this)
+        CoreUtils.swallow(liProtocolBridgeMetrics.close(), this)
 
         // Clear all reconfigurable instances stored in DynamicBrokerConfig
         config.dynamicConfig.clear()

--- a/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
+++ b/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
@@ -32,22 +32,28 @@ object LiProtocolBridgeMetrics {
   val RackIdMapperEnabled = "RackIdMapperEnabled"
   val ZookeeperPaginationEnabled = "ZookeeperPaginationEnabled"
   val DynamicTopicDeletionEnabled = "DynamicTopicDeletionEnabled"
-  val ReassignmentCancellationSafetyEnabled = "ReassignmentCancellationSafetyEnabled"
-  val LeaderTransferEnabled = "LeaderTransferEnabled"
+  val ControllerInitializationThreads = "ControllerInitializationThreads"
   val ProduceRequestInstrumentationEnabled = "ProduceRequestInstrumentationEnabled"
+  val RequestMetricBucketsEnabled = "RequestMetricBucketsEnabled"
+  val RequestChannelWatchdogEnabled = "RequestChannelWatchdogEnabled"
   val MinimumLogRollEnabled = "MinimumLogRollEnabled"
+  val ReassignmentCancellationSafetyEnabled = "ReassignmentCancellationSafetyEnabled"
   val ListOffsetsInstrumentationEnabled = "ListOffsetsInstrumentationEnabled"
   val StaticDefaultQuotasEnabled = "StaticDefaultQuotasEnabled"
   val ReplicaRequestTimeoutEnabled = "ReplicaRequestTimeoutEnabled"
   val OffsetsTopicConfigEnabled = "OffsetsTopicConfigEnabled"
-  val ControllerInitializationThreads = "ControllerInitializationThreads"
+  val LeaderTransferEnabled = "LeaderTransferEnabled"
+  val LegacyRequestMetricsEnabled = "LegacyRequestMetricsEnabled"
+  val LogTruncationMetricsEnabled = "LogTruncationMetricsEnabled"
   val MetricNames: Seq[String] = Seq(ModeEnabled, FollowerRecoveryEnabled,
     RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled, MoveControllerEnabled,
     ShutdownSafetyOverrideEnabled, PreferredControllerEnabled, FederatedTopicsEnabled,
     RackIdMapperEnabled, ZookeeperPaginationEnabled, DynamicTopicDeletionEnabled,
-    ReassignmentCancellationSafetyEnabled, LeaderTransferEnabled, ProduceRequestInstrumentationEnabled,
-    MinimumLogRollEnabled, ListOffsetsInstrumentationEnabled, StaticDefaultQuotasEnabled,
-    ReplicaRequestTimeoutEnabled, OffsetsTopicConfigEnabled, ControllerInitializationThreads)
+    ControllerInitializationThreads, ProduceRequestInstrumentationEnabled,
+    RequestMetricBucketsEnabled, RequestChannelWatchdogEnabled, MinimumLogRollEnabled,
+    ReassignmentCancellationSafetyEnabled, ListOffsetsInstrumentationEnabled,
+    StaticDefaultQuotasEnabled, ReplicaRequestTimeoutEnabled, OffsetsTopicConfigEnabled,
+    LeaderTransferEnabled, LegacyRequestMetricsEnabled, LogTruncationMetricsEnabled)
 }
 
 /** Exposes the effective value of every 3.0-li compatibility flag on each ZooKeeper broker. */
@@ -63,7 +69,7 @@ class LiProtocolBridgeMetrics(config: KafkaConfig) extends AutoCloseable {
   metricsGroup.newGauge(RecommendedLeaderElectionEnabled,
     () => enabled(config.liProtocolBridgeRecommendedElectionActive), tags)
   metricsGroup.newGauge(ExcludePartitionsEnabled,
-    () => enabled(config.liProtocolBridgeExcludePartitionsEnable), tags)
+    () => enabled(config.liProtocolBridgeExcludePartitionsActive), tags)
   metricsGroup.newGauge(MoveControllerEnabled,
     () => enabled(config.liProtocolBridgeMoveControllerActive), tags)
   metricsGroup.newGauge(ShutdownSafetyOverrideEnabled,
@@ -78,14 +84,18 @@ class LiProtocolBridgeMetrics(config: KafkaConfig) extends AutoCloseable {
     () => enabled(config.liZookeeperPaginationEnable), tags)
   metricsGroup.newGauge(DynamicTopicDeletionEnabled,
     () => enabled(config.liProtocolBridgeDynamicTopicDeletionActive), tags)
-  metricsGroup.newGauge(ReassignmentCancellationSafetyEnabled,
-    () => enabled(config.liProtocolBridgeReassignmentCancellationSafetyActive), tags)
-  metricsGroup.newGauge(LeaderTransferEnabled,
-    () => enabled(config.liProtocolBridgeLeaderTransferActive), tags)
+  metricsGroup.newGauge(ControllerInitializationThreads,
+    () => config.liNumControllerInitThreads, tags)
   metricsGroup.newGauge(ProduceRequestInstrumentationEnabled,
     () => enabled(config.liProtocolBridgeProduceRequestInstrumentationActive), tags)
+  metricsGroup.newGauge(RequestMetricBucketsEnabled,
+    () => enabled(config.liProtocolBridgeRequestMetricBucketsActive), tags)
+  metricsGroup.newGauge(RequestChannelWatchdogEnabled,
+    () => enabled(config.liProtocolBridgeRequestChannelWatchdogActive), tags)
   metricsGroup.newGauge(MinimumLogRollEnabled,
     () => enabled(config.liProtocolBridgeMinimumLogRollActive), tags)
+  metricsGroup.newGauge(ReassignmentCancellationSafetyEnabled,
+    () => enabled(config.liProtocolBridgeReassignmentCancellationSafetyActive), tags)
   metricsGroup.newGauge(ListOffsetsInstrumentationEnabled,
     () => enabled(config.liProtocolBridgeListOffsetsInstrumentationActive), tags)
   metricsGroup.newGauge(StaticDefaultQuotasEnabled,
@@ -94,8 +104,12 @@ class LiProtocolBridgeMetrics(config: KafkaConfig) extends AutoCloseable {
     () => enabled(config.liProtocolBridgeReplicaRequestTimeoutActive), tags)
   metricsGroup.newGauge(OffsetsTopicConfigEnabled,
     () => enabled(config.liProtocolBridgeOffsetsTopicConfigActive), tags)
-  metricsGroup.newGauge(ControllerInitializationThreads,
-    () => config.liNumControllerInitThreads, tags)
+  metricsGroup.newGauge(LeaderTransferEnabled,
+    () => enabled(config.liProtocolBridgeLeaderTransferActive), tags)
+  metricsGroup.newGauge(LegacyRequestMetricsEnabled,
+    () => enabled(config.liProtocolBridgeLegacyRequestMetricsActive), tags)
+  metricsGroup.newGauge(LogTruncationMetricsEnabled,
+    () => enabled(config.liProtocolBridgeLogTruncationMetricsActive), tags)
 
   private def enabled(value: Boolean): Int = if (value) 1 else 0
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -65,7 +65,7 @@ import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, Fetc
 import java.io.File
 import java.nio.file.{Files, Paths}
 import java.util
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.{CompletableFuture, Future, RejectedExecutionException, TimeUnit}
 import java.util.{Collections, Optional, OptionalInt, OptionalLong}
@@ -202,6 +202,8 @@ object ReplicaManager {
   private val IsrExpandsPerSecMetricName = "IsrExpandsPerSec"
   private val IsrShrinksPerSecMetricName = "IsrShrinksPerSec"
   private val FailedIsrUpdatesPerSecMetricName = "FailedIsrUpdatesPerSec"
+  private val OneAboveMinIsrPartitionCountMetricName = "OneAboveMinIsrPartitionCount"
+  private val NumLogDirFailureHandlerExceptionsMetricName = "NumLogDirFailureHandlerExceptions"
 
   private[server] val GaugeMetricNames = Set(
     LeaderCountMetricName,
@@ -315,6 +317,7 @@ class ReplicaManager(val config: KafkaConfig,
   protected val stateChangeLogger = new StateChangeLogger(localBrokerId, inControllerContext = false, None)
 
   private var logDirFailureHandler: LogDirFailureHandler = _
+  private val numLogDirFailureHandlerExceptions = new AtomicLong(0L)
 
   private class LogDirFailureHandler(name: String, haltBrokerOnDirFailure: Boolean) extends ShutdownableThread(name) {
     override def doWork(): Unit = {
@@ -323,7 +326,12 @@ class ReplicaManager(val config: KafkaConfig,
         fatal(s"Halting broker because dir $newOfflineLogDir is offline")
         Exit.halt(1)
       }
-      handleLogDirFailure(newOfflineLogDir)
+      try handleLogDirFailure(newOfflineLogDir)
+      catch {
+        case error: Throwable =>
+          numLogDirFailureHandlerExceptions.incrementAndGet()
+          throw error
+      }
     }
   }
 
@@ -337,6 +345,12 @@ class ReplicaManager(val config: KafkaConfig,
   metricsGroup.newGauge(UnderReplicatedPartitionsMetricName, () => underReplicatedPartitionCount)
   metricsGroup.newGauge(UnderMinIsrPartitionCountMetricName, () => leaderPartitionsIterator.count(_.isUnderMinIsr))
   metricsGroup.newGauge(AtMinIsrPartitionCountMetricName, () => leaderPartitionsIterator.count(_.isAtMinIsr))
+  if (config.liProtocolBridgeLegacyRequestMetricsActive) {
+    metricsGroup.newGauge(ReplicaManager.OneAboveMinIsrPartitionCountMetricName,
+      () => leaderPartitionsIterator.count(_.isOneAboveMinIsr))
+    metricsGroup.newGauge(ReplicaManager.NumLogDirFailureHandlerExceptionsMetricName,
+      () => numLogDirFailureHandlerExceptions.get())
+  }
   metricsGroup.newGauge(ReassigningPartitionsMetricName, () => reassigningPartitionsCount)
   metricsGroup.newGauge(PartitionsWithLateTransactionsCountMetricName, () => lateTransactionsCount)
   metricsGroup.newGauge(ProducerIdCountMetricName, () => producerIdCount)
@@ -1442,10 +1456,10 @@ class ReplicaManager(val config: KafkaConfig,
           val numAppendedMessages = info.numMessages
 
           // update stats for successfully appended bytes and messages as bytesInRate and messageInRate
-          brokerTopicStats.topicStats(topicPartition.topic).bytesInRate.mark(records.sizeInBytes)
-          brokerTopicStats.allTopicsStats.bytesInRate.mark(records.sizeInBytes)
-          brokerTopicStats.topicStats(topicPartition.topic).messagesInRate.mark(numAppendedMessages)
-          brokerTopicStats.allTopicsStats.messagesInRate.mark(numAppendedMessages)
+          brokerTopicStats.topicStats(topicPartition.topic).markBytesIn(records.sizeInBytes)
+          brokerTopicStats.allTopicsStats.markBytesIn(records.sizeInBytes)
+          brokerTopicStats.topicStats(topicPartition.topic).markMessagesIn(numAppendedMessages)
+          brokerTopicStats.allTopicsStats.markMessagesIn(numAppendedMessages)
 
           if (traceEnabled)
             trace(s"${records.sizeInBytes} written to log $topicPartition beginning at offset " +
@@ -2568,6 +2582,10 @@ class ReplicaManager(val config: KafkaConfig,
 
   def removeMetrics(): Unit = {
     ReplicaManager.MetricNames.foreach(metricsGroup.removeMetric)
+    if (config.liProtocolBridgeLegacyRequestMetricsActive) {
+      metricsGroup.removeMetric(ReplicaManager.OneAboveMinIsrPartitionCountMetricName)
+      metricsGroup.removeMetric(ReplicaManager.NumLogDirFailureHandlerExceptionsMetricName)
+    }
   }
 
   def beginControlledShutdown(): Unit = {

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1287,6 +1287,7 @@ class PartitionTest extends AbstractPartitionTest {
     val leaderEpoch = 8
 
     assertFalse(partition.isAtMinIsr)
+    assertFalse(partition.isOneAboveMinIsr)
     // Make isr set to only have leader to trigger AtMinIsr (default min isr config is 1)
     val leaderState = new LeaderAndIsrPartitionState()
       .setControllerEpoch(controllerEpoch)
@@ -1298,6 +1299,12 @@ class PartitionTest extends AbstractPartitionTest {
       .setIsNew(true)
     partition.makeLeader(leaderState, offsetCheckpoints, None)
     assertTrue(partition.isAtMinIsr)
+    assertFalse(partition.isOneAboveMinIsr)
+
+    leaderState.setLeaderEpoch(leaderEpoch + 1).setIsr(List[Integer](leader, follower1).asJava)
+    partition.makeLeader(leaderState, offsetCheckpoints, None)
+    assertFalse(partition.isAtMinIsr)
+    assertTrue(partition.isOneAboveMinIsr)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/controller/ControllerContextTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerContextTest.scala
@@ -58,6 +58,18 @@ class ControllerContextTest {
   }
 
   @Test
+  def testTopicNameLengthTotalTracksTopicChanges(): Unit = {
+    context.setAllTopics(Set("a", "orders"))
+    assertEquals(7L, context.sumOfTopicNameLengths)
+
+    context.removeTopic("orders")
+    assertEquals(1L, context.sumOfTopicNameLengths)
+
+    context.resetContext()
+    assertEquals(0L, context.sumOfTopicNameLengths)
+  }
+
+  @Test
   def testUpdatePartitionFullReplicaAssignmentUpdatesReplicaAssignment(): Unit = {
     val initialReplicas = Seq(4)
     context.updatePartitionFullReplicaAssignment(tp1, ReplicaAssignment(initialReplicas))

--- a/core/src/test/scala/unit/kafka/network/LegacyRequestMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/network/LegacyRequestMetricsTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.network
+
+import org.junit.jupiter.api.Assertions.{assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+
+class LegacyRequestMetricsTest {
+  @Test
+  def testAggregateRateAndResponseBytesRequireCompatibilityGate(): Unit = {
+    val disabled = new RequestMetrics("LegacyDisabled")
+    try {
+      assertTrue(disabled.requestRateAcrossVersions.isEmpty)
+      assertTrue(disabled.responseBytesHist.isEmpty)
+    } finally disabled.removeMetrics()
+
+    val enabled = new RequestMetrics("LegacyEnabled", legacyRequestMetricsEnabled = true)
+    try {
+      assertTrue(enabled.requestRateAcrossVersions.isDefined)
+      assertTrue(enabled.responseBytesHist.isDefined)
+    } finally enabled.removeMetrics()
+
+    assertFalse(enabled.requestRateAcrossVersions.isEmpty)
+  }
+}

--- a/core/src/test/scala/unit/kafka/network/MetadataOutgoingBytesTest.scala
+++ b/core/src/test/scala/unit/kafka/network/MetadataOutgoingBytesTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.network
+
+import java.util.{Collections, Properties}
+import kafka.server.{BrokerMetadataStats, KafkaConfig}
+import org.apache.kafka.common.network.Send
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{AbstractResponse, RequestHeader}
+import org.apache.kafka.common.utils.Time
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.{mock, when}
+
+class MetadataOutgoingBytesTest {
+  @Test
+  def testOnlyMetadataResponsesContributeToMetadataTraffic(): Unit = {
+    val props = new Properties
+    props.put("zookeeper.connect", "localhost:2181")
+    props.put(KafkaConfig.LiProtocolBridgeLegacyRequestMetricsEnableProp, "true")
+    val metrics = new RequestChannel.Metrics(Seq(ApiKeys.METADATA, ApiKeys.API_VERSIONS),
+      Some(KafkaConfig.fromProps(props)))
+    val channel = new RequestChannel(10, "", Time.SYSTEM, metrics)
+    val meter = BrokerMetadataStats.outgoingBytesRate
+    val initialCount = meter.count
+
+    def sendResponse(apiKey: ApiKeys): Unit = {
+      val request = mock(classOf[RequestChannel.Request])
+      val response = mock(classOf[AbstractResponse])
+      val send = mock(classOf[Send])
+      when(request.header).thenReturn(new RequestHeader(apiKey, 0.toShort, "test", 0))
+      when(response.errorCounts()).thenReturn(Collections.emptyMap[Errors, Integer]())
+      when(send.size()).thenReturn(42L)
+      when(request.buildResponseSend(response)).thenReturn(send)
+      when(request.callbackRequestDequeueTimeNanos).thenReturn(None)
+      when(request.responseNode(response)).thenReturn(None)
+      channel.sendResponse(request, response, None)
+    }
+
+    try {
+      sendResponse(ApiKeys.API_VERSIONS)
+      assertEquals(initialCount, meter.count)
+      sendResponse(ApiKeys.METADATA)
+      assertEquals(initialCount + 42L, meter.count)
+    } finally channel.shutdown()
+  }
+}

--- a/core/src/test/scala/unit/kafka/network/RequestChannelWatchdogTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelWatchdogTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.network
+
+import com.yammer.metrics.core.Histogram
+import org.apache.kafka.common.utils.MockTime
+import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse}
+import org.junit.jupiter.api.Test
+
+import scala.jdk.CollectionConverters._
+
+class RequestChannelWatchdogTest {
+  @Test
+  def testPollTimestampAndIntervalMetric(): Unit = {
+    val time = new MockTime
+    val channel = new RequestChannel(1, "", time, new RequestChannel.Metrics(Seq.empty),
+      enableDequeueWatchdog = true)
+    try {
+      channel.receiveRequest(0)
+      val firstPoll = channel.lastDequeueTimeMs
+      time.sleep(25)
+      channel.receiveRequest(0)
+      assertEquals(firstPoll + 25, channel.lastDequeueTimeMs)
+
+      val histogram = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.collectFirst {
+        case (name, value: Histogram) if name.getName == "RequestDequeuePollIntervalMs" => value
+      }.get
+      assertEquals(1L, histogram.count)
+      assertEquals(25L, histogram.max)
+    } finally {
+      channel.shutdown()
+    }
+    assertFalse(KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala
+      .exists(_.getName == "RequestDequeuePollIntervalMs"))
+  }
+}

--- a/core/src/test/scala/unit/kafka/network/RequestMetricBucketsTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestMetricBucketsTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.network
+
+import com.yammer.metrics.core.Counter
+import kafka.server.KafkaConfig
+import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.server.config.ZkConfigs
+import org.apache.kafka.server.metrics.KafkaYammerMetrics
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+import java.util.Properties
+import scala.jdk.CollectionConverters._
+
+class RequestMetricBucketsTest {
+  @Test
+  def testSizeMetricAndTotalTimeBucketNames(): Unit = {
+    val props = new Properties
+    props.put(ZkConfigs.ZK_CONNECT_CONFIG, "localhost:2181")
+    props.put(KafkaConfig.LiProtocolBridgeRequestMetricBucketsEnableProp, "true")
+    props.put(KafkaConfig.RequestMetricsSizeBucketsProp, "0,1")
+    props.put(KafkaConfig.RequestMetricsTotalTimeBucketsProp, "0,5")
+    props.put(KafkaConfig.TotalTimeHistogramEnabledMetricsProp, "Produce0To1MbAcks1")
+    val metrics = new RequestChannel.Metrics(Seq(ApiKeys.PRODUCE, ApiKeys.FETCH),
+      Some(KafkaConfig.fromProps(props)))
+
+    try {
+      assertEquals(Some("Produce0To1MbAcks1"), metrics.requestSizeBucketMetricName(
+        metrics.produceRequestAcksSizeMetricNameMap(1), 512 * 1024))
+      val requestMetrics = metrics("Produce0To1MbAcks1")
+      requestMetrics.totalTimeBucketHist.get.update(8)
+      val matchingCounters = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.collect {
+        case (name, counter: Counter)
+          if name.getName == "TotalTime_Bin2_5MsGreater" &&
+            name.getMBeanName.contains("request=Produce0To1MbAcks1") => counter.count
+      }
+      assertEquals(Seq(1L), matchingCounters.toSeq)
+    } finally {
+      metrics.close()
+    }
+    assertTrue(KafkaYammerMetrics.defaultRegistry.allMetrics.keySet.asScala.forall(
+      !_.getMBeanName.contains("request=Produce0To1MbAcks1")))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/ApiVersionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionManagerTest.scala
@@ -124,6 +124,26 @@ class ApiVersionManagerTest {
   }
 
   @Test
+  def testDisabledLiApisAreNotPreallocatedAsEnabledApis(): Unit = {
+    val disabled = new DefaultApiVersionManager(
+      listenerType = ListenerType.ZK_BROKER,
+      forwardingManager = None,
+      brokerFeatures = brokerFeatures,
+      metadataCache = metadataCache,
+      enableUnstableLastVersion = true)
+    assertFalse(disabled.enabledApis.exists(_.id >= 1000))
+
+    val enabled = new DefaultApiVersionManager(
+      listenerType = ListenerType.ZK_BROKER,
+      forwardingManager = None,
+      brokerFeatures = brokerFeatures,
+      metadataCache = metadataCache,
+      enableUnstableLastVersion = true,
+      liApiEnabled = _ => true)
+    assertTrue(enabled.enabledApis.exists(_.id >= 1000))
+  }
+
+  @Test
   def testEnvelopeDisabledForKRaftBroker(): Unit = {
     val forwardingManager = Mockito.mock(classOf[ForwardingManager])
     Mockito.when(forwardingManager.controllerApiVersions).thenReturn(None)

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -62,6 +62,35 @@ class KafkaConfigTest {
   }
 
   @Test
+  def testInvalidRequestMetricBuckets(): Unit = {
+    val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
+    props.setProperty(KafkaConfig.RequestMetricsSizeBucketsProp, "1,not-a-number")
+    val config = KafkaConfig.fromProps(props)
+    assertThrows(classOf[ConfigException], () => config.requestMetricsSizeBuckets)
+  }
+
+  @Test
+  def testEmptyRequestMetricBuckets(): Unit = {
+    val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
+    props.setProperty(KafkaConfig.RequestMetricsTotalTimeBucketsProp, ", ,")
+    val config = KafkaConfig.fromProps(props)
+    assertThrows(classOf[ConfigException], () => config.requestMetricsTotalTimeBuckets)
+  }
+
+  @Test
+  def testRequestMetricBucketsMustBeOrderedAndNonNegative(): Unit = {
+    Seq("-1,5", "5,5", "10,5").foreach { value =>
+      val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
+      props.setProperty(KafkaConfig.RequestMetricsSizeBucketsProp, value)
+      val config = KafkaConfig.fromProps(props)
+      assertThrows(classOf[ConfigException], () => {
+        config.requestMetricsSizeBuckets
+        ()
+      }, s"$value should not be accepted as request metric boundaries")
+    }
+  }
+
+  @Test
   def testLogRetentionTimeHoursProvided(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     props.setProperty(ServerLogConfigs.LOG_RETENTION_TIME_HOURS_CONFIG, "1")
@@ -1154,9 +1183,14 @@ class KafkaConfigTest {
         case ShareGroupConfig.SHARE_GROUP_MAX_GROUPS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
         case GroupCoordinatorConfig.SHARE_GROUP_MAX_SIZE_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", 0, -1)
 
+        // LinkedIn compatibility settings whose schema intentionally accepts arbitrary strings or lists.
         case KafkaConfig.ObserverClassNameProp |
              KafkaConfig.MaintenanceBrokerListProp |
-             KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp => // ignore string values
+             KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp |
+             KafkaConfig.RequestMetricsSizeBucketsProp |
+             KafkaConfig.RequestMetricsTotalTimeBucketsProp |
+             KafkaConfig.TotalTimeHistogramEnabledMetricsProp |
+             KafkaConfig.HeapDumpFolderProp => // ignore string and list values
 
         case _ => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1")
       }

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -34,6 +34,14 @@ import scala.jdk.CollectionConverters._
 class KafkaServerTest extends QuorumTestHarness {
 
   @Test
+  def testRequestChannelWatchdogIntervalTracksConfiguredTimeout(): Unit = {
+    assertEquals(1L, KafkaServer.requestChannelWatchdogIntervalMs(1L))
+    assertEquals(500L, KafkaServer.requestChannelWatchdogIntervalMs(1000L))
+    assertEquals(10000L, KafkaServer.requestChannelWatchdogIntervalMs(60000L))
+    assertEquals(10000L, KafkaServer.requestChannelWatchdogIntervalMs(Long.MaxValue))
+  }
+
+  @Test
   def testCompatibilityZkPathsRequireFeatureFlags(): Unit = {
     val defaultProps = new Properties
     defaultProps.put(ZkConfigs.ZK_CONNECT_CONFIG, TestUtils.MockZkConnect)

--- a/core/src/test/scala/unit/kafka/server/LiProtocolBridgeConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiProtocolBridgeConfigTest.scala
@@ -17,25 +17,38 @@
 
 package kafka.server
 
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.server.config.{ReplicationConfigs, ZkConfigs}
-import org.junit.jupiter.api.Assertions.{assertFalse, assertThrows, assertTrue}
+import org.apache.kafka.storage.internals.log.LogConfig
 import org.junit.jupiter.api.Test
 
 import java.util.Properties
 
 class LiProtocolBridgeConfigTest {
   @Test
-  def testBridgeModeDefaultsToFalseAndCanBeEnabledAt30Ibp(): Unit = {
+  def testEveryCompatibilityGateDefaultsToFalseAndCanBeEnabled(): Unit = {
     val defaultProps = new Properties
     defaultProps.put(ZkConfigs.ZK_CONNECT_CONFIG, "localhost:2181")
-    assertFalse(KafkaConfig.fromProps(defaultProps).liProtocolBridgeModeEnable)
+    val defaults = KafkaConfig.fromProps(defaultProps)
+    // The wrapper and preflight manifest must be updated deliberately when this contract changes.
+    assertEquals(22, KafkaConfig.LiProtocolBridgeEnableProps.size)
+    assertEquals(KafkaConfig.LiProtocolBridgeEnableProps.size,
+      KafkaConfig.LiProtocolBridgeEnableProps.distinct.size, "compatibility settings must be unique")
+    KafkaConfig.LiProtocolBridgeEnableProps.foreach { name =>
+      assertFalse(defaults.getBoolean(name), s"$name must default to false")
+    }
+    assertEquals(false, defaults.extractLogConfigMap.get(LogConfig.LI_LOG_TRUNCATION_METRICS_CONFIG))
 
-    val enabledProps = new Properties
-    enabledProps.put(ZkConfigs.ZK_CONNECT_CONFIG, "localhost:2181")
-    enabledProps.put(ReplicationConfigs.INTER_BROKER_PROTOCOL_VERSION_CONFIG, "3.0")
-    enabledProps.put(KafkaConfig.LiProtocolBridgeModeEnableProp, "true")
-    assertTrue(KafkaConfig.fromProps(enabledProps).liProtocolBridgeModeActive)
+    val props = new Properties
+    props.put(ZkConfigs.ZK_CONNECT_CONFIG, "localhost:2181")
+    props.put(ReplicationConfigs.INTER_BROKER_PROTOCOL_VERSION_CONFIG, "3.0")
+    KafkaConfig.LiProtocolBridgeEnableProps.foreach(props.put(_, "true"))
+    val enabled = KafkaConfig.fromProps(props)
+    KafkaConfig.LiProtocolBridgeEnableProps.foreach { name =>
+      assertTrue(enabled.getBoolean(name), s"$name was not enabled")
+    }
+    assertEquals(true, enabled.extractLogConfigMap.get(LogConfig.LI_LOG_TRUNCATION_METRICS_CONFIG))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
@@ -60,13 +60,17 @@ class LiProtocolBridgeMetricsTest {
       assertEquals(LiProtocolBridgeMetrics.MetricNames.toSet, updatedValues.keySet)
       val staticMetrics = Set(LiProtocolBridgeMetrics.PreferredControllerEnabled,
         LiProtocolBridgeMetrics.RackIdMapperEnabled, LiProtocolBridgeMetrics.ZookeeperPaginationEnabled,
-        LiProtocolBridgeMetrics.DynamicTopicDeletionEnabled, LiProtocolBridgeMetrics.MinimumLogRollEnabled,
+        LiProtocolBridgeMetrics.DynamicTopicDeletionEnabled, LiProtocolBridgeMetrics.RequestMetricBucketsEnabled,
+        LiProtocolBridgeMetrics.RequestChannelWatchdogEnabled,
+        LiProtocolBridgeMetrics.MinimumLogRollEnabled,
         LiProtocolBridgeMetrics.ReassignmentCancellationSafetyEnabled,
         LiProtocolBridgeMetrics.ListOffsetsInstrumentationEnabled,
         LiProtocolBridgeMetrics.StaticDefaultQuotasEnabled,
         LiProtocolBridgeMetrics.ReplicaRequestTimeoutEnabled,
         LiProtocolBridgeMetrics.OffsetsTopicConfigEnabled,
-        LiProtocolBridgeMetrics.LeaderTransferEnabled)
+        LiProtocolBridgeMetrics.LeaderTransferEnabled,
+        LiProtocolBridgeMetrics.LegacyRequestMetricsEnabled,
+        LiProtocolBridgeMetrics.LogTruncationMetricsEnabled)
       assertEquals(1, updatedValues(LiProtocolBridgeMetrics.ControllerInitializationThreads))
       staticMetrics.foreach(name => assertEquals(0, updatedValues(name)))
       val dynamicValues = updatedValues.filterNot { case (name, _) =>

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -194,6 +194,7 @@ public class LogConfig extends AbstractConfig {
     @Deprecated
     public static final String DEFAULT_MESSAGE_FORMAT_VERSION = ServerLogConfigs.LOG_MESSAGE_FORMAT_VERSION_DEFAULT;
     public static final String LI_MIN_SEGMENT_MS_CONFIG = "li.min.log.roll.ms";
+    public static final String LI_LOG_TRUNCATION_METRICS_CONFIG = "li.internal.log.truncation.metrics.enable";
 
     /* See `TopicConfig.MESSAGE_FORMAT_VERSION_CONFIG` for details */
     @SuppressWarnings("deprecation")
@@ -212,7 +213,8 @@ public class LogConfig extends AbstractConfig {
             TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG,
             QuotaConfigs.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG,
             QuotaConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG,
-            LI_MIN_SEGMENT_MS_CONFIG
+            LI_MIN_SEGMENT_MS_CONFIG,
+            LI_LOG_TRUNCATION_METRICS_CONFIG
     ));
 
     @SuppressWarnings("deprecation")
@@ -335,7 +337,9 @@ public class LogConfig extends AbstractConfig {
                 .define(TopicConfig.REMOTE_LOG_COPY_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_COPY_DISABLE_DOC)
                 .define(TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_CONFIG, BOOLEAN, false, MEDIUM, TopicConfig.REMOTE_LOG_DELETE_ON_DISABLE_DOC)
                 .define(LI_MIN_SEGMENT_MS_CONFIG, LONG, 0L, atLeast(0), MEDIUM,
-                        "Minimum interval before a time-based log segment roll.");
+                        "Minimum interval before a time-based log segment roll.")
+                .define(LI_LOG_TRUNCATION_METRICS_CONFIG, BOOLEAN, false, MEDIUM,
+                        "Whether to expose LinkedIn log truncation metrics.");
     }
 
     public final Set<String> overriddenConfigs;
@@ -348,6 +352,7 @@ public class LogConfig extends AbstractConfig {
     public final long segmentMs;
     public final long segmentJitterMs;
     public final long liMinSegmentMs;
+    public final boolean liLogTruncationMetricsEnable;
     public final int maxIndexSize;
     public final long flushInterval;
     public final long flushMs;
@@ -400,6 +405,7 @@ public class LogConfig extends AbstractConfig {
         this.segmentMs = getLong(TopicConfig.SEGMENT_MS_CONFIG);
         this.segmentJitterMs = getLong(TopicConfig.SEGMENT_JITTER_MS_CONFIG);
         this.liMinSegmentMs = getLong(LI_MIN_SEGMENT_MS_CONFIG);
+        this.liLogTruncationMetricsEnable = getBoolean(LI_LOG_TRUNCATION_METRICS_CONFIG);
         this.maxIndexSize = getInt(TopicConfig.SEGMENT_INDEX_BYTES_CONFIG);
         this.flushInterval = getLong(TopicConfig.FLUSH_MESSAGES_INTERVAL_CONFIG);
         this.flushMs = getLong(TopicConfig.FLUSH_MS_CONFIG);


### PR DESCRIPTION
Restore config-gated broker metrics and watchdog wiring. Storage metric primitives and their cleanup tests are now in #566. Keep process termination in PR 561. Validate bucket boundaries and derive the watchdog poll interval from its timeout.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.