### PR TITLE
tests: run the complete mixed-binary bridge migration

### DIFF
--- a/tests/bin/li_bridge_mixed_cluster_smoke.py
+++ b/tests/bin/li_bridge_mixed_cluster_smoke.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bounded, independently built ZK broker migration, rollback and old-client qualification.
+
+Only disposable loopback listeners, a fresh ZooKeeper namespace and fresh log directories
+are used. This is functional qualification, not production capacity or security approval.
+"""
+
+import contextlib
+import csv
+import datetime
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from li_bridge_artifacts import file_sha256, snapshot_archive
+from li_bridge_contract import CONTRACT_VERSION, MODE, PHASES, TOPIC_CLEANUP, scenario_spec
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def utc_now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def write_properties(path, values):
+    path.write_text("".join(f"{key}={value}\n" for key, value in values.items()), encoding="utf-8")
+
+
+def verify_connect_records(expected, actual):
+    """File connectors are at-least-once; duplicates are counted, not confused with loss.
+
+    All acknowledged source records must arrive unchanged and no unexpected records may appear.
+    Broker/idempotent/transactional ledgers have the stricter no-duplicate assertions in Java.
+    """
+    if set(actual) - set(expected):
+        raise AssertionError("Unexpected/corrupted Connect output")
+    return set(actual) == set(expected)
+
+
+class Migration:
+    def __init__(self):
+        self.scenario = scenario_spec()
+        source_files = list(SCRIPT_DIR.glob("LiBridge*.java")) + [SCRIPT_DIR / name for name in (
+            "li_bridge_mixed_cluster_smoke.py", "li_bridge_contract.py", "li_bridge_preflight.py", "li_bridge_artifacts.py")]
+        self.source_hashes = {path.name: file_sha256(path) for path in source_files}
+        self.started = utc_now()
+        self.deadline = time.monotonic() + self.scenario["BRIDGE_SCENARIO_TIMEOUT_SECONDS"]
+        self.work = Path(tempfile.mkdtemp(prefix="li-kafka-bridge-smoke.")).resolve()
+        self.evidence = Path(os.environ.get("EVIDENCE_DIR", str(self.work / "evidence"))).resolve()
+        self.evidence.mkdir(parents=True, exist_ok=True)
+        self.archives = {version: Path(os.environ[f"KAFKA_{version.replace('.', '')}_TGZ"]).resolve()
+                         for version in ("3.0", "3.9")}
+        self.homes = {}
+        self.processes = {}
+        self.handles = []
+        self.generations = {}
+        self.configs = {}
+        self.sequence = 0
+        self.connect_expected = []
+        self.port = {0: int(os.environ.get("BROKER_30_PORT", 29092)),
+                     1: int(os.environ.get("BROKER_39_PORT", 29093)),
+                     2: int(os.environ.get("BROKER_39_EXTRA_PORT", 29094))}
+        self.zk_port = int(os.environ.get("ZK_PORT", 22181))
+        self.bootstrap = f"127.0.0.1:{self.port[0]},127.0.0.1:{self.port[1]}"
+        self.timings = []
+        self.resources = []
+        self.commands = self.evidence / "process-commands.log"
+        self.client_dir = self.work / "old-clients"
+        self.client_dir.mkdir()
+        self.churn_dir = self.work / "metadata-churn"
+        self.churn_dir.mkdir()
+
+    def remaining(self, requested):
+        remaining = self.deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("Migration exceeded its scenario deadline")
+        return min(requested, remaining)
+
+    def command(self, args, check=True, input_text=None, timeout=None, allow_missing=False):
+        limit = self.remaining(timeout or self.scenario["BRIDGE_COMMAND_TIMEOUT_SECONDS"])
+        with self.commands.open("a", encoding="utf-8") as log:
+            log.write(f"\n{utc_now()} {args!r}\n")
+            # A separate process group lets a CLI timeout terminate its JVM too.
+            process = subprocess.Popen(list(map(str, args)), stdin=subprocess.PIPE if input_text is not None else subprocess.DEVNULL,
+                                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, start_new_session=True)
+            try:
+                output, _ = process.communicate(input_text, timeout=limit)
+            except BaseException:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(process.pid, signal.SIGKILL)
+                output, _ = process.communicate()
+                log.write(output)
+                raise
+            log.write(output)
+        if check and process.returncode:
+            raise subprocess.CalledProcessError(process.returncode, args, output=output[-8000:])
+        return output if process.returncode == 0 or (allow_missing and "Node does not exist:" in output) else None
+
+    def cli(self, script, *args, generation="3.9", check=True):
+        return self.command([self.homes[generation] / "bin" / script, *args], check=check)
+
+    def admin(self, script, *args, generation="3.9", check=True):
+        return self.cli(script, "--bootstrap-server", self.bootstrap, *args, generation=generation, check=check)
+
+    def java(self, helper, *args, generation="3.0"):
+        return self.command(["java", "-cp", f"{self.work / ('classes-' + generation)}:{self.homes[generation] / 'libs'}/*",
+                             helper, *map(str, args)])
+
+    def start(self, name, args, extra_env=None):
+        if name in self.processes:
+            raise AssertionError(f"Process already running: {name}")
+        log = (self.work / f"{name}.log").open("a", encoding="utf-8")
+        self.handles.append(log)
+        environment = dict(os.environ, **(extra_env or {}))
+        environment.setdefault("KAFKA_HEAP_OPTS", "-Xms256m -Xmx1g")
+        self.processes[name] = subprocess.Popen(list(map(str, args)), stdout=log, stderr=subprocess.STDOUT,
+                                                stdin=subprocess.DEVNULL, env=environment, start_new_session=True)
+
+    def stop(self, name, hard=False, cleanup=False):
+        process = self.processes.pop(name, None)
+        if process is None:
+            return
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL if hard else signal.SIGTERM)
+        try:
+            process.wait(timeout=45 if not cleanup else 10)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=10)
+            if not cleanup:
+                raise TimeoutError(f"Graceful shutdown timed out: {name}")
+
+    def until(self, label, predicate, timeout=120):
+        start = time.monotonic()
+        deadline = start + self.remaining(timeout)
+        try:
+            while time.monotonic() < deadline:
+                for name in ("old-clients", "old-connect", "metadata-churn"):
+                    clients = self.processes.get(name)
+                    if clients is not None and clients.poll() is not None:
+                        raise AssertionError(f"{name} exited unexpectedly: {clients.returncode}")
+                if predicate():
+                    self.timings.append((label, round(time.monotonic() - start, 3), "passed"))
+                    print(f"{label}: passed", flush=True)
+                    return
+                time.sleep(1)
+            raise TimeoutError(label)
+        except BaseException:
+            self.timings.append((label, round(time.monotonic() - start, 3), "failed"))
+            raise
+
+    def zk(self, command):
+        return self.command([self.homes["3.9"] / "bin/zookeeper-shell.sh", f"127.0.0.1:{self.zk_port}"],
+                            input_text=command + "\n", check=False, timeout=30, allow_missing=True) or ""
+
+    def registered(self, identifier):
+        return '"version"' in self.zk(f"get /brokers/ids/{identifier}")
+
+    def controller(self, identifier):
+        return f'"brokerid":{identifier}' in self.zk("get /controller")
+
+    def start_broker(self, identifier, generation, mode=True, ibp="3.0"):
+        config = {
+            "broker.id": identifier, "listeners": f"PLAINTEXT://127.0.0.1:{self.port[identifier]}",
+            "advertised.listeners": f"PLAINTEXT://127.0.0.1:{self.port[identifier]}",
+            "listener.security.protocol.map": "PLAINTEXT:PLAINTEXT", "inter.broker.listener.name": "PLAINTEXT",
+            "zookeeper.connect": f"127.0.0.1:{self.zk_port}", "log.dirs": self.work / f"data-{identifier}",
+            "num.partitions": 2, "default.replication.factor": 2, "min.insync.replicas": 1,
+            "offsets.topic.replication.factor": 2, "offsets.topic.num.partitions": 3,
+            "transaction.state.log.replication.factor": 2, "transaction.state.log.num.partitions": 3,
+            "transaction.state.log.min.isr": 1, "controlled.shutdown.enable": "true",
+            "controlled.shutdown.max.retries": 3, "controlled.shutdown.retry.backoff.ms": 1000,
+            "delete.topic.enable": "true", "log.segment.delete.delay.ms": 100,
+            "inter.broker.protocol.version": ibp, MODE: str(mode).lower(), TOPIC_CLEANUP: "true",
+            "remote.log.storage.system.enable": "false", "li.drop.corrupted.files.enable": "false",
+            "li.leader.election.on.corruption.wait.ms": 0,
+        }
+        if generation == "3.0":
+            config.update({"li.combined.control.request.enable": "true", "li.async.fetcher.enable": "true"})
+        else:
+            from li_bridge_contract import MIXED_REQUIRED_GATES
+            config.update({gate: "true" for gate in MIXED_REQUIRED_GATES if gate != MODE})
+            config.update({"li.protocol.bridge.reassignment.cancellation.safety.enable": "true",
+                           "li.min.original.alive.replicas": 2})
+        path = self.work / f"broker-{identifier}.properties"
+        write_properties(path, config)
+        self.configs[identifier] = config
+        self.generations[identifier] = generation
+        logs = self.work / f"broker-{identifier}-{generation}-logs"
+        logs.mkdir(exist_ok=True)
+        environment = {"LOG_DIR": str(logs)}
+        if generation == "3.0" and os.environ.get("LI_BRIDGE_JAVA_30_HOME"):
+            environment["JAVA_HOME"] = os.environ["LI_BRIDGE_JAVA_30_HOME"]
+        self.start(f"broker-{identifier}", [self.homes[generation] / "bin/kafka-server-start.sh", path], environment)
+        self.until(f"broker {identifier} {generation} registration", lambda: self.registered(identifier), 90)
+
+    def replace(self, identifier, generation, mode=True, ibp="3.0", hard=False):
+        self.stop(f"broker-{identifier}", hard=hard)
+        self.until(f"broker {identifier} old registration removed", lambda: not self.registered(identifier), 60)
+        self.start_broker(identifier, generation, mode, ibp)
+        self.until(f"broker {identifier} replacement ISR recovery", self.healthy)
+
+    def healthy(self):
+        under = self.admin("kafka-topics.sh", "--describe", "--under-replicated-partitions", check=False)
+        offline = self.admin("kafka-topics.sh", "--describe", "--unavailable-partitions", check=False)
+        return under is not None and offline is not None and not under.strip() and not offline.strip()
+
+    def force_controller(self, identifier):
+        if not self.controller(identifier):
+            other = 1 - identifier
+            generation = self.generations[other]
+            self.stop(f"broker-{other}")
+            self.until(f"{self.generations[identifier]} controller election", lambda: self.controller(identifier), 60)
+            self.start_broker(other, generation)
+            self.until("controller movement ISR recovery", self.healthy)
+
+    def create(self, topic, assignment="0:1", *extra):
+        def attempt():
+            described = self.admin("kafka-topics.sh", "--describe", "--topic", topic, check=False)
+            if described is not None and f"Topic: {topic}" in described:
+                return True
+            return self.admin("kafka-topics.sh", "--create", "--topic", topic, "--replica-assignment", assignment,
+                              *extra, check=False) is not None
+        self.until(f"create {topic}", attempt, 90)
+
+    def mutate(self, suffix):
+        topic = "bridge-mutation-" + suffix
+        for iteration in range(2):
+            self.create(topic)
+            self.admin("kafka-topics.sh", "--delete", "--topic", topic)
+            def gone():
+                names = self.admin("kafka-topics.sh", "--list", check=False)
+                if names is None or topic in names.splitlines():
+                    return False
+                if "Node does not exist" not in self.zk(f"get /brokers/topics/{topic}"):
+                    return False
+                return not any(path.name.startswith(topic + "-") for path in self.work.glob("data-*/*") if path.is_dir())
+            self.until(f"delete/recreate {topic} iteration {iteration}", gone)
+
+    def set_mode(self, enabled):
+        value = str(enabled).lower()
+        self.admin("kafka-configs.sh", "--entity-type", "brokers", "--entity-default", "--alter",
+                   "--add-config", f"{MODE}={value}")
+        self.until("native-mode dynamic configuration" if not enabled else "bridge-mode dynamic configuration",
+                   lambda: f"{MODE}={value}" in (self.admin("kafka-configs.sh", "--entity-type", "brokers",
+                                                           "--entity-default", "--describe", "--all", check=False) or ""))
+        for identifier, properties in self.configs.items():
+            properties[MODE] = value
+            write_properties(self.work / f"broker-{identifier}.properties", properties)
+
+    def preflight(self, phase):
+        args = [sys.executable, SCRIPT_DIR / "li_bridge_preflight.py", "--phase", phase,
+                "--kafka-home", self.homes["3.9"], "--zk-connect", f"127.0.0.1:{self.zk_port}",
+                "--output-json", self.evidence / f"preflight-{phase}.json"]
+        for identifier in (0, 1):
+            args.extend(["--legacy-broker-config" if self.generations[identifier] == "3.0" else "--broker-config",
+                         self.work / f"broker-{identifier}.properties"])
+        self.command(args)
+
+    def checkpoint(self, phase):
+        self.preflight(phase)
+        self.sequence += 1
+        churn_progress = self.churn_dir / "progress"
+        initial_cycles = int(churn_progress.read_text()) if churn_progress.exists() else 0
+        name = f"{self.sequence:03d}-{phase}"
+        request = self.client_dir / "request.tmp"
+        request.write_text(name)
+        request.replace(self.client_dir / "request")
+        record = f"connect-record-{name}"
+        self.connect_expected.append(record)
+        with (self.work / "connect-input.txt").open("a") as source:
+            source.write(record + "\n")
+        def clients_complete():
+            result = self.client_dir / f"{name}.done"
+            if not result.exists():
+                return False
+            report = json.loads(result.read_text())
+            if report.get("passed") is not True:
+                raise AssertionError(report)
+            output = self.work / "connect-output.txt"
+            return (output.exists() and verify_connect_records(self.connect_expected, output.read_text().splitlines())
+                    and churn_progress.exists() and int(churn_progress.read_text()) > initial_cycles)
+        self.until(f"old clients phase {phase}", clients_complete, 180)
+        report = json.loads((self.client_dir / f"{name}.done").read_text())
+        connect_records = (self.work / "connect-output.txt").read_text().splitlines()
+        report.update(connect_pid=self.processes["old-connect"].pid,
+                      connect_records=len(set(connect_records)),
+                      connect_duplicate_deliveries=len(connect_records) - len(set(connect_records)),
+                      metadata_churn_cycles=int(churn_progress.read_text()))
+        (self.evidence / f"old-clients-{name}.json").write_text(json.dumps(report, indent=2, sort_keys=True))
+        for generation in ("3.0", "3.9"):
+            self.java("LiBridgePrivateApiSmoke", self.bootstrap, f"{name}-{generation.replace('.', '')}", generation=generation)
+        self.mutate(name)
+        self.until(f"{phase} metadata/ISR health", self.healthy)
+        self.resources_at(phase)
+
+    def resources_at(self, phase):
+        for identifier in (0, 1, 2):
+            process = self.processes.get(f"broker-{identifier}")
+            if process is not None and process.poll() is None:
+                rss = self.command(["ps", "-o", "rss=", "-p", process.pid]).strip()
+                self.resources.append((utc_now(), phase, f"broker-{identifier}", process.pid, rss))
+                if shutil.which("jcmd"):
+                    heap = self.command(["jcmd", process.pid, "GC.heap_info"], check=False, timeout=15)
+                    with (self.evidence / "broker-heap-info.log").open("a") as output:
+                        output.write(f"\n{phase} broker-{identifier}\n{heap}\n")
+
+    def start_clients(self):
+        for topic in ("bridge-live", "bridge-live-tx", "bridge-live-stream-in", "bridge-live-stream-out", "bridge-live-connect"):
+            self.create(topic, "0:1,1:0")
+        self.start("old-clients", ["java", "-Xmx512m", "-cp",
+                   f"{self.work / 'classes-3.0'}:{self.homes['3.0'] / 'libs'}/*", "LiBridgeContinuousClients",
+                   self.bootstrap, self.client_dir, self.scenario["old_client_interval_ms"]])
+        self.until("persistent old clients startup", lambda: (self.client_dir / "ready").exists())
+        self.start("metadata-churn", ["java", "-Xmx256m", "-cp",
+                   f"{self.work / 'classes-3.0'}:{self.homes['3.0'] / 'libs'}/*", "LiBridgeMetadataChurn",
+                   self.bootstrap, self.churn_dir])
+        (self.work / "connect-input.txt").touch()
+        write_properties(self.work / "connect.properties", {
+            # Do not expose the test worker's unauthenticated REST API on the host's network.
+            "listeners": "http://127.0.0.1:0",
+            "bootstrap.servers": self.bootstrap, "offset.storage.file.filename": self.work / "connect.offsets",
+            "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+            "value.converter": "org.apache.kafka.connect.storage.StringConverter", "offset.flush.interval.ms": 1000,
+            "plugin.path": self.homes["3.0"] / "libs"})
+        write_properties(self.work / "connect-source.properties", {
+            "name": "bridge-old-file-source", "connector.class": "org.apache.kafka.connect.file.FileStreamSourceConnector",
+            "tasks.max": 1, "file": self.work / "connect-input.txt", "topic": "bridge-live-connect"})
+        write_properties(self.work / "connect-sink.properties", {
+            "name": "bridge-old-file-sink", "connector.class": "org.apache.kafka.connect.file.FileStreamSinkConnector",
+            "tasks.max": 1, "file": self.work / "connect-output.txt", "topics": "bridge-live-connect"})
+        self.start("old-connect", [self.homes["3.0"] / "bin/connect-standalone.sh", self.work / "connect.properties",
+                                  self.work / "connect-source.properties", self.work / "connect-sink.properties"],
+                   {"KAFKA_HEAP_OPTS": "-Xms128m -Xmx512m", "LOG_DIR": str(self.work / "connect-logs")})
+
+    def recovery(self):
+        count, size = self.scenario["RECOVERY_RECORD_COUNT"], self.scenario["RECOVERY_RECORD_SIZE"]
+        self.create("bridge-recovery")
+        self.stop("broker-1", hard=True)
+        self.until("3.0 controller election for 3.9 recovery", lambda: self.controller(0), 60)
+        self.java("LiBridgeRecords", "produce", self.bootstrap, "bridge-recovery", 0, count, size)
+        self.start_broker(1, "3.9")
+        self.until("3.9 follower recovery from a 3.0 leader", self.healthy)
+        self.stop("broker-0", hard=True)
+        self.until("3.9 controller election for old-follower recovery", lambda: self.controller(1), 60)
+        # Promotion forces reads from the recovered new replica, not the old leader's original log.
+        self.java("LiBridgeRecords", "verify", self.bootstrap, "bridge-recovery", 0, count, size)
+        self.java("LiBridgeRecords", "produce", self.bootstrap, "bridge-recovery", count, count, size)
+        self.start_broker(0, "3.0")
+        self.until("3.0 follower recovery from a 3.9 leader", self.healthy)
+        self.stop("broker-1", hard=True)
+        self.until("old recovered replica promoted", lambda: self.controller(0), 60)
+        self.java("LiBridgeRecords", "verify", self.bootstrap, "bridge-recovery", 0, 2 * count, size)
+        self.start_broker(1, "3.9")
+        self.until("recovery ledger final ISR", self.healthy)
+
+    def cancellation(self):
+        self.force_controller(1)
+        self.start_broker(2, "3.9")
+        self.create("bridge-cancel")
+        self.java("LiBridgeRecords", "produce", self.bootstrap, "bridge-cancel", 0, 100, 100000)
+        path = self.work / "reassignment.json"
+        path.write_text(json.dumps({"version": 1, "partitions": [{"topic": "bridge-cancel", "partition": 0, "replicas": [1, 2]}]}))
+        self.admin("kafka-reassign-partitions.sh", "--reassignment-json-file", path, "--execute", "--throttle", "1024")
+        self.until("throttled reassignment to begin", lambda: "is still in progress" in
+                   (self.admin("kafka-reassign-partitions.sh", "--reassignment-json-file", path, "--verify", check=False) or ""), 30)
+        self.stop("broker-1", hard=True)
+        self.stop("broker-2", hard=True)
+        self.until("3.0 controller election during reassignment", lambda: self.controller(0), 60)
+        self.start_broker(1, "3.9")
+        self.admin("kafka-reassign-partitions.sh", "--reassignment-json-file", path, "--cancel", "--preserve-throttles")
+        self.until("reassignment cancellation to restore original replicas", lambda: re.search(
+            r"Partition: 0.*Replicas: (0,1|1,0)(?:\s|$)",
+            self.admin("kafka-topics.sh", "--describe", "--topic", "bridge-cancel", check=False) or ""))
+        self.java("LiBridgeRecords", "verify", self.bootstrap, "bridge-cancel", 0, 100, 100000)
+
+    def truncation(self):
+        self.create("bridge-truncation", "1:0", "--config", "unclean.leader.election.enable=true")
+        self.until("truncation setup ISR", self.healthy)
+        self.stop("broker-0", hard=True)
+        self.until("truncation leader 3.9", lambda: self.controller(1), 60)
+        self.java("LiBridgeRecords", "produce", self.bootstrap, "bridge-truncation", 0, 50, 100000)
+        self.stop("broker-1", hard=True)
+        self.start_broker(0, "3.0")
+        self.until("stale 3.0 unclean leader", lambda: "Leader: 0" in
+                   (self.admin("kafka-topics.sh", "--describe", "--topic", "bridge-truncation", check=False) or ""))
+        self.start_broker(1, "3.9")
+        self.until("3.9 follower truncation and ISR recovery", self.healthy)
+        log = "\n".join(path.read_text(errors="replace") for path in self.work.glob("broker-1-3.9-logs/*.log"))
+        if not re.search(r"Truncating (partition )?bridge-truncation-0", log):
+            raise AssertionError("No evidence of new follower truncation to old stale leader")
+        # Only this disposable topic permits unclean loss. The persistent client ledger must still pass.
+
+    def prepare(self):
+        for generation, archive in list(self.archives.items()):
+            # Retain immutable inputs and their source metadata, including in public CI.
+            manifest = snapshot_archive(archive, generation, self.evidence / "archives")
+            (self.evidence / f"archive-{generation}.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
+            archive = Path(manifest["path"])
+            self.archives[generation] = archive
+            destination = self.work / f"extract-{generation}"
+            destination.mkdir()
+            with tarfile.open(archive, "r:gz") as source:
+                source.extractall(destination)
+            homes = [path for path in destination.iterdir() if path.is_dir()]
+            if len(homes) != 1:
+                raise ValueError("Expected exactly one Kafka distribution root")
+            self.homes[generation] = homes[0]
+            classes = self.work / f"classes-{generation}"
+            classes.mkdir()
+            helpers = ["LiBridgePrivateApiSmoke.java", "LiBridgeRecords.java"]
+            if generation == "3.0":
+                helpers.extend(["LiBridgeContinuousClients.java", "LiBridgeMetadataChurn.java"])
+            else:
+                helpers.extend(["LiBridgeMetadataScaleSmoke.java", "LiBridgeLiveInventory.java", "LiBridgeRuntimeProbe.java"])
+            self.command(["javac", "--release", "11", "-cp", f"{homes[0] / 'libs'}/*", "-d", classes,
+                          *[SCRIPT_DIR / name for name in helpers]])
+        self.java("LiBridgeContinuousClients", "--self-test")
+        self.java("LiBridgeRuntimeProbe", self.evidence / "packaged-runtime-39.json", "false", generation="3.9")
+        write_properties(self.work / "zookeeper.properties", {"clientPort": self.zk_port,
+                         "dataDir": self.work / "zk-data", "maxClientCnxns": 0, "admin.enableServer": "false"})
+        self.start("zookeeper", [self.homes["3.9"] / "bin/zookeeper-server-start.sh", self.work / "zookeeper.properties"])
+        self.until("ZooKeeper startup", lambda: "[]" in self.zk("ls /brokers/ids") or "[zookeeper]" in self.zk("ls /"), 60)
+
+    def run(self):
+        self.prepare()
+        self.start_broker(0, "3.0", mode=False)
+        self.until("3.0 controller election", lambda: self.controller(0), 60)
+        self.start_broker(1, "3.0", mode=False)
+        self.java("LiBridgeMetadataScaleSmoke", self.bootstrap, self.scenario["SCALE_TOPIC_COUNT"],
+                  self.scenario["SCALE_PARTITION_COUNT"], generation="3.9")
+        self.start_clients()
+        self.checkpoint("dormant")
+        self.set_mode(True)
+        # Clients continue while both old brokers roll; the active controller necessarily restarts.
+        self.replace(1, "3.0")
+        self.replace(0, "3.0")
+        self.checkpoint("legacy-bridge")
+        # Rehearse all-3.0 mode backout too, with metadata churn and old clients still active.
+        self.set_mode(False)
+        self.replace(1, "3.0", mode=False)
+        self.replace(0, "3.0", mode=False)
+        self.checkpoint("dormant")
+        self.set_mode(True)
+        self.replace(1, "3.0")
+        self.replace(0, "3.0")
+        self.checkpoint("legacy-bridge")
+        self.force_controller(0)
+        self.replace(1, "3.9")
+        self.checkpoint("mixed")
+        self.resources_at("mixed-metadata-loaded")
+        self.force_controller(1)
+        self.checkpoint("mixed")
+        self.replace(1, "3.0")
+        self.until("canary rollback to 3.0", self.healthy)
+        self.checkpoint("legacy-bridge")
+        self.replace(1, "3.9")
+        self.force_controller(1)
+        self.stop("broker-1", hard=True)
+        self.until("hard controller recovery", lambda: self.controller(0), 60)
+        self.start_broker(1, "3.9")
+        self.checkpoint("mixed")
+        self.resources_at("mixed-old-clients-complete")
+        self.recovery()
+        self.cancellation()
+        self.truncation()
+        self.checkpoint("mixed")
+        self.until("all final mixed-mode partitions to become healthy", self.healthy)
+        self.resources_at("mixed-final")
+        self.replace(0, "3.9")
+        self.checkpoint("all-39-bridge")
+        # Downgrade both brokers on the same directories, after 3.9 coordinated groups/transactions.
+        self.replace(1, "3.0")
+        self.checkpoint("mixed")
+        self.replace(0, "3.0")
+        self.until("all-3.9 rollback to 3.0", self.healthy)
+        self.checkpoint("legacy-bridge")
+        self.replace(1, "3.9")
+        self.checkpoint("mixed")
+        self.replace(0, "3.9")
+        self.checkpoint("all-39-bridge")
+        self.until("all-3.9 bridge-mode partitions to become healthy", self.healthy)
+        self.resources_at("all-39-bridge")
+        self.set_mode(False)
+        self.mutate("native-before-controller-roll")
+        self.replace(0, "3.9", mode=False)
+        self.replace(1, "3.9", mode=False)
+        self.checkpoint("native")
+        self.until("all final native-mode partitions to become healthy", self.healthy)
+        self.resources_at("all-39-native")
+        self.replace(1, "3.9", mode=False, ibp="3.9")
+        self.replace(0, "3.9", mode=False, ibp="3.9")
+        self.checkpoint("ibp-39")
+        self.until("all final IBP 3.9 partitions to become healthy", self.healthy)
+        self.resources_at("ibp-39-final")
+        (self.client_dir / "stop").touch()
+        (self.churn_dir / "stop").touch()
+        self.processes["old-clients"].wait(timeout=90)
+        if self.processes["old-clients"].returncode:
+            raise AssertionError("Old-client final ledger failed")
+        self.processes.pop("old-clients")
+        self.verify_protocol_logs()
+
+    def verify_protocol_logs(self):
+        selected = []
+        for generation in ("3.0", "3.9"):
+            logs = "\n".join(path.read_text(errors="replace") for path in self.work.glob(f"broker-*-{generation}-logs/controller.log"))
+            enabled = "LI protocol bridge mode enabled: LeaderAndIsr=v2, UpdateMetadata=v5, StopReplica=v1"
+            if enabled not in logs:
+                raise AssertionError(f"Missing {generation} controller bridge selection")
+            selected.extend(line for line in logs.splitlines() if "LI protocol bridge mode" in line)
+        (self.evidence / "protocol-selection.log").write_text("\n".join(selected))
+        if not any("LI protocol bridge mode disabled" in line for line in selected):
+            raise AssertionError("Native control selection missing")
+        for path in list(self.work.glob("broker-*.log")) + list(self.work.glob("broker-*-logs/*.log")):
+            if re.search(r"UnsupportedVersionException|Error parsing.*(?:LeaderAndIsr|UpdateMetadata|StopReplica)|unknown api key",
+                         path.read_text(errors="replace"), re.IGNORECASE):
+                raise AssertionError(f"Protocol error in {path}")
+
+    def diagnostics(self):
+        """Capture live failure state before cleanup destroys the blocked threads/sessions."""
+        for name, process in self.processes.items():
+            if process.poll() is None and shutil.which("jcmd"):
+                with contextlib.suppress(Exception):
+                    output = self.command(["jcmd", process.pid, "Thread.print"], check=False, timeout=10)
+                    (self.evidence / f"threads-{name}.txt").write_text(output or "jcmd failed")
+        with contextlib.suppress(Exception):
+            for path in ("/controller", "/admin/delete_topics", "/brokers/topics/bridge-continuous-mutation"):
+                output = self.zk(f"get {path}")
+                (self.evidence / ("znode-" + path.strip("/").replace("/", "-") + ".txt")).write_text(output)
+        for name in ("stage", "progress"):
+            path = self.churn_dir / name
+            if path.exists():
+                shutil.copyfile(path, self.evidence / f"metadata-churn-{name}.txt")
+
+    def finish(self, passed):
+        if not passed:
+            self.diagnostics()
+        source_unchanged = all(path.is_file() and file_sha256(path) == digest
+                               for name, digest in self.source_hashes.items() for path in [SCRIPT_DIR / name])
+        passed = passed and source_unchanged
+        for name in sorted(self.processes, key=lambda value: value == "zookeeper"):
+            with contextlib.suppress(Exception):
+                self.stop(name, cleanup=True)
+        for handle in self.handles:
+            handle.close()
+        for filename, columns, rows in (
+                ("timings.tsv", ("operation", "duration_seconds", "result"), self.timings),
+                ("broker-resources.tsv", ("timestamp_utc", "phase", "process", "pid", "rss_kib"), self.resources)):
+            with (self.evidence / filename).open("w", newline="") as output:
+                writer = csv.writer(output, delimiter="\t")
+                writer.writerow(columns)
+                writer.writerows(rows)
+        suite = ET.Element("testsuite", name="li-bridge-process", tests=str(len(self.timings) + 1),
+                           failures=str(sum(result != "passed" for _, _, result in self.timings) + (not passed)))
+        for label, seconds, result in self.timings + [("complete-migration", 0, "passed" if passed else "failed")]:
+            case = ET.SubElement(suite, "testcase", name=label, classname="LiBridgeMigration", time=str(seconds))
+            if result != "passed":
+                ET.SubElement(case, "failure", message="See retained process-commands.log and process-logs.tgz")
+        ET.ElementTree(suite).write(self.evidence / "TEST-li-bridge-process.xml", encoding="utf-8", xml_declaration=True)
+        summary = {"contract_version": CONTRACT_VERSION, "passed": passed, "exit_status": 0 if passed else 1,
+                   "started_utc": self.started, "finished_utc": utc_now(), "scenario": self.scenario,
+                   "source_sha256": self.source_hashes, "source_unchanged": source_unchanged,
+                   "archives": {generation: {"path": str(path), "sha256": file_sha256(path)}
+                                for generation, path in self.archives.items()},
+                   "scale": {"topic_count": self.scenario["SCALE_TOPIC_COUNT"], "partitions_per_topic": self.scenario["SCALE_PARTITION_COUNT"]},
+                   "recovery": {"record_count": self.scenario["RECOVERY_RECORD_COUNT"], "record_size": self.scenario["RECOVERY_RECORD_SIZE"]}}
+        (self.evidence / "run-summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True))
+        if os.environ.get("EVIDENCE_INCLUDE_LOGS", "1") == "1":
+            with tarfile.open(self.evidence / "process-logs.tgz", "w:gz") as archive:
+                for path in self.work.rglob("*.log"):
+                    if not path.is_relative_to(self.evidence):
+                        archive.add(path, arcname=str(path.relative_to(self.work)))
+        # Preserve failures and default in-work evidence. Never silently erase the only proof.
+        if passed and os.environ.get("KEEP_WORK_DIR") != "1" and not self.evidence.is_relative_to(self.work):
+            shutil.rmtree(self.work)
+        print(f"Evidence: {self.evidence}; work: {self.work}", flush=True)
+        return passed
+
+
+def main():
+    migration = Migration()
+    passed = False
+    def interrupted(_signum, _frame):
+        raise InterruptedError("Migration interrupted")
+    signal.signal(signal.SIGTERM, interrupted)
+    try:
+        migration.run()
+        passed = True
+    finally:
+        passed = migration.finish(passed)
+    if not passed:
+        raise RuntimeError("Scenario source changed during execution; evidence is invalid")
+    print("Bridge activation, mixed binaries, persisted rollback, native/IBP and unchanged old clients passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bin/li_bridge_mixed_cluster_smoke.sh
+++ b/tests/bin/li_bridge_mixed_cluster_smoke.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Run the mixed-binary migration test. See README.li-bridge.md for inputs.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCRIPT_DIR
+if [[ -n "${JAVA_HOME:-}" ]]; then
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+fi
+: "${KAFKA_30_TGZ:?Set KAFKA_30_TGZ to the 3.0 bridge archive}"
+: "${KAFKA_39_TGZ:?Set KAFKA_39_TGZ to the 3.9 bridge archive}"
+exec python3 "${SCRIPT_DIR}/li_bridge_mixed_cluster_smoke.py" "$@"

--- a/tests/unit/li_bridge_scenario_test.py
+++ b/tests/unit/li_bridge_scenario_test.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "bin"))
+from li_bridge_contract import BRIDGE_GATES, FEATURES, PHASES, scenario_spec
+from li_bridge_mixed_cluster_smoke import Migration, verify_connect_records
+from li_bridge_preflight import parse_properties, zk_command
+
+
+class LiBridgeScenarioTest(unittest.TestCase):
+    def test_scenario_defaults_validation_and_runtime_profile(self):
+        default = scenario_spec({})
+        self.assertEqual(default, scenario_spec({"SCALE_TOPIC_COUNT": "10"}))
+        for key in ("SCALE_TOPIC_COUNT", "SCALE_PARTITION_COUNT", "RECOVERY_RECORD_COUNT", "RECOVERY_RECORD_SIZE"):
+            for value in ("0", "-1", "bad", "2147483648"):
+                with self.subTest(key=key, value=value), self.assertRaises(ValueError):
+                    scenario_spec({key: value})
+            self.assertNotEqual(default, scenario_spec({key: "20"}))
+        self.assertNotEqual(default, scenario_spec({"KAFKA_HEAP_OPTS": "-Xmx2g"}))
+        self.assertNotEqual(default, scenario_spec({"LI_BRIDGE_JAVA_30_HOME": "/jdk11"}))
+        self.assertEqual({"dormant", "legacy-bridge", "mixed", "all-39-bridge", "native", "ibp-39"}, set(PHASES))
+
+    def test_manifest_has_every_gate_and_effective_metric(self):
+        root = Path(__file__).parents[2]
+        config = (root / "core/src/main/scala/kafka/server/KafkaConfig.scala").read_text()
+        metrics = (root / "core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala").read_text()
+        self.assertEqual(set(BRIDGE_GATES), set(re.findall(r'"(li\.protocol\.bridge\.[^"]+\.enable)"', config)))
+        for _, metric, _ in FEATURES:
+            self.assertIn(f'"{metric}"', metrics)
+
+    def test_connect_validation_detects_loss_and_changed_values(self):
+        self.assertTrue(verify_connect_records(["a", "b"], ["a", "b"]))
+        self.assertFalse(verify_connect_records(["a", "b"], ["a", "a"]))
+        self.assertTrue(verify_connect_records(["a", "b"], ["a", "b", "b"]))  # documented at-least-once
+        with self.assertRaises(AssertionError):
+            verify_connect_records(["a", "b"], ["a", "corrupted"])
+
+    def test_zookeeper_nonode_exit_is_not_an_authentication_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            (home / "bin").mkdir()
+            (home / "bin/zookeeper-shell.sh").touch()
+            result = subprocess.CompletedProcess([], 1, "Node does not exist: /federatedTopics\n")
+            with mock.patch("li_bridge_preflight.subprocess.run", return_value=result):
+                self.assertIn("Node does not exist", zk_command(home, "localhost", "ls /federatedTopics"))
+            result.stdout = "KeeperErrorCode = NoAuth for /federatedTopics\n"
+            with mock.patch("li_bridge_preflight.subprocess.run", return_value=result), self.assertRaises(RuntimeError):
+                zk_command(home, "localhost", "ls /federatedTopics")
+
+    def test_command_deadline_terminates_child_process(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runner = object.__new__(Migration)
+            runner.deadline = time.monotonic() + 10
+            runner.scenario = scenario_spec({})
+            runner.commands = Path(directory) / "commands.log"
+            started = time.monotonic()
+            with self.assertRaises(subprocess.TimeoutExpired):
+                runner.command([sys.executable, "-c", "import time; time.sleep(60)"], timeout=0.05)
+            self.assertLess(time.monotonic() - started, 5)
+            self.assertTrue(runner.commands.exists())
+            output = runner.command([sys.executable, "-c", "print('Node does not exist: /x'); exit(1)"],
+                                    check=False, allow_missing=True)
+            self.assertIn("Node does not exist", output)
+            self.assertIsNone(runner.command([sys.executable, "-c", "print('NoAuth'); exit(1)"],
+                                            check=False, allow_missing=True))
+
+    def test_connect_rest_listener_is_local_and_does_not_reserve_a_fixed_port(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runner = object.__new__(Migration)
+            runner.work = Path(directory)
+            runner.client_dir = runner.work / "old-clients"
+            runner.churn_dir = runner.work / "churn"
+            runner.scenario = scenario_spec({})
+            runner.bootstrap = "127.0.0.1:29092"
+            runner.homes = {"3.0": runner.work / "kafka"}
+            with mock.patch.object(runner, "create"), mock.patch.object(runner, "start"), mock.patch.object(runner, "until"):
+                runner.start_clients()
+            config = parse_properties(runner.work / "connect.properties")
+            self.assertEqual("http://127.0.0.1:0", config["listeners"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Run the full independent-process migration with unchanged old clients and active metadata mutations. Cover activation/backout, both persisted rollback paths, both controller generations, hard failures, replica recovery, reassignment cancellation, truncation, native control and final IBP 3.9. Keep Bash as a short entry point; Python owns orchestration and diagnostics. Java workloads precede this layer.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.