### PR TITLE
kafka: reconcile returning 3.0 broker logs from full metadata

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -642,7 +642,13 @@ class KafkaController(val config: KafkaConfig,
     // Send update metadata request to all the new brokers in the cluster with a full set of partition states for initialization.
     // In cases of controlled shutdown leaders will not be elected when a new broker comes up. So at least in the
     // common controlled shutdown case, the metadata will reach the new brokers faster.
-    sendUpdateMetadataRequest(newBrokers, controllerContext.partitionsWithLeaders)
+    // Bridge cleanup uses this complete image to retire unassigned local logs.
+    // Include leaderless partitions so their valid recovery logs are retained.
+    val initialPartitions = if (config.liProtocolBridgeTopicDeletionStateCleanupActive)
+      controllerContext.partitionsLeadershipInfo.keySet.toSet
+    else
+      controllerContext.partitionsWithLeaders
+    sendUpdateMetadataRequest(newBrokers, initialPartitions)
     // the very first thing to do when a new broker comes up is send it the entire list of partitions that it is
     // supposed to host. Based on that the broker starts the high watermark threads for the input list of partitions
     val allReplicasOnNewBrokers = controllerContext.replicasOnBrokers(newBrokersSet)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1488,14 +1488,20 @@ class ReplicaManager(val config: KafkaConfig,
         throw new ControllerMovedException(stateChangeLogger.messageWithPrefix(stateControllerEpochErrorMessage))
       } else {
         val zkMetadataCache = metadataCache.asInstanceOf[ZkMetadataCache]
-        val deletedPartitions = zkMetadataCache.updateMetadata(correlationId, updateMetadataRequest,
+        val update = zkMetadataCache.updateMetadataAndGetResult(correlationId, updateMetadataRequest,
           config.liProtocolBridgeTopicDeletionStateCleanupActive)
+        val deletedPartitions = update.deletedPartitions
         controllerEpoch = updateMetadataRequest.controllerEpoch
         if (config.liProtocolBridgeTopicDeletionStateCleanupActive) {
-          // A canceled reassignment can leave a loaded log without a hosted replica.
-          // Retire these local strays on metadata deletion. Hosted replicas still use
-          // StopReplica, which also controls deletion of remote data.
-          val strays = deletedPartitions.filter(tp => getPartition(tp) == HostedPartition.None &&
+          // A returning broker may have missed every deletion notification. Only a
+          // complete image can identify those unassigned logs; incremental updates cannot.
+          val unassigned = if (update.replacedSnapshot) {
+            logManager.allLogs.map(_.topicPartition).filter { tp =>
+              !zkMetadataCache.getPartitionInfo(tp.topic, tp.partition).exists(_.replicas.contains(config.brokerId))
+            }.toSeq
+          } else Seq.empty
+          // Hosted replicas still use StopReplica, which also controls remote deletion.
+          val strays = (deletedPartitions ++ unassigned).filter(tp => getPartition(tp) == HostedPartition.None &&
             logManager.getLog(tp).isDefined).map(tp => StopPartition(tp, deleteLocalLog = true)).toSet
           if (strays.nonEmpty) {
             val failures = stopPartitions(strays)

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -41,6 +41,8 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{MetadataResponse, UpdateMetadataRequest}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 
+private[server] case class ZkMetadataCacheUpdate(deletedPartitions: Seq[TopicPartition], replacedSnapshot: Boolean)
+
 /**
  *  A cache for the state (e.g., current leader) of each partition. This cache is updated through
  *  UpdateMetadataRequest from the controller. Every broker maintains the same cache, asynchronously.
@@ -308,7 +310,11 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
   // With cleanup enabled, upgraded controllers send a full first update for each epoch.
   // Later updates in that epoch remain incremental, including after a dynamic flag change.
   def updateMetadata(correlationId: Int, updateMetadataRequest: UpdateMetadataRequest,
-                     reconcileOnControllerChange: Boolean): Seq[TopicPartition] = {
+                     reconcileOnControllerChange: Boolean): Seq[TopicPartition] =
+    updateMetadataAndGetResult(correlationId, updateMetadataRequest, reconcileOnControllerChange).deletedPartitions
+
+  private[server] def updateMetadataAndGetResult(correlationId: Int, updateMetadataRequest: UpdateMetadataRequest,
+                                                reconcileOnControllerChange: Boolean): ZkMetadataCacheUpdate = {
     inWriteLock(partitionMetadataLock) {
       val replaceMetadata = reconcileOnControllerChange &&
         updateMetadataRequest.controllerEpoch > lastMetadataControllerEpoch
@@ -403,7 +409,7 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
         metadataSnapshot = MetadataSnapshot(partitionStates, topicIds.toMap, controllerIdOpt, aliveBrokers, aliveNodes)
       }
       lastMetadataControllerEpoch = math.max(lastMetadataControllerEpoch, updateMetadataRequest.controllerEpoch)
-      deletedPartitions
+      ZkMetadataCacheUpdate(deletedPartitions, replaceMetadata)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
@@ -17,11 +17,12 @@
 package kafka.server
 
 import java.io.File
+import java.util.Properties
 import kafka.api.LeaderAndIsr
-import org.apache.kafka.common.errors.ControllerMovedException
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.CompressionType
+import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.kafka.common.message.UpdateMetadataRequestData
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataPartitionState, UpdateMetadataTopicState}
 import org.apache.kafka.common.metrics.Metrics
@@ -37,9 +38,7 @@ import org.mockito.Mockito.mock
 import scala.jdk.CollectionConverters._
 
 class BridgeStrayLogDeletionTest {
-  @ParameterizedTest
-  @ValueSource(booleans = Array(false, true))
-  def testMetadataDeletionRetiresOnlyUnhostedLogsWhenEnabled(enabled: Boolean): Unit = {
+  private def withManager(enabled: Boolean)(test: (KafkaConfig, ReplicaManager) => Unit): Unit = {
     val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
     props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, enabled.toString)
     val config = KafkaConfig.fromProps(props)
@@ -51,45 +50,83 @@ class BridgeStrayLogDeletionTest {
       new java.util.concurrent.atomic.AtomicBoolean(false), quotas, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size),
       mock(classOf[AlterIsrManager]), mock(classOf[TransferLeaderManager]))
-    val stray = new TopicPartition("bridge-stray", 0)
-    val hosted = new TopicPartition("bridge-hosted", 0)
-    val unrelated = new TopicPartition("bridge-unrelated", 0)
-    def update(epoch: Int, deleted: Boolean): UpdateMetadataRequest = {
-      val states = Seq(stray, hosted).map { tp =>
-        val partition = new UpdateMetadataPartitionState().setPartitionIndex(0)
-          .setLeader(if (deleted) LeaderAndIsr.LeaderDuringDelete else 1)
-          .setReplicas(java.util.Arrays.asList(Int.box(1)))
-        new UpdateMetadataTopicState().setTopicName(tp.topic)
-          .setPartitionStates(java.util.Collections.singletonList(partition))
-      }
-      val data = new UpdateMetadataRequestData().setControllerId(0).setControllerEpoch(epoch)
-        .setBrokerEpoch(1L).setTopicStates(states.asJava)
-      UpdateMetadataRequest.parse(MessageUtil.toByteBuffer(data, 5.toShort), 5.toShort)
-    }
-    try {
-      Seq(stray, hosted, unrelated).foreach { tp =>
-        val log = logs.getOrCreateLog(tp, isNew = true, topicId = None)
-        log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE,
-          new SimpleRecord("old-generation".getBytes(java.nio.charset.StandardCharsets.UTF_8))), 0)
-        assertEquals(1L, log.logEndOffset)
-      }
-      manager.createPartition(hosted)
-      manager.maybeUpdateMetadataCache(0, update(1, deleted = false))
-      assertThrows(classOf[ControllerMovedException], () =>
-        manager.maybeUpdateMetadataCache(1, update(0, deleted = true)))
-      assertTrue(logs.getLog(stray).isDefined, "stale controllers cannot delete logs")
-      manager.maybeUpdateMetadataCache(2, update(1, deleted = true))
-      assertEquals(!enabled, logs.getLog(stray).isDefined)
-      assertTrue(logs.getLog(hosted).isDefined, "hosted replicas still await StopReplica")
-      assertTrue(logs.getLog(unrelated).isDefined, "an incremental deletion is not a full log image")
-      if (enabled)
-        assertEquals(0L, logs.getOrCreateLog(stray, isNew = true, topicId = None).logEndOffset)
-    } finally {
+    try test(config, manager)
+    finally {
       manager.shutdown(checkpointHW = false)
       logs.shutdown()
       quotas.shutdown()
       metrics.close()
       TestUtils.clearYammerMetrics()
     }
+  }
+
+  private def update(epoch: Int, states: Seq[(TopicPartition, Int, List[Int])]): UpdateMetadataRequest = {
+    val topics = states.map { case (tp, leader, replicas) =>
+      val partition = new UpdateMetadataPartitionState().setPartitionIndex(tp.partition)
+        .setLeader(leader).setReplicas(replicas.map(Int.box).asJava)
+      new UpdateMetadataTopicState().setTopicName(tp.topic)
+        .setPartitionStates(java.util.Collections.singletonList(partition))
+    }
+    val data = new UpdateMetadataRequestData().setControllerId(0).setControllerEpoch(epoch)
+      .setBrokerEpoch(1L).setTopicStates(topics.asJava)
+    UpdateMetadataRequest.parse(MessageUtil.toByteBuffer(data, 5.toShort), 5.toShort)
+  }
+
+  private def addRecord(manager: ReplicaManager, tp: TopicPartition): Unit = {
+    val log = manager.logManager.getOrCreateLog(tp, isNew = true, topicId = None)
+    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE,
+      new SimpleRecord("old-generation".getBytes(java.nio.charset.StandardCharsets.UTF_8))), 0)
+    assertEquals(1L, log.logEndOffset)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testMetadataDeletionRetiresOnlyUnhostedLogsWhenEnabled(enabled: Boolean): Unit = withManager(enabled) { (_, manager) =>
+    val logs = manager.logManager
+    val stray = new TopicPartition("bridge-stray", 0)
+    val hosted = new TopicPartition("bridge-hosted", 0)
+    val unrelated = new TopicPartition("bridge-unrelated", 0)
+    Seq(stray, hosted, unrelated).foreach(tp => addRecord(manager, tp))
+    manager.createPartition(hosted)
+    manager.maybeUpdateMetadataCache(0, update(1, Seq(stray, hosted, unrelated).map(tp => (tp, 1, List(1)))))
+    val deletions = Seq(stray, hosted).map(tp => (tp, LeaderAndIsr.LeaderDuringDelete, List(1)))
+    assertThrows(classOf[ControllerMovedException], () => manager.maybeUpdateMetadataCache(1, update(0, deletions)))
+    assertTrue(logs.getLog(stray).isDefined, "stale controllers cannot delete logs")
+    manager.maybeUpdateMetadataCache(2, update(1, deletions))
+    assertEquals(!enabled, logs.getLog(stray).isDefined)
+    assertTrue(logs.getLog(hosted).isDefined, "hosted replicas still await StopReplica")
+    assertTrue(logs.getLog(unrelated).isDefined, "an incremental deletion is not a full log image")
+    if (enabled)
+      assertEquals(0L, logs.getOrCreateLog(stray, isNew = true, topicId = None).logEndOffset)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testFullImageRetiresUnassignedLogsAndRetainsLeaderlessAssignments(enabled: Boolean): Unit = withManager(enabled) { (config, manager) =>
+    val logs = manager.logManager
+    val assigned = new TopicPartition("bridge-assigned-without-leader", 0)
+    val reassigned = new TopicPartition("bridge-reassigned-away", 0)
+    val deleted = new TopicPartition("bridge-missed-deletion", 0)
+    val later = new TopicPartition("bridge-after-initial-image", 0)
+    Seq(assigned, reassigned, deleted).foreach(tp => addRecord(manager, tp))
+    val image = Seq((assigned, LeaderAndIsr.NoLeader, List(1)), (reassigned, 0, List(0)))
+    manager.maybeUpdateMetadataCache(0, update(1, image))
+    assertTrue(logs.getLog(assigned).isDefined, "a leaderless assignment still owns its log")
+    assertEquals(!enabled, logs.getLog(reassigned).isDefined)
+    assertEquals(!enabled, logs.getLog(deleted).isDefined)
+
+    // Enabling the gate after an image was accepted must not make an incremental
+    // update look like another full image in the same controller epoch.
+    val props = new Properties
+    props.putAll(config.originals)
+    props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, "true")
+    config.updateCurrentConfig(KafkaConfig.fromProps(props))
+    addRecord(manager, later)
+    manager.maybeUpdateMetadataCache(1, update(1, Seq.empty))
+    assertTrue(logs.getLog(later).isDefined)
+    assertTrue(logs.getLog(assigned).isDefined)
+    manager.maybeUpdateMetadataCache(2, update(2, image))
+    Seq(reassigned, deleted, later).foreach(tp => assertTrue(logs.getLog(tp).isEmpty, tp.toString))
+    assertEquals(1L, logs.getLog(assigned).get.logEndOffset)
   }
 }


### PR DESCRIPTION
A former replica can miss deletion while offline and reintroduce old records after name reuse. The targeted test failed after ISR recovery and promotion: offset 0 contained an old 64-byte record, not the new 128-byte record. It now passes with the fix.

Behind the existing default-off cleanup gate, use the complete initial metadata image to retire unhosted logs that are no longer assigned here. Keep assigned leaderless logs, reject stale controller epochs, and never treat an incremental update as a complete image. Preserve existing JVM methods.

Both versions pass the updated stray-log and metadata-cache tests. The 3.9 follow-up requires scenario revision 3 and both broker directions, and retries only bounded ZooKeeper startup probes. All 68 Python tests pass. The expanded full verifier is running; this remains a draft, not rollout approval.