### PR TITLE
kafka: add the leader-transfer controller client

### DIFF
--- a/core/src/main/scala/kafka/server/LeaderTransferManager.scala
+++ b/core/src/main/scala/kafka/server/LeaderTransferManager.scala
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.utils.Logging
+import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.RetriableException
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{ElectLeadersRequest, ElectLeadersResponse}
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.server.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
+import org.apache.kafka.server.util.Scheduler
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.ConcurrentHashMap
+
+trait LeaderTransferManager {
+  def start(): Unit
+  def shutdown(): Unit
+  def submit(partition: TopicPartition, recommendedLeader: Int): Unit
+}
+
+object LeaderTransferManager {
+  object NoOp extends LeaderTransferManager {
+    override def start(): Unit = ()
+    override def shutdown(): Unit = ()
+    override def submit(partition: TopicPartition, recommendedLeader: Int): Unit = ()
+  }
+
+  def noOp: LeaderTransferManager = NoOp
+
+  def apply(config: KafkaConfig,
+            controllerNodeProvider: ControllerNodeProvider,
+            scheduler: Scheduler,
+            time: Time,
+            metrics: Metrics,
+            threadNamePrefix: String,
+            brokerEpochSupplier: () => Long): LeaderTransferManager = {
+    val channelManager = new NodeToControllerChannelManagerImpl(
+      controllerNodeProvider,
+      time,
+      metrics,
+      config,
+      "transfer-leader",
+      threadNamePrefix,
+      Long.MaxValue)
+    new DefaultLeaderTransferManager(channelManager, scheduler, brokerEpochSupplier)
+  }
+}
+
+private[server] class DefaultLeaderTransferManager(
+  channelManager: NodeToControllerChannelManager,
+  scheduler: Scheduler,
+  brokerEpochSupplier: () => Long
+) extends LeaderTransferManager with Logging {
+  private val pending = new ConcurrentHashMap[TopicPartition, Integer]
+  private val requestInFlight = new AtomicBoolean(false)
+
+  override def start(): Unit = channelManager.start()
+
+  override def shutdown(): Unit = channelManager.shutdown()
+
+  override def submit(partition: TopicPartition, recommendedLeader: Int): Unit = {
+    pending.putIfAbsent(partition, recommendedLeader)
+    maybeSend()
+  }
+
+  private def maybeSend(): Unit = {
+    if (!pending.isEmpty && requestInFlight.compareAndSet(false, true)) {
+      val recommendations = new java.util.HashMap[TopicPartition, Integer]
+      pending.forEach((partition, leader) => recommendations.put(partition, leader))
+      val request = new ElectLeadersRequest.Builder(
+        brokerEpochSupplier(), recommendations, Int.MaxValue)
+      channelManager.sendRequest(request, new ControllerRequestCompletionHandler {
+        override def onComplete(response: ClientResponse): Unit = {
+          val retry = try {
+            if (response.authenticationException != null) {
+              discardRecommendations(recommendations,
+                s"authentication failed: ${response.authenticationException.getMessage}")
+              false
+            } else if (response.versionMismatch != null) {
+              discardRecommendations(recommendations,
+                s"request version is unsupported: ${response.versionMismatch.getMessage}")
+              false
+            } else {
+              handleResponse(response.responseBody.asInstanceOf[ElectLeadersResponse], recommendations)
+            }
+          } finally {
+            requestInFlight.set(false)
+          }
+          if (retry) scheduleRetry() else maybeSend()
+        }
+
+        override def onTimeout(): Unit = {
+          requestInFlight.set(false)
+          scheduleRetry()
+        }
+      })
+    }
+  }
+
+  private def handleResponse(response: ElectLeadersResponse,
+                             recommendations: java.util.Map[TopicPartition, Integer]): Boolean = {
+    val topLevelError = Errors.forCode(response.data.errorCode)
+    if (topLevelError != Errors.NONE) {
+      if (isRetriable(topLevelError)) {
+        warn(s"Controller rejected recommended leader transfers with $topLevelError; retrying")
+        true
+      } else {
+        discardRecommendations(recommendations, s"controller returned $topLevelError")
+        false
+      }
+    } else {
+      response.data.replicaElectionResults.forEach { topicResult =>
+        topicResult.partitionResult.forEach { partitionResult =>
+          val partition = new TopicPartition(topicResult.topic, partitionResult.partitionId)
+          val error = Errors.forCode(partitionResult.errorCode)
+          if (error == Errors.NONE) {
+            info(s"Successfully transferred leadership for $partition")
+            pending.remove(partition, recommendations.get(partition))
+          } else if (isRetriable(error)) {
+            warn(s"Controller temporarily rejected leadership transfer for $partition with $error; retrying")
+          } else {
+            warn(s"Controller rejected leadership transfer for $partition with $error; dropping recommendation")
+            pending.remove(partition, recommendations.get(partition))
+          }
+        }
+      }
+      recommendations.keySet.stream().anyMatch(pending.containsKey)
+    }
+  }
+
+  private def isRetriable(error: Errors): Boolean =
+    Option(error.exception).exists(_.isInstanceOf[RetriableException])
+
+  private def discardRecommendations(recommendations: java.util.Map[TopicPartition, Integer],
+                                     reason: String): Unit = {
+    warn(s"Dropping ${recommendations.size} leader transfer recommendations because $reason")
+    recommendations.forEach((partition, leader) => pending.remove(partition, leader))
+  }
+
+  private def scheduleRetry(): Unit =
+    scheduler.scheduleOnce("retry-transfer-leader", () => maybeSend(), 50L)
+}

--- a/core/src/test/scala/unit/kafka/server/LeaderTransferManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderTransferManagerTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.ElectLeadersResponseData
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{AbstractRequest, ElectLeadersRequest, ElectLeadersResponse}
+import org.apache.kafka.server.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
+import org.apache.kafka.server.util.Scheduler
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.{any, anyString, eq => mockEq}
+import org.mockito.Mockito.{mock, times, verify, verifyNoInteractions, when}
+
+class LeaderTransferManagerTest {
+  @Test
+  def testSubmitBuildsRecommendedElectionWithBrokerEpoch(): Unit = {
+    val channel = mock(classOf[NodeToControllerChannelManager])
+    val manager = new DefaultLeaderTransferManager(channel, mock(classOf[Scheduler]), () => 99L)
+    val partition = new TopicPartition("orders", 3)
+
+    manager.submit(partition, 2)
+
+    val requestCaptor = ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[_]])
+    val callbackCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+    verify(channel).sendRequest(requestCaptor.capture(), callbackCaptor.capture())
+    val request = requestCaptor.getValue.build(2).asInstanceOf[ElectLeadersRequest]
+    assertEquals(99L, request.data.brokerEpoch)
+    val topic = request.data.topicPartitions.find("orders")
+    assertEquals(3, topic.recommendedPartitionLeaders.get(0).partitionIndex)
+    assertEquals(2, topic.recommendedPartitionLeaders.get(0).recommendedLeader)
+  }
+
+  @Test
+  def testRetriableTopLevelErrorSchedulesRetry(): Unit = {
+    val channel = mock(classOf[NodeToControllerChannelManager])
+    val scheduler = mock(classOf[Scheduler])
+    val manager = new DefaultLeaderTransferManager(channel, scheduler, () => 99L)
+    manager.submit(new TopicPartition("orders", 3), 2)
+
+    val callbackCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+    verify(channel).sendRequest(any(classOf[AbstractRequest.Builder[_]]), callbackCaptor.capture())
+    val clientResponse = mock(classOf[ClientResponse])
+    when(clientResponse.responseBody).thenReturn(new ElectLeadersResponse(
+      new ElectLeadersResponseData().setErrorCode(Errors.NOT_CONTROLLER.code)))
+    callbackCaptor.getValue.onComplete(clientResponse)
+
+    verify(scheduler).scheduleOnce(anyString(), any(classOf[Runnable]), mockEq(50L))
+  }
+
+  @Test
+  def testNonRetriableTopLevelErrorDropsRecommendation(): Unit = {
+    val channel = mock(classOf[NodeToControllerChannelManager])
+    val scheduler = mock(classOf[Scheduler])
+    val manager = new DefaultLeaderTransferManager(channel, scheduler, () => 99L)
+    val partition = new TopicPartition("orders", 3)
+    manager.submit(partition, 2)
+
+    val callbackCaptor = ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+    verify(channel).sendRequest(any(classOf[AbstractRequest.Builder[_]]), callbackCaptor.capture())
+    val clientResponse = mock(classOf[ClientResponse])
+    when(clientResponse.responseBody).thenReturn(new ElectLeadersResponse(
+      new ElectLeadersResponseData().setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code)))
+    callbackCaptor.getValue.onComplete(clientResponse)
+
+    verifyNoInteractions(scheduler)
+    manager.submit(partition, 2)
+    verify(channel, times(2)).sendRequest(any(classOf[AbstractRequest.Builder[_]]),
+      any(classOf[ControllerRequestCompletionHandler]))
+  }
+}


### PR DESCRIPTION
Add the controller client used by ISR leader transfer. Retry retriable controller errors and drop rejected recommendations.

Include focused response and retry tests.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.