### PR TITLE
storage: restore opt-in legacy broker metrics

### DIFF
--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogDirFailureChannel.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogDirFailureChannel.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.storage.internals.log;
 
+import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,10 +40,29 @@ public class LogDirFailureChannel {
     private static final Logger log = LoggerFactory.getLogger(LogDirFailureChannel.class);
     private final ConcurrentMap<String, String> offlineLogDirs;
     private final BlockingQueue<String> offlineLogDirQueue;
+    private final KafkaMetricsGroup metricsGroup;
 
     public LogDirFailureChannel(int logDirNum) {
+        this(logDirNum, false);
+    }
+
+    public LogDirFailureChannel(int logDirNum, boolean legacyMetricsEnabled) {
         this.offlineLogDirs = new ConcurrentHashMap<>();
         this.offlineLogDirQueue = new ArrayBlockingQueue<>(logDirNum);
+        if (legacyMetricsEnabled) {
+            this.metricsGroup = new KafkaMetricsGroup("kafka.server", "LogDirFailureChannel");
+            this.metricsGroup.newGauge("NumOfflineLogDirsDetected", this::numOfflineLogDirsDetected);
+        } else {
+            this.metricsGroup = null;
+        }
+    }
+
+    public void close() {
+        if (metricsGroup != null) metricsGroup.removeMetric("NumOfflineLogDirsDetected");
+    }
+
+    public int numOfflineLogDirsDetected() {
+        return offlineLogDirs.size();
     }
 
     public boolean hasOfflineLogDir(String logDir) {

--- a/storage/src/main/java/org/apache/kafka/storage/log/metrics/BrokerTopicMetrics.java
+++ b/storage/src/main/java/org/apache/kafka/storage/log/metrics/BrokerTopicMetrics.java
@@ -18,7 +18,9 @@ package org.apache.kafka.storage.log.metrics;
 
 import org.apache.kafka.server.log.remote.storage.RemoteStorageMetrics;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
+import org.apache.kafka.server.metrics.KafkaYammerMetrics;
 
+import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.Meter;
 
 import java.util.Collections;
@@ -33,6 +35,8 @@ import java.util.concurrent.locks.ReentrantLock;
 public final class BrokerTopicMetrics {
     public static final String MESSAGE_IN_PER_SEC = "MessagesInPerSec";
     public static final String BYTES_IN_PER_SEC = "BytesInPerSec";
+    public static final String MESSAGES_IN_TOTAL = "MessagesInTotal";
+    public static final String BYTES_IN_TOTAL = "BytesInTotal";
     public static final String BYTES_OUT_PER_SEC = "BytesOutPerSec";
     public static final String BYTES_REJECTED_PER_SEC = "BytesRejectedPerSec";
     public static final String REPLICATION_BYTES_IN_PER_SEC = "ReplicationBytesInPerSec";
@@ -56,21 +60,34 @@ public final class BrokerTopicMetrics {
     private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup("kafka.server", "BrokerTopicMetrics");
     private final Map<String, String> tags;
     private final Map<String, MeterWrapper> metricTypeMap = new java.util.HashMap<>();
+    private final Map<String, CounterWrapper> counterTypeMap = new java.util.HashMap<>();
     private final Map<String, GaugeWrapper> metricGaugeTypeMap = new java.util.HashMap<>();
 
     public BrokerTopicMetrics(boolean remoteStorageEnabled) {
-        this(Optional.empty(), remoteStorageEnabled);
+        this(Optional.empty(), remoteStorageEnabled, false);
+    }
+
+    public BrokerTopicMetrics(boolean remoteStorageEnabled, boolean legacyMetricsEnabled) {
+        this(Optional.empty(), remoteStorageEnabled, legacyMetricsEnabled);
     }
 
     public BrokerTopicMetrics(String name, boolean remoteStorageEnabled) {
-        this(Optional.of(name), remoteStorageEnabled);
+        this(Optional.of(name), remoteStorageEnabled, false);
     }
 
-    private BrokerTopicMetrics(Optional<String> name, boolean remoteStorageEnabled) {
+    public BrokerTopicMetrics(String name, boolean remoteStorageEnabled, boolean legacyMetricsEnabled) {
+        this(Optional.of(name), remoteStorageEnabled, legacyMetricsEnabled);
+    }
+
+    private BrokerTopicMetrics(Optional<String> name, boolean remoteStorageEnabled, boolean legacyMetricsEnabled) {
         this.tags = name.map(s -> Collections.singletonMap("topic", s)).orElse(Collections.emptyMap());
 
         metricTypeMap.put(MESSAGE_IN_PER_SEC, new MeterWrapper(MESSAGE_IN_PER_SEC, "messages"));
         metricTypeMap.put(BYTES_IN_PER_SEC, new MeterWrapper(BYTES_IN_PER_SEC, "bytes"));
+        if (legacyMetricsEnabled) {
+            counterTypeMap.put(MESSAGES_IN_TOTAL, new CounterWrapper(MESSAGES_IN_TOTAL));
+            counterTypeMap.put(BYTES_IN_TOTAL, new CounterWrapper(BYTES_IN_TOTAL));
+        }
         metricTypeMap.put(BYTES_OUT_PER_SEC, new MeterWrapper(BYTES_OUT_PER_SEC, "bytes"));
         metricTypeMap.put(BYTES_REJECTED_PER_SEC, new MeterWrapper(BYTES_REJECTED_PER_SEC, "bytes"));
         metricTypeMap.put(FAILED_PRODUCE_REQUESTS_PER_SEC, new MeterWrapper(FAILED_PRODUCE_REQUESTS_PER_SEC, "requests"));
@@ -118,10 +135,13 @@ public final class BrokerTopicMetrics {
         if (mw != null) mw.close();
         GaugeWrapper mg = metricGaugeTypeMap.get(metricName);
         if (mg != null) mg.close();
+        CounterWrapper mc = counterTypeMap.get(metricName);
+        if (mc != null) mc.close();
     }
 
     public void close() {
         metricTypeMap.values().forEach(MeterWrapper::close);
+        counterTypeMap.values().forEach(CounterWrapper::close);
         metricGaugeTypeMap.values().forEach(GaugeWrapper::close);
     }
 
@@ -140,6 +160,28 @@ public final class BrokerTopicMetrics {
 
     public Meter bytesInRate() {
         return metricTypeMap.get(BYTES_IN_PER_SEC).meter();
+    }
+
+    public Optional<Counter> messagesInTotal() {
+        CounterWrapper counter = counterTypeMap.get(MESSAGES_IN_TOTAL);
+        return counter == null ? Optional.empty() : Optional.of(counter.counter());
+    }
+
+    public Optional<Counter> bytesInTotal() {
+        CounterWrapper counter = counterTypeMap.get(BYTES_IN_TOTAL);
+        return counter == null ? Optional.empty() : Optional.of(counter.counter());
+    }
+
+    public void markMessagesIn(long value) {
+        messagesInRate().mark(value);
+        CounterWrapper counter = counterTypeMap.get(MESSAGES_IN_TOTAL);
+        if (counter != null) counter.counter().inc(value);
+    }
+
+    public void markBytesIn(long value) {
+        bytesInRate().mark(value);
+        CounterWrapper counter = counterTypeMap.get(BYTES_IN_TOTAL);
+        if (counter != null) counter.counter().inc(value);
     }
 
     public Meter bytesOutRate() {
@@ -320,6 +362,46 @@ public final class BrokerTopicMetrics {
 
     public Meter failedBuildRemoteLogAuxStateRate() {
         return metricTypeMap.get(RemoteStorageMetrics.FAILED_BUILD_REMOTE_LOG_AUX_STATE_PER_SEC_METRIC.getName()).meter();
+    }
+
+    private class CounterWrapper {
+        private final String metricType;
+        private volatile Counter lazyCounter;
+        private final Lock counterLock = new ReentrantLock();
+
+        CounterWrapper(String metricType) {
+            this.metricType = metricType;
+            if (tags.isEmpty()) counter();
+        }
+
+        Counter counter() {
+            Counter counter = lazyCounter;
+            if (counter == null) {
+                counterLock.lock();
+                try {
+                    counter = lazyCounter;
+                    if (counter == null) {
+                        counter = KafkaYammerMetrics.defaultRegistry().newCounter(metricsGroup.metricName(metricType, tags));
+                        lazyCounter = counter;
+                    }
+                } finally {
+                    counterLock.unlock();
+                }
+            }
+            return counter;
+        }
+
+        void close() {
+            counterLock.lock();
+            try {
+                if (lazyCounter != null) {
+                    metricsGroup.removeMetric(metricType, tags);
+                    lazyCounter = null;
+                }
+            } finally {
+                counterLock.unlock();
+            }
+        }
     }
 
     private class MeterWrapper {

--- a/storage/src/test/java/org/apache/kafka/storage/internals/log/LogDirFailureChannelTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/internals/log/LogDirFailureChannelTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.storage.internals.log;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LogDirFailureChannelTest {
+    @Test
+    public void testOfflineDirectoryCountIsDeduplicated() {
+        LogDirFailureChannel channel = new LogDirFailureChannel(2, true);
+        try {
+            channel.maybeAddOfflineLogDir("one", "failed", new IOException("one"));
+            channel.maybeAddOfflineLogDir("one", "failed again", new IOException("one"));
+            channel.maybeAddOfflineLogDir("two", "failed", new IOException("two"));
+            assertEquals(2, channel.numOfflineLogDirsDetected());
+        } finally {
+            channel.close();
+        }
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/storage/log/metrics/BrokerTopicMetricsTest.java
+++ b/storage/src/test/java/org/apache/kafka/storage/log/metrics/BrokerTopicMetricsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.storage.log.metrics;
+
+import com.yammer.metrics.core.MetricName;
+
+import org.apache.kafka.server.metrics.KafkaYammerMetrics;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BrokerTopicMetricsTest {
+    @Test
+    public void testCumulativeIngressMetricsRequireLegacyGate() {
+        BrokerTopicMetrics disabled = new BrokerTopicMetrics(false, false);
+        try {
+            assertFalse(disabled.messagesInTotal().isPresent());
+            assertFalse(disabled.bytesInTotal().isPresent());
+        } finally {
+            disabled.close();
+        }
+
+        BrokerTopicMetrics enabled = new BrokerTopicMetrics(false, true);
+        try {
+            enabled.markMessagesIn(3);
+            enabled.markBytesIn(100);
+            assertEquals(3L, enabled.messagesInTotal().get().count());
+            assertEquals(100L, enabled.bytesInTotal().get().count());
+        } finally {
+            enabled.close();
+        }
+    }
+
+    @Test
+    public void testCloseMetricClosesCumulativeIngressCounters() {
+        Set<MetricName> metricsBeforeTest = new HashSet<>(KafkaYammerMetrics.defaultRegistry().allMetrics().keySet());
+        BrokerTopicMetrics metrics = new BrokerTopicMetrics("counter-close-test", false, true);
+        try {
+            metrics.messagesInTotal();
+            metrics.bytesInTotal();
+            Set<MetricName> createdCounters = new HashSet<>(KafkaYammerMetrics.defaultRegistry().allMetrics().keySet());
+            createdCounters.removeAll(metricsBeforeTest);
+            createdCounters.removeIf(name -> !name.getName().equals(BrokerTopicMetrics.MESSAGES_IN_TOTAL) &&
+                !name.getName().equals(BrokerTopicMetrics.BYTES_IN_TOTAL));
+            assertEquals(2, createdCounters.size());
+
+            metrics.closeMetric(BrokerTopicMetrics.MESSAGES_IN_TOTAL);
+            metrics.closeMetric(BrokerTopicMetrics.BYTES_IN_TOTAL);
+            assertTrue(Collections.disjoint(
+                createdCounters, KafkaYammerMetrics.defaultRegistry().allMetrics().keySet()));
+        } finally {
+            metrics.close();
+        }
+    }
+}


### PR DESCRIPTION
Restore opt-in cumulative ingress metrics and the offline-directory helper. Keep broker wiring in the next layer; test gates and metric cleanup here.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.