### PR TITLE
tests: require protected qualification of the published bridge pair

### DIFF
--- a/.github/workflows/li-bridge-release-qualification.yml
+++ b/.github/workflows/li-bridge-release-qualification.yml
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Qualify published bridge and internal wrapper
+on:
+  workflow_dispatch:
+    inputs:
+      archive_30_url:
+        description: Approved published 3.0 archive HTTPS URL
+        required: true
+        type: string
+      archive_39_url:
+        description: Approved published 3.9 archive HTTPS URL
+        required: true
+        type: string
+      archive_30_sha256:
+        description: Published 3.0 archive SHA-256
+        required: true
+        type: string
+      archive_39_sha256:
+        description: Published 3.9 archive SHA-256
+        required: true
+        type: string
+      commit_30:
+        description: Approved 40-character 3.0 source commit
+        required: true
+        type: string
+      commit_39:
+        description: Approved 40-character 3.9 source commit
+        required: true
+        type: string
+      wrapper_commit:
+        description: Approved wrapper commit with official regenerated dependencies
+        required: true
+        type: string
+permissions:
+  contents: read
+jobs:
+  qualified-wrapper-and-brokers:
+    # Release owners must provision this runner and protect the environment with reviewers.
+    # Never run untrusted pull-request code with internal credentials.
+    runs-on: [self-hosted, li-bridge-qualification]
+    environment: li-bridge-release
+    timeout-minutes: 240
+    env:
+      KAFKA_30_COMMIT: ${{ inputs.commit_30 }}
+      KAFKA_39_COMMIT: ${{ inputs.commit_39 }}
+      WRAPPER_COMMIT: ${{ inputs.wrapper_commit }}
+      KAFKA_30_SHA256: ${{ inputs.archive_30_sha256 }}
+      KAFKA_39_SHA256: ${{ inputs.archive_39_sha256 }}
+      ARCHIVE_30_URL: ${{ inputs.archive_30_url }}
+      ARCHIVE_39_URL: ${{ inputs.archive_39_url }}
+      EVIDENCE_DIR: ${{ runner.temp }}/li-bridge-release-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Validate immutable release inputs
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+          from urllib.parse import urlparse
+          for name in ('KAFKA_30_COMMIT', 'KAFKA_39_COMMIT', 'WRAPPER_COMMIT'):
+              if not re.fullmatch('[0-9a-f]{40}', os.environ[name]):
+                  raise SystemExit(f'{name} must be a full commit hash')
+          for name in ('KAFKA_30_SHA256', 'KAFKA_39_SHA256'):
+              if not re.fullmatch('[0-9a-f]{64}', os.environ[name]):
+                  raise SystemExit(f'{name} must be a SHA-256 checksum')
+          for name in ('ARCHIVE_30_URL', 'ARCHIVE_39_URL'):
+              url = urlparse(os.environ[name])
+              if url.scheme != 'https' or url.hostname != 'github.com':
+                  raise SystemExit(f'{name} must use GitHub HTTPS')
+              if not url.path.startswith('/linkedin/kafka/releases/download/'):
+                  raise SystemExit(f'{name} must name a Kafka release asset')
+          PY
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_39 }}
+          fetch-depth: 0
+          path: kafka
+      - name: Require internal repository authorization
+        env:
+          WRAPPER_TOKEN: ${{ secrets.LI_BRIDGE_WRAPPER_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${WRAPPER_TOKEN}" ]]; then
+            echo 'BLOCKED: missing internal wrapper repository token' >&2
+            exit 1
+          fi
+      - uses: actions/checkout@v4
+        with:
+          repository: linkedin-multiproduct/kafka-server
+          ref: ${{ inputs.wrapper_commit }}
+          token: ${{ secrets.LI_BRIDGE_WRAPPER_TOKEN }}
+          persist-credentials: false
+          fetch-depth: 0
+          path: wrapper
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Download and qualify the actual published artifacts
+        working-directory: kafka
+        run: |
+          set -euo pipefail
+          mkdir -p "${EVIDENCE_DIR}/downloads"
+          export KAFKA_30_TGZ="${EVIDENCE_DIR}/downloads/kafka-30.tgz"
+          export KAFKA_39_TGZ="${EVIDENCE_DIR}/downloads/kafka-39.tgz"
+          export WRAPPER_ROOT="${GITHUB_WORKSPACE}/wrapper"
+          curl --fail --location --proto '=https' --proto-redir '=https' \
+            "${ARCHIVE_30_URL}" -o "${KAFKA_30_TGZ}"
+          curl --fail --location --proto '=https' --proto-redir '=https' \
+            "${ARCHIVE_39_URL}" -o "${KAFKA_39_TGZ}"
+          tests/bin/verify_li_bridge_release.sh
+      - name: Retain qualification evidence even on failure
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: li-bridge-release-evidence
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: warn

--- a/.github/workflows/li-ci.yml
+++ b/.github/workflows/li-ci.yml
@@ -222,6 +222,70 @@ jobs:
             transaction-coordinator:integrationTest \
             tools:tools-api:unitTest tools:tools-api:integrationTest
 
+  bridge-process:
+    name: bridge-process
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      # Checkout fixes the companion source for this run. Record its commit and
+      # archive hash; release CI separately requires approved commit hashes.
+      LI_BRIDGE_LEGACY_REF: ${{ vars.LI_BRIDGE_LEGACY_REF || '3.0-li-bridge/stray-log-cleanup' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Checkout independent legacy source
+        uses: actions/checkout@v4
+        with:
+          repository: linkedin/kafka
+          ref: ${{ env.LI_BRIDGE_LEGACY_REF }}
+          path: legacy-source
+          fetch-depth: 0
+      - name: Record the fixed companion revision
+        working-directory: legacy-source
+        run: |
+          set -euo pipefail
+          revision="$(git rev-parse HEAD)"
+          git checkout --detach "${revision}"
+          echo "Legacy companion for this run: ${revision}"
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: gradle
+      - name: Build independent 3.0 archive
+        working-directory: legacy-source
+        run: ./gradlew --no-daemon --max-workers=2 -PscalaVersion=2.12 core:releaseTarGz
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+      - name: Build current 3.9 archive
+        run: ./gradlew --no-daemon --max-workers=2 -PscalaVersion=2.12 core:releaseTarGz
+      - name: Qualify activation, rollback, mixed/native protocols and old clients
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/bridge-process-evidence
+        run: |
+          set -euo pipefail
+          old_dist="${GITHUB_WORKSPACE}/legacy-source/core/build/distributions"
+          new_dist="${GITHUB_WORKSPACE}/core/build/distributions"
+          export KAFKA_30_TGZ="${old_dist}/kafka_2.12-3.0.1-SNAPSHOT.tgz"
+          export KAFKA_39_TGZ="${new_dist}/kafka_2.12-3.9.2.tgz"
+          export LI_BRIDGE_JAVA_30_HOME="${JAVA_HOME_11_X64}"
+          tests/bin/li_bridge_mixed_cluster_smoke.sh
+          python3 tests/bin/audit_li_bridge_evidence.py \
+            --process-only --require-archives \
+            --evidence-dir "${EVIDENCE_DIR}" \
+            --output-json "${EVIDENCE_DIR}/process-audit.json"
+      - name: Retain process qualification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bridge-process-evidence
+          path: ${{ runner.temp }}/bridge-process-evidence
+          if-no-files-found: error
+
   scala-2-13-compile:
     name: scala_2.13
     runs-on: ubuntu-latest

--- a/tests/bin/verify_li_bridge_release.py
+++ b/tests/bin/verify_li_bridge_release.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Require the selected release inputs before running complete qualification.
+
+The caller supplies source commits and checksums from the approved release record.
+This verifies their identity; it does not grant human or security approval.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from li_bridge_artifacts import file_sha256, inspect_archive
+
+REQUIRED_INPUTS = {
+    "KAFKA_30_TGZ": "the published 3.0 archive",
+    "KAFKA_39_TGZ": "the published 3.9 archive",
+    "KAFKA_30_SHA256": "the published 3.0 checksum",
+    "KAFKA_39_SHA256": "the published 3.9 checksum",
+    "KAFKA_30_COMMIT": "the approved 3.0 source commit",
+    "KAFKA_39_COMMIT": "the approved 3.9 source commit",
+    "WRAPPER_COMMIT": "the approved wrapper commit",
+    "WRAPPER_ROOT": "the wrapper checkout with official dependencies",
+    "EVIDENCE_DIR": "an external evidence directory",
+}
+
+
+def check_inputs(root, environment):
+    for name, description in REQUIRED_INPUTS.items():
+        if not environment.get(name):
+            raise ValueError(f"Supply {description}: {name}")
+    for generation, prefix in (("3.0", "KAFKA_30"), ("3.9", "KAFKA_39")):
+        archive = Path(environment[prefix + "_TGZ"])
+        commit, checksum = environment[prefix + "_COMMIT"], environment[prefix + "_SHA256"]
+        if not re.fullmatch(r"[0-9a-f]{40}", commit) or not re.fullmatch(r"[0-9a-f]{64}", checksum):
+            raise ValueError("Release commits and checksums must be explicit immutable hex values")
+        if file_sha256(archive) != checksum:
+            raise ValueError(f"Published checksum mismatch: {archive}")
+        encoded = inspect_archive(archive, generation).get("commit_id") or ""
+        if not re.fullmatch(r"[0-9a-f]{12,40}", encoded) or not commit.startswith(encoded):
+            raise ValueError(f"Archive source metadata does not match the selected commit: {archive}")
+    for checkout, expected in ((root, environment["KAFKA_39_COMMIT"]),
+                               (Path(environment["WRAPPER_ROOT"]), environment["WRAPPER_COMMIT"])):
+        if not re.fullmatch(r"[0-9a-f]{40}", expected):
+            raise ValueError("Wrapper/source revisions must be 40-character hashes")
+        actual = subprocess.check_output(["git", "-C", str(checkout), "rev-parse", "HEAD"], text=True).strip()
+        dirty = subprocess.check_output(["git", "-C", str(checkout), "status", "--porcelain"], text=True)
+        if actual != expected or dirty:
+            raise ValueError(f"Release qualification requires the clean selected checkout: {checkout}")
+
+
+def main():
+    root = Path(__file__).resolve().parents[2]
+    environment = dict(os.environ)
+    try:
+        check_inputs(root, environment)
+        environment.update(SKIP_LOCAL_STAGE="1", BRIDGE_VERIFY_FULL="1", ALLOW_PARTIAL="0")
+        subprocess.run([str(root / "tests/bin/verify_li_bridge.sh")], env=environment, check=True)
+        evidence = Path(environment["EVIDENCE_DIR"])
+        subprocess.run([sys.executable, str(root / "tests/bin/audit_li_bridge_evidence.py"),
+                        "--evidence-dir", str(evidence), "--require-clean", "--require-full", "--require-archives",
+                        "--allow-missing-stage", "--output-json", str(evidence / "release-evidence-audit.json")],
+                       env=environment, check=True, timeout=300)
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        print(f"Release qualification blocked: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bin/verify_li_bridge_release.sh
+++ b/tests/bin/verify_li_bridge_release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Check the selected release inputs and run complete bridge qualification.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCRIPT_DIR
+if [[ -n "${JAVA_HOME:-}" ]]; then
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+fi
+exec python3 "${SCRIPT_DIR}/verify_li_bridge_release.py" "$@"

--- a/tests/unit/li_bridge_entry_points_test.py
+++ b/tests/unit/li_bridge_entry_points_test.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "bin"))
+from li_bridge_contract import BRIDGE_GATES, FEATURES, PHASES, scenario_spec
+from li_bridge_mixed_cluster_smoke import Migration, verify_connect_records
+from li_bridge_preflight import parse_properties, zk_command
+
+
+class LiBridgeEntryPointsTest(unittest.TestCase):
+    def test_bridge_shell_entry_points_follow_the_small_wrapper_style(self):
+        directory = Path(__file__).parents[1] / "bin"
+        for name in ("li_bridge_mixed_cluster_smoke.sh", "verify_li_bridge.sh",
+                     "stage_li_bridge_ivy.sh", "verify_li_bridge_release.sh"):
+            with self.subTest(name=name):
+                lines = (directory / name).read_text().splitlines()
+                self.assertEqual("#!/bin/bash", lines[0])
+                self.assertTrue(lines[2].startswith("# "))
+                self.assertLess(len(lines), 100)
+                self.assertTrue(all(len(line) <= 80 and "\t" not in line for line in lines))
+                subprocess.run(["bash", "-n", str(directory / name)], check=True)
+
+    def test_release_gate_cannot_succeed_with_missing_inputs(self):
+        script = Path(__file__).parents[1] / "bin/verify_li_bridge_release.sh"
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = subprocess.run(["bash", str(script)], capture_output=True, text=True)
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("published 3.0 archive", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Run the public mixed-process check after its helpers are present. Add a protected release workflow for the approved published binary pair and wrapper revision. Release owners still need to configure the private runner and approvals.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.