### PR TITLE
tests: reject incomplete or mismatched bridge evidence

### DIFF
--- a/tests/bin/audit_li_bridge_evidence.py
+++ b/tests/bin/audit_li_bridge_evidence.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit a li-bridge verification evidence directory for coverage and internal consistency."""
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from li_bridge_contract import CONTRACT_VERSION, PHASES, inventory_issues, scenario_spec
+from li_bridge_preflight import inspect_config
+
+
+REQUIRED_COMMANDS: Tuple[str, ...] = (
+    "archive-input-30",
+    "preflight-unit",
+    "source-whitespace",
+    "wrapper-whitespace",
+    "scala-212-compile",
+    "scala-213-compile",
+    "clients-bridge-tests",
+    "core-bridge-tests",
+    "vendor-pagination",
+    "storage-bridge-tests",
+    "stage-wrapper-artifacts",
+    "wrapper-artifacts",
+    "wrapper-tests",
+    "wrapper-artifacts-unchanged",
+    "release-39",
+    "stop-kafka-gradle",
+    "stop-wrapper-gradle",
+    "mixed-process",
+)
+
+FULL_COMMANDS: Tuple[str, ...] = ("clients-full", "server-full", "storage-full")
+
+REQUIRED_TIMING_OPERATIONS: Tuple[str, ...] = (
+    "3.0 controller election",
+    "3.9 controller election",
+    "all final mixed-mode partitions to become healthy",
+    "all-3.9 bridge-mode partitions to become healthy",
+    "native-mode dynamic configuration",
+    "all final native-mode partitions to become healthy",
+    "all final IBP 3.9 partitions to become healthy",
+    "canary rollback to 3.0",
+    "all-3.9 rollback to 3.0",
+    "hard controller recovery",
+) + tuple(f"old clients phase {phase}" for phase in PHASES)
+
+REQUIRED_RESOURCE_PHASES: Tuple[str, ...] = (
+    "mixed-metadata-loaded",
+    "mixed-old-clients-complete",
+    "mixed-final",
+    "all-39-bridge",
+    "all-39-native",
+    "ibp-39-final",
+)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def source_fingerprint(root: Path) -> Dict[str, object]:
+    names = subprocess.check_output(
+        ["git", "-C", str(root), "ls-files", "--cached", "--others", "--exclude-standard", "-z"])
+    paths = sorted(Path(name.decode("utf-8")) for name in names.split(b"\0") if name)
+    digest = hashlib.sha256()
+    for relative in paths:
+        digest.update(str(relative).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update((root / relative).read_bytes())
+        digest.update(b"\0")
+    return {"sha256": digest.hexdigest(), "file_count": len(paths)}
+
+
+def verification_fingerprints(kafka_root: Path, wrapper_root: Path,
+                              legacy_archive: Optional[Path], skip_local_stage: bool,
+                              supplied_archive: Optional[Path] = None,
+                              build_version: Optional[str] = None) -> Dict[str, object]:
+    def archive(path):
+        return None if path is None else {"path": str(path.resolve()), "sha256": file_sha256(path)}
+    return {
+        "kafka": source_fingerprint(kafka_root),
+        "wrapper": source_fingerprint(wrapper_root),
+        "inputs": {"legacy_archive": archive(legacy_archive), "broker_archive": archive(supplied_archive),
+                   "skip_local_stage": skip_local_stage, "build_version": build_version,
+                   "scenario": scenario_spec(),
+                   "verification_timeout_seconds": int(os.environ.get("BRIDGE_VERIFY_COMMAND_TIMEOUT_SECONDS", "3600"))},
+    }
+
+
+def load_json(path: Path, issues: List[str]) -> Dict[str, object]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or not data:
+            issues.append(f"Expected a non-empty JSON object in {path}")
+            return {}
+        return data
+    except FileNotFoundError:
+        issues.append(f"Missing evidence file: {path}")
+    except json.JSONDecodeError as error:
+        issues.append(f"Invalid JSON in {path}: {error}")
+    except (OSError, UnicodeError) as error:
+        issues.append(f"Cannot read JSON in {path}: {error}")
+    return {}
+
+
+def load_tsv(path: Path, issues: List[str]) -> List[Dict[str, str]]:
+    try:
+        with path.open(encoding="utf-8", newline="") as source:
+            return list(csv.DictReader(source, delimiter="\t"))
+    except FileNotFoundError:
+        issues.append(f"Missing evidence file: {path}")
+    except (OSError, UnicodeError, csv.Error) as error:
+        issues.append(f"Cannot read TSV in {path}: {error}")
+    return []
+
+
+def audit_commands(root: Path, require_full: bool, require_stage: bool, issues: List[str],
+                   supplied_archive: bool = False) -> None:
+    rows = load_tsv(root / "commands.tsv", issues)
+    results = {row.get("command"): row.get("result") for row in rows}
+    base_commands = REQUIRED_COMMANDS if require_stage else tuple(
+        command for command in REQUIRED_COMMANDS if command != "stage-wrapper-artifacts")
+    if supplied_archive:
+        base_commands = tuple(command for command in base_commands
+                              if command != "release-39") + ("provided-39",)
+    required: Sequence[str] = base_commands + (FULL_COMMANDS if require_full else ())
+    for command in required:
+        if command not in results:
+            issues.append(f"Required verification command was not recorded: {command}")
+        elif results[command] != "passed":
+            issues.append(f"Verification command did not pass: {command}={results[command]}")
+
+
+def audit_preflight(path: Path, expected_phase: str, issues: List[str]) -> None:
+    evidence = load_json(path, issues)
+    if evidence and evidence.get("phase") != expected_phase:
+        issues.append(f"{path} has phase {evidence.get('phase')!r}, expected {expected_phase!r}")
+    if evidence and evidence.get("passed") is not True:
+        issues.append(f"{path} did not pass: {evidence.get('issues')}")
+    if not evidence:
+        return
+    if evidence.get("issues") != []:
+        issues.append(f"{path} does not contain an empty issue list")
+    configs = evidence.get("broker_configs")
+    if not isinstance(configs, list) or not configs:
+        issues.append(f"{path} lacks broker configuration evidence")
+        return
+    broker_ids = [config.get("broker_id") for config in configs if isinstance(config, dict)]
+    if len(broker_ids) != len(configs) or any(not isinstance(value, str) or not value.isdecimal()
+                                           for value in broker_ids):
+        issues.append(f"{path} has incomplete broker IDs")
+        return
+    if len(set(broker_ids)) != len(broker_ids):
+        issues.append(f"{path} has duplicate broker IDs")
+    if evidence.get("contract_version") != CONTRACT_VERSION:
+        issues.append(f"{path} does not use bridge contract {CONTRACT_VERSION}; regenerate qualification evidence")
+    expected_ibp, expected_mode, generations = PHASES[expected_phase]
+    issues.extend(inventory_issues(expected_phase, [config.get("generation", "unknown") for config in configs]))
+    for config in configs:
+        if config.get("bridge_mode") is not expected_mode:
+            issues.append(f"{path} records an incorrect bridge mode for broker {config.get('broker_id')}")
+        if config.get("inter_broker_protocol_version") not in {expected_ibp, expected_ibp + "-IV0", expected_ibp + "-IV1"}:
+            issues.append(f"{path} records an incorrect IBP for broker {config.get('broker_id')}")
+        generation = config.get("generation")
+        if generation not in generations:
+            issues.append(f"{path} records an incorrect binary generation for broker {config.get('broker_id')}")
+        properties = config.get("properties")
+        if not isinstance(properties, dict):
+            issues.append(f"{path} lacks effective configuration values")
+        else:
+            config_issues, observed = inspect_config(path, properties, expected_phase,
+                                                     evidence.get("require_all_gates") is True, generation)
+            issues.extend(config_issues)
+            for field in ("broker_id", "bridge_mode", "inter_broker_protocol_version"):
+                if config.get(field) != observed.get(field):
+                    issues.append(f"{path} has inconsistent {field} for broker {config.get('broker_id')}")
+    state = evidence.get("zookeeper_state")
+    if not isinstance(state, dict) or not isinstance(state.get("/brokers/ids"), list):
+        issues.append(f"{path} lacks live ZooKeeper broker inventory")
+    elif any(not isinstance(value, str) or not value.isdecimal() for value in state["/brokers/ids"]):
+        issues.append(f"{path} has invalid live broker IDs")
+    elif set(state["/brokers/ids"]) != set(broker_ids):
+        issues.append(f"{path} broker configs do not match live ZooKeeper inventory")
+
+
+def audit_archive_hashes(summary: Dict[str, object], require_archives: bool,
+                         issues: List[str], warnings: List[str]) -> None:
+    archives = summary.get("archives", {})
+    if not isinstance(archives, dict):
+        issues.append("Mixed-process summary has no archive map")
+        return
+    for generation in ("3.0", "3.9"):
+        archive = archives.get(generation)
+        if not isinstance(archive, dict) or not archive.get("path") or not archive.get("sha256"):
+            issues.append(f"Mixed-process summary lacks {generation} archive path or hash")
+            continue
+        path = Path(str(archive["path"]))
+        if not path.is_file():
+            message = f"Cannot re-hash absent {generation} archive: {path}"
+            if require_archives:
+                issues.append(message)
+            else:
+                warnings.append(message)
+            continue
+        try:
+            digest = file_sha256(path)
+        except OSError as error:
+            issues.append(f"Cannot hash archive {path}: {error}")
+            continue
+        if digest != archive["sha256"]:
+            issues.append(f"Archive checksum mismatch for {path}: {digest} != {archive['sha256']}")
+
+
+def audit_mixed_process(root: Path, require_archives: bool,
+                        issues: List[str], warnings: List[str], direct: bool = False) -> Dict[str, object]:
+    mixed = root if direct else root / "mixed-process"
+    summary = load_json(mixed / "run-summary.json", issues)
+    if summary and summary.get("passed") is not True:
+        issues.append(f"Mixed-process run did not pass: exit_status={summary.get('exit_status')}")
+    if summary:
+        audit_archive_hashes(summary, require_archives, issues, warnings)
+        if summary.get("source_unchanged") is not True or not summary.get("source_sha256"):
+            issues.append("Process scenario lacks unchanged-source evidence")
+
+    for phase in PHASES:
+        audit_preflight(mixed / f"preflight-{phase}.json", phase, issues)
+
+    timings = load_tsv(mixed / "timings.tsv", issues)
+    timing_results = {row.get("operation"): row.get("result") for row in timings}
+    for operation in REQUIRED_TIMING_OPERATIONS:
+        if timing_results.get(operation) != "passed":
+            issues.append(f"Required process transition was not recorded as passed: {operation}")
+
+    old_client_phases = set()
+    old_client_pids = set()
+    connect_pids = set()
+    for path in sorted(mixed.glob("old-clients-*.json")):
+        client = load_json(path, issues)
+        phase = str(client.get("phase", "")).split("-", 1)[-1]
+        if client.get("passed") is not True or client.get("aborted_records_visible") is not False:
+            issues.append(f"Old client checkpoint failed: {path}")
+        elif phase not in PHASES or not isinstance(client.get("acknowledged_records"), int) or client["acknowledged_records"] <= 0:
+            issues.append(f"Incomplete old client checkpoint: {path}")
+        else:
+            old_client_phases.add(phase)
+        connect_pid = client.get("connect_pid")
+        count = client.get("connect_records")
+        if type(connect_pid) is not int or connect_pid <= 0 or type(count) is not int or count <= 0:
+            issues.append(f"Missing persistent Connect evidence: {path}")
+        else:
+            connect_pids.add(connect_pid)
+        if not isinstance(client.get("metadata_churn_cycles"), int) or client["metadata_churn_cycles"] <= 0:
+            issues.append(f"Missing concurrent metadata mutation evidence: {path}")
+        pid = client.get("pid")
+        if not isinstance(pid, int) or pid <= 0:
+            issues.append(f"Missing old client process identity: {path}")
+        else:
+            old_client_pids.add(pid)
+    if old_client_phases != set(PHASES):
+        issues.append(f"Old-client evidence does not cover all phases: {sorted(old_client_phases)}")
+    if len(old_client_pids) != 1 or len(connect_pids) != 1:
+        issues.append("The same unchanged old-client process and Connect worker must survive every phase")
+
+    resources = load_tsv(mixed / "broker-resources.tsv", issues)
+    phases = {row.get("phase") for row in resources}
+    for phase in REQUIRED_RESOURCE_PHASES:
+        if phase not in phases:
+            issues.append(f"Required broker resource phase is missing: {phase}")
+
+    protocol_path = mixed / "protocol-selection.log"
+    try:
+        protocol_log = protocol_path.read_text(encoding="utf-8")
+        enabled_count = protocol_log.count(
+            "LI protocol bridge mode enabled: LeaderAndIsr=v2, UpdateMetadata=v5, StopReplica=v1")
+        if enabled_count < 2:
+            issues.append(f"Expected bridge-selection evidence from both generations, found {enabled_count}")
+        if "LI protocol bridge mode disabled" not in protocol_log:
+            issues.append("Native protocol selection was not recorded")
+    except FileNotFoundError:
+        issues.append(f"Missing evidence file: {protocol_path}")
+    except (OSError, UnicodeError) as error:
+        issues.append(f"Cannot read protocol evidence {protocol_path}: {error}")
+    return summary
+
+
+def audit_wrapper_artifacts(root: Path, archives: Dict[str, object], issues: List[str]) -> None:
+    before = load_json(root / "wrapper-artifacts.json", issues)
+    after = load_json(root / "wrapper-artifacts-after.json", issues)
+    broker = load_json(root / "archive-39.json", issues)
+    if before.get("passed") is not True or before != after:
+        issues.append("Wrapper artifact checks failed or changed during testing")
+    used = archives.get("3.9", {}) if isinstance(archives, dict) else {}
+    if not isinstance(used, dict) or not used.get("sha256"):
+        issues.append("Wrapper artifact check has no mixed-process 3.9 archive")
+    elif before.get("archive_sha256") != used["sha256"] or broker.get("sha256") != used["sha256"]:
+        issues.append("Wrapper artifacts were checked against a different 3.9 archive")
+    artifacts = before.get("artifacts")
+    libraries = broker.get("libraries")
+    if not isinstance(artifacts, list) or not artifacts or not isinstance(libraries, dict):
+        issues.append("Wrapper artifact check lacks the resolved jars or archive library hashes")
+        return
+    main_modules = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict) or artifact.get("group") != "com.linkedin.kafka" or \
+                artifact.get("version") != broker.get("version") or not artifact.get("sha256"):
+            issues.append("Wrapper artifact check has an invalid Kafka coordinate or hash")
+            continue
+        if artifact.get("classifier") is None:
+            name = artifact.get("name")
+            if not isinstance(name, str) or artifact["sha256"] != libraries.get(f"{name}-{broker.get('version')}.jar"):
+                issues.append(f"Wrapper main jar does not match the selected archive: {name}")
+            else:
+                main_modules.add(name)
+    if not {"kafka-clients", "kafka_" + str(broker.get("scala_version"))}.issubset(main_modules):
+        issues.append("Wrapper artifact check lacks matching Kafka core and clients jars")
+
+
+def audit(root: Path, require_full: bool = False, require_clean: bool = False,
+          require_archives: bool = False, require_stage: bool = True,
+          summary_override: Optional[Dict[str, object]] = None) -> Dict[str, object]:
+    issues: List[str] = []
+    warnings: List[str] = []
+    # The verifier checks an in-memory candidate before publishing a successful summary.
+    # Standalone audits always read the final result from disk.
+    summary = summary_override if summary_override is not None else load_json(root / "verification-summary.json", issues)
+    fingerprints = load_json(root / "source-fingerprints.json", issues)
+    if summary and summary.get("passed") is not True:
+        issues.append("Top-level verification summary did not pass")
+    for checkout in ("kafka", "wrapper"):
+        checkout_summary = summary.get(checkout, {}) if summary else {}
+        fingerprint_summary = fingerprints.get(checkout, {}) if fingerprints else {}
+        if not isinstance(checkout_summary, dict) or not checkout_summary.get("commit"):
+            issues.append(f"Top-level summary lacks the {checkout} source revision")
+            continue
+        if require_clean and checkout_summary.get("dirty") is not False:
+            issues.append(f"{checkout} checkout was dirty")
+        if not isinstance(fingerprint_summary, dict) or not fingerprint_summary.get("sha256"):
+            issues.append(f"Source fingerprint is missing for {checkout}")
+        elif checkout_summary.get("source_sha256") != fingerprint_summary.get("sha256"):
+            issues.append(f"Top-level summary does not match the {checkout} source fingerprint")
+
+    inputs = fingerprints.get("inputs", {})
+    supplied_input = inputs.get("broker_archive") if isinstance(inputs, dict) else None
+    if supplied_input is not None and inputs.get("skip_local_stage") is not True:
+        issues.append("A supplied 3.9 archive must not use local wrapper staging")
+    audit_commands(root, require_full, require_stage, issues, supplied_input is not None)
+    mixed = audit_mixed_process(root, require_archives, issues, warnings)
+    legacy_input = inputs.get("legacy_archive") if isinstance(inputs, dict) else None
+    archives = mixed.get("archives", {})
+    legacy_used = archives.get("3.0") if isinstance(archives, dict) else None
+    if not isinstance(legacy_input, dict) or not legacy_input.get("sha256"):
+        issues.append("The verification input fingerprint lacks the 3.0 archive")
+    elif not isinstance(legacy_used, dict) or legacy_input.get("sha256") != legacy_used.get("sha256"):
+        issues.append("The mixed-process 3.0 archive does not match the verification input")
+    if supplied_input is not None:
+        broker_used = archives.get("3.9") if isinstance(archives, dict) else None
+        if not isinstance(supplied_input, dict) or not supplied_input.get("sha256") or \
+                not isinstance(broker_used, dict) or supplied_input["sha256"] != broker_used.get("sha256"):
+            issues.append("The mixed-process 3.9 archive does not match the supplied verification input")
+    expected_scenario = inputs.get("scenario") if isinstance(inputs, dict) else None
+    if not isinstance(expected_scenario, dict) or expected_scenario.get("contract_version") != CONTRACT_VERSION:
+        issues.append("Verification fingerprint lacks the current normalized scenario")
+    elif mixed.get("scenario") != expected_scenario:
+        issues.append("Mixed-process scenario does not match the requested verification inputs")
+    audit_wrapper_artifacts(root, archives, issues)
+    return {"passed": not issues, "issues": issues, "warnings": warnings}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence-dir", required=True, type=Path)
+    parser.add_argument("--process-only", action="store_true",
+                        help="Audit a standalone process evidence directory, not full wrapper/release qualification")
+    parser.add_argument("--require-full", action="store_true",
+                        help="Require complete clients, server, and storage suite records")
+    parser.add_argument("--require-clean", action="store_true",
+                        help="Reject evidence produced from dirty source checkouts")
+    parser.add_argument("--require-archives", action="store_true",
+                        help="Require archive files to remain available and match recorded hashes")
+    parser.add_argument("--allow-missing-stage", action="store_true",
+                        help="Do not require the local artifact-staging command")
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+
+    if args.process_only:
+        if args.require_full or args.require_clean:
+            parser.error("--process-only cannot establish full-suite or clean-checkout qualification")
+        issues, warnings = [], []
+        summary = audit_mixed_process(args.evidence_dir, args.require_archives, issues, warnings, direct=True)
+        if summary.get("scenario") != scenario_spec():
+            issues.append("Process evidence does not match the requested environment/scenario")
+        result = {"kind": "process-qualification-only", "passed": not issues, "issues": issues, "warnings": warnings}
+    else:
+        result = audit(args.evidence_dir, args.require_full, args.require_clean,
+                       args.require_archives, not args.allow_missing_stage)
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output_json:
+        args.output_json.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/li_bridge_evidence_audit_test.py
+++ b/tests/unit/li_bridge_evidence_audit_test.py
@@ -1,0 +1,378 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "bin" / "audit_li_bridge_evidence.py"
+SPEC = importlib.util.spec_from_file_location("audit_li_bridge_evidence", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load evidence auditor module from {SCRIPT}")
+AUDITOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUDITOR)
+
+
+class LiBridgeEvidenceAuditTest(unittest.TestCase):
+    def create_evidence(self, root: Path):
+        mixed = root / "mixed-process"
+        mixed.mkdir(parents=True)
+        fingerprints = {
+            "kafka": {"sha256": "kafka-source", "file_count": 1},
+            "wrapper": {"sha256": "wrapper-source", "file_count": 1},
+        }
+        self.write_json(root / "source-fingerprints.json", fingerprints)
+        self.write_json(root / "verification-summary.json", {
+            "passed": True,
+            "kafka": {"commit": "abc", "dirty": False, "source_sha256": "kafka-source"},
+            "wrapper": {"commit": "def", "dirty": False, "source_sha256": "wrapper-source"},
+        })
+
+        commands = AUDITOR.REQUIRED_COMMANDS + AUDITOR.FULL_COMMANDS
+        (root / "commands.tsv").write_text(
+            "command\tduration_seconds\tresult\n" +
+            "".join(f"{command}\t1\tpassed\n" for command in commands), encoding="utf-8")
+
+        archives = {}
+        for generation in ("3.0", "3.9"):
+            path = root / f"kafka-{generation}.tgz"
+            path.write_bytes(generation.encode("utf-8"))
+            archives[generation] = {
+                "path": str(path),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+        fingerprints["inputs"] = {"legacy_archive": archives["3.0"], "skip_local_stage": False,
+                                  "scenario": AUDITOR.scenario_spec()}
+        self.write_json(root / "source-fingerprints.json", fingerprints)
+        self.write_json(mixed / "run-summary.json", {
+            "passed": True, "exit_status": 0, "archives": archives, "scenario": AUDITOR.scenario_spec(),
+            "source_unchanged": True, "source_sha256": {"script.py": "source-digest"},
+        })
+        artifacts = []
+        libraries = {}
+        for name in ("kafka-clients", "kafka_2.12"):
+            filename = name + "-3.9.2.17.jar"
+            digest = hashlib.sha256(name.encode()).hexdigest()
+            libraries[filename] = digest
+            artifacts.append({"group": "com.linkedin.kafka", "name": name, "version": "3.9.2.17",
+                              "classifier": None, "sha256": digest, "path": str(root / filename)})
+        self.write_json(root / "archive-39.json", dict(archives["3.9"], version="3.9.2.17",
+                                                      scala_version="2.12", libraries=libraries))
+        wrapper_artifacts = {"passed": True, "archive_sha256": archives["3.9"]["sha256"], "artifacts": artifacts}
+        self.write_json(root / "wrapper-artifacts.json", wrapper_artifacts)
+        self.write_json(root / "wrapper-artifacts-after.json", wrapper_artifacts)
+        from li_bridge_contract import BRIDGE_GATES, MODE
+        for phase, (ibp, mode, generations) in AUDITOR.PHASES.items():
+            self.write_json(mixed / f"old-clients-001-{phase}.json", {
+                "phase": f"001-{phase}", "passed": True, "pid": 100, "acknowledged_records": 10,
+                "aborted_records_visible": False, "connect_pid": 101, "connect_records": 10,
+                "metadata_churn_cycles": 10,
+            })
+            configs = []
+            for identifier, generation in enumerate(generations):
+                properties = {gate: "true" for gate in BRIDGE_GATES}
+                properties.update({"broker.id": str(identifier), "inter.broker.protocol.version": ibp,
+                                   MODE: str(mode).lower()})
+                _, config = AUDITOR.inspect_config(Path("broker"), properties, phase, False, generation)
+                configs.append(config)
+            self.write_json(mixed / f"preflight-{phase}.json", {
+                "contract_version": 2, "phase": phase, "passed": True, "issues": [],
+                "broker_configs": configs, "zookeeper_state": {"/brokers/ids": [c["broker_id"] for c in configs]},
+            })
+        (mixed / "timings.tsv").write_text(
+            "operation\tduration_seconds\tresult\n" +
+            "".join(f"{operation}\t1\tpassed\n" for operation in AUDITOR.REQUIRED_TIMING_OPERATIONS),
+            encoding="utf-8")
+        (mixed / "broker-resources.tsv").write_text(
+            "timestamp_utc\tphase\tprocess\tpid\trss_kib\n" +
+            "".join(f"now\t{phase}\tbroker-0\t1\t100\n" for phase in AUDITOR.REQUIRED_RESOURCE_PHASES),
+            encoding="utf-8")
+        enabled = "LI protocol bridge mode enabled: LeaderAndIsr=v2, UpdateMetadata=v5, StopReplica=v1"
+        (mixed / "protocol-selection.log").write_text(
+            enabled + "\n" + enabled + "\nLI protocol bridge mode disabled\n", encoding="utf-8")
+        return archives
+
+    @staticmethod
+    def write_json(path: Path, value):
+        path.write_text(json.dumps(value), encoding="utf-8")
+
+    def test_empty_or_wrong_json_shape_is_rejected(self):
+        files = ("verification-summary.json", "source-fingerprints.json", "mixed-process/run-summary.json",
+                 "mixed-process/preflight-mixed.json", "mixed-process/preflight-native.json")
+        for filename in files:
+            for value in ({}, [], ["invalid"], None, False, "passed"):
+                with self.subTest(filename=filename, value=value), tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    self.create_evidence(root)
+                    self.write_json(root / filename, value)
+                    result = AUDITOR.audit(root, require_full=True, require_clean=True, require_archives=True)
+                    self.assertFalse(result["passed"], result)
+
+    def test_preflight_requires_live_broker_evidence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            path = root / "mixed-process/preflight-mixed.json"
+            self.write_json(path, {"phase": "mixed", "passed": True, "issues": []})
+            self.assertFalse(AUDITOR.audit(root)["passed"])
+
+    def test_preflight_pass_marker_does_not_override_configuration_evidence(self):
+        for key, value in (("bridge_mode", False), ("inter_broker_protocol_version", "3.9"),
+                           ("generation", "unknown")):
+            with self.subTest(key=key), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                self.create_evidence(root)
+                path = root / "mixed-process/preflight-mixed.json"
+                data = json.loads(path.read_text())
+                data["broker_configs"][0][key] = value
+                self.write_json(path, data)
+                self.assertFalse(AUDITOR.audit(root)["passed"])
+
+    def test_preflight_summary_must_match_its_effective_properties(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            path = root / "mixed-process/preflight-ibp-39.json"
+            data = json.loads(path.read_text())
+            data["broker_configs"][0]["inter_broker_protocol_version"] = "3.9-IV1"
+            self.write_json(path, data)
+            result = AUDITOR.audit(root)
+            self.assertFalse(result["passed"])
+            self.assertIn("inconsistent inter_broker_protocol_version", "\n".join(result["issues"]))
+
+    def test_archive_must_match_verification_input(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            path = root / "source-fingerprints.json"
+            fingerprints = json.loads(path.read_text())
+            fingerprints["inputs"]["legacy_archive"]["sha256"] = "different"
+            self.write_json(path, fingerprints)
+            result = AUDITOR.audit(root)
+            self.assertFalse(result["passed"])
+            self.assertIn("does not match the verification input", "\n".join(result["issues"]))
+
+    def test_resume_fingerprint_includes_archive_bytes_and_staging_mode(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for name in ("kafka", "wrapper"):
+                subprocess.run(["git", "init", "-q", str(root / name)], check=True)
+                (root / name / "source.txt").write_text("unchanged source")
+            archive = root / "legacy.tgz"
+            archive.write_bytes(b"first archive")
+            supplied = root / "supplied.tgz"
+            supplied.write_bytes(b"first supplied archive")
+            first = AUDITOR.verification_fingerprints(root / "kafka", root / "wrapper", archive, False, supplied)
+            archive.write_bytes(b"second archive")
+            second = AUDITOR.verification_fingerprints(root / "kafka", root / "wrapper", archive, False, supplied)
+            supplied.write_bytes(b"second supplied archive")
+            third = AUDITOR.verification_fingerprints(root / "kafka", root / "wrapper", archive, False, supplied)
+            fourth = AUDITOR.verification_fingerprints(root / "kafka", root / "wrapper", archive, True, supplied)
+            self.assertEqual(first["kafka"], second["kafka"])
+            self.assertEqual(first["wrapper"], second["wrapper"])
+            self.assertNotEqual(first, second)
+            self.assertNotEqual(second, third)
+            self.assertNotEqual(third, fourth)
+
+    def test_resume_fingerprint_includes_effective_scenario(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for name in ("kafka", "wrapper"):
+                subprocess.run(["git", "init", "-q", str(root / name)], check=True)
+            with mock.patch.dict("os.environ", {}, clear=True):
+                first = AUDITOR.verification_fingerprints(root / "kafka", root / "wrapper", None, False)
+            for key in ("SCALE_TOPIC_COUNT", "SCALE_PARTITION_COUNT", "RECOVERY_RECORD_COUNT", "RECOVERY_RECORD_SIZE"):
+                with mock.patch.dict("os.environ", {key: "999"}, clear=True):
+                    changed = AUDITOR.verification_fingerprints(root / "kafka", root / "wrapper", None, False)
+                    self.assertNotEqual(first, changed)
+            with mock.patch.dict("os.environ", {"SCALE_TOPIC_COUNT": "10"}, clear=True):
+                self.assertEqual(first, AUDITOR.verification_fingerprints(root / "kafka", root / "wrapper", None, False))
+
+    def test_process_scenario_must_match_requested_workload(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            path = root / "mixed-process/run-summary.json"
+            data = json.loads(path.read_text())
+            data["scenario"]["SCALE_TOPIC_COUNT"] += 1
+            self.write_json(path, data)
+            self.assertFalse(AUDITOR.audit(root)["passed"])
+
+    def supplied_evidence(self, root):
+        archives = self.create_evidence(root)
+        path = root / "source-fingerprints.json"
+        fingerprints = json.loads(path.read_text())
+        fingerprints["inputs"].update(broker_archive=archives["3.9"], skip_local_stage=True)
+        self.write_json(path, fingerprints)
+        commands = root / "commands.tsv"
+        commands.write_text("".join(line for line in commands.read_text().splitlines(True)
+                                   if line.split("\t")[0] not in ("release-39", "stage-wrapper-artifacts"))
+                            + "provided-39\t1\tpassed\n")
+
+    def test_supplied_archive_replaces_the_local_release_stage(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.supplied_evidence(root)
+            result = AUDITOR.audit(root, require_stage=False, require_archives=True)
+            self.assertTrue(result["passed"], result)
+            path = root / "source-fingerprints.json"
+            fingerprints = json.loads(path.read_text())
+            fingerprints["inputs"]["broker_archive"]["sha256"] = "different"
+            self.write_json(path, fingerprints)
+            result = AUDITOR.audit(root, require_stage=False)
+            self.assertFalse(result["passed"])
+            self.assertIn("3.9 archive does not match", "\n".join(result["issues"]))
+
+    def test_supplied_mode_rejects_local_staging_and_missing_archive_stage(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.supplied_evidence(root)
+            commands = root / "commands.tsv"
+            commands.write_text(commands.read_text().replace("provided-39\t1\tpassed\n", ""))
+            path = root / "source-fingerprints.json"
+            fingerprints = json.loads(path.read_text())
+            fingerprints["inputs"]["skip_local_stage"] = False
+            self.write_json(path, fingerprints)
+            result = AUDITOR.audit(root, require_stage=False)
+            self.assertFalse(result["passed"])
+            self.assertIn("must not use local wrapper staging", "\n".join(result["issues"]))
+            self.assertIn("provided-39", "\n".join(result["issues"]))
+
+    def test_wrapper_report_must_match_archive_and_remain_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            path = root / "wrapper-artifacts.json"
+            report = json.loads(path.read_text())
+            report["artifacts"][0]["sha256"] = "another jar"
+            self.write_json(path, report)
+            result = AUDITOR.audit(root)
+            self.assertFalse(result["passed"])
+            self.assertIn("changed during testing", "\n".join(result["issues"]))
+            self.assertIn("does not match the selected archive", "\n".join(result["issues"]))
+
+    def test_complete_evidence_passes_strict_audit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            result = AUDITOR.audit(root, require_full=True, require_clean=True, require_archives=True)
+            self.assertTrue(result["passed"], result)
+            self.assertEqual([], result["issues"])
+
+    def test_phase_labels_cannot_replace_unchanged_client_evidence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            path = root / "mixed-process/old-clients-001-native.json"
+            data = json.loads(path.read_text())
+            data["pid"] = 200
+            self.write_json(path, data)
+            result = AUDITOR.audit(root)
+            self.assertFalse(result["passed"])
+            self.assertIn("same unchanged old-client process", "\n".join(result["issues"]))
+            path.unlink()
+            self.assertFalse(AUDITOR.audit(root)["passed"])
+
+    def test_failed_or_missing_command_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            command_file = root / "commands.tsv"
+            command_file.write_text(
+                command_file.read_text(encoding="utf-8").replace(
+                    "core-bridge-tests\t1\tpassed", "core-bridge-tests\t1\tfailed(1)"),
+                encoding="utf-8")
+            result = AUDITOR.audit(root)
+            self.assertFalse(result["passed"])
+            self.assertTrue(any("core-bridge-tests" in issue for issue in result["issues"]))
+
+    def test_missing_local_stage_can_be_allowed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            command_file = root / "commands.tsv"
+            command_file.write_text(
+                "".join(line for line in command_file.read_text(encoding="utf-8").splitlines(True)
+                        if not line.startswith("stage-wrapper-artifacts\t")),
+                encoding="utf-8")
+            result = AUDITOR.audit(root, require_stage=False)
+            self.assertTrue(result["passed"], result)
+
+    def test_source_fingerprint_mismatch_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            summary = json.loads((root / "verification-summary.json").read_text(encoding="utf-8"))
+            summary["kafka"]["source_sha256"] = "different"
+            self.write_json(root / "verification-summary.json", summary)
+            result = AUDITOR.audit(root)
+            self.assertFalse(result["passed"])
+            self.assertTrue(any("source fingerprint" in issue for issue in result["issues"]))
+
+    def test_archive_hash_mismatch_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archives = self.create_evidence(root)
+            Path(archives["3.9"]["path"]).write_bytes(b"modified")
+            result = AUDITOR.audit(root, require_archives=True)
+            self.assertFalse(result["passed"])
+            self.assertTrue(any("checksum mismatch" in issue for issue in result["issues"]))
+
+    def test_missing_process_transition_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            timings = root / "mixed-process" / "timings.tsv"
+            missing_operation = AUDITOR.REQUIRED_TIMING_OPERATIONS[0]
+            timings.write_text(
+                "".join(line for line in timings.read_text(encoding="utf-8").splitlines(True)
+                        if not line.startswith(f"{missing_operation}\t")),
+                encoding="utf-8")
+
+            result = AUDITOR.audit(root)
+            self.assertFalse(result["passed"])
+            self.assertTrue(any(missing_operation in issue for issue in result["issues"]))
+
+    def test_invalid_utf8_is_an_issue_not_an_auditor_crash(self):
+        for filename in ("verification-summary.json", "commands.tsv", "mixed-process/protocol-selection.log"):
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                self.create_evidence(root)
+                (root / filename).write_bytes(b"\xff\xfe\xff")
+                result = AUDITOR.audit(root)
+                self.assertFalse(result["passed"])
+                self.assertTrue(any("Cannot read" in issue for issue in result["issues"]))
+
+    def test_malformed_verification_summary_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            summary = root / "verification-summary.json"
+            summary.write_text("{not valid json", encoding="utf-8")
+
+            result = AUDITOR.audit(root)
+            self.assertFalse(result["passed"])
+            self.assertTrue(any("Invalid JSON" in issue and str(summary) in issue
+                                for issue in result["issues"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reject missing phases, missing client outcomes, malformed input, changed scenarios, mismatched archives and changed wrapper dependencies. Test failed and incomplete evidence, not only the pass marker.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.