### PR TITLE
tests: check supplied archive and wrapper jar identity

### DIFF
--- a/tests/bin/li_bridge_artifacts.py
+++ b/tests/bin/li_bridge_artifacts.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Retain bridge archives and check the wrapper against the selected broker artifact."""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+def stream_sha256(source):
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: source.read(1024 * 1024), b""):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def file_sha256(path):
+    with Path(path).open("rb") as source:
+        return stream_sha256(source)
+
+
+def inspect_archive(path, generation):
+    libraries = {}
+    properties = None
+    with tarfile.open(path, "r:gz") as archive:
+        for member in archive:
+            parts = PurePosixPath(member.name).parts
+            if member.name.startswith("/") or ".." in parts or not (member.isfile() or member.isdir()):
+                raise ValueError(f"Unsafe archive entry: {member.name}")
+            if not member.isfile() or len(parts) != 3 or parts[1] != "libs":
+                continue
+            name = parts[-1]
+            if not name.startswith("kafka") or not name.endswith(".jar"):
+                continue
+            if name in libraries:
+                raise ValueError(f"Duplicate Kafka library in archive: {name}")
+            with archive.extractfile(member) as source:
+                if re.fullmatch(r"kafka-clients-[0-9].*\.jar", name) and not name.endswith("-test.jar"):
+                    if properties is not None:
+                        raise ValueError("Archive contains multiple Kafka clients jars")
+                    data = source.read()
+                    with zipfile.ZipFile(io.BytesIO(data)) as jar:
+                        text = jar.read("kafka/kafka-version.properties").decode("utf-8")
+                    properties = dict(line.split("=", 1) for line in text.splitlines()
+                                      if "=" in line and not line.startswith("#"))
+                    libraries[name] = hashlib.sha256(data).hexdigest()
+                else:
+                    libraries[name] = stream_sha256(source)
+    if properties is None:
+        raise ValueError("Archive has no Kafka clients version metadata")
+    version = properties.get("version", "")
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:\.\d+)?(?:-SNAPSHOT)?", version) or not version.startswith(generation + "."):
+        raise ValueError(f"Expected a Kafka {generation} archive, found version {version!r}")
+    core_names = [name for name in libraries if re.fullmatch(r"kafka_2\.(?:12|13)-" + re.escape(version) + r"\.jar", name)]
+    if len(core_names) != 1 or f"kafka-clients-{version}.jar" not in libraries:
+        raise ValueError(f"Archive lacks matching Kafka core and clients jars for {version}")
+    return {"version": version, "commit_id": properties.get("commitId"),
+            "scala_version": core_names[0].split("_", 1)[1].split("-", 1)[0], "libraries": libraries}
+
+
+def snapshot_archive(source, generation, output_dir):
+    source = Path(source).resolve()
+    digest = file_sha256(source)
+    destination = Path(output_dir).resolve() / f"kafka-{generation}-{digest}.tgz"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if not destination.exists():
+        with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as temporary:
+            temporary_path = Path(temporary.name)
+        try:
+            shutil.copyfile(source, temporary_path)
+            if file_sha256(temporary_path) != digest:
+                raise ValueError(f"Archive changed while copying: {source}")
+            inspect_archive(temporary_path, generation)
+            os.replace(temporary_path, destination)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+    if file_sha256(destination) != digest:
+        raise ValueError(f"Retained archive checksum mismatch: {destination}")
+    result = inspect_archive(destination, generation)
+    result.update({"path": str(destination), "input_path": str(source), "sha256": digest})
+    return result
+
+
+def check_wrapper_spec(wrapper_root, archive):
+    spec = json.loads((Path(wrapper_root) / "product-spec.json").read_text(encoding="utf-8"))
+    version = archive["version"]
+    versions = spec["build"]["versions"]
+    if versions.get("linkedin-kafka") != version or versions.get("baseScala") != archive["scala_version"]:
+        raise ValueError("Wrapper Kafka/Scala build versions do not match the selected archive")
+    dependencies = [coordinate.split(":") for coordinate in spec["external"].values()
+                    if isinstance(coordinate, str) and coordinate.startswith("com.linkedin.kafka:")]
+    if not dependencies or not any(parts[1] == "kafka_" + archive["scala_version"] for parts in dependencies):
+        raise ValueError("Wrapper has no matching LinkedIn Kafka core dependency")
+    if any(len(parts) < 3 or parts[2] != version for parts in dependencies):
+        raise ValueError(f"Every wrapper Kafka dependency must use version {version}")
+
+
+def check_wrapper_classpath(archive, artifacts):
+    if not isinstance(artifacts, list) or not artifacts:
+        raise ValueError("Wrapper classpath has no LinkedIn Kafka artifacts")
+    checked = []
+    main_modules = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict) or artifact.get("group") != "com.linkedin.kafka" or artifact.get("version") != archive["version"]:
+            raise ValueError(f"Wrapper resolved an unexpected Kafka coordinate: {artifact}")
+        path = Path(artifact["path"])
+        digest = file_sha256(path)
+        classifier = artifact.get("classifier")
+        suffix = "" if classifier is None else f"-{classifier}"
+        expected_name = f"{artifact['name']}-{archive['version']}{suffix}.jar"
+        if path.name != expected_name:
+            raise ValueError(f"Wrapper jar filename does not match its coordinate: {path}")
+        if classifier is None:
+            if archive["libraries"].get(expected_name) != digest:
+                raise ValueError(f"Wrapper jar does not match the selected archive: {path}")
+            main_modules.add(artifact["name"])
+        elif classifier != "test":
+            raise ValueError(f"Unexpected Kafka runtime classifier: {classifier}")
+        checked.append(dict(artifact, sha256=digest))
+    if not {"kafka-clients", "kafka_" + archive["scala_version"]}.issubset(main_modules):
+        raise ValueError("Wrapper classpath lacks Kafka core or clients")
+    return {"passed": True, "archive_sha256": archive["sha256"], "version": archive["version"],
+            "main_modules": sorted(main_modules), "artifacts": checked}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    snapshot = commands.add_parser("snapshot", help="Validate and retain an immutable archive copy")
+    snapshot.add_argument("--archive", required=True, type=Path)
+    snapshot.add_argument("--generation", required=True, choices=("3.0", "3.9"))
+    snapshot.add_argument("--output-dir", required=True, type=Path)
+    snapshot.add_argument("--output-json", required=True, type=Path)
+    wrapper = commands.add_parser("wrapper", help="Check wrapper version declarations and resolved Kafka jars")
+    wrapper.add_argument("--archive-json", required=True, type=Path)
+    wrapper.add_argument("--wrapper-root", required=True, type=Path)
+    wrapper.add_argument("--classpath-json", type=Path)
+    wrapper.add_argument("--output-json", type=Path)
+    wrapper.add_argument("--compare-report", type=Path,
+                         help="Require the resolved files to match a previous wrapper report")
+    args = parser.parse_args()
+    try:
+        if args.command == "snapshot":
+            result = snapshot_archive(args.archive, args.generation, args.output_dir)
+        else:
+            archive = json.loads(args.archive_json.read_text(encoding="utf-8"))
+            if file_sha256(archive["path"]) != archive["sha256"]:
+                raise ValueError("Retained broker archive changed")
+            actual = inspect_archive(archive["path"], "3.9")
+            if any(archive.get(key) != value for key, value in actual.items()):
+                raise ValueError("Broker archive metadata does not match its contents")
+            check_wrapper_spec(args.wrapper_root, archive)
+            result = {"passed": True, "version": archive["version"]}
+            if args.classpath_json:
+                result = check_wrapper_classpath(archive, json.loads(args.classpath_json.read_text(encoding="utf-8")))
+            if args.compare_report:
+                previous = json.loads(args.compare_report.read_text(encoding="utf-8"))
+                if not args.classpath_json or previous != result:
+                    raise ValueError("Wrapper dependencies changed during testing")
+        rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+        if args.output_json:
+            args.output_json.write_text(rendered, encoding="utf-8")
+        print(rendered, end="")
+        return 0
+    except (OSError, ValueError, KeyError, tarfile.TarError, zipfile.BadZipFile) as error:
+        print(f"Artifact validation failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bin/li_bridge_wrapper_artifacts.gradle
+++ b/tests/bin/li_bridge_wrapper_artifacts.gradle
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonOutput
+
+// Run with the wrapper's Gradle build. Retain the exact Kafka coordinates and files it resolves.
+gradle.projectsEvaluated {
+    rootProject.tasks.register('liBridgeArtifactClasspath') {
+        doLast {
+            def output = System.getenv('BRIDGE_WRAPPER_ARTIFACTS_OUTPUT')
+            if (!output) throw new GradleException('BRIDGE_WRAPPER_ARTIFACTS_OUTPUT is required')
+            def wrapper = rootProject.project(':likafka:kafka-impl_2.12')
+            def artifacts = wrapper.configurations.getByName('testRuntimeClasspath')
+                .resolvedConfiguration.resolvedArtifacts
+                .findAll { it.moduleVersion.id.group == 'com.linkedin.kafka' }
+                .collect { artifact ->
+                    [group: artifact.moduleVersion.id.group,
+                     name: artifact.moduleVersion.id.name,
+                     version: artifact.moduleVersion.id.version,
+                     classifier: artifact.classifier,
+                     path: artifact.file.canonicalPath]
+                }.sort { it.path }
+            new File(output).text = JsonOutput.prettyPrint(JsonOutput.toJson(artifacts)) + '\n'
+        }
+    }
+}

--- a/tests/unit/li_bridge_artifacts_test.py
+++ b/tests/unit/li_bridge_artifacts_test.py
@@ -1,0 +1,178 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+BIN = Path(__file__).parents[1] / "bin"
+SPEC = importlib.util.spec_from_file_location("li_bridge_artifacts", BIN / "li_bridge_artifacts.py")
+ARTIFACTS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ARTIFACTS)
+
+
+class LiBridgeArtifactsTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+
+    def archive(self, version="3.9.2.17", scala="2.12", extra=None):
+        jar = io.BytesIO()
+        with zipfile.ZipFile(jar, "w") as source:
+            source.writestr("kafka/kafka-version.properties", f"version={version}\ncommitId=abcdef0123456789\n")
+        libraries = {f"kafka-clients-{version}.jar": jar.getvalue(),
+                     f"kafka_{scala}-{version}.jar": b"core jar"}
+        path = self.root / f"kafka_{scala}-{version}.tgz"
+        with tarfile.open(path, "w:gz") as archive:
+            for name, data in libraries.items():
+                member = tarfile.TarInfo(f"kafka_{scala}-{version}/libs/{name}")
+                member.size = len(data)
+                archive.addfile(member, io.BytesIO(data))
+            if extra is not None:
+                archive.addfile(extra)
+        return path, libraries
+
+    def wrapper(self, libraries, version="3.9.2.17", scala="2.12"):
+        root = self.root / "wrapper"
+        root.mkdir(exist_ok=True)
+        spec = {"build": {"versions": {"linkedin-kafka": version, "baseScala": scala}},
+                "external": {"kafka": f"com.linkedin.kafka:kafka_{scala}:{version}",
+                             "clients-test": f"com.linkedin.kafka:kafka-clients:{version}:test"}}
+        (root / "product-spec.json").write_text(json.dumps(spec))
+        artifacts = []
+        for filename, data in libraries.items():
+            path = root / filename
+            path.write_bytes(data)
+            artifacts.append({"group": "com.linkedin.kafka", "name": filename.removesuffix(f"-{version}.jar"),
+                              "version": version, "classifier": None, "path": str(path)})
+        return root, artifacts
+
+    def test_snapshots_include_versions_and_survive_build_cleanup(self):
+        for version, generation in (("3.0.1.83", "3.0"), ("3.9.2.17", "3.9")):
+            with self.subTest(version=version):
+                archive, _ = self.archive(version)
+                info = ARTIFACTS.snapshot_archive(archive, generation, self.root / "evidence/archives")
+                self.assertEqual(version, info["version"])
+                self.assertEqual("2.12", info["scala_version"])
+                self.assertEqual(archive.read_bytes(), Path(info["path"]).read_bytes())
+                archive.unlink()
+                self.assertEqual(info["sha256"], ARTIFACTS.file_sha256(info["path"]))
+                again = ARTIFACTS.snapshot_archive(info["path"], generation, self.root / "evidence/archives")
+                self.assertEqual(info["path"], again["path"])
+
+    def test_generation_comes_from_jar_metadata(self):
+        archive, _ = self.archive("3.0.1.83")
+        renamed = archive.with_name("kafka_2.12-3.9.2.17.tgz")
+        archive.rename(renamed)
+        with self.assertRaisesRegex(ValueError, "Expected a Kafka 3.9 archive"):
+            ARTIFACTS.snapshot_archive(renamed, "3.9", self.root / "evidence")
+
+    def test_corrupted_retained_archive_is_rejected(self):
+        archive, _ = self.archive()
+        info = ARTIFACTS.snapshot_archive(archive, "3.9", self.root / "evidence")
+        Path(info["path"]).write_bytes(b"corrupted archive")
+        with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+            ARTIFACTS.snapshot_archive(archive, "3.9", self.root / "evidence")
+
+    def test_unsafe_archive_entries_are_rejected(self):
+        path_traversal = tarfile.TarInfo("../outside")
+        symlink = tarfile.TarInfo("kafka/escape")
+        symlink.type = tarfile.SYMTYPE
+        symlink.linkname = "/outside"
+        for entry in (path_traversal, symlink):
+            with self.subTest(entry=entry.name):
+                archive, _ = self.archive(extra=entry)
+                with self.assertRaisesRegex(ValueError, "Unsafe archive entry"):
+                    ARTIFACTS.inspect_archive(archive, "3.9")
+
+    def test_missing_version_metadata_is_rejected(self):
+        archive = self.root / "empty.tgz"
+        with tarfile.open(archive, "w:gz"):
+            pass
+        with self.assertRaisesRegex(ValueError, "no Kafka clients"):
+            ARTIFACTS.inspect_archive(archive, "3.9")
+
+    def test_wrapper_versions_and_main_jar_hashes_match_archive(self):
+        path, libraries = self.archive()
+        archive = ARTIFACTS.snapshot_archive(path, "3.9", self.root / "evidence")
+        wrapper, artifacts = self.wrapper(libraries)
+        ARTIFACTS.check_wrapper_spec(wrapper, archive)
+        report = ARTIFACTS.check_wrapper_classpath(archive, artifacts)
+        self.assertTrue(report["passed"])
+        self.assertEqual(archive["sha256"], report["archive_sha256"])
+        self.assertEqual(["kafka-clients", "kafka_2.12"], report["main_modules"])
+        Path(artifacts[0]["path"]).write_bytes(b"another jar under the same version")
+        with self.assertRaisesRegex(ValueError, "does not match the selected archive"):
+            ARTIFACTS.check_wrapper_classpath(archive, artifacts)
+
+    def test_wrapper_rejects_mixed_versions_and_missing_core(self):
+        path, libraries = self.archive()
+        archive = ARTIFACTS.snapshot_archive(path, "3.9", self.root / "evidence")
+        wrapper, artifacts = self.wrapper(libraries)
+        spec_path = wrapper / "product-spec.json"
+        valid = json.loads(spec_path.read_text())
+        for section, key, value in (("versions", "linkedin-kafka", "3.0.1.83"),
+                                    ("versions", "baseScala", "2.13"),
+                                    ("external", "clients-test", "com.linkedin.kafka:kafka-clients:3.0.1.83:test")):
+            spec = json.loads(json.dumps(valid))
+            target = spec["build"]["versions"] if section == "versions" else spec["external"]
+            target[key] = value
+            spec_path.write_text(json.dumps(spec))
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                ARTIFACTS.check_wrapper_spec(wrapper, archive)
+        with self.assertRaisesRegex(ValueError, "lacks Kafka core"):
+            ARTIFACTS.check_wrapper_classpath(archive, artifacts[:1])
+        artifacts[0]["version"] = "3.0.1.83"
+        with self.assertRaisesRegex(ValueError, "unexpected Kafka coordinate"):
+            ARTIFACTS.check_wrapper_classpath(archive, artifacts)
+
+    def test_test_classifier_changes_are_recorded(self):
+        path, libraries = self.archive()
+        archive = ARTIFACTS.snapshot_archive(path, "3.9", self.root / "evidence")
+        wrapper, artifacts = self.wrapper(libraries)
+        test_jar = wrapper / "kafka-clients-3.9.2.17-test.jar"
+        test_jar.write_bytes(b"test classes")
+        artifacts.append({"group": "com.linkedin.kafka", "name": "kafka-clients", "version": "3.9.2.17",
+                          "classifier": "test", "path": str(test_jar)})
+        before = ARTIFACTS.check_wrapper_classpath(archive, artifacts)
+        test_jar.write_bytes(b"changed test classes")
+        self.assertNotEqual(before, ARTIFACTS.check_wrapper_classpath(archive, artifacts))
+
+    def test_forged_archive_library_manifest_is_rejected(self):
+        path, libraries = self.archive()
+        archive = ARTIFACTS.snapshot_archive(path, "3.9", self.root / "evidence")
+        wrapper, _ = self.wrapper(libraries)
+        archive["libraries"]["kafka-clients-3.9.2.17.jar"] = "wrong"
+        manifest = self.root / "archive.json"
+        manifest.write_text(json.dumps(archive))
+        result = subprocess.run(["python3", str(BIN / "li_bridge_artifacts.py"), "wrapper",
+                                 "--archive-json", str(manifest), "--wrapper-root", str(wrapper)],
+                                capture_output=True, text=True)
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("metadata does not match", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Validate and retain supplied archive bytes. Check embedded versions, safe archive paths, wrapper coordinates and resolved jar hashes. Keep verifier/stager integration in the later verifier layer; this PR contains the standalone artifact checker and its tests.

## Verification and release boundary

The latest clean-source mixed migration and process-evidence audit pass locally. The current wrapper suite passes 132 tests, with unchanged Kafka dependencies before and after the run. The reorganized Python suite passes 65 tests. These results apply to the complete candidate stack, not every intermediate commit. Focused tests are included with the relevant layers.

The final requirement audit and remote CI review remain open. Published artifact qualification, live production state, the client/tool floor, the deployed ZooKeeper server, capacity limits and named security/release approvals remain release gates. Do not deploy an intermediate stack commit.

Replaces #563, which GitHub automatically closed when its head became an ancestor of its old base during the reorder. No release branch was merged. The restored branch is reviewed here at the corrected dependency boundary.