### PR TITLE
ci: test and publish every 3.9-li commit

### DIFF
--- a/.github/scripts/li_release.py
+++ b/.github/scripts/li_release.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Release bookkeeping for the independent 3.0 and 3.9 CI workflows.
+
+Allocation pushes a tag. Publication changes GitHub releases. Run these commands
+only in the release workflow; tests use a disposable local Git remote and stubs.
+"""
+
+import argparse
+import hashlib
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PREFIXES = {"3.0": "3.0.1", "3.9": "3.9.2"}
+BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+
+def output(args):
+    return subprocess.check_output(args, text=True).strip()
+
+
+def run(args):
+    subprocess.run(args, check=True)
+
+
+def append_environment(path, values):
+    with Path(path).open("a", encoding="utf-8") as destination:
+        for key, value in values.items():
+            if "\n" in str(value) or "\r" in str(value):
+                raise ValueError(f"Invalid multiline environment value for {key}")
+            destination.write(f"{key}={value}\n")
+
+
+def tags_for_line(text, prefix):
+    pattern = re.compile(re.escape(prefix) + r"\.\d+")
+    return sorted({line for line in text.splitlines() if pattern.fullmatch(line)},
+                  key=lambda tag: int(tag.rsplit(".", 1)[1]))
+
+
+def is_ancestor(tag, commit):
+    result = subprocess.run(["git", "merge-base", "--is-ancestor", tag, commit], check=False)
+    if result.returncode not in (0, 1):
+        raise subprocess.CalledProcessError(result.returncode, result.args)
+    return result.returncode == 0
+
+
+def allocate(line, environment):
+    prefix = PREFIXES[line]
+    commit = environment["GITHUB_SHA"]
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise ValueError("GITHUB_SHA must be a full source commit hash")
+    run(["git", "fetch", "--force", "--tags", "origin"])
+    all_tags = tags_for_line(output(["git", "tag", "--list", prefix + ".*"]), prefix)
+    existing = tags_for_line(output(["git", "tag", "--points-at", commit, "--list", prefix + ".*"]), prefix)
+    if line == "3.0":
+        published = output(["gh", "api", "--paginate",
+                            f"repos/{environment['GITHUB_REPOSITORY']}/releases?per_page=100",
+                            "--jq", ".[] | select(.prerelease == false and .draft == false) | .tag_name"])
+        candidates = tags_for_line(published, prefix)
+        first = 82  # Existing 3.0 release numbering starts after 3.0.1.82.
+        previous = ""
+    else:
+        candidates = all_tags.copy()
+        first = 0
+        previous = "3.9.2"
+    if existing:
+        # Preserve the two release lines' existing retry policies.
+        version = existing[0] if line == "3.0" else existing[-1]
+    else:
+        next_number = int(candidates[-1].rsplit(".", 1)[1]) + 1 if candidates else first + 1
+        version = f"{prefix}.{next_number}"
+        while version in all_tags:
+            next_number += 1
+            version = f"{prefix}.{next_number}"
+        run(["git", "config", "user.name", "github-actions[bot]"])
+        run(["git", "config", "user.email", BOT_EMAIL])
+        run(["git", "tag", "--annotate", version, "--message", f"LinkedIn Kafka {version}", commit])
+        run(["git", "push", "origin", f"refs/tags/{version}"])
+    for tag in candidates:
+        if tag != version and is_ancestor(tag, commit + "^"):
+            previous = tag
+    result = {"release_version": version, "previous_version": previous}
+    append_environment(environment["GITHUB_OUTPUT"], result)
+    return result
+
+
+def release_parameters(environment):
+    version, scala = environment["RELEASE_VERSION"], environment["SCALA_VERSION"]
+    if not re.fullmatch(r"3\.(?:0\.1|9\.2)\.\d+", version) or scala not in ("2.12", "2.13"):
+        raise ValueError("Expected an internal 3.0.1.N/3.9.2.N release and Scala 2.12 or 2.13")
+    return version, scala
+
+
+def build_archive(environment):
+    version, scala = release_parameters(environment)
+    run(["./gradlew", "--no-daemon", f"-Pversion={version}", f"-PscalaVersion={scala}", "core:releaseTarGz"])
+    archive = Path("core/build/distributions") / f"kafka_{scala}-{version}.tgz"
+    digest = hashlib.sha256()
+    with archive.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    # The checksum uses only the filename so it works from a download directory.
+    Path(str(archive) + ".sha256").write_text(f"{digest.hexdigest()}  {archive.name}\n", encoding="utf-8")
+    append_environment(environment["GITHUB_ENV"], {"RELEASE_ARCHIVE": str(archive)})
+    return archive
+
+
+def notes(environment):
+    version, scala = release_parameters(environment)
+    args = ["gh", "api", f"repos/{environment['GITHUB_REPOSITORY']}/releases/generate-notes", "--method", "POST",
+            "-f", f"tag_name={version}", "-f", f"target_commitish={environment['GITHUB_SHA']}"]
+    if environment.get("PREVIOUS_VERSION"):
+        args += ["-f", "previous_tag_name=" + environment["PREVIOUS_VERSION"]]
+    args += ["--jq", ".body"]
+    generated = output(args) + "\n"
+    Path("generated-notes.md").write_text(generated, encoding="utf-8")
+    text = (f"LinkedIn Kafka {version}\n\nSource commit: `{environment['GITHUB_SHA']}`\n\n"
+            f"Maven coordinates: `com.linkedin.kafka`, Scala {scala}\n\n{generated}")
+    Path("release-notes.md").write_text(text, encoding="utf-8")
+    return text
+
+
+def publish(environment):
+    version, _ = release_parameters(environment)
+    archive = Path(environment["RELEASE_ARCHIVE"])
+    checksum = Path(str(archive) + ".sha256")
+    if not archive.is_file() or not checksum.is_file():
+        raise ValueError("Release archive and checksum must exist before publication")
+    exists = subprocess.run(["gh", "release", "view", version], stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL, check=False).returncode == 0
+    options = ["--title", f"LinkedIn Kafka {version}", "--notes-file", "release-notes.md",
+               "--target", environment["GITHUB_SHA"]]
+    if exists:
+        run(["gh", "release", "edit", version, *options])
+        run(["gh", "release", "upload", version, str(archive), str(checksum), "--clobber"])
+    else:
+        run(["gh", "release", "create", version, str(archive), str(checksum), *options, "--verify-tag"])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("allocate", "archive", "notes", "publish"))
+    parser.add_argument("--line", choices=tuple(PREFIXES))
+    args = parser.parse_args()
+    if args.command == "allocate" and not args.line:
+        parser.error("allocate requires --line")
+    try:
+        if args.command == "allocate":
+            allocate(args.line, os.environ)
+        else:
+            {"archive": build_archive, "notes": notes, "publish": publish}[args.command](os.environ)
+    except (OSError, ValueError, KeyError, subprocess.SubprocessError) as error:
+        print(f"Release step failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/tests/li_release_test.py
+++ b/.github/tests/li_release_test.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test release steps with a disposable Git remote and local command stubs."""
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("li_release", ROOT / ".github/scripts/li_release.py")
+RELEASE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RELEASE)
+
+
+class ReleaseTest(unittest.TestCase):
+    line = "3.9"
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "source"
+        self.source.mkdir()
+        self.old_cwd = Path.cwd()
+        os.chdir(self.source)
+        self.addCleanup(os.chdir, self.old_cwd)
+        self.git("init", "-q")
+        self.git("config", "user.name", "release-test")
+        self.git("config", "user.email", "release-test@example.invalid")
+        self.git("config", "commit.gpgSign", "false")
+        self.git("config", "tag.gpgSign", "false")
+        self.remote = self.root / "remote.git"
+        self.git("init", "-q", "--bare", str(self.remote))
+        self.git("remote", "add", "origin", str(self.remote))
+        self.prefix = RELEASE.PREFIXES[self.line]
+        self.first = 82 if self.line == "3.0" else 1
+        self.commits, self.tags = [], []
+        for index in range(3):
+            self.git("commit", "-q", "--allow-empty", "-m", f"Source {index}")
+            self.commits.append(self.git("rev-parse", "HEAD"))
+            tag = f"{self.prefix}.{self.first + index}"
+            self.git("tag", tag)
+            self.tags.append(tag)
+        if self.line == "3.9":
+            self.git("tag", "3.9.2", self.commits[0])
+        self.git("push", "-q", "origin", "HEAD", "--tags")
+        binaries = self.root / "bin"
+        binaries.mkdir()
+        gh = binaries / "gh"
+        gh.write_text('''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+args = sys.argv[1:]
+with Path(os.environ["GH_CALLS"]).open("a") as out:
+    out.write(json.dumps(args) + "\\n")
+if args[:2] == ["api", "--paginate"]:
+    assert args[2] == "repos/local/release-test/releases?per_page=100"
+    assert args[3:] == ["--jq", ".[] | select(.prerelease == false and .draft == false) | .tag_name"]
+    print(os.environ["PUBLISHED_TAGS"])
+elif args[:2] == ["api", "repos/local/release-test/releases/generate-notes"]:
+    assert args[2:4] == ["--method", "POST"]
+    fields = dict(args[i + 1].split("=", 1) for i in range(4, len(args) - 2, 2))
+    assert fields["tag_name"] == os.environ["RELEASE_VERSION"]
+    assert fields["target_commitish"] == os.environ["GITHUB_SHA"]
+    assert fields.get("previous_tag_name", "") == os.environ.get("PREVIOUS_VERSION", "")
+    assert args[-2:] == ["--jq", ".body"]
+    print("Fixture release notes")
+elif args[:2] == ["release", "view"]:
+    sys.exit(0 if os.environ.get("EXISTING_RELEASE") == "1" else 1)
+elif args[:2] not in (["release", "edit"], ["release", "create"], ["release", "upload"]):
+    raise AssertionError(args)
+''')
+        gh.chmod(0o755)
+        self.environment = dict(os.environ, PATH=str(binaries) + os.pathsep + os.environ["PATH"],
+                                GITHUB_REPOSITORY="local/release-test", GITHUB_SHA=self.commits[1],
+                                GITHUB_OUTPUT=str(self.root / "output"), GITHUB_ENV=str(self.root / "env"),
+                                PUBLISHED_TAGS="\n".join(self.tags), GH_CALLS=str(self.root / "gh-calls.jsonl"),
+                                SCALA_VERSION="2.12", RELEASE_VERSION=self.tags[1])
+        self.patch = mock.patch.dict(os.environ, self.environment, clear=True)
+        self.patch.start()
+        self.addCleanup(self.patch.stop)
+
+    def git(self, *args):
+        return subprocess.check_output(["git", *args], text=True, stderr=subprocess.DEVNULL).strip()
+
+    def test_retry_reuses_tag_and_notes_exclude_newer_commits(self):
+        result = RELEASE.allocate(self.line, os.environ)
+        self.assertEqual({"release_version": self.tags[1], "previous_version": self.tags[0]}, result)
+        self.assertEqual(3 + (self.line == "3.9"), len(self.git("tag", "--list").splitlines()))
+
+    def test_new_version_is_pushed_and_retry_does_not_allocate_again(self):
+        self.git("commit", "-q", "--allow-empty", "-m", "New source")
+        os.environ["GITHUB_SHA"] = self.git("rev-parse", "HEAD")
+        self.git("push", "-q", "origin", "HEAD")
+        result = RELEASE.allocate(self.line, os.environ)
+        expected = f"{self.prefix}.{self.first + 3}"
+        self.assertEqual(expected, result["release_version"])
+        self.assertEqual(self.tags[2], result["previous_version"])
+        self.assertEqual(os.environ["GITHUB_SHA"], self.git("rev-parse", expected + "^{}"))
+        self.assertIn(os.environ["GITHUB_SHA"], self.git("ls-remote", "origin", f"refs/tags/{expected}^{{}}"))
+        self.assertEqual(result, RELEASE.allocate(self.line, os.environ))
+
+    def test_reserved_versions_are_not_reused(self):
+        reserved = f"{self.prefix}.{self.first + 3}"
+        self.git("tag", reserved, self.commits[0])
+        self.git("push", "-q", "origin", "--tags")
+        self.git("commit", "-q", "--allow-empty", "-m", "After reserved version")
+        os.environ["GITHUB_SHA"] = self.git("rev-parse", "HEAD")
+        self.assertEqual(f"{self.prefix}.{self.first + 4}", RELEASE.allocate(self.line, os.environ)["release_version"])
+
+    def test_archive_checksum_works_after_download_and_notes_use_scala(self):
+        gradle = self.source / "gradlew"
+        gradle.write_text('''#!/usr/bin/env python3
+import os, sys
+from pathlib import Path
+assert "-Pversion=" + os.environ["RELEASE_VERSION"] in sys.argv
+assert "-PscalaVersion=" + os.environ["SCALA_VERSION"] in sys.argv
+output = Path("core/build/distributions")
+output.mkdir(parents=True, exist_ok=True)
+(output / ("kafka_" + os.environ["SCALA_VERSION"] + "-" + os.environ["RELEASE_VERSION"] + ".tgz")).write_bytes(b"archive")
+''')
+        gradle.chmod(0o755)
+        for scala in ("2.12", "2.13"):
+            os.environ["SCALA_VERSION"] = scala
+            archive = RELEASE.build_archive(os.environ)
+            destination = self.root / f"download-{scala}"
+            destination.mkdir()
+            shutil.copyfile(archive, destination / archive.name)
+            shutil.copyfile(str(archive) + ".sha256", destination / (archive.name + ".sha256"))
+            digest, filename = (destination / (archive.name + ".sha256")).read_text().split()
+            self.assertEqual(archive.name, filename)
+            self.assertEqual(digest, hashlib.sha256((destination / filename).read_bytes()).hexdigest())
+            checksum_tool = shutil.which("sha256sum")
+            if checksum_tool:
+                subprocess.run([checksum_tool, "-c", archive.name + ".sha256"], cwd=destination, check=True)
+            for previous in (self.tags[0], ""):
+                os.environ["PREVIOUS_VERSION"] = previous
+                text = RELEASE.notes(os.environ)
+                self.assertIn(f"Scala {scala}", text)
+                self.assertIn("Fixture release notes", text)
+                self.assertIn(os.environ["GITHUB_SHA"], text)
+
+    def test_publication_create_and_retry_paths(self):
+        archive = self.source / "archive.tgz"
+        archive.write_bytes(b"archive")
+        Path(str(archive) + ".sha256").write_text("checksum")
+        os.environ["RELEASE_ARCHIVE"] = str(archive)
+        for existing in ("0", "1"):
+            os.environ["EXISTING_RELEASE"] = existing
+            RELEASE.publish(os.environ)
+        calls = [json.loads(line) for line in Path(os.environ["GH_CALLS"]).read_text().splitlines()]
+        self.assertTrue(any(call[:2] == ["release", "create"] and "--verify-tag" in call for call in calls))
+        self.assertTrue(any(call[:2] == ["release", "edit"] for call in calls))
+        self.assertTrue(any(call[:2] == ["release", "upload"] and "--clobber" in call for call in calls))
+
+    def test_workflow_calls_the_tested_steps_and_keeps_release_queue(self):
+        workflow = (ROOT / ".github/workflows/li-release.yml").read_text()
+        for command in (f"allocate --line {self.line}", "archive", "notes", "publish"):
+            self.assertIn("run: python3 .github/scripts/li_release.py " + command, workflow)
+        self.assertIn("  queue: max\n", workflow)
+        self.assertIn("  cancel-in-progress: false\n", workflow)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("line", choices=("3.0", "3.9"))
+    arguments, remaining = parser.parse_known_args()
+    ReleaseTest.line = arguments.line
+    unittest.main(argv=[sys.argv[0], *remaining])

--- a/.github/workflows/li-ci.yml
+++ b/.github/workflows/li-ci.yml
@@ -1,0 +1,229 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: LinkedIn CI
+
+on:
+  pull_request:
+    branches:
+      - 3.9-li
+      - '3.9-li-**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: li-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  JAVA_VERSION: '17'
+  SCALA_VERSION: '2.12'
+
+jobs:
+  all:
+    name: all
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+      - name: Check release workflow
+        run: python3 .github/tests/li_release_test.py 3.9
+      - name: Check bridge rollout tooling
+        if: hashFiles('tests/unit/li_bridge*_test.py') != ''
+        run: |
+          # Check the rollout tools before starting broker processes.
+          set -euo pipefail
+          python3 -m unittest discover -s tests/unit -p 'li_bridge*_test.py'
+          for script in tests/bin/*li_bridge*.sh; do
+            if [[ -f "${script}" ]]; then
+              bash -n "${script}"
+            fi
+          done
+      - name: Run code analysis
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon "-PscalaVersion=${SCALA_VERSION}" \
+            -PxmlSpotBugsReport=true \
+            rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest
+
+  module-tests:
+    name: ${{ matrix.name }}_2.12
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include:
+          - name: clients
+            path: clients
+          - name: generator
+            path: generator
+          - name: metadata
+            path: metadata
+          - name: raft
+            path: raft
+          - name: server-common
+            path: server-common
+          - name: shell
+            path: shell
+          - name: storage
+            path: storage
+          - name: storage:api
+            path: storage:storage-api
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+      - name: Run unit and integration tests
+        env:
+          MODULE: ${{ matrix.path }}
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon "-PscalaVersion=${SCALA_VERSION}" \
+            -PmaxTestRetries=3 -PtestLoggingEvents=started,passed,skipped,failed \
+            cleanTest "${MODULE}:unitTest" "${MODULE}:integrationTest"
+
+  core-unit:
+    name: core_2.12
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+      - name: Run core unit tests
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon "-PscalaVersion=${SCALA_VERSION}" \
+            -PmaxTestRetries=3 -PtestLoggingEvents=started,passed,skipped,failed \
+            cleanTest core:unitTest
+
+  core-integration:
+    name: core_2.12 (${{ matrix.prefixes }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        prefixes:
+          - A B C
+          - D E F
+          - G H I J K
+          - L M N O
+          - P Q
+          - R S
+          - T U V W X Y Z
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+      - name: Run core integration tests
+        env:
+          PREFIXES: ${{ matrix.prefixes }}
+        run: |
+          # Turn the fixed class-name prefixes into separate Gradle arguments.
+          set -euo pipefail
+          read -r -a class_prefixes <<<"${PREFIXES}"
+          filters=()
+          for prefix in "${class_prefixes[@]}"; do
+            filters+=(--tests "${prefix}*")
+          done
+          ./gradlew --no-daemon "-PscalaVersion=${SCALA_VERSION}" \
+            -PmaxTestRetries=3 -PtestLoggingEvents=started,passed,skipped,failed \
+            cleanTest core:integrationTest "${filters[@]}"
+
+  additional-modules:
+    name: additional-modules_2.12
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+      - name: Test additional published modules
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon "-PscalaVersion=${SCALA_VERSION}" \
+            -PmaxTestRetries=3 -PtestLoggingEvents=started,passed,skipped,failed \
+            cleanTest \
+            group-coordinator:unitTest group-coordinator:integrationTest \
+            group-coordinator:group-coordinator-api:unitTest \
+            group-coordinator:group-coordinator-api:integrationTest \
+            server:unitTest server:integrationTest \
+            transaction-coordinator:unitTest \
+            transaction-coordinator:integrationTest \
+            tools:tools-api:unitTest tools:tools-api:integrationTest
+
+  scala-2-13-compile:
+    name: scala_2.13
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
+      - name: Compile Scala 2.13 main and test code
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon -PscalaVersion=2.13 core:clean \
+            clients:compileTestJava core:compileScala core:compileTestScala

--- a/.github/workflows/li-release.yml
+++ b/.github/workflows/li-release.yml
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish LinkedIn Kafka 3.9
+
+on:
+  push:
+    branches:
+      - 3.9-li
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-3.9-li
+  cancel-in-progress: false
+  # Keep pending releases when several PRs merge. GitHub queues up to 100 runs.
+  queue: max
+
+env:
+  JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
+  JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
+  SCALA_VERSION: '2.12'
+
+jobs:
+  publish:
+    name: Publish commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Allocate an internal release version
+        id: version
+        run: python3 .github/scripts/li_release.py allocate --line 3.9
+
+      - name: Publish Maven modules to JFrog
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        shell: bash
+        run: |
+          # Publish the modules required by the wrapper.
+          set -euo pipefail
+          ./gradlew --no-daemon \
+            "-Pversion=${RELEASE_VERSION}" \
+            "-PscalaVersion=${SCALA_VERSION}" \
+            :clients:publish \
+            :core:publish \
+            :group-coordinator:publish \
+            :group-coordinator:group-coordinator-api:publish \
+            :metadata:publish \
+            :raft:publish \
+            :server:publish \
+            :server-common:publish \
+            :storage:publish \
+            :storage:storage-api:publish \
+            :tools:tools-api:publish \
+            :transaction-coordinator:publish
+
+      - name: Build release archive and checksum
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        run: python3 .github/scripts/li_release.py archive
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+          PREVIOUS_VERSION: ${{ steps.version.outputs.previous_version }}
+        run: python3 .github/scripts/li_release.py notes
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        run: python3 .github/scripts/li_release.py publish

--- a/build.gradle
+++ b/build.gradle
@@ -87,9 +87,12 @@ ext {
   skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
   shouldSign = !skipSigning && !version.endsWith("SNAPSHOT")
 
-  mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
-  mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''
-  mavenPassword = project.hasProperty('mavenPassword') ? project.mavenPassword : ''
+  jfrogUsername = System.getenv('JFROG_USERNAME')
+  jfrogApiKey = System.getenv('JFROG_API_KEY')
+
+  mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : jfrogRepoUrl
+  mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : (jfrogUsername ?: '')
+  mavenPassword = project.hasProperty('mavenPassword') ? project.mavenPassword : (jfrogApiKey ?: '')
 
   userShowStandardStreams = project.hasProperty("showStandardStreams") ? showStandardStreams : null
 
@@ -325,9 +328,11 @@ subprojects {
         // To test locally, invoke gradlew with `-PmavenUrl=file:///some/local/path`
         maven {
           url = mavenUrl
-          credentials {
-            username = mavenUsername
-            password = mavenPassword
+          if (!mavenUrl.toString().startsWith('file:')) {
+            credentials {
+              username = mavenUsername
+              password = mavenPassword
+            }
           }
         }
       }

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -213,7 +213,10 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
     assertTrue(tempBytes >= recordSize, s"Unexpected temporary memory size requestBytes $requestBytes tempBytes $tempBytes")
 
     verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=ProduceMessageConversionsPerSec")
-    verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=MessageConversionsTimeMs,request=Produce", value => value > 0.0)
+    // Submillisecond conversions round to zero in this histogram.
+    val conversionTime = yammerHistogram(s"$requestMetricsPrefix,name=MessageConversionsTimeMs,request=Produce")
+    assertTrue(conversionTime.count > 0, "Message conversion time was not recorded")
+    assertTrue(conversionTime.min >= 0, "Message conversion time must be non-negative")
     verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=RequestBytes,request=Fetch")
     verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=TemporaryMemoryBytes,request=Fetch", value => value == 0.0)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-group=org.apache.kafka
+group=com.linkedin.kafka
 # NOTE: When you change this version number, you should also make sure to update
 # the version numbers in
 #  - tests/kafkatest/__init__.py
@@ -30,3 +30,5 @@ swaggerVersion=2.2.8
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
 org.gradle.parallel=true
+skipSigning=true
+jfrogRepoUrl=https://linkedin.jfrog.io/artifactory/kafka


### PR DESCRIPTION
Run the 3.9 Java 17 checks, compile both Scala lines, and publish 3.9-li commits through the release workflow. Use Python for allocation, notes, archive/checksum handling and publication retries. Six fixture tests pass. Keep 3.9 tag-based numbering, configurable Scala filenames/notes and checksums that verify outside the build directory. This CI foundation has no upgrade label; review it alongside PR 559 without mixing release histories.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.