### PR TITLE
clients: define LI controller operation wire formats

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -130,7 +130,12 @@ public enum ApiKeys {
     READ_SHARE_GROUP_STATE(ApiMessageType.READ_SHARE_GROUP_STATE, true),
     WRITE_SHARE_GROUP_STATE(ApiMessageType.WRITE_SHARE_GROUP_STATE, true),
     DELETE_SHARE_GROUP_STATE(ApiMessageType.DELETE_SHARE_GROUP_STATE, true),
-    READ_SHARE_GROUP_STATE_SUMMARY(ApiMessageType.READ_SHARE_GROUP_STATE_SUMMARY, true);
+    READ_SHARE_GROUP_STATE_SUMMARY(ApiMessageType.READ_SHARE_GROUP_STATE_SUMMARY, true),
+
+    // Private 3.0-li APIs retained while ZooKeeper operational tooling is migrated.
+    LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK(
+            ApiMessageType.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, true, true),
+    LI_MOVE_CONTROLLER(ApiMessageType.LI_MOVE_CONTROLLER, true);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -350,6 +350,10 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return DeleteShareGroupStateRequest.parse(buffer, apiVersion);
             case READ_SHARE_GROUP_STATE_SUMMARY:
                 return ReadShareGroupStateSummaryRequest.parse(buffer, apiVersion);
+            case LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK:
+                return LiControlledShutdownSkipSafetyCheckRequest.parse(buffer, apiVersion);
+            case LI_MOVE_CONTROLLER:
+                return LiMoveControllerRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -287,6 +287,10 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return DeleteShareGroupStateResponse.parse(responseBuffer, version);
             case READ_SHARE_GROUP_STATE_SUMMARY:
                 return ReadShareGroupStateSummaryResponse.parse(responseBuffer, version);
+            case LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK:
+                return LiControlledShutdownSkipSafetyCheckResponse.parse(responseBuffer, version);
+            case LI_MOVE_CONTROLLER:
+                return LiMoveControllerResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData;
+import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+public class LiControlledShutdownSkipSafetyCheckRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiControlledShutdownSkipSafetyCheckRequest> {
+        private final LiControlledShutdownSkipSafetyCheckRequestData data;
+
+        public Builder(LiControlledShutdownSkipSafetyCheckRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiControlledShutdownSkipSafetyCheckRequest build(short version) {
+            return new LiControlledShutdownSkipSafetyCheckRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiControlledShutdownSkipSafetyCheckRequestData data;
+
+    public LiControlledShutdownSkipSafetyCheckRequest(LiControlledShutdownSkipSafetyCheckRequestData data, short version) {
+        super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, version);
+        this.data = data;
+    }
+
+    public static LiControlledShutdownSkipSafetyCheckRequest parse(ByteBuffer buffer, short version) {
+        return new LiControlledShutdownSkipSafetyCheckRequest(new LiControlledShutdownSkipSafetyCheckRequestData(
+            new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiControlledShutdownSkipSafetyCheckResponseData data = new LiControlledShutdownSkipSafetyCheckResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiControlledShutdownSkipSafetyCheckResponse(data);
+    }
+
+    @Override
+    public LiControlledShutdownSkipSafetyCheckRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiControlledShutdownSkipSafetyCheckResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class LiControlledShutdownSkipSafetyCheckResponse extends AbstractResponse {
+    private final LiControlledShutdownSkipSafetyCheckResponseData data;
+
+    public LiControlledShutdownSkipSafetyCheckResponse(LiControlledShutdownSkipSafetyCheckResponseData data) {
+        super(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK);
+        this.data = data;
+    }
+
+    public static LiControlledShutdownSkipSafetyCheckResponse parse(ByteBuffer buffer, short version) {
+        return new LiControlledShutdownSkipSafetyCheckResponse(new LiControlledShutdownSkipSafetyCheckResponseData(
+            new ByteBufferAccessor(buffer), version));
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return 0;
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        // This internal controller operation is not throttled.
+    }
+
+    @Override
+    public LiControlledShutdownSkipSafetyCheckResponseData data() {
+        return data;
+    }
+
+    public static LiControlledShutdownSkipSafetyCheckResponse prepareResponse(Errors error) {
+        LiControlledShutdownSkipSafetyCheckResponseData data = new LiControlledShutdownSkipSafetyCheckResponseData();
+        data.setErrorCode(error.code());
+        return new LiControlledShutdownSkipSafetyCheckResponse(data);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.message.LiMoveControllerRequestData;
+import org.apache.kafka.common.message.LiMoveControllerResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+public class LiMoveControllerRequest extends AbstractRequest {
+    public static class Builder extends AbstractRequest.Builder<LiMoveControllerRequest> {
+        private final LiMoveControllerRequestData data;
+
+        public Builder(LiMoveControllerRequestData data, short allowedVersion) {
+            super(ApiKeys.LI_MOVE_CONTROLLER, allowedVersion);
+            this.data = data;
+        }
+
+        @Override
+        public LiMoveControllerRequest build(short version) {
+            return new LiMoveControllerRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+
+    private final LiMoveControllerRequestData data;
+
+    LiMoveControllerRequest(LiMoveControllerRequestData data, short version) {
+        super(ApiKeys.LI_MOVE_CONTROLLER, version);
+        this.data = data;
+    }
+
+    public static LiMoveControllerRequest parse(ByteBuffer buffer, short version) {
+        return new LiMoveControllerRequest(new LiMoveControllerRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        LiMoveControllerResponseData data = new LiMoveControllerResponseData()
+            .setErrorCode(Errors.forException(e).code());
+        return new LiMoveControllerResponse(data, version());
+    }
+
+    public LiMoveControllerRequestData data() {
+        return data;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LiMoveControllerResponse.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.message.LiMoveControllerResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+public class LiMoveControllerResponse extends AbstractResponse {
+    private final LiMoveControllerResponseData data;
+    private final short version;
+
+    public LiMoveControllerResponse(LiMoveControllerResponseData data, short version) {
+        super(ApiKeys.LI_MOVE_CONTROLLER);
+        this.data = data;
+        this.version = version;
+    }
+
+    public Errors error() {
+        return Errors.forCode(data.errorCode());
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return Collections.singletonMap(error(), 1);
+    }
+
+    @Override
+    public LiMoveControllerResponseData data() {
+        return data;
+    }
+
+    public static LiMoveControllerResponse prepareResponse(Errors error, short version) {
+        LiMoveControllerResponseData data = new LiMoveControllerResponseData();
+        data.setErrorCode(error.code());
+        return new LiMoveControllerResponse(data, version);
+    }
+
+    public static LiMoveControllerResponse parse(ByteBuffer buffer, short version) {
+        return new LiMoveControllerResponse(new LiMoveControllerResponseData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return 0;
+    }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+        // This internal ZooKeeper operation is not throttled.
+    }
+
+    public short version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+}

--- a/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
+++ b/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckRequest.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1000,
+  "type": "request",
+  // The current implementation of this feature involves recording the shutting down broker's epoch on zk,
+  // so probably doesn't make sense for the listener type "broker" for now.
+  // In the future, if/when we adopt KIP-500 changes, this request can be augmented to include the "broker" listener.
+  "listeners": [],
+  "name": "LiControlledShutdownSkipSafetyCheckRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
+      "about": "The id of the broker for which controlled shutdown has been requested." },
+    { "name": "BrokerEpoch", "type": "int64", "versions": "0+", "about": "The broker epoch." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckResponse.json
+++ b/clients/src/main/resources/common/message/LiControlledShutdownSkipSafetyCheckResponse.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1000,
+  "type": "response",
+  "name": "LiControlledShutdownSkipSafetyCheckResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." }
+  ]
+}

--- a/clients/src/main/resources/common/message/LiMoveControllerRequest.json
+++ b/clients/src/main/resources/common/message/LiMoveControllerRequest.json
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1002,
+  "type": "request",
+  "listeners": [],
+  "name": "LiMoveControllerRequest",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+  ]
+}

--- a/clients/src/main/resources/common/message/LiMoveControllerResponse.json
+++ b/clients/src/main/resources/common/message/LiMoveControllerResponse.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1002,
+  "type": "response",
+  "name": "LiMoveControllerResponse",
+  "validVersions": "0-1",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top-level error code." }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -56,7 +56,7 @@ public class NodeApiVersionsTest {
     @Test
     public void testUnknownApiVersionsToString() {
         NodeApiVersions versions = NodeApiVersions.create((short) 337, (short) 0, (short) 1);
-        assertTrue(versions.toString().endsWith("UNKNOWN(337): 0 to 1)"));
+        assertTrue(versions.toString().contains("UNKNOWN(337): 0 to 1"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/message/BridgePrivateApiFixtureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/BridgePrivateApiFixtureTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.message;
+
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Message;
+import org.apache.kafka.common.protocol.MessageUtil;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Fixtures generated from compiled 3.0-li-3.9-bridge classes. */
+public class BridgePrivateApiFixtureTest {
+    @Test
+    public void testControlledShutdownOverride() {
+        byte[] fixture = bytes("00000007000000000000006300");
+        LiControlledShutdownSkipSafetyCheckRequestData data =
+            new LiControlledShutdownSkipSafetyCheckRequestData(accessor(fixture), (short) 0);
+        assertEquals(7, data.brokerId());
+        assertEquals(99L, data.brokerEpoch());
+        assertFixture(fixture, data);
+    }
+
+    @Test
+    public void testMoveController() {
+        byte[] fixture = bytes("00");
+        assertFixture(fixture, new LiMoveControllerRequestData(accessor(fixture), (short) 0));
+    }
+
+    private static ByteBufferAccessor accessor(byte[] fixture) {
+        return new ByteBufferAccessor(ByteBuffer.wrap(fixture));
+    }
+
+    private static void assertFixture(byte[] expected, Message message) {
+        ByteBuffer buffer = MessageUtil.toByteBuffer(message, (short) 0);
+        byte[] actual = new byte[buffer.remaining()];
+        buffer.get(actual);
+        assertArrayEquals(expected, actual);
+    }
+
+    private static byte[] bytes(String hex) {
+        byte[] result = new byte[hex.length() / 2];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return result;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.protocol.types.Schema;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
@@ -84,8 +83,9 @@ public class ApiKeysTest {
                 apisMissingScope.add(apiKey);
             }
         }
-        assertEquals(Collections.emptySet(), apisMissingScope,
-            "Found some APIs missing scope definition");
+        // These wire definitions stay unadvertised until the broker handlers are added.
+        assertEquals(EnumSet.of(ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK, ApiKeys.LI_MOVE_CONTROLLER),
+            apisMissingScope, "Only the pending control RPC definitions may lack listener scopes");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/protocol/BridgeProtocolConstantsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/BridgeProtocolConstantsTest.java
@@ -17,17 +17,35 @@
 package org.apache.kafka.common.protocol;
 
 import org.apache.kafka.common.ElectionType;
+import org.apache.kafka.common.message.ApiMessageType.ListenerType;
 import org.apache.kafka.common.requests.ListOffsetsRequest;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class BridgeProtocolConstantsTest {
     @Test
     public void testLinkedInClientProtocolConstants() {
+        assertEquals(1000, ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK.id);
+        assertEquals(1002, ApiKeys.LI_MOVE_CONTROLLER.id);
         assertEquals(2, ElectionType.RECOMMENDED.value);
         assertEquals(-104L, ListOffsetsRequest.LI_EARLIEST_LOCAL_TIMESTAMP);
         assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE, Errors.forCode((short) 1107));
         assertEquals(Errors.NOT_ENOUGH_PREFERRED_CONTROLLERS, Errors.forCode((short) 2000));
+    }
+
+    @Test
+    public void testControlApiDefinitionsAreNotAdvertisedWithoutHandlers() {
+        for (ApiKeys apiKey : Arrays.asList(
+            ApiKeys.LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK,
+            ApiKeys.LI_MOVE_CONTROLLER
+        )) {
+            for (ListenerType listener : ListenerType.values()) {
+                assertFalse(apiKey.inScope(listener));
+            }
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1123,6 +1123,12 @@ public class RequestResponseTest {
             case WRITE_SHARE_GROUP_STATE: return createWriteShareGroupStateRequest(version);
             case DELETE_SHARE_GROUP_STATE: return createDeleteShareGroupStateRequest(version);
             case READ_SHARE_GROUP_STATE_SUMMARY: return createReadShareGroupStateSummaryRequest(version);
+            case LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK:
+                return new LiControlledShutdownSkipSafetyCheckRequest(
+                        new org.apache.kafka.common.message.LiControlledShutdownSkipSafetyCheckRequestData(), version);
+            case LI_MOVE_CONTROLLER:
+                return new LiMoveControllerRequest(
+                        new org.apache.kafka.common.message.LiMoveControllerRequestData(), version);
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -1217,6 +1223,10 @@ public class RequestResponseTest {
             case WRITE_SHARE_GROUP_STATE: return createWriteShareGroupStateResponse();
             case DELETE_SHARE_GROUP_STATE: return createDeleteShareGroupStateResponse();
             case READ_SHARE_GROUP_STATE_SUMMARY: return createReadShareGroupStateSummaryResponse();
+            case LI_CONTROLLED_SHUTDOWN_SKIP_SAFETY_CHECK:
+                return LiControlledShutdownSkipSafetyCheckResponse.prepareResponse(Errors.NONE);
+            case LI_MOVE_CONTROLLER:
+                return LiMoveControllerResponse.prepareResponse(Errors.NONE, version);
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -85,6 +85,9 @@ object RequestConvertToJson {
       case req: ListClientMetricsResourcesRequest => ListClientMetricsResourcesRequestDataJsonConverter.write(req.data, request.version)
       case req: ListGroupsRequest => ListGroupsRequestDataJsonConverter.write(req.data, request.version)
       case req: ListOffsetsRequest => ListOffsetsRequestDataJsonConverter.write(req.data, request.version)
+      case req: LiControlledShutdownSkipSafetyCheckRequest =>
+        LiControlledShutdownSkipSafetyCheckRequestDataJsonConverter.write(req.data, request.version)
+      case req: LiMoveControllerRequest => LiMoveControllerRequestDataJsonConverter.write(req.data, request.version)
       case req: ListPartitionReassignmentsRequest => ListPartitionReassignmentsRequestDataJsonConverter.write(req.data, request.version)
       case req: ListTransactionsRequest => ListTransactionsRequestDataJsonConverter.write(req.data, request.version)
       case req: MetadataRequest => MetadataRequestDataJsonConverter.write(req.data, request.version)
@@ -180,6 +183,9 @@ object RequestConvertToJson {
       case res: ListClientMetricsResourcesResponse => ListClientMetricsResourcesResponseDataJsonConverter.write(res.data, version)
       case res: ListGroupsResponse => ListGroupsResponseDataJsonConverter.write(res.data, version)
       case res: ListOffsetsResponse => ListOffsetsResponseDataJsonConverter.write(res.data, version)
+      case res: LiControlledShutdownSkipSafetyCheckResponse =>
+        LiControlledShutdownSkipSafetyCheckResponseDataJsonConverter.write(res.data, version)
+      case res: LiMoveControllerResponse => LiMoveControllerResponseDataJsonConverter.write(res.data, version)
       case res: ListPartitionReassignmentsResponse => ListPartitionReassignmentsResponseDataJsonConverter.write(res.data, version)
       case res: ListTransactionsResponse => ListTransactionsResponseDataJsonConverter.write(res.data, version)
       case res: MetadataResponse => MetadataResponseDataJsonConverter.write(res.data, version)


### PR DESCRIPTION
Define APIs 1000 and 1002 and test their bytes. Keep their listener scopes empty until the next PR adds gated broker handlers.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.