### PR TITLE
docs: define bridge rollout, rollback and release checks

### DIFF
--- a/docs/ops/li-bridge-review-comments.md
+++ b/docs/ops/li-bridge-review-comments.md
@@ -1,0 +1,127 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Review comment dispositions
+
+All 62 original threads were inspected and now have replies with published source decisions. Resolved status alone was not accepted as proof. Final readback, new-comment and coverage checks remain required.
+
+## PR 541
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/541#discussion_r3926640391) | Reject bridge mode below IBP 2.2. | KafkaConfig validation; KafkaConfigTest and ControllerChannelManagerTest. | [reply](https://github.com/linkedin/kafka/pull/541#discussion_r3984220462) |
+| [2](https://github.com/linkedin/kafka/pull/541#discussion_r3926640437) | The same IBP guard covers StopReplica v1. | KafkaConfig validation; controller version-selection tests. | [reply](https://github.com/linkedin/kafka/pull/541#discussion_r3984220659) |
+| [3](https://github.com/linkedin/kafka/pull/541#discussion_r3926640487) | Treat malformed minimum-log-roll originals as disabled; do not throw from an MBean read. | LiProtocolBridgeMetricsTest.testMalformedMinimumLogRollValueDoesNotBreakGauge. | [reply](https://github.com/linkedin/kafka/pull/541#discussion_r3984220917) |
+| [4](https://github.com/linkedin/kafka/pull/541#discussion_r3926885180) | Recheck activation after dequeue and while draining. Finish callbacks for work already admitted; do not admit a new combined request. | RequestSendThreadBridgeTest: blocked dequeue, sustained queue and admitted deletion callback. | [reply](https://github.com/linkedin/kafka/pull/541#discussion_r3984221128) |
+| [5](https://github.com/linkedin/kafka/pull/541#discussion_r3926885240) | Tightened the sender and documented the admitted-work exception and required controller restart. | ControllerChannelManager and KafkaConfig docs; RequestSendThreadBridgeTest; runbook activation steps. | [reply](https://github.com/linkedin/kafka/pull/541#discussion_r3984221320) |
+| [6](https://github.com/linkedin/kafka/pull/541#discussion_r3927016213) | Validate all three arguments before parsing. | CI 559: ClientUtils uses Objects.requireNonNull; ClientUtilsTest. | [reply](https://github.com/linkedin/kafka/pull/541#discussion_r3984221566) |
+
+## PR 547
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/547#discussion_r3925893534) | Refresh controller metadata and retry NOT_CONTROLLER for create. | KafkaAdminClient handleNotControllerError; LiKafkaAdminClientTest.testCreateFederatedTopicRetriesAfterControllerChange. | [reply](https://github.com/linkedin/kafka/pull/547#discussion_r3984221855) |
+| [2](https://github.com/linkedin/kafka/pull/547#discussion_r3925893591) | Refresh controller metadata and retry NOT_CONTROLLER for delete. | LiKafkaAdminClientTest.testDeleteFederatedTopicRetriesAfterControllerChange. | [reply](https://github.com/linkedin/kafka/pull/547#discussion_r3984222148) |
+| [3](https://github.com/linkedin/kafka/pull/547#discussion_r3925893635) | Corrected the create-options Javadoc signature. | CreateFederatedTopicZnodesOptions Javadoc links to the Admin method. | [reply](https://github.com/linkedin/kafka/pull/547#discussion_r3984222348) |
+| [4](https://github.com/linkedin/kafka/pull/547#discussion_r3925893670) | Corrected the delete-options Javadoc signature. | DeleteFederatedTopicZnodesOptions Javadoc links to the Admin method. | [reply](https://github.com/linkedin/kafka/pull/547#discussion_r3984222574) |
+
+## PR 548
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/548#discussion_r3925879715) | Catch observer failures on response delivery; continue sending the response. | RequestChannel.sendResponse exception boundary; full core test suite is required in final verification. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984222804) |
+| [2](https://github.com/linkedin/kafka/pull/548#discussion_r3925879779) | Catch observer failures before produce handling. | KafkaApis observeProduceRequest exception boundary; core request tests. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984223047) |
+| [3](https://github.com/linkedin/kafka/pull/548#discussion_r3925879817) | Use Locale.ROOT and isolate the library-tracking callback. | KafkaApis client-software normalization and trackClientLibrary exception boundary. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984223356) |
+| [4](https://github.com/linkedin/kafka/pull/548#discussion_r3925879855) | Use the declared replication-factor default when originals omit the setting. | LiCreateTopicPolicyTest.testDefaultReplicationFactorIsUsedWhenConfigIsAbsent. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984223549) |
+| [5](https://github.com/linkedin/kafka/pull/548#discussion_r3925879891) | Catch LinkageError separately and fall back to NoOpObserver. | Observer.apply class-loading boundary; startup and observer tests. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984223801) |
+| [6](https://github.com/linkedin/kafka/pull/548#discussion_r3925879933) | Corrected the interface documentation to name observe, observeProduceRequest and trackClientLibrary. | Observer Scaladoc; the nonexistent record reference is removed. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984223963) |
+| [7](https://github.com/linkedin/kafka/pull/548#discussion_r3926406046) | Trim the class name and use NoOpObserver without reflection when it is blank. | ObserverTest.testBlankObserverClassUsesNoOpObserver. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984224156) |
+| [8](https://github.com/linkedin/kafka/pull/548#discussion_r3927367747) | Preserved the old RequestChannel JVM constructor. | ObserverTest.testObserverParametersPreserveOldJvmConstructors. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984224332) |
+| [9](https://github.com/linkedin/kafka/pull/548#discussion_r3927367833) | Preserved the old SocketServer JVM constructor. | ObserverTest.testObserverParametersPreserveOldJvmConstructors. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984224508) |
+| [10](https://github.com/linkedin/kafka/pull/548#discussion_r3927367895) | Preserved the old KafkaServer JVM constructor. | ObserverTest.testObserverParametersPreserveOldJvmConstructors. | [reply](https://github.com/linkedin/kafka/pull/548#discussion_r3984224724) |
+
+## PR 549
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/549#discussion_r3925880084) | Create the deletion-flag znode when SetData returns NONODE, tolerating another creator. | KafkaZkClientTest.testSetTopicDeletionFlagCreatesMissingZnode. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984224958) |
+| [2](https://github.com/linkedin/kafka/pull/549#discussion_r3925880153) | Check the pagination result code and propagate failures. Also reject an enabled but unsupported packaged client at startup. | KafkaZkClient.getAllEntitiesWithConfig; vendor missing-path/authorization tests; stock-client startup rejection. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984225182) |
+| [3](https://github.com/linkedin/kafka/pull/549#discussion_r3925880188) | Exclude out-of-sync replicas from the recommendation. | Partition.maybeTransferToNewLeader; PartitionTest.testLeaderTransferSelectsLowestInSyncFollower. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984225389) |
+| [4](https://github.com/linkedin/kafka/pull/549#discussion_r3925880226) | Reuse a controller-owned executor instead of making one per load. | KafkaController.controllerInitExecutor lifecycle and load methods. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984225626) |
+| [5](https://github.com/linkedin/kafka/pull/549#discussion_r3925880272) | Report a ConfigException naming the malformed maintenance setting. | KafkaConfigTest.testInvalidMaintenanceBrokerList. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984225815) |
+| [6](https://github.com/linkedin/kafka/pull/549#discussion_r3925880321) | Report an AdminOperationException for malformed ZooKeeper maintenance values. | AdminZkClientTest.testInvalidMaintenanceBrokerListHasAdminError. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984226000) |
+| [7](https://github.com/linkedin/kafka/pull/549#discussion_r3925880371) | Use one named daemon pagination thread per client instead of ten unnamed non-daemon threads. | ZooKeeperClient paginationExecutor; isolated pagination lifecycle tests. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984226183) |
+| [8](https://github.com/linkedin/kafka/pull/549#discussion_r3926416124) | Classify leader transfer as restart-only, matching manager and partition construction. | DynamicBrokerConfig excludes the setting; dynamic-scope test and phase contract both require restart. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984226331) |
+| [9](https://github.com/linkedin/kafka/pull/549#discussion_r3926416173) | Choose the lowest eligible in-sync broker ID. | PartitionTest.testLeaderTransferSelectsLowestInSyncFollower. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984226522) |
+| [10](https://github.com/linkedin/kafka/pull/549#discussion_r3926416211) | Acquire initializationLock inside the executor task before accessing the session. | ZooKeeperClient paginated-request task; session-expiry/watch-renewal vendor test. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984226676) |
+| [11](https://github.com/linkedin/kafka/pull/549#discussion_r3926416257) | Shut down the executor through the two-phase ThreadUtils helper before closing the session. | ZooKeeperClient.close; vendor fixture teardown and lifecycle checks. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984226898) |
+| [12](https://github.com/linkedin/kafka/pull/549#discussion_r3927365912) | Always invoke the response callback, including executor rejection and unexpected failures. | ZooKeeperClient uses execute with task and submission exception handling; no thenAccept-only path remains. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984227099) |
+| [13](https://github.com/linkedin/kafka/pull/549#discussion_r3927365992) | Unwrap CompletionException and throw its cause. | KafkaController.joinControllerInit is used by both parallel load methods. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984227279) |
+| [14](https://github.com/linkedin/kafka/pull/549#discussion_r3927426758) | No source change needed: Scala emits a valid static forwarder on this trait. | javap of the compiled LeaderTransferManager shows public static noOp(); ReplicaManagerBuilder compiles against it. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984227448) |
+| [15](https://github.com/linkedin/kafka/pull/549#discussion_r3927426849) | Retry only retriable top-level errors and retain only retriable partition recommendations. | LeaderTransferManager.handleResponse; LeaderTransferManagerTest retriable/non-retriable cases. | [reply](https://github.com/linkedin/kafka/pull/549#discussion_r3984227639) |
+
+## PR 550
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/550#discussion_r3925887787) | Make usage state private and initialize it to an empty map; synchronize snapshots and resets. | ListOffsetsRequestInstrumentation; testConcurrentUsageTrackingDoesNotLoseRequests. | [reply](https://github.com/linkedin/kafka/pull/550#discussion_r3984227814) |
+| [2](https://github.com/linkedin/kafka/pull/550#discussion_r3925887866) | Use numPartitionsInIsrState and update the instrumentation caller; retain the old name as a deprecated alias. | ReplicaManager and ProduceRequestInstrumentation use the clearer method name. | [reply](https://github.com/linkedin/kafka/pull/550#discussion_r3984228039) |
+| [3](https://github.com/linkedin/kafka/pull/550#discussion_r3927365937) | Create and register the produce instrumentation logger only on the data plane. | KafkaApis checks DataPlaneAcceptor.MetricPrefix before constructing the logger. | [reply](https://github.com/linkedin/kafka/pull/550#discussion_r3984228224) |
+| [4](https://github.com/linkedin/kafka/pull/550#discussion_r3927366021) | Rewrote the instrumentation description to state what is counted. | ListOffsetsRequestInstrumentation class and usage-logging documentation. | [reply](https://github.com/linkedin/kafka/pull/550#discussion_r3984228409) |
+| [5](https://github.com/linkedin/kafka/pull/550#discussion_r3927434319) | Log completion on the acks=0 path as well as the response callback. | KafkaApis.handleProduceRequest invokes maybeLog before the acks=0 response path. | [reply](https://github.com/linkedin/kafka/pull/550#discussion_r3984228587) |
+| [6](https://github.com/linkedin/kafka/pull/550#discussion_r3927434386) | Do not record zero-size samples for absent timestamp modes. | ListOffsetsRequestInstrumentationTest.testAbsentTimestampModesDoNotRecordZeroSizedSamples. | [reply](https://github.com/linkedin/kafka/pull/550#discussion_r3984228793) |
+| [7](https://github.com/linkedin/kafka/pull/550#discussion_r3927434447) | Use optional callbacks when the data-plane logger is absent. | KafkaApis uses Option.foreach/map for both completion paths. | [reply](https://github.com/linkedin/kafka/pull/550#discussion_r3984228954) |
+
+## PR 551
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/551#discussion_r3925877328) | Capture the post-truncation offset and size while holding the log lock. | UnifiedLog.truncateTo; truncation test and mixed stale-leader process scenario. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984229174) |
+| [2](https://github.com/linkedin/kafka/pull/551#discussion_r3925877401) | Convert malformed numbers to ConfigException. Keep empty lists as an intentional way to disable a bucket dimension. | KafkaConfigTest.testInvalidRequestMetricBuckets and testEmptyRequestMetricBuckets; empty is not rejected because it is supported. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984229326) |
+| [3](https://github.com/linkedin/kafka/pull/551#discussion_r3925877442) | Close cumulative counters when their associated ingress metric is removed. | BrokerTopicMetricsTest.testCloseMetricClosesCumulativeIngressCounters; moved to the storage-metrics split. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984229507) |
+| [4](https://github.com/linkedin/kafka/pull/551#discussion_r3926413418) | Reject negative and non-increasing boundaries. | KafkaConfigTest.testRequestMetricBucketsMustBeOrderedAndNonNegative. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984229700) |
+| [5](https://github.com/linkedin/kafka/pull/551#discussion_r3926413465) | Assert on the specific metric names, not global registry size. | BrokerTopicMetricsTest uses per-metric presence checks; storage split tests pass. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984229872) |
+| [6](https://github.com/linkedin/kafka/pull/551#discussion_r3927365059) | Fall back to a non-atomic move when the filesystem rejects ATOMIC_MOVE. | PoisonPill; separate-process heap-dump test in PR 561. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984230077) |
+| [7](https://github.com/linkedin/kafka/pull/551#discussion_r3927365100) | Synchronize close and clear the metrics map. | RequestChannel.Metrics.close uses the same monitor as apply. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984230263) |
+| [8](https://github.com/linkedin/kafka/pull/551#discussion_r3927365140) | Prefix the watchdog histogram with the request-channel metric prefix. | RequestChannel and RequestChannelWatchdogTest. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984230448) |
+| [9](https://github.com/linkedin/kafka/pull/551#discussion_r3927365177) | Derive the watchdog check interval from the configured timeout. | KafkaServerTest.testRequestChannelWatchdogIntervalTracksConfiguredTimeout. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984230674) |
+| [10](https://github.com/linkedin/kafka/pull/551#discussion_r3927365245) | Remove the hard-coded count. Check uniqueness and compare the actual registry with the shared Python contract. | LiProtocolBridgeConfigTest; preflight/scenario registry-consistency tests; 23 gates are currently registered. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984230900) |
+| [11](https://github.com/linkedin/kafka/pull/551#discussion_r3927475761) | Cache the total topic-name length and update it with topic membership. | ControllerContextTest.testTopicNameLengthTotalTracksTopicChanges; controller gauge reads the cached total. | [reply](https://github.com/linkedin/kafka/pull/551#discussion_r3984231122) |
+
+## PR 552
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/552#discussion_r3926398457) | Test ZooKeeper state parsing and issue generation. | test_inspect_zookeeper_parses_state and test_inspect_zookeeper_reports_inventory_and_corruption. | [reply](https://github.com/linkedin/kafka/pull/552#discussion_r3984231299) |
+| [2](https://github.com/linkedin/kafka/pull/552#discussion_r3927340912) | Split native control at IBP 3.0 from final IBP 3.9. Test each phase instead of requiring a premature IBP bump. | test_native_phase_rejects_premature_ibp_change and test_all_phase_and_retained_gate_contracts. | [reply](https://github.com/linkedin/kafka/pull/552#discussion_r3984231483) |
+| [3](https://github.com/linkedin/kafka/pull/552#discussion_r3927416052) | Require IBP 3.0 in mixed mode and assert the current message. | test_mixed_config_rejects_new_ibp_and_unsafe_features. | [reply](https://github.com/linkedin/kafka/pull/552#discussion_r3984231717) |
+| [4](https://github.com/linkedin/kafka/pull/552#discussion_r3927470913) | Check the dynamic import specification and loader and report a clear error. | li_bridge_preflight_test.py import guard. | [reply](https://github.com/linkedin/kafka/pull/552#discussion_r3984231952) |
+| [5](https://github.com/linkedin/kafka/pull/552#discussion_r3927470956) | Test corruption, ID mismatch and deletion-flag values, including the normal null/empty znode. | ZooKeeper parsing tests and test_deletion_flag_value_is_retained_and_invalid_data_is_rejected. | [reply](https://github.com/linkedin/kafka/pull/552#discussion_r3984232154) |
+
+## PR 554
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/554#discussion_r3926405123) | Reject missing transitions and malformed summaries. Also report invalid UTF-8 as an audit issue. | test_missing_process_transition_is_rejected; test_malformed_verification_summary_is_rejected; test_invalid_utf8_is_an_issue_not_an_auditor_crash. These now belong to the preceding evidence-audit PR. | [reply](https://github.com/linkedin/kafka/pull/554#discussion_r3984232332) |
+
+## PR 558
+
+| Comment | Decision | Code/test evidence | Reply |
+|---|---|---|---|
+| [1](https://github.com/linkedin/kafka/pull/558#discussion_r3962628747) | Exercise release-note API arguments and returned content with a gh stub. | li_release_test.py fixture suite; six cases pass on both release lines. | [reply](https://github.com/linkedin/kafka/pull/558#discussion_r3984232512) |
+| [2](https://github.com/linkedin/kafka/pull/558#discussion_r3962628803) | Build the archive name from the supplied Scala version. | li_release.py archive handling and Scala 2.13 fixture. | [reply](https://github.com/linkedin/kafka/pull/558#discussion_r3984232707) |
+| [3](https://github.com/linkedin/kafka/pull/558#discussion_r3962628838) | Build the notes text from the supplied Scala version. | li_release.py notes handling and fixture assertions. | [reply](https://github.com/linkedin/kafka/pull/558#discussion_r3984232915) |

--- a/docs/ops/li-bridge-review.md
+++ b/docs/ops/li-bridge-review.md
@@ -1,0 +1,335 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Review: 3.0-li to 3.9-li rolling upgrade
+
+## Current verdict
+
+**The reviewed implementation and tools are published as 32 open PRs. Every diff is below 1,000 changed lines. The clean-source process scenario, its strict audit, and the 132-test wrapper suite pass locally. This is not rollout approval.** The final requirement audit, full verifier run, remote CI review and production release gates remain open.
+
+The findings below record what the initial review and later tests found. Instructions in an original finding describe the repair that was needed; use the current disposition and evidence sections for status. This is not a line-by-line approval of every Kafka change.
+
+### Reviewed revisions
+
+- Workspace plan: `LI-3.0-TO-3.9-ROLLING-UPGRADE-PLAN.md`. Canonical runbook: `docs/ops/li-bridge-upgrade.md`.
+- Qualified 3.9 source snapshot: `1578464defd931f95cecef78b55ebd2769a41381`; the current complete stack ends at PR 574.
+- Current 3.0 source: PR 577, `cb85262cb15675a19f628ff0010bacf72065a7b5`.
+- CI: PR 558, `3e799b08ea`; PR 559, `a86214e2da`.
+- Wrapper: `1a9ecccf`, including the ACL test fix `6ddf2a87`.
+
+GitHub heads, bases, labels and sizes were read back after publication. The upgrade stacks rooted at PRs 543 and 575 retain separate release histories. CI foundations have no upgrade label. PRs 563/564 were automatically closed during the reorder; replacement reviews 579/578 preserve those scopes. No release branch was merged by this work. Original findings began from aggregate `a658c512df`; aggregate PR 542 and old docs PR 555 remain closed.
+
+## Findings
+
+### F1 — P1: Activation does not provide the promised bounded merging cutoff
+
+**Owner:** PR 541. **Plan:** lines 71 and 223–239.
+
+In the 3.0 `core/src/main/scala/kafka/controller/ControllerChannelManager.scala:350–425`, `nextRequestAndCallback` snapshots bridge mode before it can block in `queue.take()`. Neither the subsequent dequeue/merge nor the queue-draining loop rechecks the setting. Consequently, work enqueued after activation can still enter `LiCombinedControl`. A continuously replenished queue can also extend the merge loop after activation; it is not bounded to work already removed and merged.
+
+A deterministic review-only reproduction against the local compiled 3.0 artifact blocked the sender on an empty queue, enabled bridge mode, then enqueued one UpdateMetadata request. It returned:
+
+```text
+bridge=true, requests dequeued and merged AFTER activation=1, selected=Builder, api=LI_COMBINED_CONTROL
+```
+
+The existing `testProtocolBridgeModeStopsNewLiCombinedControlRequests` compares counts after two post-activation batches. It allows the first batch to merge and does not test activation while blocked or continuously draining.
+
+**Required change:** enforce a cutoff when deciding whether a dequeued item can be merged, and recheck activation while draining without losing or duplicating callbacks. Keep the mandatory controller restart before 3.9 admission; fixing the race is not a replacement for that fence. Alternatively, explicitly redesign the operational contract around an unconditional restart rather than claiming a bounded pre-restart drain.
+
+**Acceptance tests:** latch-controlled activation during a blocked dequeue and during sustained queue replenishment; assert no newly accepted work enters the merger after the defined cutoff, every callback has the correct lifecycle, and controller replacement completes while mutations continue.
+
+### F2 — P1: Preflight rejects the production 3.0 configuration, and the mixed test avoids it
+
+**Owners:** PRs 552 and 553. **Plan:** lines 126–127, 138–151, and 587.
+
+`tests/bin/li_bridge_preflight.py:179–184` rejects `li.async.fetcher.enable=true` and `li.combined.control.request.enable=true` for **both** generations. Both settings are enabled in the documented 3.0 production configuration. Bridge mode suppresses new combined sends without requiring the original combined-control setting to change, and the plan deliberately leaves the 3.0 fetcher unchanged.
+
+Calling the current preflight inspector with a bridge-enabled, IBP-3.0 legacy configuration reproduces both errors:
+
+```text
+legacy.properties: unsupported 3.9 behavior li.combined.control.request.enable is enabled
+legacy.properties: unsupported 3.9 behavior li.async.fetcher.enable is enabled
+```
+
+The mixed-process harness omits both properties from its legacy broker configuration. They default to false in 3.0 `KafkaConfig`, so its recovery tests do not exercise production's LI async fetcher. This is a functional coverage gap, not just the already-documented throughput qualification gap.
+
+**Required change:** make rejection generation-specific. Preserve the old fetcher and combined-control settings on legacy brokers, while requiring effective bridge mode and verifying the actual combined-send cutoff. Reject these settings on 3.9 as intended.
+
+**Acceptance tests:** a production-shaped legacy config passes; the equivalent 3.9 config fails; mixed recovery runs with the old async fetcher enabled in both leader directions; dormant-to-active bridge testing starts with combined control enabled.
+
+### F3 — P1: Qualify rollback before promising it for the first canary
+
+**Owners:** PR 553 or a dedicated rollback qualification PR; deployment owner. **Plan:** lines 353 and 371–384.
+
+The canary instructions unconditionally say to replace a failed 3.9 broker with the 3.0 bridge. Only later does the plan condition rollback on persisted-state compatibility. The process harness upgrades the final old broker on its existing log directory, but never runs the reverse replacement.
+
+Wire compatibility does not prove that 3.0 can reopen state written by a 3.9 leader, group/transaction coordinator, controller, or plugin. This condition applies to the first canary as well as the all-3.9 bake.
+
+**Required change:** make successful persisted-state rollback qualification an entry gate before any production 3.9 admission, or document a tested forward-recovery alternative instead of promising binary rollback.
+
+**Acceptance tests:** 3.0 → 3.9 → 3.0 on the same log directories and ZooKeeper state, with acknowledged data, committed offsets, transaction/coordinator state, topic IDs, dynamic configs, and retained plugin state. Exercise both a canary rollback and rollback from an all-3.9 bridge-mode cluster. Verify exact records and resumed application progress, not only successful registration.
+
+### F4 — P1: The unchanged-client matrix is not implemented through the final transitions
+
+**Owners:** PR 553; internal wrapper/tool qualification. **Plan:** lines 348 and 486–497.
+
+The harness runs short-lived old producer/consumer, transaction/group, Streams, and Connect cases during the mixed phase. Later produce/consume phases use `KAFKA_39_HOME`, including native mode and IBP 3.9 (`tests/bin/li_bridge_mixed_cluster_smoke.sh:726,761,786`). No old workload remains alive across the complete transition sequence.
+
+The private-API helper is also compiled and executed against **3.9** jars (`:345–349,610–611`), despite PR 553's description saying its private-API traffic comes from the 3.0 archive. That proves the restored new Admin surface, not unchanged deployed `ktool` or LI AdminClient behavior.
+
+**Required change:** keep supported old client artifacts running across broker replacements, controller changes, bridge deactivation, and IBP changes. Run the private-API helper with old jars as well as new jars, and qualify the actual operational tools. Define the supported deployed client floor rather than equating it with one 3.0 archive.
+
+**Acceptance tests:** the six phases listed in the plan have results for old producer, consumer, transactional client, Admin/tool, Streams, and Connect artifacts. Include coordinator movement, reconnect/rebalance, transaction commit/abort/fencing, and existing group-offset recovery. No client binary/configuration changes are allowed between phases.
+
+### F5 — P1 release gate: Pagination is tested with vendor jars, not established for the deployed runtime
+
+**Owners:** PRs 549 and 564; wrapper/deployment dependency PR. **Plan:** lines 129 and 526.
+
+The pagination implementation invokes `ZooKeeper.getAllChildrenPaginated` reflectively (`core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala:206–234`). A stock client lacking that method produces `SYSTEMERROR`; there is deliberately no silent fallback.
+
+PR 564 correctly qualifies the adapter with isolated, hash-pinned LinkedIn ZooKeeper 3.6.3-23 jars. Its normal Kafka runtime remains stock ZooKeeper 3.8.4. Meanwhile, the wrapper's `config/app/kafka-war/application.src:29` enables pagination. The test-only dependency change does not establish which client implementation the final wrapper package will actually load, or compatibility with the live server ensemble.
+
+**Required change:** identify and pin the actual deployed client/Jute/server combination in the release/deployment contract. Add a startup/preflight capability check and qualification using the packaged wrapper runtime with pagination enabled. Do not disable pagination merely to make a large production cluster start.
+
+**Acceptance tests:** inspect actual loaded class locations and hashes; launch the packaged broker/wrapper against the qualified server; enumerate topic, topic-config, and federated paths above the response limit; verify watches, authorization failures, reconnect/session expiry, and controller startup. If deployment already substitutes the vendor client, retain evidence of that substitution rather than assuming it.
+
+### F6 — P2: The preflight state model contradicts the separate native/IBP steps
+
+**Owners:** PRs 552 and 554. **Plan:** lines 396–419.
+
+The current preflight's `native` phase requires IBP 3.9 (`tests/bin/li_bridge_preflight.py:148–151`). The runbook explicitly requires a native-control bake at IBP 3.0 before raising IBP. That legitimate intermediate state is rejected:
+
+```text
+new.properties: native phase requires IBP 3.9, found 3.0
+```
+
+Conversely, at IBP 3.9 the inspector returns no issues with **all** compatibility gates false, even with `require_all_gates=True`. Required-gate enforcement only runs in `mixed`. Native control does not retire `ktool`, federated APIs, authorization/placement behavior, or operational metrics.
+
+**Required change:** model the real states explicitly: dormant 3.0, all-3.0 bridge, mixed bridge, all-3.9 bridge, native-at-old-IBP, and final IBP 3.9. Define retained gates independently of the outbound protocol gate. Make the evidence auditor consume the same phase expectations.
+
+**Acceptance tests:** each allowed state passes, invalid transitions fail, the native-at-old-IBP state passes without changing IBP, and disabling a still-required retained feature fails in every applicable phase. Document which settings require a restart.
+
+### F7 — P2: Green public CI does not include the mixed-process migration
+
+**Owners:** PRs 553, 554, 558, 559, and internal CI. **Plan:** line 591.
+
+The current `.github/workflows/li-ci.yml` runs bridge Python tests and shell syntax checks, plus Kafka suites and the isolated pagination test. It does not execute `li_bridge_mixed_cluster_smoke.sh` or the wrapper verifier. Therefore, all PR checks being green does not satisfy the plan's explicit mixed-process CI requirement.
+
+The local evidence bundles are valuable and a retained supplied-artifact bundle passes the current strict auditor. They are not a repeatable CI gate for future protocol changes or the final published artifacts.
+
+**Required change:** add an automated cross-artifact job using pinned independently built release inputs, and an internal wrapper/security job where private dependencies are available. Require these results for release qualification. Record which checks are per-PR gates versus slower release gates.
+
+**Acceptance tests:** final merged/published archives are the actual process-test inputs; evidence and JUnit/process logs are retained; absence of a required archive or private test environment yields an explicit blocked result, never a successful partial qualification.
+
+### F8 — P2: Strengthen the process test's behavioral assertions
+
+**Owner:** PR 553. **Plan:** lines 368 and 472–484.
+
+Several assertions are too weak for the stated safety claims:
+
+- `consume_count` checks line count, not exact record identity, duplicates, or ordering. Old transaction consumption checks a prefix and count.
+- `create_and_delete_topic` submits deletion but does not wait for metadata, ZooKeeper, and replica/log removal; it never verifies immediate recreation of the same name.
+- Catch-up asserts ISR membership; it does not compare the recovered records on both replicas.
+- The common process configuration sets `controlled.shutdown.enable=false`, and stop helpers use normal termination rather than hard failures. Other focused tests cover some shutdown behavior, but the mixed binary shutdown/crash contract is not established by this harness.
+
+**Required change:** use a per-partition record ledger/checksum, acknowledged-write tracking, explicit deletion/recreation completion checks, and bounded crash/recovery cases. Keep intentional unclean-election data loss isolated from the no-loss workload. Add explicit process/command timeouts so a hang yields useful failure evidence.
+
+**Acceptance tests:** deliberate dropped/duplicated records and incomplete deletion make the test fail; production-like controlled shutdown and hard controller/broker termination recover under active mutations.
+
+### F9 — P2: The dormant-feature gate does not collect or validate all required inputs
+
+**Owner:** PR 552 and live-discovery/deployment tooling. **Plan:** lines 113–119, 151, 578, and 588–589.
+
+The preflight validates supplied properties and selected ZooKeeper paths. It does not collect effective dynamic broker/topic configuration or inspect remote-storage metadata. It also does not reject `li.leader.election.on.corruption.wait.ms > 0`, even though delayed corrupt elections are explicitly not ported. A config with all bridge gates true and that setting at 1000 currently produces no issues.
+
+An empty `/brokers/corrupted` at one instant is not proof that a legacy broker with recovery enabled cannot create new state during the roll. A broker-level remote-storage boolean alone does not establish the disposition of previously written remote/topic/plugin state.
+
+**Required change:** give the live configuration/state collector an owner and a versioned evidence format. Validate delayed-election settings on legacy brokers, dynamic topic/broker overrides, remote metadata/state disposition, and collection completeness/freshness. Distinguish offline config lint from a live admission gate. Require live inputs for production approval.
+
+**Acceptance tests:** dangerous static/dynamic overrides and enabled delayed election fail; missing live evidence is blocked; the report includes source, collection time, cluster identity, and disposition for every required persistent path.
+
+### F10 — P2: Resume does not fingerprint workload qualification parameters
+
+**Owners:** PRs 554 and 563.
+
+`verification_fingerprints` in `tests/bin/audit_li_bridge_evidence.py:92–103` covers source, archives, staging mode, and build version, but not `SCALE_TOPIC_COUNT`, `SCALE_PARTITION_COUNT`, `RECOVERY_RECORD_COUNT`, or `RECOVERY_RECORD_SIZE`. Changing these on a resumed invocation can reuse the previous successful `mixed-process` stage instead of running the requested larger workload.
+
+The old workload parameters remain visible in nested evidence, so this is not evidence that results were fabricated. It is nevertheless an unsafe mismatch between requested verification and reused verification.
+
+**Required change:** fingerprint a normalized scenario specification, including effective defaults, and validate its match to the process summary. Rerun affected stages or refuse resume when the scenario changes.
+
+**Acceptance tests:** increasing metadata/recovery scale or changing the required runtime profile invalidates reuse; identical scenarios still resume successfully.
+
+### F11 — P2: Make the reviewed plan and merge/release dependencies authoritative
+
+**Owner:** a replacement documentation PR; Kafka/wrapper release owners.
+
+The requested plan still describes the aggregate implementation and has no inventory of the current split PRs. The open stack does not track this plan; the old docs PR 555 is closed. Later local working notes are useful but are not a substitute for a reviewed runbook attached to the actual release line.
+
+The wrapper's official dependency update and security review also remain separate dependencies. A published branch and local compilation are not an approved wrapper release. In particular, `LiKafkaAuthorizerV2.authorizeByResourceType` changes producer-ID authorization behavior and needs an explicit security-owner decision plus positive/negative tests with production authentication.
+
+**Required change:** publish a single reviewed runbook with the PR inventory below, exact release/wrapper provenance, merge order, owners, and evidence links. Separate historical experiment notes from current acceptance criteria. Do not describe green CI or a branch push as approval/publication.
+
+**Acceptance tests/checks:** the merged release references the runbook; artifact versions/checksums map to approved commits; the wrapper resolves official main/test classifiers; required security and operational approvals are recorded; rollback/admission automation cannot start a non-bridge old binary or an ordinary 3.9 binary during the mixed phase.
+
+### F12 — P1: The old offline-deletion shortcut needs a bridge-mode replacement
+
+**Owner:** PR 541. This was found while testing the fixes above.
+
+The continuous metadata test stopped making progress after a 3.9-to-3.0 controller change. The old controller removed the topic's ZooKeeper entry while its only replica was offline. It skipped the metadata deletion update. The running brokers kept a ghost topic: CreateTopics reported that it existed, while DeleteTopics reported that it did not exist.
+
+The failure is in the 3.0 `TopicDeletionManager.resumeDeletions` shortcut that counts `OfflineReplica` as successful deletion. That shortcut relies on native full-state control messages, which the bridge cannot send.
+
+The new regression `TopicDeletionManagerTest.testBridgeDeletionWaitsForOfflineReplicaAfterControllerFailover` failed before the fix: ZooKeeper deletion ran without a metadata update. The bridge now uses the older Kafka behavior: send the metadata deletion update, retain offline replicas for retry when they return, and wait for their deletion acknowledgements. The native 3.0 path is unchanged. The full deletion-manager suite and activation regressions pass. A complete mixed-process rerun is still required before closing this finding.
+
+### F13 — P1: A recreated topic inherits stale deletion state
+
+**Owners:** PR 541 and the 3.9 controller fixes after PR 549. This was found in the next process run.
+
+The 3.9 controller finished deleting a topic while a reassignment had marked it ineligible for deletion. `ControllerContext.removeTopic` cleared the other deletion sets but left `topicsIneligibleForDeletion` unchanged. Recreating the name then made every DeleteTopics request time out. The controller thread was idle, not deadlocked; the stale marker prevented it from starting deletion.
+
+The same missing cleanup exists in 3.0. The first regression failed before the fix. To keep every upgrade behavior opt-in, cleanup now runs in `TopicDeletionManager` only when `li.protocol.bridge.topic.deletion.state.cleanup.enable` is true. The flag defaults false, is cluster-wide and dynamic, and has the same gauge on both versions. The wrapper enables it explicitly and keeps it enabled after protocol bridge mode is disabled. `testTopicNameReuseCleanupRequiresItsFlag` passes with both flag settings on both versions. The final process rerun is still required.
+
+### F14 — P2: The wrapper ACL test verifies an unfinished async read
+
+**Owner:** the wrapper test update.
+
+The full wrapper run failed in `KafkaAclManagerTest.testAccessDenyWithFederatedAcls`. Initialization reads the topic list once on the calling thread and once on a background reader. The test expected two calls but verified the mock without waiting for the second call. It also left background readers running when teardown reset their mocks.
+
+The test now waits on a latch with a ten-second limit and closes both readers before resetting mocks. It still requires exactly two reads; no assertion was removed. All 18 tests in the class passed in five fresh runs. This changes tests only, not authorization policy. The complete wrapper suite is part of the new full verification run.
+
+### F15 — P1: Controller failover can leave a ghost metadata-cache entry
+
+**Owners:** the 3.0 and 3.9 controller follow-ups.
+
+A controller can remove a topic's ZooKeeper entry, then stop before every broker receives the metadata deletion update. The next controller no longer knows that it must send that deletion. The incremental metadata cache keeps the topic, so a later create/delete loop stalls.
+
+With `li.protocol.bridge.topic.deletion.state.cleanup.enable` enabled, each new ZooKeeper controller sends a full first partition image. Brokers replace their cached partition and topic-ID maps only on the first update of a newer controller epoch. Same-epoch updates stay incremental, including after dynamic activation. The flag-off path is unchanged. Enable the setting on every broker before restarting the controller; it is a shared protocol assumption, not a receiver-only cleanup switch.
+
+`BridgeMetadataCacheEpochTest` and the existing metadata-cache suites pass on both generations. The next process run passed all sixteen phase checkpoints, including active deletion/recreation with records, but its final log audit found F16. It is not a qualifying pass.
+
+### F16 — P1: An ISR retry loses fields when the controller version changes
+
+**Owner:** the 3.9 broker retry follow-up.
+
+`AlterPartitionRequest.Builder` changes its stored data when building an older request version. A queued request built for a 3.0 controller can then reach a 3.9 controller after failover. Building version 3 from that changed data fails with `UnsupportedVersionException: Attempted to write a non-default newIsr at version 3`. The final process-log audit caught this even though ISR recovery eventually completed.
+
+In bridge mode, the broker now builds each retry from a fresh copy. The dynamic flag is checked when the request is built, not only when it is queued. The existing JVM constructor and flag-off builder behavior stay intact. The new test covers versions 3, 1, 3, 1, 3 on the same queued builder and activates the flag after queueing. That activation case failed with the first, allocation-time-only check. The corrected build-time check and the existing ISR-manager suite pass. The clean-source complete process run and evidence audit now pass. The earlier failed runs remain recorded.
+
+### F17 — P1: Reassignment can leave an unhosted log behind after restart
+
+**Owners:** the 3.0 and 3.9 stray-log follow-ups.
+
+A short mixed-controller diagnostic failed the empty-log check after recreating a topic. The retained segment contains `cycle-5`, written before deletion. Broker 0 loaded that segment during restart, received the metadata deletion update, but never removed the unhosted local log. The next create reused its directory. This is not a late producer write: the log was loaded with end offset 1 before the deletion and no new write was sent before the failed check.
+
+With the cleanup flag enabled, `ReplicaManager.maybeUpdateMetadataCache` now retires local logs that have no hosted replica when metadata reports their deletion. Hosted replicas still wait for `StopReplica`; unrelated logs and stale-controller requests do not trigger this cleanup. The 3.9 path excludes KRaft-controller updates. This is a targeted repair, not a claim that every offline name-reuse case has been qualified.
+
+`BridgeStrayLogDeletionTest` failed on the old 3.0 implementation and passes with the fix on both versions. It covers both flag settings, stale controller fencing, hosted and unrelated logs, and empty-log recreation. The complete clean-source migration and process audit also pass with this repair and without diagnostic logging. Broader offline name-reuse cases still require qualification.
+
+## PR dispositions and dependency audit
+
+Every PR below has a distinct migration or CI purpose. Keep these scopes, but do not treat publication, a resolved thread or a green job as release approval. New review layers are drafts. The controller/ZooKeeper, security, storage and operational changes still need the corresponding owners' review.
+
+| PR | Responsibility / reviewer |
+|---|---|
+| [559](https://github.com/linkedin/kafka/pull/559) | 3.0 CI/publication — release engineering |
+| [575](https://github.com/linkedin/kafka/pull/575) | 3.0 wire fixtures — protocol |
+| [541](https://github.com/linkedin/kafka/pull/541) | 3.0 bridge, activation and deletion recovery — controller |
+| [577](https://github.com/linkedin/kafka/pull/577) | 3.0 unhosted-log cleanup — storage/controller |
+| [558](https://github.com/linkedin/kafka/pull/558) | 3.9 CI/publication — release engineering |
+| [543](https://github.com/linkedin/kafka/pull/543) | 3.9 outbound bridge — protocol/controller |
+| [544](https://github.com/linkedin/kafka/pull/544) | old wire/client/recovery compatibility — protocol/replication |
+| [565](https://github.com/linkedin/kafka/pull/565) | control RPC wire definitions and fixtures — protocol |
+| [545](https://github.com/linkedin/kafka/pull/545) | gated shutdown and controller-movement handlers — operations |
+| [546](https://github.com/linkedin/kafka/pull/546) | federated APIs/state — security/controller |
+| [547](https://github.com/linkedin/kafka/pull/547) | restored Admin surface and retries — clients/tools |
+| [548](https://github.com/linkedin/kafka/pull/548) | wrapper extension points — wrapper/security |
+| [560](https://github.com/linkedin/kafka/pull/560) | leader-transfer controller client — replication |
+| [549](https://github.com/linkedin/kafka/pull/549) | ZooKeeper operational parity — controller/placement |
+| [550](https://github.com/linkedin/kafka/pull/550) | quotas, timeouts, log/internal-topic defaults — server/storage |
+| [561](https://github.com/linkedin/kafka/pull/561) | heap dump and termination — operations/runtime |
+| [566](https://github.com/linkedin/kafka/pull/566) | storage metric primitives and cleanup — observability |
+| [551](https://github.com/linkedin/kafka/pull/551) | broker metrics/watchdog wiring — observability/operations |
+| [567](https://github.com/linkedin/kafka/pull/567) | gated deletion-state and metadata-cache recovery — controller |
+| [576](https://github.com/linkedin/kafka/pull/576) | 3.9 unhosted-log cleanup — storage/controller |
+| [568](https://github.com/linkedin/kafka/pull/568) | version-changing ISR retries — replication |
+| [578](https://github.com/linkedin/kafka/pull/578) | packaged-client rejection and vendor pagination tests — ZooKeeper |
+| [579](https://github.com/linkedin/kafka/pull/579) | supplied archives and wrapper-jar identity — release |
+| [552](https://github.com/linkedin/kafka/pull/552) | phase/live preflight contract — deployment |
+| [569](https://github.com/linkedin/kafka/pull/569) | unchanged-client and record-ledger helpers — verification |
+| [570](https://github.com/linkedin/kafka/pull/570) | continuous old clients and metadata mutations — verification |
+| [571](https://github.com/linkedin/kafka/pull/571) | live configuration and runtime collection — deployment |
+| [553](https://github.com/linkedin/kafka/pull/553) | complete migration process runner — verification |
+| [572](https://github.com/linkedin/kafka/pull/572) | strict evidence audit and negative tests — verification |
+| [554](https://github.com/linkedin/kafka/pull/554) | verifier, local staging and command handling — verification/release |
+| [573](https://github.com/linkedin/kafka/pull/573) | public process CI and protected release gate — release |
+| [574](https://github.com/linkedin/kafka/pull/574) | runbook and review records — operations |
+
+Merge CI 558/559 into their own release branches first. Then retarget the upgrade stack bottoms as described in the runbook. Never force a Git dependency between the 3.0 and 3.9 CI branches. When reordering again, change PR bases before pushing a head that becomes an ancestor of its former base; GitHub can otherwise auto-close and delete that branch.
+
+The oversized original scopes were split. Control wire definitions are in 565 (503 lines), handlers in 545 (845); storage metrics are in 566 (221), broker metrics/watchdog wiring in 551 (910); workload helpers precede runner 553 (754). The new evidence auditor, verifier and release gate are separate layers. All 32 current diffs pass the size and dependency audit.
+
+The original 62 review threads now have replies with published source decisions and code/test references. See `li-bridge-review-comments.md`. The static `LeaderTransferManager.noOp()` call is valid: javap confirms the forwarder, and the Java builder compiles. Empty metric bucket lists remain intentionally supported; malformed, negative and unordered boundaries are rejected. A fresh comment/readback audit is still required before closing the goal.
+
+## Verification and remaining requirements
+
+Passing a suite only covers what that suite asserts. These results are not substitutes for the remaining gates.
+
+| Requirement | Files or checks | Current evidence / remaining work |
+|---|---|---|
+| Include every open public PR | Runbook inventory; GitHub readback | 32 open PRs, exact heads/bases checked. All 30 upgrade PRs have the requested label; CI 558/559 do not. |
+| Keep PRs reviewable | GitHub additions plus deletions | Every current PR is below 1,000 lines. Stack memberships are 27 PRs on 3.9 and three on 3.0. |
+| Use common control versions | Schemas, fixtures, controller selectors | v2/v5/v1 checked on both generations. Full process test exercises both controller directions. |
+| Gate runtime changes | KafkaConfig, DynamicBrokerConfig, bridge metrics and wrapper mapping | 23 default-off 3.9 gates; wrapper enables them explicitly. Flag-off and activation tests exist. Final per-change gate audit remains required. |
+| Fence activation and retain callbacks | RequestSendThreadBridgeTest | Blocked dequeue, sustained queue and admitted-callback regressions pass. Controller restart remains mandatory. |
+| Validate all six phases | li_bridge_contract.py; preflight | 65 Python tests pass. Native control remains at IBP 3.0 before a separate IBP 3.9 roll. |
+| Keep old clients unchanged | Continuous client/Streams/Connect helpers and private APIs | Same old processes remain alive across the migration. Exact records, transaction outcomes, offsets and process identities are checked. Clean process run and audit pass. |
+| Prove persisted rollback and recovery | Process runner | Canary and all-3.9 rollback use the same directories. Both recovery directions, cancellation, hard failures and truncation pass. |
+| Handle deletion and recreation | TopicDeletionManager, ZkMetadataCache, ReplicaManager | F12/F13/F15/F17 have gated repairs and regressions. Known unhosted-log case passes; broader offline name reuse remains a qualification item. |
+| Handle version-changing ISR retries | AlterPartitionManager | Dynamic activation and version changes on one queued builder pass. Clean process run has no unsupported-version error. Earlier failed evidence is retained. |
+| Collect actual runtime/state | Live inventory and runtime probe | Disposable-cluster collection and negative-input tests pass. Actual production config, runtime and client floor are still needed. |
+| Qualify ZooKeeper pagination | KafkaZkClient and isolated vendor tests | Stock-client startup rejection and five vendor cases pass. This does not qualify a different deployed client/server pair. |
+| Follow Google shell style | Four wrappers and extracted workflow run blocks | ShellCheck, shfmt, syntax and wrapper-length tests pass. Complex orchestration/release bookkeeping is Python. Recheck after final docs/workflow edits. |
+| Verify wrapper compatibility | Factory mapping, ACL race fix, full wrapper suite | 132 tests pass; no failures or skips. Main and test-classifier hashes match before and after the suite. Main jars match the selected 3.9 archive. |
+| Validate new orchestration on real artifacts | Python stager, artifact checker, verifier/release guard | Real staging and artifact/classpath comparison pass. Full new verifier and protected release-guard runs are still needed. |
+| Review comments with evidence | Per-thread ledger and published replies | All original 62 decisions posted. Re-fetch threads/reviews and verify new comments before completion. |
+| Keep docs consistent | Workspace plan and canonical docs | Current 32-PR inventory is written; final synchronization, link and wording audit remain required. |
+| Preserve side task PR 2039 | Wrapper ADU worktree | Rebased and pushed on master; formatting is one commit and is idempotent. No functional patch changes. |
+
+### Retained local evidence
+
+- `/tmp/li-bridge-clean-final-process`: all sixteen checkpoints pass, source inputs unchanged, strict process audit has no issues or warnings. Diagnostic logging is absent from the archive.
+- `/tmp/li-clean-30-build.log`: standalone clean Git checkout `cb85262cb1`, Java 11, targeted controller/cache/deletion tests and archive build pass. Embedded commit ID matches that checkout.
+- `/tmp/li-final-stray-39.log`: clean restack source, targeted cache/ISR/stray-log and packaged-client tests, archive build pass. The linked-worktree archive embeds `commitId=unknown`; source checkout identity and archive hashes are retained. Final published qualification must verify source identity again.
+- `/tmp/li-wrapper-current-verification`: 132 retained JUnit results and identical before/after artifact reports.
+- `/tmp/li-stager-real.log`: the new Python stager builds and installs actual artifacts and writes its scoped checksum manifest.
+- `/tmp/li-restack-python-tests.log`: 65 tests pass. Test-method AST comparison confirms that splitting files did not remove or change assertions.
+- `/tmp/li-publication-pr-audit-result.json`: 32 PRs, no head/base/label/size issues.
+
+The complete verifier has not yet passed as one final bundle. Previous failed runs are not green evidence. Do not relabel or edit them to claim success. Any source, archive or scenario change must be checked against the evidence fingerprint before reuse.
+
+### Inputs still required before production
+
+- Approved Kafka/wrapper commits, official artifact checksums and regenerated wrapper dependencies.
+- Named security/release approvals, including producer-ID authorization policy.
+- Live broker/topic settings, binaries, persistent state, client/tool floor and owner dispositions.
+- The deployed ZooKeeper/Jute/server combination and qualification results.
+- Capacity, bake duration, latency, ISR recovery and failover limits, with evidence and an approver.
+- Protected internal runner/environment setup and authorized wrapper access.
+
+These are open release requirements, not assumptions to mark green. The goal remains active until the final prompt-to-artifact audit succeeds.

--- a/docs/ops/li-bridge-upgrade.md
+++ b/docs/ops/li-bridge-upgrade.md
@@ -1,0 +1,280 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Moving `3.0-li` to `3.9-li`
+
+## Status and source of truth
+
+**This plan is not approval to deploy.** The cluster stays in ZooKeeper mode. Before rollout, we need source tests, tests of the published binaries, live configuration and state checks, capacity results, security review and rollout approval.
+
+The implementation base is Apache **3.9.2** with the reviewed LI bridge stack. Pin the final internal `3.9.2.N`, matching `3.0.1.N`, wrapper commit, archive checksums, JDKs and ZooKeeper runtime in the release record. A maintenance-baseline change requires a new qualification run; do not substitute a newer tag during rollout.
+
+The current implementation is the split stack through `3.9-li-bridge/runbook`, with the companion `3.0-li-bridge/stray-log-cleanup` branch. It is not the closed aggregate PR 542. The canonical mergeable runbook is `docs/ops/li-bridge-upgrade.md` in that stack. This top-level file is the review workspace copy. Historical experiments are evidence, not current acceptance criteria.
+
+**Clients do not change.** The supported producer, consumer, transactional client, Streams application, Connect worker, LI AdminClient and operational-tool artifacts/configuration must remain unchanged across every phase. Discovery must name their deployed version floor and owners. One 3.0 test archive is not proof for every externally deployed client.
+
+## Why we need two bridge-capable binaries
+
+LI 3.0 inserted `MaxBrokerEpoch` into standard controller requests and shifted later fields. Apache reused some numeric versions with different layouts. Negotiation alone cannot detect this collision.
+
+| Controller request | Common version |
+|---|---:|
+| `LeaderAndIsr` | 2 |
+| `UpdateMetadata` | 5 |
+| `StopReplica` | 1 |
+
+Both controller generations must send these versions throughout the mixed phase, regardless of the target broker generation. Any ZooKeeper broker can become controller; an ordinary Apache 3.9 binary is not an admissible replacement while 3.0 remains.
+
+The bridge keeps native Apache schemas intact on 3.9. It does not merge the entire old fork forward. Bridge mode omits reassignment fields, flexible control encoding, topic IDs in these requests, full/incremental control type, and per-partition StopReplica epochs/delete flags. Legacy deletion and reassignment semantics must be tested, not merely serialized.
+
+Deletion recovery also needs a shared rule: with `li.protocol.bridge.topic.deletion.state.cleanup.enable` enabled, a new ZooKeeper controller sends a full first metadata image. Each broker replaces its cache only on the first update of a newer controller epoch. This removes ghost topics whose deletion update was lost during failover. Same-epoch updates remain incremental. Enable this setting on every broker and verify its gauge before restarting the controller. Keep it enabled after bridge mode is disabled. The same gate retires an unhosted local log when metadata reports its deletion; hosted replicas still wait for `StopReplica`. Qualification must include persisted logs, canceled reassignments and name reuse across restart, not just empty-topic metadata operations.
+
+Broker-to-controller ISR updates also need a bridge-mode retry fix on 3.9. A queued `AlterPartition` request must build from fresh data when controller failover changes the negotiated version. Check bridge mode when building each retry, including requests queued before activation; do not reuse data changed by an earlier version's builder.
+
+LI combined control (private API 1001) is intentionally not retained on 3.9. The demonstrated collisions concern the **versions of standard control APIs**, not an asserted Apache assignment of key 1001. Disabling combined control and `MaxBrokerEpoch` sharing increases request count, allocations and potentially controller heap/queue pressure.
+
+## The phase contract
+
+`tests/bin/li_bridge_contract.py` defines the phase rules used by preflight, the process test and the evidence checker. If those rules change, run the tests again. Do not relabel old results.
+
+| Preflight phase | Broker generations | IBP | `li.protocol.bridge.mode.enable` | Allowed next state |
+|---|---|---|---|---|
+| `dormant` | all 3.0 bridge | 3.0 | false | `legacy-bridge` |
+| `legacy-bridge` | all 3.0 bridge | 3.0 | true | `mixed`, or validated return to `dormant` |
+| `mixed` | both 3.0 bridge and 3.9 bridge | 3.0 | true | `all-39-bridge`, or qualified rollback to `legacy-bridge` |
+| `all-39-bridge` | all 3.9 bridge | 3.0 | true | `native`, or qualified rollback through `mixed` |
+| `native` | all 3.9 | **3.0** | false | `ibp-39` |
+| `ibp-39` | all 3.9 | 3.9 | false | tested recovery on the 3.9 release line |
+
+Do not combine bridge deactivation and IBP elevation. Kafka rejects bridge mode at IBP 3.2 or newer because `LeaderAndIsr` v2 cannot encode non-default leader recovery state. IBP is static: update rendered configuration and roll brokers separately. There is deliberately no native-to-3.0 rollback transition.
+
+For a phase change, supply `--previous-phase` to preflight and retain both reports. The deployment system must independently enforce the binary/image allowlist and the approved transition; config files cannot prove which executable automation will restart.
+
+## Feature contract and lifecycle
+
+Kafka's 23 LI compatibility gates default false. The wrapper explicitly enables the production profile. With `--require-all-gates`, every gate below except the phase-dependent mode gate must stay true on 3.9 **including native and final-IBP phases**. Turning bridge mode off is not permission to turn off operational compatibility.
+
+All names below have the prefix `li.protocol.bridge.` and suffix `.enable`. Effective gauges are under `kafka.server:type=LiProtocolBridgeMetrics,broker-id=<id>`.
+
+| Setting suffix | Effective gauge | Change scope | Owner / disposition |
+|---|---|---|---|
+| `mode` | `ModeEnabled` | cluster dynamic; controller restart fence | Protocol: temporary control versions and version-changing ISR retries |
+| `topic.deletion.state.cleanup` | `TopicDeletionStateCleanupEnabled` | cluster dynamic; enable on all brokers before controller restart | Controller: clear deletion blocks and replace stale metadata on a new controller epoch |
+| `follower.recovery` | `FollowerRecoveryEnabled` | cluster dynamic | Replication: retain until old recovery callers are retired |
+| `recommended.leader.election` | `RecommendedLeaderElectionEnabled` | cluster dynamic | Controller: retain old election type 2 |
+| `metadata.exclude.partitions` | `ExcludePartitionsEnabled` | cluster dynamic | Clients: retain LI AdminClient behavior |
+| `move.controller` | `MoveControllerEnabled` | cluster dynamic | Operations: retain API 1002 until tool replacement |
+| `shutdown.safety.override` | `ShutdownSafetyOverrideEnabled` | cluster dynamic | Operations: retain API 1000 until tool replacement |
+| `preferred.controller` | `PreferredControllerEnabled` | restart | Controller: placement and shutdown parity |
+| `federated.topics` | `FederatedTopicsEnabled` | cluster dynamic | Security: retain APIs 1003–1005 and authorization state |
+| `rack.id.mapper` | `RackIdMapperEnabled` | restart | Placement: production parity |
+| `dynamic.topic.deletion` | `DynamicTopicDeletionEnabled` | restart | Controller: production parity |
+| `produce.request.instrumentation` | `ProduceRequestInstrumentationEnabled` | cluster dynamic | Observability: production parity |
+| `request.metric.buckets` | `RequestMetricBucketsEnabled` | restart | Observability: production parity |
+| `request.channel.watchdog` | `RequestChannelWatchdogEnabled` | restart | Operations: production parity |
+| `minimum.log.roll` | `MinimumLogRollEnabled` | restart | Storage: production parity |
+| `reassignment.cancellation.safety` | `ReassignmentCancellationSafetyEnabled` | cluster dynamic | Controller: production parity |
+| `list.offsets.instrumentation` | `ListOffsetsInstrumentationEnabled` | restart | Observability: production parity |
+| `static.default.quotas` | `StaticDefaultQuotasEnabled` | restart | Operations: production parity |
+| `replica.request.timeout` | `ReplicaRequestTimeoutEnabled` | restart | Replication: production parity |
+| `offsets.topic.config` | `OffsetsTopicConfigEnabled` | restart | Storage: internal-topic creation parity |
+| `leader.transfer.on.isr.shrink` | `LeaderTransferEnabled` | restart | Replication: safe leader transfer |
+| `legacy.request.metrics` | `LegacyRequestMetricsEnabled` | restart | Observability: production dashboards |
+| `log.truncation.metrics` | `LogTruncationMetricsEnabled` | restart | Observability: production dashboards |
+
+Per-broker dynamic overrides of cluster-dynamic compatibility gates are rejected. The smoke profile intentionally enables only wire/tool compatibility and cancellation safety; it is not the complete production wrapper profile. Wrapper qualification and live admission use the full profile.
+
+Two additional settings are not members of the 23-gate bundle: `li.zookeeper.pagination.enable` and `li.num.controller.init.threads`. Record their effective values and `ZookeeperPaginationEnabled` / `ControllerInitializationThreads` gauges. The documented source profile enables pagination and uses ten controller-init threads; confirm live values.
+
+### Generation-specific behavior
+
+- Leave `li.async.fetcher.enable=true` and `li.combined.control.request.enable=true` on legacy brokers if that is their existing production configuration. The bridge suppresses merging independently. Preflight rejects these obsolete implementations on **3.9 only**.
+- Test Apache's replacement fetcher against the enabled LI async fetcher, not the old default synchronous path. Test recovery and truncation first. Then measure throughput, thread use and lag at production scale.
+- In bridge mode, deletion must wait for every replica to acknowledge `StopReplica`, including replicas that were offline. LI's native fast-delete path can remove ZooKeeper state before sending a metadata deletion update. Without full-state control messages, that leaves ghost topics or orphaned replicas. Do not force-delete the ZooKeeper entry to bypass this wait. The old fast-delete behavior is unchanged while bridge mode is off.
+- Preserve LI local-offset timestamp `-104` and error 1107 alongside Apache `-4` and 109. Bridge followers emit LI-compatible values without advertising unsupported ListOffsets v8 on 3.0. Native outbound recovery uses Apache values. Retained inbound compatibility does not migrate remote storage.
+- Remote storage must be confirmed unused, including previously written topic/plugin/remote metadata and objects. Otherwise stop and create a separate conversion/compatibility plan.
+- Corrupted-file dropping and delayed corrupt elections are not ported. Require `li.drop.corrupted.files.enable=false`, `li.leader.election.on.corruption.wait.ms=0`, and an approved disposition for corrupted-broker state. An empty znode alone is insufficient.
+- Determine usage/disposition of LICLOSEST, passthrough clients, federated APIs, observer/security hooks and operational metrics. Unknown usage is not permission to remove a feature.
+
+## Discovery and fail-closed admission
+
+Assign one named owner for each release role above and one rollout approver per cluster. Before production admission, collect:
+
+1. Every rendered broker config and deployment image/build identity.
+2. Effective static/dynamic broker settings and dynamic topic settings, including defaults/synonyms.
+3. Live broker IDs, cluster ID, controller epoch and compatibility gauges.
+4. ZooKeeper client/Jute/server versions, loaded jar hashes, authentication and response-size settings.
+5. Persistent state under `/brokers/preferred_controllers`, `/brokers/corrupted`, `/brokers/shutdown`, `/federatedTopics`, `/topic_deletion_flag`, plus remote/plugin state.
+6. Actual client/tool versions, private-API traffic, production plugin set, JDK and operational metric consumers.
+
+### Read-only live collector
+
+Compile the helper using the selected 3.9 release jars. Client credentials remain in the supplied properties file and are not emitted into inventory JSON:
+
+```bash
+javac --release 11 -cp '/releases/kafka-39/libs/*' -d /tmp/bridge-tools \
+  tests/bin/LiBridgeLiveInventory.java tests/bin/LiBridgeRuntimeProbe.java
+java -cp '/tmp/bridge-tools:/releases/kafka-39/libs/*' LiBridgeLiveInventory \
+  broker:9092 /secure/admin-client.properties /evidence/live-inventory.json
+```
+
+The collector reads the effective protocol and safety settings in bounded requests. It includes internal topics and checks that the broker/topic inventory did not change during collection. Retry a changed inventory; do not omit brokers or topics to make it pass.
+
+This is not a dump of every broker property. Keep the full rendered configurations and other operational settings in protected storage alongside the report. Preflight records hashes of its input files. Credentials are not copied into the inventory JSON. The collector is read-only; ordinary metadata mutations can continue.
+
+Run the runtime probe on **each actual packaged broker/wrapper classpath**, not on the isolated vendor-test classpath:
+
+```bash
+java -cp '/tmp/bridge-tools:/actual/package/lib/*' LiBridgeRuntimeProbe \
+  /evidence/broker-0-runtime.json true
+```
+
+A stock client without `getAllChildrenPaginated` must fail when pagination is required. Broker startup also validates this capability before opening its ZooKeeper session. Do not disable pagination to evade this failure on a large cluster.
+
+The owner-reviewed state-disposition JSON must contain contract version 2, the cluster ID, a timezone-qualified collection timestamp, and `decisions` keyed by every inspected ZooKeeper path plus `remote-storage`, `plugin-state`, `client-floor`, and `artifact-admission`. Each decision needs `owner`, `evidence`, and `disposition`. Require `remote-storage.disposition=unused` and `artifact-admission.disposition=bridge-artifacts-only`.
+
+Its `broker_runtimes` map, keyed by broker ID, must reference the probe's `pagination_supported`, `zookeeper_sha256` and `jute_sha256`, plus the deployed `server_version` and retained `qualification_evidence`. These are reviewed observations, not values to fabricate to satisfy the validator. The isolated 3.6.3-23 pagination test does not qualify a different deployed combination.
+
+### Production preflight
+
+```bash
+python3 tests/bin/li_bridge_preflight.py \
+  --previous-phase legacy-bridge --phase mixed \
+  --require-live --require-all-gates --cluster-id '<expected-cluster-id>' \
+  --legacy-broker-config /rendered/broker-0.properties \
+  --broker-config /rendered/broker-1.properties \
+  --live-inventory /evidence/live-inventory.json \
+  --state-dispositions /evidence/state-dispositions.json \
+  --kafka-home /releases/kafka-39 --zk-connect '<ensemble/chroot>' \
+  --output-json /evidence/admission.json
+```
+
+Before starting a replacement, pass the **current** cluster's live gate and lint the prospective mixed configuration without `--require-live`/ZooKeeper arguments; also verify the candidate's approved image and packaged runtime. After registration, run the **new** phase's live gate before assigning workload or advancing the wave. A not-yet-started broker cannot supply a live config observation. The candidate must already have the symmetric bridge enabled because it could win a controller election immediately.
+
+Repeat config arguments for **every** live broker. Reports distinguish `configuration-check` from `live-admission`. Production automation must require the latter, `passed=true`, contract version 2 and the expected cluster ID. Missing/stale/future-dated observations, unsafe overrides, missing dispositions and incomplete inventory block admission. Default freshness is 900 seconds; choose an approved limit for the cluster. Configure ZooKeeper shell authentication/TLS through the approved runtime environment; never bypass ACLs to obtain a green report.
+
+## Qualification before the first canary
+
+Run qualification against independently built archives, then repeat it against the actual published archives and official wrapper dependencies. Retain checksums, source identities, commands, phase results and logs.
+
+```bash
+JAVA_HOME=/path/to/jdk17 \
+LI_BRIDGE_JAVA_30_HOME=/path/to/jdk11 \
+KAFKA_30_TGZ=/releases/kafka-30.tgz \
+KAFKA_39_TGZ=/releases/kafka-39.tgz \
+SKIP_LOCAL_STAGE=1 WRAPPER_ROOT=/checkouts/kafka-server \
+BRIDGE_VERIFY_FULL=1 EVIDENCE_DIR=/evidence/bridge \
+tests/bin/verify_li_bridge.sh
+```
+
+For the protected release gate, use `tests/bin/verify_li_bridge_release.sh` with published `KAFKA_30_SHA256`, `KAFKA_39_SHA256`, approved full `KAFKA_30_COMMIT`, `KAFKA_39_COMMIT`, and `WRAPPER_COMMIT` in addition to the inputs above. It rejects dirty/unapproved checkouts, archive/source/checksum mismatches and partial verification, and runs a strict final audit.
+
+Run the process test through `tests/bin/li_bridge_mixed_cluster_smoke.sh`. The Python runner starts and stops the processes, applies the phase rules, checks results, limits command runtime and saves failure logs. It tests:
+
+- all-3.0 dormant operation with combined control and async fetching enabled;
+- activation and all-3.0 backout while metadata mutations continue, with an old-controller restart at each boundary;
+- both mixed controller/leader directions;
+- canary and all-3.9 **persisted-state rollback** on the same log directories;
+- old producer, subscribed consumer/group, transaction commit/abort/fencing, AdminClient and Streams instances kept alive across all phases;
+- an unchanged Connect worker, and old/new private-API helpers in each phase;
+- exact acknowledged record histories, recovery bytes verified after promoting each recovered replica, cancellation during failover, hard broker/controller termination, and delete/recreate completion;
+- native control at IBP 3.0, then a separate IBP 3.9 roll.
+
+Only the disposable truncation topic permits intentional unclean loss. The no-loss ledger is separate. File connectors are at-least-once: validate complete unchanged contents and report duplicate delivery separately; do not reinterpret normal connector replay as broker record duplication.
+
+Set `SCALE_TOPIC_COUNT`, `SCALE_PARTITION_COUNT`, `RECOVERY_RECORD_COUNT`, and `RECOVERY_RECORD_SIZE` for a larger scenario. Effective defaults, deadlines and runtime profile are fingerprinted. `BRIDGE_VERIFY_RESUME=1` may reuse stages only for the same source/archive/scenario inputs; changing scale or runtime invalidates reuse. Functional smoke evidence is not a throughput benchmark.
+
+The public `bridge-process` CI job checks out the matching 3.0 review branch, fixes that checkout to one commit, and builds the two binaries separately. The evidence records the commit and archive hash. `LI_BRIDGE_LEGACY_REF` selects the companion branch or commit; change it to the release branch after the 3.0 review branch is retired. This is review feedback, not release approval. Release CI requires approved commit hashes and published archive checksums. The protected `li-bridge-release-qualification.yml` workflow runs final published artifacts and the actual wrapper on an approved-network runner. Release owners must provision the `li-bridge-qualification` runner, protect the `li-bridge-release` environment, and authorize the wrapper checkout. A missing runner, token, archive or private dependency is **blocked**, not green. Never expose internal credentials to untrusted PR code.
+
+### Qualification that cannot be inferred from the public smoke
+
+Before admission, retain separate owner-approved results for:
+
+- actual deployed client floor and `ktool`, production authentication/authorization and all enabled wrapper features;
+- `LiKafkaAuthorizerV2.authorizeByResourceType`, producer-ID allocation policy and positive/negative security tests;
+- packaged pagination against the actual server, including large lists, watch renewal/session expiry and authorization errors;
+- rollback of any additional plugin/remote/internal state absent from the disposable fixture;
+- disaster recovery and forward recovery where binary rollback is prohibited;
+- production-shaped controller heap, GC, queue growth and failover, and replacement-fetcher capacity.
+
+Each cluster's qualification record must name a baseline, tested metadata/partition shape and workload, acceptable p99 client impact, ISR recovery/failover bounds, heap/GC headroom, queue limits, bake durations, approver and evidence URL. **Do not proceed with blank thresholds.** There are no universal safe values to invent here.
+
+## Rollout procedure and stop conditions
+
+1. Collect baseline telemetry without changing behavior: control request versions, API 1001 sends/size, private APIs, recovery values/errors, controller memory/queues/serialization/network, failover, client software/errors and SLOs. Existing telemetry may replace a separate observation build only with an owner's completeness check.
+2. Roll the 3.0 bridge with mode false. Confirm every live broker has the approved bridge build and automation cannot restart an original non-bridge image. The wire protocol stays unchanged. After every broker has the code, enable `li.protocol.bridge.topic.deletion.state.cleanup.enable` at cluster level. Wait for `TopicDeletionStateCleanupEnabled=1` on every broker before restarting the controller. This separately gated fix clears blocked-deletion state and reconciles stale metadata on a new controller epoch. Keep it enabled after disabling protocol bridge mode.
+3. Set cluster-level bridge mode true. Wait for every broker's effective gauge. The sender rechecks activation after dequeue and during draining; work already admitted before its observation may finish. Config publication can race admission, so **do not rely on a quiet queue or a zero counter alone**.
+4. Roll the same 3.0 bridge build again. Confirm the active controller restarted, its epoch advanced after activation, and the replacement selected v2/v5/v1 with fresh queues. Require no new API 1001 sends after that fence. Keep creations, deletions, reassignments, cancellations and client traffic running.
+5. Bake all-3.0 bridge mode to the approved limits. Backout here is mode false plus propagation, another controller restart and verified resumption of LI native control/combined behavior.
+6. Admit the first 3.9 canary only after final-artifact, persisted-state rollback and live admission gates pass. Start as a non-controller; exercise both leader/follower directions, clients/tools and mutations; then force it to become controller while old brokers remain.
+7. Roll by failure domain and approved waves. Exercise controller movement in both directions. A failed canary may return to the **3.0 bridge only if the exact state/profile has qualified rollback**. Otherwise use the approved forward-recovery procedure. Never fall back to the original non-bridge 3.0 binary.
+8. Bake all-3.9 with bridge mode still true. Revalidate retained features and performance; this remains the final qualified 3.0 rollback window.
+9. Cross the recorded rollback boundary: disable outbound bridge mode, leave retained gates enabled, verify native control, restart the controller, and bake at IBP 3.0. From this point do not downgrade to 3.0.
+10. Separately render IBP 3.9 and roll brokers. Re-run unchanged-client/tool checks and the `ibp-39` admission gate. Recovery stays on the tested 3.9 release line.
+
+Automatically stop for unexpected control versions, post-fence API 1001 traffic, parse/version errors, offline partitions, persistent under-replication, ISR recovery failure, controller loops, security/tool regressions, acknowledged-record loss, or client impact outside approved rolling-restart SLOs. Preserve the evidence and identify the failing boundary before taking a recovery action. Do not “fix” a failed compatibility test by upgrading clients.
+
+## PR inventory and merge order
+
+All 32 open public PRs are covered below. Upgrade PRs carry `kafka-upgrade-august-2026`; CI foundations 558 and 559 do not. All current diffs are below 1,000 changed lines. These checks do not grant approval to deploy.
+
+Closed PRs 542 and 555 are superseded. GitHub automatically closed 563 and 564 during the dependency reorder because their new heads were contained in their former base branches. No release branch was merged. Their restored, separate reviews are 579 and 578.
+
+| PR | Responsibility / reviewer |
+|---|---|
+| [559](https://github.com/linkedin/kafka/pull/559) | 3.0 CI/publication — release engineering |
+| [575](https://github.com/linkedin/kafka/pull/575) | 3.0 wire fixtures — protocol |
+| [541](https://github.com/linkedin/kafka/pull/541) | 3.0 bridge, activation and deletion recovery — controller |
+| [577](https://github.com/linkedin/kafka/pull/577) | 3.0 unhosted-log cleanup — storage/controller |
+| [558](https://github.com/linkedin/kafka/pull/558) | 3.9 CI/publication — release engineering |
+| [543](https://github.com/linkedin/kafka/pull/543) | 3.9 outbound bridge — protocol/controller |
+| [544](https://github.com/linkedin/kafka/pull/544) | old wire/client/recovery compatibility — protocol/replication |
+| [565](https://github.com/linkedin/kafka/pull/565) | control RPC wire definitions and fixtures — protocol |
+| [545](https://github.com/linkedin/kafka/pull/545) | gated shutdown and controller-movement handlers — operations |
+| [546](https://github.com/linkedin/kafka/pull/546) | federated APIs/state — security/controller |
+| [547](https://github.com/linkedin/kafka/pull/547) | restored Admin surface and retries — clients/tools |
+| [548](https://github.com/linkedin/kafka/pull/548) | wrapper extension points — wrapper/security |
+| [560](https://github.com/linkedin/kafka/pull/560) | leader-transfer controller client — replication |
+| [549](https://github.com/linkedin/kafka/pull/549) | ZooKeeper operational parity — controller/placement |
+| [550](https://github.com/linkedin/kafka/pull/550) | quotas, timeouts, log/internal-topic defaults — server/storage |
+| [561](https://github.com/linkedin/kafka/pull/561) | heap dump and termination — operations/runtime |
+| [566](https://github.com/linkedin/kafka/pull/566) | storage metric primitives and cleanup — observability |
+| [551](https://github.com/linkedin/kafka/pull/551) | broker metrics/watchdog wiring — observability/operations |
+| [567](https://github.com/linkedin/kafka/pull/567) | gated deletion-state and metadata-cache recovery — controller |
+| [576](https://github.com/linkedin/kafka/pull/576) | 3.9 unhosted-log cleanup — storage/controller |
+| [568](https://github.com/linkedin/kafka/pull/568) | version-changing ISR retries — replication |
+| [578](https://github.com/linkedin/kafka/pull/578) | packaged-client rejection and vendor pagination tests — ZooKeeper |
+| [579](https://github.com/linkedin/kafka/pull/579) | supplied archives and wrapper-jar identity — release |
+| [552](https://github.com/linkedin/kafka/pull/552) | phase/live preflight contract — deployment |
+| [569](https://github.com/linkedin/kafka/pull/569) | unchanged-client and record-ledger helpers — verification |
+| [570](https://github.com/linkedin/kafka/pull/570) | continuous old clients and metadata mutations — verification |
+| [571](https://github.com/linkedin/kafka/pull/571) | live configuration and runtime collection — deployment |
+| [553](https://github.com/linkedin/kafka/pull/553) | complete migration process runner — verification |
+| [572](https://github.com/linkedin/kafka/pull/572) | strict evidence audit and negative tests — verification |
+| [554](https://github.com/linkedin/kafka/pull/554) | verifier, local staging and command handling — verification/release |
+| [573](https://github.com/linkedin/kafka/pull/573) | public process CI and protected release gate — release |
+| [574](https://github.com/linkedin/kafka/pull/574) | runbook and review records — operations |
+
+Merge 558 into `3.9-li` and 559 into `3.0-li` first. They have different release bases, so do not put them in one dependent Git stack. Rebase/retarget 575 to `3.0-li` and 543 to `3.9-li`; do not merge feature work into temporary CI branches.
+
+The GitHub stack rooted at PR 575 has the 3.0 order **575 → 541 → 577**. The stack rooted at PR 543 has the 3.9 order:
+
+**543 → 544 → 565 → 545 → 546 → 547 → 548 → 560 → 549 → 550 → 561 → 566 → 551 → 567 → 576 → 568 → 578 → 579 → 552 → 569 → 570 → 571 → 553 → 572 → 554 → 573 → 574**.
+
+Retarget remaining layers after each independent merge. The wrapper branch contains the ACL test repair (`6ddf2a87`) and cleanup mapping/tests (`1a9ecccf`); its source suite passes 132 tests. Add the approved wrapper/dependency/security PR and named deployment-gate owner to the release record.
+
+Publish the final matching archives and all required modules/test classifiers, regenerate wrapper dependency metadata from official artifacts, and run final-artifact qualification again. Automatic publication of an intermediate stack commit is not permission to deploy it. Remove temporary compatibility only after telemetry, caller owners and a separate retirement decision establish that it is safe.

--- a/tests/bin/README.li-bridge.md
+++ b/tests/bin/README.li-bridge.md
@@ -1,0 +1,121 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Bridge artifact verification
+
+Use Java 17 and Python 3.9 or newer. Run the verifier from the current split-stack Kafka checkout with a matching kafka-server wrapper checkout. The [rolling-upgrade runbook](../../docs/ops/li-bridge-upgrade.md) defines the phase, deployment and approval contract.
+
+## Locally built 3.9 artifacts
+
+```sh
+JAVA_HOME=/path/to/jdk17 \
+KAFKA_30_TGZ=/releases/kafka_2.12-3.0.1.83.tgz \
+WRAPPER_ROOT=/checkouts/kafka-server \
+EVIDENCE_DIR=/evidence/local-bridge \
+tests/bin/verify_li_bridge.sh
+```
+
+The verifier stages Scala 2.12 jars for the wrapper and builds the 3.9 archive. `LI_BRIDGE_VERSION` selects the local artifact version. Its default comes from `gradle.properties`.
+
+## Supplied release archives
+
+Download both archives from approved releases and verify their published SHA-256 checksums. Update the wrapper's `product-spec.json` and generated dependency metadata to the selected 3.9 version.
+
+```sh
+JAVA_HOME=/path/to/jdk17 \
+KAFKA_30_TGZ=/releases/kafka_2.12-3.0.1.83.tgz \
+KAFKA_39_TGZ=/releases/kafka_2.12-3.9.2.17.tgz \
+SKIP_LOCAL_STAGE=1 \
+WRAPPER_ROOT=/checkouts/kafka-server \
+EVIDENCE_DIR=/evidence/released-bridge \
+tests/bin/verify_li_bridge.sh
+```
+
+`KAFKA_39_TGZ` disables the local archive build. It requires `SKIP_LOCAL_STAGE=1` and a 3.0 archive. The verifier checks the version inside each archive and retains the exact input bytes before compilation starts.
+
+The wrapper's declared Kafka and Scala versions must match the 3.9 archive. Every resolved main Kafka jar must match a jar in that archive byte for byte. Test classifiers must use the selected version. Their hashes are recorded. The verifier checks the resolved files before and after wrapper testing.
+
+Source compilation and focused source tests still run. `BRIDGE_VERIFY_FULL=1` adds the complete clients, server, and storage suites. The mixed-process test runs the retained archives.
+
+## Evidence and resume
+
+Archives are copied under `EVIDENCE_DIR/archives` with content-addressed names. `archive-30.json` and `archive-39.json` record versions, source metadata, and jar hashes. `wrapper-artifacts.json` records the wrapper's resolved Kafka files.
+
+Set `BRIDGE_VERIFY_RESUME=1` to reuse passed stages. Source contents, retained archive bytes, staging mode, local build version, effective metadata/recovery scale, deadlines and runtime profile must match. Archive and wrapper-artifact checks run again. If an original build-directory archive has been removed, pass its retained copy on the resumed invocation.
+
+A strict audit is available after verification:
+
+```sh
+python3 tests/bin/audit_li_bridge_evidence.py \
+  --evidence-dir /evidence/released-bridge \
+  --require-clean --require-archives --allow-missing-stage
+```
+
+Add `--require-full` for a full-suite run. Omit `--allow-missing-stage` for locally staged artifacts.
+
+## LinkedIn ZooKeeper pagination
+
+Run the positive pagination fixture with its isolated vendor runtime:
+
+```sh
+JAVA_HOME=/path/to/jdk17 ./gradlew --no-daemon -PscalaVersion=2.12 \
+  -I tests/bin/li_bridge_zookeeper_test.gradle core:liZookeeperPaginationTest
+```
+
+The task downloads LinkedIn ZooKeeper `3.6.3-23` and its matching Jute jar from the public LinkedIn ZooKeeper repository. It checks their pinned SHA-256 values. Only this test task uses those jars. The broker build and normal test classpaths retain stock ZooKeeper.
+
+The fixture sets a 1 MiB client and server response limit. It checks complete results for 6,000 long topic names in each paginated path, watch delivery, session-expiry/rescan/watch renewal, missing paths, and authorization failures. The dedicated task has a five-minute timeout. The standard test suites leave this fixture disabled. The required CI `all` job runs the dedicated task and retains its JUnit report.
+
+The verifier runs this fixture as the `vendor-pagination` stage. The packaged-runtime probe and broker startup check separately reject enabled pagination with a stock client. The isolated fixture does **not** select the deployed dependency or qualify an untested server version.
+
+## Phase and workload evidence (contract version 2)
+
+The shell entry point runs `li_bridge_mixed_cluster_smoke.py`. The test starts all-3.0 with bridge mode off, LI async fetching on and combined control on. It tests activation and backout, both binary rollback paths, hard failures, replica recovery, and deletion followed by name reuse. It then tests native control at IBP 3.0 and a separate IBP 3.9 roll.
+
+The same old clients and Connect worker stay alive throughout. A second old Admin client keeps creating, expanding, cancelling, shrinking and deleting a topic while brokers roll. Private APIs run with both old and new jars. The record checks compare contents, not just counts. Ordinary traffic is limited to one record pair every 100 ms so the in-memory test ledger stays bounded; this is not a throughput benchmark.
+
+Per-phase reports are `preflight-dormant.json`, `preflight-legacy-bridge.json`, `preflight-mixed.json`, `preflight-all-39-bridge.json`, `preflight-native.json`, and `preflight-ibp-39.json`. The old meaning of `native` (IBP 3.9) is deliberately removed. Old evidence is not silently accepted as contract-2 qualification.
+
+Optional scenario inputs and defaults:
+
+| Input | Default |
+|---|---:|
+| `SCALE_TOPIC_COUNT` | 10 |
+| `SCALE_PARTITION_COUNT` | 5 |
+| `RECOVERY_RECORD_COUNT` | 200 |
+| `RECOVERY_RECORD_SIZE` | 100000 bytes |
+| `BRIDGE_COMMAND_TIMEOUT_SECONDS` | 180 |
+| `BRIDGE_SCENARIO_TIMEOUT_SECONDS` | 2400 |
+
+`LI_BRIDGE_JAVA_30_HOME` optionally selects the legacy broker JDK independently from the Java 17 client/3.9 harness. JVM/runtime option changes invalidate resume. All archive inputs and process logs are retained by default; failed work directories are never silently removed. Connect's at-least-once duplicate deliveries are permitted, but missing/changed/unexpected contents fail; the broker/idempotent/transactional ledgers reject duplicate committed records.
+
+To check a standalone process result, use the same scenario environment as the run:
+
+```sh
+python3 tests/bin/audit_li_bridge_evidence.py --process-only --require-archives \
+  --evidence-dir /evidence/process-run
+```
+
+This checks all phase reports, record checks, process identities and archive hashes. It does not claim that wrapper tests, full suites or release approval passed. Failures retain thread dumps and the relevant ZooKeeper state before cleanup. The process test also writes a JUnit report.
+
+Use `LiBridgeLiveInventory` plus owner-reviewed state dispositions and `li_bridge_preflight.py --require-live --require-all-gates` for production admission. Offline config lint is not live admission. See the runbook for credentials, freshness, cluster identity and runtime-probe requirements.
+
+## CI and protected release gate
+
+The public `bridge-process` job builds both sources separately. It resolves `LI_BRIDGE_LEGACY_REF` (the 3.0 review branch by default) to one commit at checkout and records that commit and archive hash. After retiring the review branch, set the variable to the release branch or a chosen commit. Public CI provides review feedback; release CI requires approved commits and published checksums. The protected `li-bridge-release-qualification.yml` workflow requires approved published archive URLs/checksums, exact Kafka/wrapper commits, an internal runner and authorized wrapper access. `verify_li_bridge_release.sh` also provides that fail-closed entry point for existing internal CI.
+
+Archive/jar checks and source tests establish which bytes were tested. Release approval, official publication, production client/plugin/runtime qualification, actual deployed ZooKeeper versions, live configuration and capacity approval remain separate requirements. No missing approval, runner or private artifact may be treated as a successful partial release gate.


### PR DESCRIPTION
Document the phase contract, permanent and temporary flags, controller restart boundary, rollback limits and required release evidence. This runbook does not grant permission to deploy.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.