### PR TITLE
clients: add watchdog heap dumps and process termination

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/PoisonPill.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Value;
+
+
+class PoisonPillStats {
+    private final Metrics metrics;
+    private final Sensor timeSinceLastDequeueSensor;
+    public PoisonPillStats(Metrics metrics) {
+        if (metrics == null) {
+            throw new IllegalArgumentException("The metrics for PoisonPillStats should not be null");
+        }
+        this.metrics = metrics;
+
+        String metricGroupName = "PoisonPill-metrics";
+        this.timeSinceLastDequeueSensor = metrics.sensor("time-since-last-dequeue");
+
+        this.timeSinceLastDequeueSensor.add(metrics.metricName("time-since-last-dequeue",
+            metricGroupName,
+            "The latest time-since-last-dequeue in milliseconds"),
+            new Value());
+        this.timeSinceLastDequeueSensor.add(metrics.metricName("time-since-last-dequeue-max",
+            metricGroupName,
+            "The maximum value of time-since-last-dequeue in milliseconds"),
+            new Max());
+    }
+
+    public void recordTimeSinceLastDequeue(final long timeSinceLastDequeueMs) {
+        this.timeSinceLastDequeueSensor.record(timeSinceLastDequeueMs, Time.SYSTEM.milliseconds(), false);
+    }
+}
+
+/**
+ * The PoisonPill class provides the die method to
+ * 1) generate a heap-dump file under the provided directory;
+ * 2) exit the JVM process.
+ *
+ * A maxWait time can be specified for generating the heap-dump. If the heap-dump cannot be finished within the maxWait,
+ * the JVM process will be terminated.
+ * Logs from this class are sent to standard error output (which means they are sent to the kafka.out file within LinkedIn).
+ */
+public class PoisonPill {
+    private final PoisonPillStats poisonPillStats;
+
+    public PoisonPill(Metrics metrics) {
+        poisonPillStats = new PoisonPillStats(metrics);
+    }
+
+    public void die() {
+        die(null, -1, 1);
+    }
+
+    public void die(File heapDumpFolder, final long maxWaitForDump) {
+        die(heapDumpFolder, maxWaitForDump, 1);
+    }
+
+    public void die(File heapDumpFolder, final long maxWaitForDump, int haltStatusCode) {
+        try {
+            if (maxWaitForDump > 0 && heapDumpFolder != null) {
+                grabHeapDump(heapDumpFolder, maxWaitForDump, haltStatusCode);
+            }
+        } catch (Exception e) {
+            System.err.println("unable to complete heap dump");
+            e.printStackTrace(System.err);
+            System.err.flush();
+        } finally {
+            Runtime.getRuntime().halt(haltStatusCode);
+        }
+    }
+
+    public void recordTimeSinceLastDequeue(final long timeSinceLastDequeueMs) {
+        this.poisonPillStats.recordTimeSinceLastDequeue(timeSinceLastDequeueMs);
+    }
+
+    private void grabHeapDump(File heapDumpFolder, final long maxWait, final int haltStatusCode) throws Exception {
+
+        //set up a watchdog background thread that will halt in ~maxWait regardless of whether or not
+        //we succeed in taking a heap dump (since we dont know when it'll ever complete)
+        final CountDownLatch latch = new CountDownLatch(1);
+        Thread watchdog = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    latch.countDown();
+                    System.err.println("PoisonPill watch-dog will sleep for " + maxWait + "ms, waiting for heap-dump to be completed");
+                    Thread.sleep(maxWait);
+                    //at this point ~maxWait has passed since the call to die().
+                    //if the heap dump process completed successfully die() would
+                    //have called halt() and we wouldnt be here (99.99%)
+                    System.err.println("heap dump (probably) did not complete within timeout. halting.");
+                    System.err.flush();
+                } catch (Exception e) {
+                    System.err.println("watchdog caught exception");
+                    e.printStackTrace(System.err);
+                    System.err.flush();
+                } finally {
+                    Runtime.getRuntime().halt(haltStatusCode);
+                }
+            }
+        });
+        watchdog.setDaemon(true);
+        watchdog.setName("clark the death watchdog");
+        watchdog.start();
+
+        //make sure the watchdog is up and running before we go off attempting to dump
+        if (!latch.await(maxWait, TimeUnit.MILLISECONDS)) {
+            System.err.println("unable to start watchdog within timeout. will not proceed with dump");
+            System.err.flush();
+            return;
+        }
+
+        System.err.println("PoisonPill dumping heap to " + heapDumpFolder.getCanonicalPath());
+        System.err.flush();
+
+        //we dump into dump.inprogress and atomically rename it to be dump.complete
+        //(overwriting any previous such file). this attempts to guarantee there are
+        //at most 2 (potentially large) dump files at any point in time.
+
+        File inProgress = new File(heapDumpFolder, "dump.inprogress.hprof");
+        File complete = new File(heapDumpFolder, "dump.complete.hprof");
+        if (inProgress.exists() && !inProgress.delete()) {
+            System.err.println("unable to delete existing dump file. will not proceed with dump");
+            System.err.flush();
+            return;
+        }
+
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        server.invoke(
+            new ObjectName("com.sun.management:type=HotSpotDiagnostic"),
+            "dumpHeap",
+            new Object[] {inProgress.getCanonicalPath(), false},
+            new String[] {String.class.getName(), boolean.class.getName()});
+        try {
+            Files.move(inProgress.toPath(), complete.toPath(), StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(inProgress.toPath(), complete.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/PoisonPillProcessTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/PoisonPillProcessTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PoisonPillProcessTest {
+    @Test
+    public void testDieAttemptsHeapDumpAndHaltsProcess() throws Exception {
+        Path dumpDirectory = Files.createTempDirectory("poison-pill-test");
+        Path output = dumpDirectory.resolve("process-output.log");
+        String javaBinary = new File(System.getProperty("java.home"), "bin/java").getAbsolutePath();
+        Process process = new ProcessBuilder(
+            javaBinary,
+            "-Xmx64m",
+            "-cp",
+            System.getProperty("java.class.path"),
+            HaltProcess.class.getName(),
+            dumpDirectory.toString()
+        ).redirectErrorStream(true).redirectOutput(output.toFile()).start();
+
+        try {
+            assertTrue(process.waitFor(60, TimeUnit.SECONDS), "PoisonPill child process did not halt");
+            assertEquals(23, process.exitValue());
+            String processOutput = new String(Files.readAllBytes(output), StandardCharsets.UTF_8);
+            assertTrue(processOutput.contains("PoisonPill dumping heap to"), processOutput);
+            assertTrue(Files.size(dumpDirectory.resolve("dump.complete.hprof")) > 0);
+            assertFalse(Files.exists(dumpDirectory.resolve("dump.inprogress.hprof")));
+        } finally {
+            process.destroyForcibly();
+            Utils.delete(dumpDirectory.toFile());
+        }
+    }
+
+    public static final class HaltProcess {
+        public static void main(String[] args) {
+            new PoisonPill(new Metrics()).die(new File(args[0]), 30_000, 23);
+        }
+    }
+}


### PR DESCRIPTION
Add heap-dump creation and process termination for the broker watchdog. Handle filesystems without atomic renames.

A separate-process test checks the heap dump and exit status.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.