### PR TITLE
kafka: retire unhosted logs when bridge metadata deletes a topic

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1931,6 +1931,17 @@ class ReplicaManager(val config: KafkaConfig,
         val deletedPartitions = zkMetadataCache.updateMetadata(correlationId, updateMetadataRequest,
           config.liProtocolBridgeTopicDeletionStateCleanupActive)
         controllerEpoch = updateMetadataRequest.controllerEpoch
+        if (config.liProtocolBridgeTopicDeletionStateCleanupActive && !updateMetadataRequest.isKRaftController) {
+          // A canceled reassignment can leave a loaded log without a hosted replica.
+          // Retire these local strays on metadata deletion. Hosted replicas still use
+          // StopReplica, which also controls deletion of remote data.
+          val strays = deletedPartitions.filter(tp => getPartition(tp) == HostedPartition.None &&
+            logManager.getLog(tp).isDefined).map(tp => StopPartition(tp, deleteLocalLog = true)).toSet
+          if (strays.nonEmpty) {
+            val failures = stopPartitions(strays)
+            if (failures.nonEmpty) throw failures.head._2
+          }
+        }
         deletedPartitions
       }
     }

--- a/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import java.io.File
+import kafka.api.LeaderAndIsr
+import org.apache.kafka.common.errors.ControllerMovedException
+import kafka.utils.TestUtils
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.compress.Compression
+import org.apache.kafka.common.message.UpdateMetadataRequestData
+import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataPartitionState, UpdateMetadataTopicState}
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.protocol.MessageUtil
+import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.requests.UpdateMetadataRequest
+import org.apache.kafka.server.util.{MockScheduler, MockTime}
+import org.apache.kafka.storage.internals.log.LogDirFailureChannel
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.Mockito.mock
+
+import scala.jdk.CollectionConverters._
+
+class BridgeStrayLogDeletionTest {
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testMetadataDeletionRetiresOnlyUnhostedLogsWhenEnabled(enabled: Boolean): Unit = {
+    val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
+    props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, enabled.toString)
+    val config = KafkaConfig.fromProps(props)
+    val time = new MockTime
+    val metrics = new Metrics
+    val quotas = QuotaFactory.instantiate(config, metrics, time, "")
+    val logs = TestUtils.createLogManager(config.logDirs.map(new File(_)))
+    val manager = new ReplicaManager(config = config, metrics = metrics, time = time,
+      scheduler = new MockScheduler(time), logManager = logs, quotaManagers = quotas,
+      metadataCache = MetadataCache.zkMetadataCache(config.brokerId, config.interBrokerProtocolVersion),
+      logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size),
+      alterPartitionManager = mock(classOf[AlterPartitionManager]))
+    val stray = new TopicPartition("bridge-stray", 0)
+    val hosted = new TopicPartition("bridge-hosted", 0)
+    val unrelated = new TopicPartition("bridge-unrelated", 0)
+    def update(epoch: Int, deleted: Boolean): UpdateMetadataRequest = {
+      val states = Seq(stray, hosted).map { tp =>
+        val partition = new UpdateMetadataPartitionState().setPartitionIndex(0)
+          .setLeader(if (deleted) LeaderAndIsr.LeaderDuringDelete else 1)
+          .setReplicas(java.util.Arrays.asList(Int.box(1)))
+        new UpdateMetadataTopicState().setTopicName(tp.topic)
+          .setPartitionStates(java.util.Collections.singletonList(partition))
+      }
+      val data = new UpdateMetadataRequestData().setControllerId(0).setControllerEpoch(epoch)
+        .setBrokerEpoch(1L).setTopicStates(states.asJava)
+      UpdateMetadataRequest.parse(MessageUtil.toByteBuffer(data, 5.toShort), 5.toShort)
+    }
+    try {
+      Seq(stray, hosted, unrelated).foreach { tp =>
+        val log = logs.getOrCreateLog(tp, isNew = true, topicId = None)
+        log.appendAsLeader(MemoryRecords.withRecords(Compression.NONE,
+          new SimpleRecord("old-generation".getBytes(java.nio.charset.StandardCharsets.UTF_8))), 0)
+        assertEquals(1L, log.logEndOffset)
+      }
+      manager.createPartition(hosted)
+      manager.maybeUpdateMetadataCache(0, update(1, deleted = false))
+      assertThrows(classOf[ControllerMovedException], () =>
+        manager.maybeUpdateMetadataCache(1, update(0, deleted = true)))
+      assertTrue(logs.getLog(stray).isDefined, "stale controllers cannot delete logs")
+      manager.maybeUpdateMetadataCache(2, update(1, deleted = true))
+      assertEquals(!enabled, logs.getLog(stray).isDefined)
+      assertTrue(logs.getLog(hosted).isDefined, "hosted replicas still await StopReplica")
+      assertTrue(logs.getLog(unrelated).isDefined, "an incremental deletion is not a full log image")
+      if (enabled)
+        assertEquals(0L, logs.getOrCreateLog(stray, isNew = true, topicId = None).logEndOffset)
+    } finally {
+      manager.shutdown(checkpointHW = false)
+      logs.shutdown()
+      quotas.shutdown()
+      metrics.close()
+      TestUtils.clearYammerMetrics()
+    }
+  }
+}


### PR DESCRIPTION
Retire an unhosted local log when metadata reports its deletion, behind the cleanup flag. Preserve hosted replicas, unrelated logs and stale-controller fencing. Point process CI at the companion 3.0 repair.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.