### PR TITLE
tests: make bridge verification reproducible and auditable

### DIFF
--- a/tests/bin/li_bridge_commands.py
+++ b/tests/bin/li_bridge_commands.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run verification commands with deadlines and retained output."""
+
+import contextlib
+import csv
+import os
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+
+class Commands:
+    def __init__(self, evidence, environment, resume=False, dry_run=False):
+        self.evidence = Path(evidence)
+        self.evidence.mkdir(parents=True, exist_ok=True)
+        self.environment = dict(environment)
+        self.resume = resume
+        self.dry_run = dry_run
+        self.timeout = int(environment.get("BRIDGE_VERIFY_COMMAND_TIMEOUT_SECONDS", "3600"))
+        if self.timeout <= 0:
+            raise ValueError("BRIDGE_VERIFY_COMMAND_TIMEOUT_SECONDS must be positive")
+        self.records = self.evidence / "commands.tsv"
+        self.results = {}
+        if resume and self.records.is_file():
+            with self.records.open(newline="", encoding="utf-8") as source:
+                for row in csv.DictReader(source, delimiter="\t"):
+                    self.results[row["command"]] = row["result"]
+        else:
+            self.records.write_text("command\tduration_seconds\tresult\n", encoding="utf-8")
+
+    def record(self, label, started, result):
+        with self.records.open("a", encoding="utf-8", newline="") as output:
+            csv.writer(output, delimiter="\t").writerow((label, round(time.monotonic() - started, 3), result))
+        self.results[label] = result
+
+    def run(self, label, args, cwd, extra_env=None, always=False):
+        print(f"===== {label} =====", flush=True)
+        if self.resume and not always and self.results.get(label) == "passed":
+            print(f"Reusing previously passed command {label}", flush=True)
+            return
+        environment = dict(self.environment, **(extra_env or {}))
+        command = list(map(str, args))
+        if self.dry_run:
+            exports = " ".join(f"{key}={shlex.quote(str(value))}" for key, value in (extra_env or {}).items())
+            print(f"DRY RUN: {exports} {shlex.join(command)}", flush=True)
+            return
+        log_path = self.evidence / f"{label}.log"
+        if log_path.exists():
+            attempt = 1
+            while (self.evidence / f"{label}-attempt-{attempt}.log").exists():
+                attempt += 1
+            shutil.copyfile(log_path, self.evidence / f"{label}-attempt-{attempt}.log")
+        started = time.monotonic()
+        result = "failed(start)"
+        with log_path.open("w", encoding="utf-8") as log:
+            log.write(f"Command: {shlex.join(command)}\nDirectory: {cwd}\n")
+            try:
+                process = subprocess.Popen(command, cwd=cwd, env=environment, stdout=subprocess.PIPE,
+                                           stderr=subprocess.STDOUT, text=True, errors="replace", start_new_session=True)
+            except OSError:
+                self.record(label, started, result)
+                raise
+            reader_errors = []
+
+            def copy_output():
+                try:
+                    for line in process.stdout:
+                        log.write(line)
+                        log.flush()
+                        sys.stdout.write(line)
+                        sys.stdout.flush()
+                except Exception as error:
+                    reader_errors.append(error)
+
+            reader = threading.Thread(target=copy_output, daemon=True)
+            reader.start()
+            try:
+                status = process.wait(timeout=self.timeout)
+                reader.join(timeout=10)
+                if reader.is_alive() or reader_errors:
+                    raise RuntimeError(f"Could not retain complete output for {label}")
+                result = "passed" if status == 0 else f"failed({status})"
+                if status != 0:
+                    raise subprocess.CalledProcessError(status, command)
+            except BaseException:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(process.pid, signal.SIGTERM)
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    with contextlib.suppress(ProcessLookupError):
+                        os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=10)
+                reader.join(timeout=10)
+                raise
+            finally:
+                process.stdout.close()
+                self.record(label, started, result)

--- a/tests/bin/li_bridge_test_selection.ini
+++ b/tests/bin/li_bridge_test_selection.ini
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Focused tests for the local verifier. Each entry is a Gradle --tests filter.
+# Full mode adds the complete clients, server and storage suites.
+[clients]
+org.apache.kafka.common.message.Bridge*
+org.apache.kafka.common.protocol.BridgeProtocolConstantsTest
+org.apache.kafka.common.requests.RequestResponseTest
+org.apache.kafka.clients.NodeApiVersionsTest
+org.apache.kafka.clients.admin.LiKafkaAdminClientTest
+org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListenerTest
+org.apache.kafka.common.utils.PoisonPillProcessTest
+
+[core]
+kafka.controller.ControllerChannelManagerTest
+kafka.controller.ControllerContextTest
+kafka.controller.KafkaControllerTest
+kafka.controller.LiShutdownSafetyTest
+kafka.controller.TopicDeletionManagerTest
+kafka.admin.BrokerApiVersionsCommandTest
+kafka.admin.AdminZkClientTest.testInvalidMaintenanceBrokerListHasAdminError
+kafka.cluster.PartitionTest.testLeaderTransferSelectsLowestInSyncFollower
+kafka.log.UnifiedLogTest.testTruncateTo
+kafka.network.RequestChannelWatchdogTest
+kafka.network.RequestMetricBucketsTest
+kafka.network.LegacyRequestMetricsTest
+kafka.network.MetadataOutgoingBytesTest
+kafka.server.ApiVersionManagerTest
+kafka.server.BridgeMetadataCacheEpochTest
+kafka.server.BridgeAlterPartitionRetryTest
+kafka.server.BridgeStrayLogDeletionTest
+kafka.server.ApiVersionsRequestTest
+kafka.server.KafkaActionsTest
+kafka.server.KafkaConfigTest.testFromPropsInvalid
+kafka.server.KafkaConfigTest.testEmptyRequestMetricBuckets
+kafka.server.KafkaConfigTest.testInvalidMaintenanceBrokerList
+kafka.server.KafkaConfigTest.testInvalidRequestMetricBuckets
+kafka.server.KafkaConfigTest.testRequestMetricBucketsMustBeOrderedAndNonNegative
+kafka.server.KafkaServerTest.testRequestChannelWatchdogIntervalTracksConfiguredTimeout
+kafka.server.DynamicBrokerConfigTest.testProtocolBridgeFlagDefaultsAndDynamicScope
+kafka.server.LiControllerOperationsTest
+kafka.server.LiDynamicTopicDeletionTest
+kafka.server.KafkaApisTest
+kafka.server.LegacyBrokerConstructorTest
+kafka.server.QuotaFactoryTest
+kafka.server.ClientQuotaManagerTest
+kafka.server.LeaderTransferManagerTest
+kafka.server.LiCreateTopicPolicyTest
+kafka.server.LiProtocolBridgeConfigTest
+kafka.server.LiProtocolBridgeMetricsTest
+kafka.server.ListOffsetsRequestInstrumentationTest
+kafka.server.ObserverTest
+kafka.server.ProduceRequestInstrumentationTest
+kafka.server.RackIdMapperTest
+kafka.server.RequestQuotaTest
+kafka.server.SaslApiVersionsRequestTest
+kafka.zk.KafkaZkClientTest.testPaginatedConfigReadPropagatesClientFailure
+kafka.zk.KafkaZkClientTest.testSetTopicDeletionFlagCreatesMissingZnode
+kafka.zk.LiControllerZkOperationsTest
+
+[storage]
+org.apache.kafka.storage.internals.log.LogDirFailureChannelTest
+org.apache.kafka.storage.log.metrics.BrokerTopicMetricsTest

--- a/tests/bin/stage_li_bridge_ivy.py
+++ b/tests/bin/stage_li_bridge_ivy.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build and stage local Scala 2.12 artifacts. This does not publish a release."""
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ORGANISATION = "com.linkedin.kafka"
+MAVEN_NAMESPACE = "http://ant.apache.org/ivy/maven"
+# Build output, Gradle project, published module, test classifier required by the wrapper.
+MODULES = (
+    ("clients", "clients", "kafka-clients", True),
+    ("server", "server", "kafka-server", False),
+    ("server-common", "server-common", "kafka-server-common", True),
+    ("storage", "storage", "kafka-storage", False),
+    ("storage/api", "storage:storage-api", "kafka-storage-api", False),
+    ("metadata", "metadata", "kafka-metadata", False),
+    ("raft", "raft", "kafka-raft", False),
+    ("group-coordinator", "group-coordinator", "kafka-group-coordinator", False),
+    ("group-coordinator/group-coordinator-api", "group-coordinator:group-coordinator-api",
+     "kafka-group-coordinator-api", False),
+    ("transaction-coordinator", "transaction-coordinator", "kafka-transaction-coordinator", False),
+    ("core", "core", "kafka_2.12", True),
+)
+
+
+def java_17(environment):
+    executable = str(Path(environment["JAVA_HOME"]) / "bin/java") if environment.get("JAVA_HOME") else "java"
+    result = subprocess.run([executable, "-version"], stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, text=True, check=True, timeout=30)
+    if not re.search(r'version "17(?:[.\-"])', result.stdout):
+        raise ValueError("Set JAVA_HOME to a Java 17 installation before staging bridge artifacts")
+
+
+def write_ivy(path, module, version, test_classifier):
+    ET.register_namespace("m", MAVEN_NAMESPACE)
+    root = ET.Element("ivy-module", version="2.0")
+    ET.SubElement(root, "info", organisation=ORGANISATION, module=module, revision=version)
+    configurations = ET.SubElement(root, "configurations")
+    ET.SubElement(configurations, "conf", name="default", visibility="public")
+    publications = ET.SubElement(root, "publications")
+    ET.SubElement(publications, "artifact", name=module, type="jar", ext="jar", conf="default")
+    if test_classifier:
+        ET.SubElement(publications, "artifact", name=module, type="jar", ext="jar", conf="default",
+                      attrib={f"{{{MAVEN_NAMESPACE}}}classifier": "test"})
+    if module == "kafka_2.12":
+        dependencies = ET.SubElement(root, "dependencies")
+        for name, revision in (("scala-collection-compat_2.12", "2.10.0"),
+                               ("scala-java8-compat_2.12", "1.0.2")):
+            ET.SubElement(dependencies, "dependency", org="org.scala-lang.modules", name=name,
+                          rev=revision, conf="default->default")
+        for _, _, dependency, _ in MODULES:
+            if dependency != module:
+                ET.SubElement(dependencies, "dependency", org=ORGANISATION, name=dependency,
+                              rev=version, conf="default->default")
+    ET.indent(root)
+    ET.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def stage(root, repository, version, environment):
+    java_17(environment)
+    if not re.fullmatch(r"3\.9\.\d+(?:\.\d+)?(?:-SNAPSHOT)?", version):
+        raise ValueError(f"Invalid local bridge version: {version!r}")
+    tasks = []
+    for _, project, module, tests in MODULES:
+        tasks.append(f"{project}:{'shadowJar' if module == 'kafka-clients' else 'jar'}")
+        if tests:
+            tasks.append(f"{project}:testJar")
+    subprocess.run([str(root / "gradlew"), "--no-daemon", "--max-workers=4", "-PscalaVersion=2.12",
+                    f"-Pversion={version}", *tasks], cwd=root, env=environment, check=True, timeout=3600)
+    artifact_root = repository / Path(*ORGANISATION.split("."))
+    installed = []
+    for output, _, module, tests in MODULES:
+        destination = artifact_root / module / version
+        destination.mkdir(parents=True, exist_ok=True)
+        for classifier in (("", "-test") if tests else ("",)):
+            name = f"{module}-{version}{classifier}.jar"
+            shutil.copyfile(root / output / "build/libs" / name, destination / name)
+            installed.append(destination / name)
+        ivy = destination / f"{module}-{version}.ivy"
+        write_ivy(ivy, module, version, tests)
+        installed.append(ivy)
+    revision = subprocess.run(["git", "rev-parse", "HEAD"], cwd=root, capture_output=True, text=True)
+    status = subprocess.run(["git", "status", "--porcelain"], cwd=root, capture_output=True, text=True)
+    manifest = {
+        "version": version, "scala_binary_version": "2.12",
+        "source_commit": revision.stdout.strip() if revision.returncode == 0 else "unknown",
+        "source_dirty": status.returncode != 0 or bool(status.stdout.strip()),
+        # Do not scan the repository: unrelated artifacts from older runs must stay out.
+        "files": [{"path": str(path.relative_to(artifact_root)),
+                   "sha256": hashlib.sha256(path.read_bytes()).hexdigest()} for path in sorted(installed)],
+    }
+    path = artifact_root / "bridge-artifact-manifest.json"
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Staged local bridge artifacts under {artifact_root}")
+    print(f"Wrote artifact checksums to {path}")
+    return manifest
+
+
+def main():
+    root = Path(__file__).resolve().parents[2]
+    environment = dict(os.environ)
+    repository = Path(environment.get("LI_IVY_REPO", str(Path.home() / "local-repo"))).expanduser()
+    version = environment.get("LI_BRIDGE_VERSION", "3.9.2")
+    try:
+        stage(root, repository, version, environment)
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        print(f"Local artifact staging failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bin/stage_li_bridge_ivy.sh
+++ b/tests/bin/stage_li_bridge_ivy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Build and stage local bridge artifacts. See README.li-bridge.md for inputs.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCRIPT_DIR
+exec python3 "${SCRIPT_DIR}/stage_li_bridge_ivy.py" "$@"

--- a/tests/bin/verify_li_bridge.py
+++ b/tests/bin/verify_li_bridge.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify both bridge archives, wrapper dependencies and the migration scenario.
+
+The shell entry point preserves existing environment-variable usage. This module
+owns command selection, input checks, resume rules and the final result.
+"""
+
+import configparser
+import datetime
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from audit_li_bridge_evidence import audit, verification_fingerprints
+from li_bridge_commands import Commands
+from stage_li_bridge_ivy import java_17
+
+
+def write_json(path, data):
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def selection(path):
+    parser = configparser.ConfigParser(allow_no_value=True, interpolation=None)
+    parser.optionxform = str
+    with path.open(encoding="utf-8") as source:
+        parser.read_file(source)
+    if set(parser.sections()) != {"clients", "core", "storage"}:
+        raise ValueError("Test selection must define clients, core and storage")
+    result = {section: list(parser[section]) for section in parser.sections()}
+    if any(not tests for tests in result.values()):
+        raise ValueError("Each focused suite must contain at least one test")
+    return result
+
+
+class Verification:
+    def __init__(self, root, environment):
+        self.root = Path(root).resolve()
+        self.bin = self.root / "tests/bin"
+        self.env = dict(environment)
+        self.wrapper = Path(self.env.get("WRAPPER_ROOT", str(Path.home() / "code/li/kafka-server"))).resolve()
+        self.full = self.env.get("BRIDGE_VERIFY_FULL") == "1"
+        self.resume = self.env.get("BRIDGE_VERIFY_RESUME") == "1"
+        self.dry_run = self.env.get("BRIDGE_VERIFY_DRY_RUN") == "1"
+        self.skip_stage = self.env.get("SKIP_LOCAL_STAGE") == "1"
+        self.offline = self.env.get("WRAPPER_GRADLE_OFFLINE") == "1"
+        self.legacy = Path(self.env["KAFKA_30_TGZ"]).resolve() if self.env.get("KAFKA_30_TGZ") else None
+        self.supplied = Path(self.env["KAFKA_39_TGZ"]).resolve() if self.env.get("KAFKA_39_TGZ") else None
+        self.broker = self.supplied
+        if self.supplied and (not self.skip_stage or not self.legacy):
+            raise ValueError("KAFKA_39_TGZ requires KAFKA_30_TGZ and SKIP_LOCAL_STAGE=1")
+        if not self.dry_run and not self.legacy and self.env.get("ALLOW_PARTIAL") != "1":
+            raise ValueError("Set KAFKA_30_TGZ for complete verification, or ALLOW_PARTIAL=1 for local checks")
+        java_17(self.env)
+        if not self.wrapper.is_dir():
+            raise ValueError(f"Wrapper checkout not found at {self.wrapper}")
+        default_version = next(line.split("=", 1)[1] for line in (self.root / "gradle.properties").read_text().splitlines()
+                               if line.startswith("version="))
+        self.version = self.env.get("LI_BRIDGE_VERSION", default_version)
+        stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        self.evidence = Path(self.env.get("EVIDENCE_DIR", f"/tmp/li-bridge-verification-{stamp}")).resolve()
+        if self.evidence.is_relative_to(self.root) or self.evidence.is_relative_to(self.wrapper):
+            raise ValueError("EVIDENCE_DIR must be outside both source checkouts")
+        self.evidence.mkdir(parents=True, exist_ok=True)
+        self.fingerprint_file = self.evidence / "source-fingerprints.json"
+        self.fingerprints = None
+        self.started = False
+        self.commands = None
+
+    def current_fingerprints(self):
+        result = verification_fingerprints(self.root, self.wrapper, self.legacy, self.skip_stage,
+                                           self.supplied, self.version)
+        # Input filenames can disappear during core:clean. Identify archives by their
+        # retained, content-addressed path before writing or reusing any stage result.
+        for key, generation in (("legacy_archive", "3.0"), ("broker_archive", "3.9")):
+            archive = result["inputs"][key]
+            if archive is not None:
+                archive["path"] = str(self.evidence / "archives" / f"kafka-{generation}-{archive['sha256']}.tgz")
+        return result
+
+    def check_inputs(self):
+        if self.dry_run:
+            return
+        current = self.current_fingerprints()
+        if self.resume:
+            if not self.fingerprint_file.is_file():
+                raise ValueError("Cannot resume without source-fingerprints.json")
+            recorded = json.loads(self.fingerprint_file.read_text())
+            if recorded != current:
+                raise ValueError("Source, archive, staging or scenario inputs changed; use a new evidence directory")
+        else:
+            write_json(self.fingerprint_file, current)
+        self.fingerprints = current
+
+    def command(self, label, args, cwd=None, extra_env=None, always=False):
+        self.commands.run(label, args, cwd or self.root, extra_env, always)
+
+    def gradle(self, label, tasks, cwd=None):
+        directory = cwd or self.root
+        self.command(label, [directory / "gradlew", "--no-daemon", *tasks], directory)
+
+    def snapshot(self, path, generation, label):
+        manifest = self.evidence / f"archive-{generation.replace('.', '')}.json"
+        self.command(label, [sys.executable, self.bin / "li_bridge_artifacts.py", "snapshot", "--archive", path,
+                             "--generation", generation, "--output-dir", self.evidence / "archives",
+                             "--output-json", manifest], always=True)
+        return path if self.dry_run else Path(json.loads(manifest.read_text())["path"])
+
+    def wrapper_artifacts(self, after=False):
+        arguments = [sys.executable, self.bin / "li_bridge_artifacts.py", "wrapper",
+                     "--archive-json", self.evidence / "archive-39.json", "--wrapper-root", self.wrapper,
+                     "--classpath-json", self.evidence / "wrapper-classpath.json"]
+        if not after:
+            tasks = [self.wrapper / "gradlew", "--no-daemon", "-I", self.bin / "li_bridge_wrapper_artifacts.gradle",
+                     "liBridgeArtifactClasspath", "-x", "format"]
+            if self.offline:
+                tasks.append("--offline")
+            self.command("wrapper-classpath", tasks, self.wrapper,
+                         {"BRIDGE_WRAPPER_ARTIFACTS_OUTPUT": str(self.evidence / "wrapper-classpath.json")}, always=True)
+            arguments += ["--output-json", self.evidence / "wrapper-artifacts.json"]
+            self.command("wrapper-artifacts", arguments, always=True)
+        else:
+            arguments += ["--output-json", self.evidence / "wrapper-artifacts-after.json",
+                          "--compare-report", self.evidence / "wrapper-artifacts.json"]
+            self.command("wrapper-artifacts-unchanged", arguments, always=True)
+
+    def summary(self, passed, error=None):
+        result = {"passed": passed,
+                  "finished_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                  "level": "full-suites" if self.full else "focused"}
+        if self.fingerprints:
+            for name, directory in (("kafka", self.root), ("wrapper", self.wrapper)):
+                commit = subprocess.check_output(["git", "-C", str(directory), "rev-parse", "HEAD"], text=True).strip()
+                dirty = bool(subprocess.check_output(["git", "-C", str(directory), "status", "--porcelain"], text=True))
+                result[name] = {"commit": commit, "dirty": dirty, "source_sha256": self.fingerprints[name]["sha256"]}
+        if error:
+            result["error"] = str(error)
+        return result
+
+    def finish(self):
+        if self.dry_run:
+            print(f"Bridge verification plan rendered: {self.evidence}")
+            return
+        if self.current_fingerprints() != self.fingerprints:
+            raise ValueError("Source, archive or scenario inputs changed during verification")
+        if not self.legacy:
+            result = self.summary(False)
+            result["partial_checks_passed"] = True
+            write_json(self.evidence / "verification-summary.json", result)
+            print(f"Partial checks passed; cross-artifact verification was not run: {self.evidence}")
+            return
+        started = time.monotonic()
+        candidate = self.summary(True)
+        # Do not write a successful summary before the final audit. The candidate exists
+        # only in memory; failure publishes passed=false and cannot leave a stale green file.
+        result = audit(self.evidence, require_full=self.full, require_archives=True,
+                       require_stage=not self.skip_stage, summary_override=candidate)
+        write_json(self.evidence / "evidence-audit.json", result)
+        self.commands.record("evidence-audit", started, "passed" if result["passed"] else "failed(1)")
+        candidate["passed"] = result["passed"]
+        write_json(self.evidence / "verification-summary.json", candidate)
+        if not result["passed"]:
+            raise ValueError("Evidence audit failed: " + "; ".join(result["issues"]))
+        print(f"Bridge verification passed: {self.evidence}")
+
+    def run(self):
+        self.check_inputs()
+        self.commands = Commands(self.evidence, self.env, self.resume, self.dry_run)
+        self.started = True
+        if not self.dry_run:
+            write_json(self.evidence / "verification-summary.json", self.summary(False, "Verification is running"))
+        if self.legacy:
+            self.legacy = self.snapshot(self.legacy, "3.0", "archive-input-30")
+        if self.supplied:
+            self.supplied = self.snapshot(self.supplied, "3.9", "provided-39")
+            self.broker = self.supplied
+            self.command("provided-wrapper-version", [sys.executable, self.bin / "li_bridge_artifacts.py", "wrapper",
+                         "--archive-json", self.evidence / "archive-39.json", "--wrapper-root", self.wrapper], always=True)
+        self.command("preflight-unit", [sys.executable, "-m", "unittest", "discover", "-s", "tests/unit",
+                                       "-p", "li_bridge*_test.py"])
+        self.command("source-whitespace", ["git", "diff", "--check"])
+        self.command("wrapper-whitespace", ["git", "diff", "--check"], self.wrapper)
+        for scala in ("2.12", "2.13"):
+            self.gradle(f"scala-{scala.replace('.', '')}-compile", ["--max-workers=4", f"-PscalaVersion={scala}",
+                        "core:clean", "clients:compileTestJava", "core:compileScala", "core:compileTestScala",
+                        "jmh-benchmarks:compileJava"])
+        for project, filters in selection(self.bin / "li_bridge_test_selection.ini").items():
+            tasks = [f"{project}:cleanTest", f"{project}:test", "--max-workers=4"]
+            for pattern in filters:
+                tasks += ["--tests", pattern]
+            self.gradle(f"{project}-bridge-tests", tasks)
+        self.gradle("vendor-pagination", ["--max-workers=3", "-PscalaVersion=2.12", "-I",
+                                          "tests/bin/li_bridge_zookeeper_test.gradle", "core:liZookeeperPaginationTest"])
+        if self.full:
+            for project in ("clients", "server", "storage"):
+                self.gradle(f"{project}-full", [f"{project}:cleanTest", f"{project}:test", "--max-workers=4"])
+        if not self.skip_stage:
+            self.command("stage-wrapper-artifacts", [self.bin / "stage_li_bridge_ivy.sh"],
+                         extra_env={"LI_BRIDGE_VERSION": self.version})
+        if self.legacy:
+            if not self.supplied:
+                archive = self.root / f"core/build/distributions/kafka_2.12-{self.version}.tgz"
+                manifest = self.evidence / "archive-39.json"
+                if self.resume and self.commands.results.get("release-39") == "passed" and manifest.is_file():
+                    archive = Path(json.loads(manifest.read_text())["path"])
+                self.gradle("release-39", ["-PscalaVersion=2.12", f"-Pversion={self.version}", "core:releaseTarGz"])
+                self.broker = self.snapshot(archive, "3.9", "archive-built-39")
+            self.wrapper_artifacts()
+            tasks = [self.wrapper / "gradlew", "--no-daemon", ":likafka:kafka-impl_2.12:cleanTest",
+                     ":likafka:kafka-impl_2.12:test", "-x", "format"]
+            if self.offline:
+                tasks.append("--offline")
+            self.command("wrapper-tests", tasks, self.wrapper, {"KAFKA_30_TGZ": str(self.legacy)})
+            self.wrapper_artifacts(after=True)
+            self.gradle("stop-kafka-gradle", ["--stop"])
+            self.gradle("stop-wrapper-gradle", ["--stop"], self.wrapper)
+            self.command("mixed-process", [self.bin / "li_bridge_mixed_cluster_smoke.sh"], extra_env={
+                "KAFKA_30_TGZ": str(self.legacy), "KAFKA_39_TGZ": str(self.broker),
+                "EVIDENCE_DIR": str(self.evidence / "mixed-process")})
+        self.finish()
+
+
+def main():
+    verification = None
+    def interrupted(_signum, _frame):
+        raise InterruptedError("Verification interrupted")
+    signal.signal(signal.SIGTERM, interrupted)
+    try:
+        verification = Verification(Path(__file__).resolve().parents[2], os.environ)
+        verification.run()
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError, KeyboardInterrupt) as error:
+        if verification and verification.started and not verification.dry_run:
+            write_json(verification.evidence / "verification-summary.json", verification.summary(False, error))
+        print(f"Bridge verification failed: {error}", file=sys.stderr)
+        return 2 if verification is None else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bin/verify_li_bridge.sh
+++ b/tests/bin/verify_li_bridge.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Verify the bridge binaries and wrapper. See README.li-bridge.md for inputs.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCRIPT_DIR
+if [[ -n "${JAVA_HOME:-}" ]]; then
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+fi
+exec python3 "${SCRIPT_DIR}/verify_li_bridge.py" "$@"

--- a/tests/unit/li_bridge_commands_test.py
+++ b/tests/unit/li_bridge_commands_test.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "bin"))
+from li_bridge_commands import Commands
+from verify_li_bridge import Verification, selection, write_json
+
+
+class LiBridgeCommandsTest(unittest.TestCase):
+    def test_failed_last_attempt_is_not_reused_and_logs_are_retained(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            commands = Commands(root, os.environ)
+            commands.run("probe", [sys.executable, "-c", "print('first pass')"], root)
+            with self.assertRaises(subprocess.CalledProcessError):
+                commands.run("probe", [sys.executable, "-c", "raise SystemExit(7)"], root)
+            resumed = Commands(root, os.environ, resume=True)
+            resumed.run("probe", [sys.executable, "-c", "print('fresh pass')"], root)
+            self.assertEqual("passed", resumed.results["probe"])
+            self.assertIn("fresh pass", (root / "probe.log").read_text())
+            self.assertIn("first pass", (root / "probe-attempt-1.log").read_text())
+            self.assertTrue((root / "probe-attempt-2.log").is_file())
+            resumed.run("probe", ["must-not-run"], root)
+
+    def test_timeout_and_start_failure_are_not_successes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            environment = dict(os.environ, BRIDGE_VERIFY_COMMAND_TIMEOUT_SECONDS="1")
+            commands = Commands(root, environment)
+            started = time.monotonic()
+            with self.assertRaises(subprocess.TimeoutExpired):
+                commands.run("timeout", [sys.executable, "-c", "import time; time.sleep(60)"], root)
+            self.assertLess(time.monotonic() - started, 10)
+            self.assertNotEqual("passed", commands.results["timeout"])
+            with self.assertRaises(FileNotFoundError):
+                commands.run("missing", [str(root / "missing-command")], root)
+            self.assertNotEqual("passed", commands.results["missing"])
+
+    def test_result_is_published_only_after_audit(self):
+        for passed in (False, True):
+            with self.subTest(passed=passed), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                verification = object.__new__(Verification)
+                verification.evidence = root
+                verification.dry_run = False
+                verification.full = False
+                verification.skip_stage = False
+                verification.legacy = root / "legacy.tgz"
+                verification.fingerprints = {"source": "unchanged"}
+                verification.commands = Commands(root, os.environ)
+                write_json(root / "verification-summary.json", {"passed": False})
+
+                def check_candidate(*args, **kwargs):
+                    self.assertFalse(json.loads((root / "verification-summary.json").read_text())["passed"])
+                    self.assertTrue(kwargs["summary_override"]["passed"])
+                    return {"passed": passed, "issues": [] if passed else ["audit failed"], "warnings": []}
+
+                with mock.patch.object(verification, "current_fingerprints", return_value=verification.fingerprints), \
+                        mock.patch.object(verification, "summary", return_value={"passed": True}), \
+                        mock.patch("verify_li_bridge.audit", side_effect=check_candidate):
+                    if passed:
+                        verification.finish()
+                    else:
+                        with self.assertRaisesRegex(ValueError, "audit failed"):
+                            verification.finish()
+                self.assertEqual(passed, json.loads((root / "verification-summary.json").read_text())["passed"])
+                self.assertEqual("passed" if passed else "failed(1)", verification.commands.results["evidence-audit"])
+
+    def test_selection_names_tests_and_requires_all_suites(self):
+        path = Path(__file__).parents[1] / "bin/li_bridge_test_selection.ini"
+        selected = selection(path)
+        self.assertIn("kafka.controller.TopicDeletionManagerTest", selected["core"])
+        self.assertIn("org.apache.kafka.common.message.Bridge*", selected["clients"])
+        with tempfile.TemporaryDirectory() as directory:
+            invalid = Path(directory) / "selection.ini"
+            invalid.write_text("[core]\nkafka.Foo\n")
+            with self.assertRaises(ValueError):
+                selection(invalid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/li_bridge_tooling_test.py
+++ b/tests/unit/li_bridge_tooling_test.py
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+BIN = Path(__file__).parents[1] / "bin"
+SPEC = importlib.util.spec_from_file_location("li_bridge_artifacts", BIN / "li_bridge_artifacts.py")
+ARTIFACTS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ARTIFACTS)
+
+
+class LiBridgeToolingTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+
+    def java_home(self):
+        java = self.root / "jdk/bin/java"
+        java.parent.mkdir(parents=True, exist_ok=True)
+        java.write_text('#!/usr/bin/env python3\nimport sys\nprint(\'openjdk version "17.0.5"\', file=sys.stderr)\n')
+        java.chmod(0o755)
+        return str(java.parents[1])
+
+    def verifier_plan(self, supplied, skip_stage):
+        wrapper = self.root / "wrapper"
+        wrapper.mkdir(exist_ok=True)
+        environment = dict(os.environ, JAVA_HOME=self.java_home(), WRAPPER_ROOT=str(wrapper),
+                           BRIDGE_VERIFY_DRY_RUN="1", BRIDGE_VERIFY_RESUME="0", BRIDGE_VERIFY_FULL="0",
+                           KAFKA_30_TGZ=str(self.root / "kafka_2.12-3.0.1.83.tgz"), SKIP_LOCAL_STAGE=skip_stage,
+                           LI_BRIDGE_VERSION="3.9.2.19", EVIDENCE_DIR=str(self.root / "plan"))
+        environment.pop("KAFKA_39_TGZ", None)
+        if supplied:
+            environment["KAFKA_39_TGZ"] = str(self.root / "kafka_2.12-3.9.2.17.tgz")
+        return subprocess.run(["bash", str(BIN / "verify_li_bridge.sh")], env=environment,
+                              capture_output=True, text=True)
+
+    def test_supplied_verifier_plan_does_not_build_or_stage(self):
+        result = self.verifier_plan(supplied=True, skip_stage="1")
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("provided-39", result.stdout)
+        self.assertIn("KAFKA_39_TGZ=" + str((self.root / "kafka_2.12-3.9.2.17.tgz").resolve()), result.stdout)
+        self.assertIn("wrapper-artifacts", result.stdout)
+        self.assertNotIn("releaseTarGz", result.stdout)
+        self.assertNotIn("stage-wrapper-artifacts", result.stdout)
+
+    def test_supplied_archive_requires_staging_disabled(self):
+        result = self.verifier_plan(supplied=True, skip_stage="0")
+        self.assertEqual(2, result.returncode)
+        self.assertIn("SKIP_LOCAL_STAGE=1", result.stderr)
+
+    def test_staging_passes_version_to_gradle_and_limits_the_manifest(self):
+        project = self.root / "kafka"
+        script = project / "tests/bin/stage_li_bridge_ivy.sh"
+        script.parent.mkdir(parents=True)
+        shutil.copy2(BIN / script.name, script)
+        shutil.copy2(BIN / "stage_li_bridge_ivy.py", script.with_suffix(".py"))
+        subprocess.run(["git", "init", "-q", str(project)], check=True)
+        gradle = project / "gradlew"
+        gradle.write_text('''#!/usr/bin/env python3
+import os, sys
+from pathlib import Path
+version = os.environ["LI_BRIDGE_VERSION"]
+assert "-Pversion=" + version in sys.argv
+assert "-PscalaVersion=2.12" in sys.argv
+projects = {"clients": "kafka-clients", "core": "kafka_2.12", "server": "kafka-server",
+            "server-common": "kafka-server-common", "storage": "kafka-storage",
+            "storage/api": "kafka-storage-api", "metadata": "kafka-metadata", "raft": "kafka-raft",
+            "group-coordinator": "kafka-group-coordinator",
+            "group-coordinator/group-coordinator-api": "kafka-group-coordinator-api",
+            "transaction-coordinator": "kafka-transaction-coordinator"}
+for directory, module in projects.items():
+    output = Path(directory) / "build/libs"
+    output.mkdir(parents=True, exist_ok=True)
+    (output / (module + "-" + version + ".jar")).write_bytes(b"main jar")
+    if directory in ("clients", "core", "server-common"):
+        (output / (module + "-" + version + "-test.jar")).write_bytes(b"test jar")
+''')
+        gradle.chmod(0o755)
+        repository = self.root / "ivy"
+        foreign = repository / "com/linkedin/kafka/kafka-extra/3.9.2.19/foreign.jar"
+        foreign.parent.mkdir(parents=True)
+        foreign.write_bytes(b"unrelated artifact")
+        result = subprocess.run(["bash", str(script)], capture_output=True, text=True,
+                                env=dict(os.environ, JAVA_HOME=self.java_home(), LI_IVY_REPO=str(repository),
+                                         LI_BRIDGE_VERSION="3.9.2.19"))
+        self.assertEqual(0, result.returncode, result.stderr)
+        manifest = json.loads((repository / "com/linkedin/kafka/bridge-artifact-manifest.json").read_text())
+        self.assertEqual("3.9.2.19", manifest["version"])
+        self.assertEqual(25, len(manifest["files"]))
+        self.assertTrue(all("/3.9.2.19/" in artifact["path"] for artifact in manifest["files"]))
+        self.assertFalse(any("foreign.jar" in artifact["path"] for artifact in manifest["files"]))
+
+    def test_local_verifier_plan_uses_requested_build_version(self):
+        result = self.verifier_plan(supplied=False, skip_stage="0")
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("-Pversion=3.9.2.19", result.stdout)
+        self.assertIn("kafka_2.12-3.9.2.19.tgz", result.stdout)
+        self.assertIn("LI_BRIDGE_VERSION=3.9.2.19", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Build and verify the candidate, stage local wrapper artifacts, run the selected suites and retain command evidence. Support supplied archives without local restaging. Audit the in-memory result before writing success. The auditor and its negative tests now precede this PR in #572. Complex orchestration is Python, with small Bash wrappers.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.