### PR TITLE
tests: qualify LinkedIn ZooKeeper pagination

### DIFF
--- a/.github/workflows/li-ci.yml
+++ b/.github/workflows/li-ci.yml
@@ -68,6 +68,21 @@ jobs:
           ./gradlew --no-daemon "-PscalaVersion=${SCALA_VERSION}" \
             -PxmlSpotBugsReport=true \
             rat checkstyleMain checkstyleTest spotbugsMain spotbugsTest
+      - name: Test LinkedIn ZooKeeper pagination
+        id: zk-pagination
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon --max-workers=4 \
+            "-PscalaVersion=${SCALA_VERSION}" \
+            -I tests/bin/li_bridge_zookeeper_test.gradle \
+            core:liZookeeperPaginationTest
+      - name: Retain ZooKeeper pagination results
+        if: always() && steps.zk-pagination.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: zookeeper-pagination-results
+          path: core/build/test-results/liZookeeperPaginationTest/*.xml
+          if-no-files-found: warn
 
   module-tests:
     name: ${{ matrix.name }}_2.12

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -2373,6 +2373,20 @@ object KafkaZkClient {
             enableEntityConfigControllerCheck: Boolean = true,
             paginateTopics: Boolean = false
   ): KafkaZkClient = {
+    // Fail before opening a session or registering a broker. Otherwise a packaged stock client
+    // can join the cluster and repeatedly fail controller initialization when pagination is on.
+    if (paginateTopics) {
+      try {
+        val method = classOf[ZooKeeper].getMethod("getAllChildrenPaginated", classOf[String], java.lang.Boolean.TYPE)
+        require(classOf[java.util.List[_]].isAssignableFrom(method.getReturnType),
+          "getAllChildrenPaginated must return a java.util.List")
+      } catch {
+        case e: ReflectiveOperationException =>
+          val origin = Option(classOf[ZooKeeper].getProtectionDomain.getCodeSource).map(_.getLocation).orNull
+          throw new org.apache.kafka.common.config.ConfigException(
+            s"li.zookeeper.pagination.enable requires a qualified LinkedIn ZooKeeper client; loaded $origin: ${e.getMessage}")
+      }
+    }
 
     /* ZooKeeper 3.6.0 changed the default configuration for JUTE_MAXBUFFER from 4 MB to 1 MB.
      * This causes a regression if Kafka tries to retrieve a large amount of data across many

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -47,7 +47,6 @@ import org.apache.kafka.security.authorizer.AclEntry
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.config.{ConfigType, ReplicationConfigs, ZkConfigs}
 import org.apache.kafka.storage.internals.log.LogConfig
-import org.apache.zookeeper.KeeperException
 import org.apache.zookeeper.KeeperException.{Code, NoAuthException, NoNodeException, NodeExistsException}
 import org.apache.zookeeper.{CreateMode, ZooDefs}
 import org.apache.zookeeper.client.ZKClientConfig
@@ -126,22 +125,11 @@ class KafkaZkClientTest extends QuorumTestHarness {
 
   @Test
   def testPaginatedConfigReadPropagatesClientFailure(): Unit = {
-    val paginatedClient = KafkaZkClient(zkConnect,
-      zkAclsEnabled.getOrElse(JaasUtils.isZkSaslEnabled),
-      zkSessionTimeout,
-      zkConnectionTimeout,
-      zkMaxInFlightRequests,
-      Time.SYSTEM,
-      name = "KafkaZkClientPaginationFailureTest",
-      zkClientConfig = new ZKClientConfig,
-      enableEntityConfigControllerCheck = false,
-      paginateTopics = true)
-    try {
-      assertThrows(classOf[KeeperException],
-        () => paginatedClient.getAllEntitiesWithConfig(ConfigType.TOPIC))
-    } finally {
-      paginatedClient.close()
-    }
+    val error = assertThrows(classOf[org.apache.kafka.common.config.ConfigException], () =>
+      KafkaZkClient("unreachable.invalid:1", false, zkSessionTimeout, zkConnectionTimeout,
+        zkMaxInFlightRequests, Time.SYSTEM, name = "KafkaZkClientPaginationFailureTest",
+        zkClientConfig = new ZKClientConfig, paginateTopics = true))
+    assertTrue(error.getMessage.contains("qualified LinkedIn ZooKeeper client"))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/zk/LiZookeeperPaginationTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/LiZookeeperPaginationTest.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.zk
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Collections
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import kafka.server.QuorumTestHarness
+import kafka.zookeeper.{StateChangeHandler, ZNodeChildChangeHandler}
+import org.apache.jute.BinaryInputArchive
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.server.config.ConfigType
+import org.apache.zookeeper.{KeeperException, ZooDefs, ZooKeeper}
+import org.apache.zookeeper.client.ZKClientConfig
+import org.apache.zookeeper.common.ZKConfig
+import org.apache.zookeeper.data.{ACL, Id}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, TestInfo, Timeout}
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/** Run with the isolated LinkedIn ZooKeeper task in tests/bin/li_bridge_zookeeper_test.gradle. */
+@EnabledIfSystemProperty(named = "li.zookeeper.pagination.test", matches = "true")
+@Timeout(120)
+class LiZookeeperPaginationTest extends QuorumTestHarness {
+  private val maxResponseBytes = 1024 * 1024
+  private var paginatedClient: KafkaZkClient = _
+
+  @BeforeEach
+  override def setUp(testInfo: TestInfo): Unit = {
+    assertNotNull(classOf[ZooKeeper].getMethod("getAllChildrenPaginated", classOf[String], java.lang.Boolean.TYPE))
+    assertEquals(maxResponseBytes, BinaryInputArchive.maxBuffer)
+    super.setUp(testInfo)
+    val clientConfig = new ZKClientConfig
+    clientConfig.setProperty(ZKConfig.JUTE_MAXBUFFER, maxResponseBytes.toString)
+    paginatedClient = KafkaZkClient(zkConnect, isSecure = false,
+      zkSessionTimeout, zkConnectionTimeout, zkMaxInFlightRequests, Time.SYSTEM,
+      name = "LiZookeeperPaginationTest", zkClientConfig = clientConfig,
+      enableEntityConfigControllerCheck = false, paginateTopics = true)
+    assertEquals(maxResponseBytes.toString,
+      paginatedClient.currentZooKeeper.getClientConfig.getProperty(ZKConfig.JUTE_MAXBUFFER))
+  }
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    try {
+      if (paginatedClient != null) paginatedClient.close()
+    } finally {
+      if (implementation != null) super.tearDown()
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("topics", "configs", "federated"))
+  def testListingsLargerThanResponseLimit(kind: String): Unit = {
+    val parentPath = kind match {
+      case "topics" => TopicsZNode.path
+      case "configs" => ConfigEntityTypeZNode.path(ConfigType.TOPIC)
+      case "federated" => FederatedTopicZNode.namespacePath("west")
+    }
+    val prefix = "topic-" + "x" * 180
+    val expected = (0 until 6000).map(index => s"$prefix-$index").toSet
+    // Each child uses four bytes for its string length in the ZooKeeper response.
+    val responseBytes = expected.iterator.map(_.getBytes(UTF_8).length.toLong + 4).sum + 4
+    assertTrue(responseBytes > maxResponseBytes, s"Fixture must exceed the response limit: $responseBytes")
+    zkClient.createRecursive(parentPath)
+    expected.foreach(name => zkClient.createRecursive(s"$parentPath/$name"))
+
+    val changed = new CountDownLatch(1)
+    paginatedClient.registerZNodeChildChangeHandler(new ZNodeChildChangeHandler {
+      override val path: String = parentPath
+      override def handleChildChange(): Unit = changed.countDown()
+    })
+    def list(): Set[String] = kind match {
+      case "topics" => paginatedClient.getAllTopicsInCluster(registerWatch = true)
+      case "configs" => paginatedClient.getAllEntitiesWithConfig(ConfigType.TOPIC).toSet
+      case "federated" => paginatedClient.getAllFederatedTopicsInNamespace("west", registerWatch = true)
+    }
+
+    assertEquals(expected, list())
+    val added = "topic-added-after-paginated-read"
+    zkClient.createRecursive(s"$parentPath/$added")
+    if (kind != "configs")
+      assertTrue(changed.await(10, TimeUnit.SECONDS), s"No child watch delivered for $parentPath")
+    assertEquals(expected + added, list())
+  }
+
+  @Test
+  def testPaginationAndWatchRenewalAfterSessionExpiry(): Unit = {
+    zkClient.createRecursive(TopicsZNode.path)
+    zkClient.createRecursive(s"${TopicsZNode.path}/before-expiry")
+    val reconnected = new CountDownLatch(1)
+    val changed = new CountDownLatch(1)
+    paginatedClient.registerZNodeChildChangeHandler(new ZNodeChildChangeHandler {
+      override val path: String = TopicsZNode.path
+      override def handleChildChange(): Unit = changed.countDown()
+    })
+    paginatedClient.registerStateChangeHandler(new StateChangeHandler {
+      override val name: String = "pagination-watch-renewal"
+      override def afterInitializingSession(): Unit = {
+        assertEquals(Set("before-expiry"), paginatedClient.getAllTopicsInCluster(registerWatch = true))
+        reconnected.countDown()
+      }
+    })
+    assertEquals(Set("before-expiry"), paginatedClient.getAllTopicsInCluster(registerWatch = true))
+    val session = paginatedClient.currentZooKeeper.getSessionId
+    paginatedClient.currentZooKeeper.getTestable.injectSessionExpiration()
+    assertTrue(reconnected.await(30, TimeUnit.SECONDS), "Paginated rescan failed after session expiry")
+    assertNotEquals(session, paginatedClient.currentZooKeeper.getSessionId)
+    zkClient.createRecursive(s"${TopicsZNode.path}/after-expiry")
+    assertTrue(changed.await(10, TimeUnit.SECONDS), "Renewed watch did not fire")
+    assertEquals(Set("before-expiry", "after-expiry"), paginatedClient.getAllTopicsInCluster(registerWatch = true))
+  }
+
+  @Test
+  def testMissingAndUnauthorizedNamespaceResults(): Unit = {
+    assertTrue(paginatedClient.getAllFederatedTopicsInNamespace("missing").isEmpty)
+    val path = FederatedTopicZNode.namespacePath("restricted")
+    zkClient.createRecursive(path)
+    zkClient.currentZooKeeper.setACL(path,
+      Collections.singletonList(new ACL(ZooDefs.Perms.ADMIN, new Id("world", "anyone"))), -1)
+    assertThrows(classOf[KeeperException.NoAuthException],
+      () => paginatedClient.getAllFederatedTopicsInNamespace("restricted"))
+  }
+}

--- a/tests/bin/li_bridge_zookeeper_test.gradle
+++ b/tests/bin/li_bridge_zookeeper_test.gradle
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.security.MessageDigest
+import java.time.Duration
+
+// Keep vendor dependencies confined to this test task's runtime classpath.
+gradle.projectsEvaluated {
+    def core = rootProject.project(':core')
+    core.repositories.maven {
+        url = 'https://linkedin.jfrog.io/artifactory/zookeeper'
+        metadataSources { artifact() }
+        content { includeGroup 'com.linkedin.zookeeper' }
+    }
+    def vendor = core.configurations.detachedConfiguration(
+        core.dependencies.create('com.linkedin.zookeeper:zookeeper:3.6.3-23'),
+        core.dependencies.create('com.linkedin.zookeeper:zookeeper-jute:3.6.3-23'))
+    vendor.transitive = false
+    def expectedHashes = [
+        'zookeeper-3.6.3-23.jar': '1776e71b42089cb91e1ec4a31122c9e9e597a35a02b1f0e2fe1ae4b26a81925b',
+        'zookeeper-jute-3.6.3-23.jar': '88492e694a9fa0ff786272ccfdbb07b5aa1b53c59d695e7c3d62ceabf971297a'
+    ]
+    core.tasks.register('liZookeeperPaginationTest', Test) {
+        group = 'verification'
+        description = 'Test paginated topic reads with the LinkedIn ZooKeeper implementation.'
+        dependsOn core.tasks.named('testClasses')
+        testClassesDirs = core.sourceSets.test.output.classesDirs
+        classpath = core.files(vendor, core.sourceSets.test.runtimeClasspath.filter {
+            !(it.name ==~ /zookeeper(-jute)?-.+\.jar/)
+        })
+        filter { includeTestsMatching 'kafka.zk.LiZookeeperPaginationTest' }
+        useJUnitPlatform { includeEngines 'junit-jupiter' }
+        maxParallelForks = 1
+        maxHeapSize = '1g'
+        jvmArgs = rootProject.ext.defaultJvmArgs
+        timeout = Duration.ofMinutes(5)
+        systemProperty 'li.zookeeper.pagination.test', 'true'
+        systemProperty 'jute.maxbuffer', '1048576'
+        testLogging { events 'passed', 'skipped', 'failed'; exceptionFormat = 'full' }
+        doFirst {
+            vendor.files.each { file ->
+                def actual = MessageDigest.getInstance('SHA-256').digest(file.bytes).encodeHex().toString()
+                if (actual != expectedHashes[file.name]) {
+                    throw new GradleException("ZooKeeper fixture checksum mismatch: ${file.name}")
+                }
+                logger.lifecycle("ZooKeeper fixture ${file.name} sha256=${actual}")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reject enabled pagination at startup if the packaged client lacks the required API. Run five isolated vendor-client cases, including large listings, errors, session expiry and watch renewal, with pinned jar hashes. Add the fixture to CI. The deployed ZooKeeper server/runtime pair still needs release qualification.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.

Replaces #564, which GitHub automatically closed when its head became an ancestor of its old base during the reorder. No release branch was merged. The restored branch is reviewed here at the corrected dependency boundary.