### PR TITLE
tests: collect live broker settings and packaged ZooKeeper capability

### DIFF
--- a/tests/bin/LiBridgeLiveInventory.java
+++ b/tests/bin/LiBridgeLiveInventory.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.DescribeConfigsOptions;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.config.ConfigResource;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/** Read-only inventory. Uses real effective broker/topic configs; never emits client credentials. */
+public final class LiBridgeLiveInventory {
+    private LiBridgeLiveInventory() { }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 3) {
+            throw new IllegalArgumentException("Expected <bootstrap-server> <client.properties> <output.json>");
+        }
+        Properties properties = new Properties();
+        try (InputStream input = Files.newInputStream(Path.of(args[1]))) {
+            properties.load(input);
+        }
+        properties.put("bootstrap.servers", args[0]);
+        properties.put("default.api.timeout.ms", "60000");
+        properties.put("request.timeout.ms", "30000");
+        Map<String, Object> evidence = new LinkedHashMap<>();
+        evidence.put("contract_version", 2);
+        // Time denotes the start of collection so a slow scan cannot look artificially fresh.
+        evidence.put("collected_at_utc", Instant.now().toString());
+        try (Admin admin = Admin.create(properties)) {
+            String clusterId = admin.describeCluster().clusterId().get(60, TimeUnit.SECONDS);
+            Collection<Node> nodes = admin.describeCluster().nodes().get(60, TimeUnit.SECONDS);
+            Set<String> topicNames = new TreeSet<>(admin.listTopics(new ListTopicsOptions().listInternal(true))
+                .names().get(60, TimeUnit.SECONDS));
+            evidence.put("cluster_id", clusterId);
+            List<Map<String, Object>> brokers = new ArrayList<>();
+            for (Node node : nodes) {
+                ConfigResource resource = new ConfigResource(ConfigResource.Type.BROKER, node.idString());
+                Map<String, String> config = collect(admin, Collections.singletonList(resource)).get(resource.name());
+                config.put("broker.id", node.idString());
+                Map<String, Object> broker = new LinkedHashMap<>();
+                broker.put("broker_id", node.idString());
+                broker.put("source", "AdminClient.describeConfigs(includeSynonyms=true)");
+                broker.put("properties", config);
+                brokers.add(broker);
+            }
+            evidence.put("brokers", brokers);
+            Map<String, Map<String, String>> topics = new TreeMap<>();
+            List<String> names = new ArrayList<>(topicNames);
+            for (int start = 0; start < names.size(); start += 100) {
+                List<ConfigResource> batch = names.subList(start, Math.min(names.size(), start + 100)).stream()
+                    .map(name -> new ConfigResource(ConfigResource.Type.TOPIC, name)).collect(Collectors.toList());
+                topics.putAll(collect(admin, batch));
+            }
+            evidence.put("topic_names", topicNames);
+            evidence.put("topics", topics);
+            Set<Integer> ids = nodes.stream().map(Node::id).collect(Collectors.toSet());
+            if (!ids.equals(admin.describeCluster().nodes().get(60, TimeUnit.SECONDS).stream()
+                    .map(Node::id).collect(Collectors.toSet())) ||
+                    !clusterId.equals(admin.describeCluster().clusterId().get(60, TimeUnit.SECONDS)) ||
+                    !topicNames.equals(admin.listTopics(new ListTopicsOptions().listInternal(true))
+                        .names().get(60, TimeUnit.SECONDS))) {
+                throw new IllegalStateException("Inventory changed during collection; retry the read-only scan");
+            }
+        }
+        new ObjectMapper().writerWithDefaultPrettyPrinter().writeValue(Path.of(args[2]).toFile(), evidence);
+    }
+
+    private static Map<String, Map<String, String>> collect(Admin admin, List<ConfigResource> resources) throws Exception {
+        Map<ConfigResource, Config> results = admin.describeConfigs(resources,
+            new DescribeConfigsOptions().includeSynonyms(true)).all().get(60, TimeUnit.SECONDS);
+        Map<String, Map<String, String>> configs = new TreeMap<>();
+        for (ConfigResource resource : resources) {
+            Map<String, String> values = new TreeMap<>();
+            results.get(resource).entries().forEach(entry -> {
+                String name = entry.name();
+                if (!entry.isSensitive() && entry.value() != null && (name.startsWith("li.protocol.bridge.") ||
+                        name.equals("broker.id") || name.equals("inter.broker.protocol.version") ||
+                        name.equals("process.roles") || name.equals("li.async.fetcher.enable") ||
+                        name.equals("li.combined.control.request.enable") || name.equals("li.drop.corrupted.files.enable") ||
+                        name.equals("li.leader.election.on.corruption.wait.ms") || name.equals("li.zookeeper.pagination.enable") ||
+                        name.equals("li.num.controller.init.threads") ||
+                        name.equals("remote.log.storage.system.enable") || name.equals("remote.log.storage.enable") ||
+                        name.equals("remote.storage.enable"))) {
+                    values.put(name, entry.value());
+                }
+            });
+            configs.put(resource.name(), values);
+        }
+        return configs;
+    }
+}

--- a/tests/bin/LiBridgeRuntimeProbe.java
+++ b/tests/bin/LiBridgeRuntimeProbe.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.jute.BinaryInputArchive;
+import org.apache.zookeeper.ZooKeeper;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Run on the packaged broker/wrapper classpath, not the isolated vendor test classpath. */
+public final class LiBridgeRuntimeProbe {
+    private LiBridgeRuntimeProbe() { }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 2) {
+            throw new IllegalArgumentException("Expected <output.json> <require-pagination:true|false>");
+        }
+        if (!args[1].equals("true") && !args[1].equals("false")) {
+            throw new IllegalArgumentException("require-pagination must be true or false");
+        }
+        boolean supported;
+        try {
+            supported = List.class.isAssignableFrom(ZooKeeper.class.getMethod(
+                "getAllChildrenPaginated", String.class, boolean.class).getReturnType());
+        } catch (NoSuchMethodException e) {
+            supported = false;
+        }
+        Map<String, Object> evidence = new LinkedHashMap<>();
+        evidence.put("contract_version", 2);
+        evidence.put("collected_at_utc", Instant.now().toString());
+        evidence.put("pagination_supported", supported);
+        describe(evidence, "zookeeper", ZooKeeper.class);
+        describe(evidence, "jute", BinaryInputArchive.class);
+        new ObjectMapper().writerWithDefaultPrettyPrinter().writeValue(Path.of(args[0]).toFile(), evidence);
+        if (Boolean.parseBoolean(args[1]) && !supported) {
+            throw new IllegalStateException("Packaged runtime lacks LinkedIn ZooKeeper pagination; do not admit this broker");
+        }
+    }
+
+    private static void describe(Map<String, Object> evidence, String name, Class<?> type) throws Exception {
+        Path path = Path.of(type.getProtectionDomain().getCodeSource().getLocation().toURI());
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (InputStream input = Files.newInputStream(path)) {
+            byte[] buffer = new byte[65536];
+            int size;
+            while ((size = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, size);
+            }
+        }
+        StringBuilder hex = new StringBuilder();
+        for (byte value : digest.digest()) {
+            hex.append(String.format("%02x", value));
+        }
+        evidence.put(name + "_jar", path.toString());
+        evidence.put(name + "_sha256", hex.toString());
+        evidence.put(name + "_version", type.getPackage().getImplementationVersion());
+    }
+}


### PR DESCRIPTION
Collect effective broker configuration and probe the packaged ZooKeeper/Jute client. Record observations; do not treat this as production server qualification.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.