### PR TITLE
tests: add unchanged-client and record-ledger helpers

### DIFF
--- a/tests/bin/LiBridgeMetadataScaleSmoke.java
+++ b/tests/bin/LiBridgeMetadataScaleSmoke.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/** Creates configurable metadata volume before mixed-controller failover testing. */
+public final class LiBridgeMetadataScaleSmoke {
+    private LiBridgeMetadataScaleSmoke() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3) {
+            throw new IllegalArgumentException("Expected <bootstrap-server> <topic-count> <partitions-per-topic>");
+        }
+        String bootstrapServer = args[0];
+        int topicCount = Integer.parseInt(args[1]);
+        int partitionCount = Integer.parseInt(args[2]);
+        if (topicCount < 0 || partitionCount < 1) {
+            throw new IllegalArgumentException("Topic count must be non-negative and partition count must be positive");
+        }
+        if (topicCount == 0) {
+            return;
+        }
+
+        Collection<NewTopic> topics = new ArrayList<>(topicCount);
+        for (int i = 0; i < topicCount; i++) {
+            topics.add(new NewTopic("bridge-scale-" + i, partitionCount, (short) 2));
+        }
+        Map<String, Object> config = new HashMap<>();
+        config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        config.put(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, (int) Duration.ofMinutes(5).toMillis());
+
+        long startNanos = System.nanoTime();
+        try (Admin admin = Admin.create(config)) {
+            admin.createTopics(topics).all().get(5, TimeUnit.MINUTES);
+        }
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        System.out.printf("Created %d scale topics with %d partitions each in %d ms%n",
+            topicCount, partitionCount, elapsedMillis);
+    }
+}

--- a/tests/bin/LiBridgeOldClientSmoke.java
+++ b/tests/bin/LiBridgeOldClientSmoke.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/** Exercises an unchanged 3.0 client artifact against the mixed bridge cluster. */
+public final class LiBridgeOldClientSmoke {
+    private static final int MESSAGE_COUNT = 10;
+
+    private LiBridgeOldClientSmoke() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 2) {
+            throw new IllegalArgumentException("Expected <bootstrap-server> <topic>");
+        }
+        String bootstrapServer = args[0];
+        String topic = args[1];
+
+        Properties producerProperties = new Properties();
+        producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProperties.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "bridge-old-client-transaction");
+        producerProperties.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, "30000");
+
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerProperties)) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            for (int i = 0; i < MESSAGE_COUNT; i++) {
+                producer.send(new ProducerRecord<>(topic, "key-" + i, "old-client-message-" + i))
+                    .get(30, TimeUnit.SECONDS);
+            }
+            producer.commitTransaction();
+        }
+
+        Properties consumerProperties = new Properties();
+        consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, "bridge-old-client-group");
+        consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerProperties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        consumerProperties.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+
+        int received = 0;
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(45);
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProperties)) {
+            consumer.subscribe(Collections.singleton(topic));
+            while (received < MESSAGE_COUNT && System.nanoTime() < deadlineNanos) {
+                ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(1));
+                for (ConsumerRecord<String, String> record : records) {
+                    if (record.value().startsWith("old-client-message-")) {
+                        received++;
+                    }
+                }
+            }
+            if (received != MESSAGE_COUNT) {
+                throw new AssertionError("Expected " + MESSAGE_COUNT + " committed records, received " + received);
+            }
+            consumer.commitSync(Duration.ofSeconds(10));
+        }
+    }
+}

--- a/tests/bin/LiBridgeOldStreamsSmoke.java
+++ b/tests/bin/LiBridgeOldStreamsSmoke.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/** Exercises an unchanged 3.0 Kafka Streams artifact against the mixed bridge cluster. */
+public final class LiBridgeOldStreamsSmoke {
+    private static final int MESSAGE_COUNT = 10;
+
+    private LiBridgeOldStreamsSmoke() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3) {
+            throw new IllegalArgumentException("Expected <bootstrap-server> <input-topic> <output-topic>");
+        }
+        String bootstrapServer = args[0];
+        String inputTopic = args[1];
+        String outputTopic = args[2];
+
+        StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+            .mapValues(value -> "streams-processed-" + value)
+            .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+
+        Properties streamsProperties = new Properties();
+        streamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, "bridge-old-streams-application");
+        streamsProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        streamsProperties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+        streamsProperties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+        streamsProperties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, "1");
+        streamsProperties.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, "0");
+
+        KafkaStreams streams = new KafkaStreams(builder.build(), streamsProperties);
+        try {
+            streams.start();
+            waitForRunning(streams);
+            produceInput(bootstrapServer, inputTopic);
+            consumeOutput(bootstrapServer, outputTopic);
+        } finally {
+            if (!streams.close(Duration.ofSeconds(30))) {
+                throw new AssertionError("Kafka Streams did not close within 30 seconds");
+            }
+        }
+    }
+
+    private static void waitForRunning(KafkaStreams streams) throws InterruptedException {
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(45);
+        while (streams.state() != KafkaStreams.State.RUNNING && System.nanoTime() < deadlineNanos) {
+            Thread.sleep(100);
+        }
+        if (streams.state() != KafkaStreams.State.RUNNING) {
+            throw new AssertionError("Kafka Streams did not reach RUNNING state: " + streams.state());
+        }
+    }
+
+    private static void produceInput(String bootstrapServer, String inputTopic) throws Exception {
+        Properties properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+            for (int i = 0; i < MESSAGE_COUNT; i++) {
+                producer.send(new ProducerRecord<>(inputTopic, "key-" + i, "message-" + i))
+                    .get(30, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private static void consumeOutput(String bootstrapServer, String outputTopic) {
+        Properties properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "bridge-old-streams-verifier");
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+
+        int received = 0;
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(45);
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties)) {
+            consumer.subscribe(Collections.singleton(outputTopic));
+            while (received < MESSAGE_COUNT && System.nanoTime() < deadlineNanos) {
+                ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(1));
+                for (ConsumerRecord<String, String> record : records) {
+                    if (record.value().startsWith("streams-processed-message-")) {
+                        received++;
+                    }
+                }
+            }
+        }
+        if (received != MESSAGE_COUNT) {
+            throw new AssertionError("Expected " + MESSAGE_COUNT + " Streams records, received " + received);
+        }
+    }
+}

--- a/tests/bin/LiBridgePrivateApiSmoke.java
+++ b/tests/bin/LiBridgePrivateApiSmoke.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.MoveControllerOptions;
+import org.apache.kafka.clients.admin.SkipShutdownSafetyCheckOptions;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/** Exercises retained operational APIs against a running mixed cluster. */
+public final class LiBridgePrivateApiSmoke {
+    private LiBridgePrivateApiSmoke() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 2) {
+            throw new IllegalArgumentException("Expected <bootstrap-server> <suffix>");
+        }
+        String bootstrapServer = args[0];
+        String topic = "federated-smoke-" + args[1];
+        String namespace = "bridge-smoke";
+        Map<String, String> federatedTopic = Collections.singletonMap(topic, namespace);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        config.put(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, (int) Duration.ofSeconds(30).toMillis());
+
+        try (Admin admin = Admin.create(config)) {
+            admin.createFederatedTopicZnodes(federatedTopic).all().get(topic).get(30, TimeUnit.SECONDS);
+            List<String> topics = admin.listFederatedTopicZnodes().topics().get(30, TimeUnit.SECONDS);
+            String expected = "/" + namespace + "/" + topic;
+            if (!topics.contains(expected)) {
+                throw new AssertionError("Federated topic " + expected + " missing from " + topics);
+            }
+            admin.deleteFederatedTopicZnodes(federatedTopic).all().get(topic).get(30, TimeUnit.SECONDS);
+            topics = admin.listFederatedTopicZnodes().topics().get(30, TimeUnit.SECONDS);
+            if (topics.contains(expected)) {
+                throw new AssertionError("Federated topic " + expected + " remained after deletion");
+            }
+
+            // A maximum epoch is intentionally used only by this disposable cluster. API 1000
+            // rejects stale epochs and accepts this value for the currently registered broker.
+            admin.skipShutdownSafetyCheck(new SkipShutdownSafetyCheckOptions()
+                .brokerId(1)
+                .brokerEpoch(Long.MAX_VALUE)
+                .timeoutMs(30000)).all().get(30, TimeUnit.SECONDS);
+            admin.moveController(new MoveControllerOptions().timeoutMs(30000))
+                .all().get(30, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/tests/bin/LiBridgeRecords.java
+++ b/tests/bin/LiBridgeRecords.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/** Deterministic single-partition recovery ledger; detects loss, duplicates and changed bytes. */
+public final class LiBridgeRecords {
+    private LiBridgeRecords() { }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 6) {
+            throw new IllegalArgumentException("Expected produce|verify <bootstrap> <topic> <start> <count> <size>");
+        }
+        String mode = args[0];
+        String topic = args[2];
+        int start = Integer.parseInt(args[3]);
+        int count = Integer.parseInt(args[4]);
+        int size = Integer.parseInt(args[5]);
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", args[1]);
+        properties.put("request.timeout.ms", "30000");
+        if (mode.equals("produce")) {
+            properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+            properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+            properties.put("acks", "all");
+            properties.put("enable.idempotence", "true");
+            try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+                for (int index = start; index < start + count; index++) {
+                    producer.send(new ProducerRecord<>(topic, 0, Integer.toString(index), value(index, size)))
+                        .get(60, TimeUnit.SECONDS);
+                }
+            }
+        } else if (mode.equals("verify")) {
+            properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+            properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+            properties.put("enable.auto.commit", "false");
+            TopicPartition partition = new TopicPartition(topic, 0);
+            try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties)) {
+                consumer.assign(Collections.singleton(partition));
+                consumer.seek(partition, start);
+                long end = consumer.endOffsets(Collections.singleton(partition)).get(partition);
+                if (end != start + count) {
+                    throw new AssertionError("Expected log end " + (start + count) + ", found " + end);
+                }
+                int expected = start;
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(90);
+                while (expected < end && System.nanoTime() < deadline) {
+                    for (var record : consumer.poll(Duration.ofSeconds(1))) {
+                        if (record.offset() != expected || !Integer.toString(expected).equals(record.key()) ||
+                                !value(expected, size).equals(record.value())) {
+                            throw new AssertionError("Record mismatch at " + expected + ": " + record.offset());
+                        }
+                        expected++;
+                    }
+                }
+                if (expected != end) {
+                    throw new AssertionError("Missing records: read through " + expected + ", expected " + end);
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown mode " + mode);
+        }
+    }
+
+    private static String value(int index, int size) {
+        String prefix = index + ":";
+        return prefix + "x".repeat(Math.max(0, size - prefix.length()));
+    }
+}


### PR DESCRIPTION
Add unchanged-client, private-API, Streams and exact-record helpers. The process runner follows separately.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.