### PR TITLE
kafka: reconcile returning 3.9 broker logs from full metadata

### DIFF
--- a/.github/workflows/li-ci.yml
+++ b/.github/workflows/li-ci.yml
@@ -229,7 +229,7 @@ jobs:
     env:
       # Checkout fixes the companion source for this run. Record its commit and
       # archive hash; release CI separately requires approved commit hashes.
-      LI_BRIDGE_LEGACY_REF: ${{ vars.LI_BRIDGE_LEGACY_REF || '3.0-li-bridge/stray-log-cleanup' }}
+      LI_BRIDGE_LEGACY_REF: ${{ vars.LI_BRIDGE_LEGACY_REF || '3.0-li-bridge/full-metadata-log-recovery' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -647,7 +647,13 @@ class KafkaController(val config: KafkaConfig,
     // Send update metadata request to all the new brokers in the cluster with a full set of partition states for initialization.
     // In cases of controlled shutdown leaders will not be elected when a new broker comes up. So at least in the
     // common controlled shutdown case, the metadata will reach the new brokers faster.
-    sendUpdateMetadataRequest(newBrokers, controllerContext.partitionsWithLeaders)
+    // Bridge cleanup uses this complete image to retire unassigned local logs.
+    // Include leaderless partitions so their valid recovery logs are retained.
+    val initialPartitions = if (config.liProtocolBridgeTopicDeletionStateCleanupActive)
+      controllerContext.partitionsLeadershipInfo.keySet.toSet
+    else
+      controllerContext.partitionsWithLeaders
+    sendUpdateMetadataRequest(newBrokers, initialPartitions)
     // the very first thing to do when a new broker comes up is send it the entire list of partitions that it is
     // supposed to host. Based on that the broker starts the high watermark threads for the input list of partitions
     val allReplicasOnNewBrokers = controllerContext.replicasOnBrokers(newBrokersSet)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1928,14 +1928,20 @@ class ReplicaManager(val config: KafkaConfig,
         throw new ControllerMovedException(stateChangeLogger.messageWithPrefix(stateControllerEpochErrorMessage))
       } else {
         val zkMetadataCache = metadataCache.asInstanceOf[ZkMetadataCache]
-        val deletedPartitions = zkMetadataCache.updateMetadata(correlationId, updateMetadataRequest,
+        val update = zkMetadataCache.updateMetadataAndGetResult(correlationId, updateMetadataRequest,
           config.liProtocolBridgeTopicDeletionStateCleanupActive)
+        val deletedPartitions = update.deletedPartitions
         controllerEpoch = updateMetadataRequest.controllerEpoch
         if (config.liProtocolBridgeTopicDeletionStateCleanupActive && !updateMetadataRequest.isKRaftController) {
-          // A canceled reassignment can leave a loaded log without a hosted replica.
-          // Retire these local strays on metadata deletion. Hosted replicas still use
-          // StopReplica, which also controls deletion of remote data.
-          val strays = deletedPartitions.filter(tp => getPartition(tp) == HostedPartition.None &&
+          // A returning broker may have missed every deletion notification. Only a
+          // complete image can identify those unassigned logs; incremental updates cannot.
+          val unassigned = if (update.replacedSnapshot) {
+            logManager.allLogs.map(_.topicPartition).filter { tp =>
+              !zkMetadataCache.getPartitionInfo(tp.topic, tp.partition).exists(_.replicas.contains(config.brokerId))
+            }.toSeq
+          } else Seq.empty
+          // Hosted replicas still use StopReplica, which also controls remote deletion.
+          val strays = (deletedPartitions ++ unassigned).filter(tp => getPartition(tp) == HostedPartition.None &&
             logManager.getLog(tp).isDefined).map(tp => StopPartition(tp, deleteLocalLog = true)).toSet
           if (strays.nonEmpty) {
             val failures = stopPartitions(strays)

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -64,6 +64,8 @@ case class MetadataSnapshot(partitionStates: mutable.AnyRefMap[String, mutable.L
   val topicNames: Map[Uuid, String] = topicIds.map { case (topicName, topicId) => (topicId, topicName) }
 }
 
+private[server] case class ZkMetadataCacheUpdate(deletedPartitions: Seq[TopicPartition], replacedSnapshot: Boolean)
+
 object ZkMetadataCache {
   def transformKRaftControllerFullMetadataRequest(
     currentMetadata: MetadataSnapshot,
@@ -472,7 +474,14 @@ class ZkMetadataCache(
     correlationId: Int,
     originalUpdateMetadataRequest: UpdateMetadataRequest,
     reconcileOnControllerChange: Boolean
-  ): Seq[TopicPartition] = {
+  ): Seq[TopicPartition] =
+    updateMetadataAndGetResult(correlationId, originalUpdateMetadataRequest, reconcileOnControllerChange).deletedPartitions
+
+  private[server] def updateMetadataAndGetResult(
+    correlationId: Int,
+    originalUpdateMetadataRequest: UpdateMetadataRequest,
+    reconcileOnControllerChange: Boolean
+  ): ZkMetadataCacheUpdate = {
     var updateMetadataRequest = originalUpdateMetadataRequest
     inWriteLock(partitionMetadataLock) {
       // Upgraded ZK controllers send a full first update for each epoch. Keep the
@@ -622,7 +631,7 @@ class ZkMetadataCache(
         metadataSnapshot = MetadataSnapshot(partitionStates, topicIds.toMap, controllerIdOpt, aliveBrokers, aliveNodes)
       }
       lastMetadataControllerEpoch = math.max(lastMetadataControllerEpoch, updateMetadataRequest.controllerEpoch)
-      deletedPartitions.asScala.toSeq
+      ZkMetadataCacheUpdate(deletedPartitions.asScala.toSeq, replaceMetadata)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
@@ -17,11 +17,12 @@
 package kafka.server
 
 import java.io.File
+import java.util.Properties
 import kafka.api.LeaderAndIsr
-import org.apache.kafka.common.errors.ControllerMovedException
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.compress.Compression
+import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.kafka.common.message.UpdateMetadataRequestData
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataPartitionState, UpdateMetadataTopicState}
 import org.apache.kafka.common.metrics.Metrics
@@ -38,9 +39,7 @@ import org.mockito.Mockito.mock
 import scala.jdk.CollectionConverters._
 
 class BridgeStrayLogDeletionTest {
-  @ParameterizedTest
-  @ValueSource(booleans = Array(false, true))
-  def testMetadataDeletionRetiresOnlyUnhostedLogsWhenEnabled(enabled: Boolean): Unit = {
+  private def withManager(enabled: Boolean)(test: (KafkaConfig, ReplicaManager) => Unit): Unit = {
     val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
     props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, enabled.toString)
     val config = KafkaConfig.fromProps(props)
@@ -53,45 +52,83 @@ class BridgeStrayLogDeletionTest {
       metadataCache = MetadataCache.zkMetadataCache(config.brokerId, config.interBrokerProtocolVersion),
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size),
       alterPartitionManager = mock(classOf[AlterPartitionManager]))
-    val stray = new TopicPartition("bridge-stray", 0)
-    val hosted = new TopicPartition("bridge-hosted", 0)
-    val unrelated = new TopicPartition("bridge-unrelated", 0)
-    def update(epoch: Int, deleted: Boolean): UpdateMetadataRequest = {
-      val states = Seq(stray, hosted).map { tp =>
-        val partition = new UpdateMetadataPartitionState().setPartitionIndex(0)
-          .setLeader(if (deleted) LeaderAndIsr.LeaderDuringDelete else 1)
-          .setReplicas(java.util.Arrays.asList(Int.box(1)))
-        new UpdateMetadataTopicState().setTopicName(tp.topic)
-          .setPartitionStates(java.util.Collections.singletonList(partition))
-      }
-      val data = new UpdateMetadataRequestData().setControllerId(0).setControllerEpoch(epoch)
-        .setBrokerEpoch(1L).setTopicStates(states.asJava)
-      UpdateMetadataRequest.parse(MessageUtil.toByteBuffer(data, 5.toShort), 5.toShort)
-    }
-    try {
-      Seq(stray, hosted, unrelated).foreach { tp =>
-        val log = logs.getOrCreateLog(tp, isNew = true, topicId = None)
-        log.appendAsLeader(MemoryRecords.withRecords(Compression.NONE,
-          new SimpleRecord("old-generation".getBytes(java.nio.charset.StandardCharsets.UTF_8))), 0)
-        assertEquals(1L, log.logEndOffset)
-      }
-      manager.createPartition(hosted)
-      manager.maybeUpdateMetadataCache(0, update(1, deleted = false))
-      assertThrows(classOf[ControllerMovedException], () =>
-        manager.maybeUpdateMetadataCache(1, update(0, deleted = true)))
-      assertTrue(logs.getLog(stray).isDefined, "stale controllers cannot delete logs")
-      manager.maybeUpdateMetadataCache(2, update(1, deleted = true))
-      assertEquals(!enabled, logs.getLog(stray).isDefined)
-      assertTrue(logs.getLog(hosted).isDefined, "hosted replicas still await StopReplica")
-      assertTrue(logs.getLog(unrelated).isDefined, "an incremental deletion is not a full log image")
-      if (enabled)
-        assertEquals(0L, logs.getOrCreateLog(stray, isNew = true, topicId = None).logEndOffset)
-    } finally {
+    try test(config, manager)
+    finally {
       manager.shutdown(checkpointHW = false)
       logs.shutdown()
       quotas.shutdown()
       metrics.close()
       TestUtils.clearYammerMetrics()
     }
+  }
+
+  private def update(epoch: Int, states: Seq[(TopicPartition, Int, List[Int])]): UpdateMetadataRequest = {
+    val topics = states.map { case (tp, leader, replicas) =>
+      val partition = new UpdateMetadataPartitionState().setPartitionIndex(tp.partition)
+        .setLeader(leader).setReplicas(replicas.map(Int.box).asJava)
+      new UpdateMetadataTopicState().setTopicName(tp.topic)
+        .setPartitionStates(java.util.Collections.singletonList(partition))
+    }
+    val data = new UpdateMetadataRequestData().setControllerId(0).setControllerEpoch(epoch)
+      .setBrokerEpoch(1L).setTopicStates(topics.asJava)
+    UpdateMetadataRequest.parse(MessageUtil.toByteBuffer(data, 5.toShort), 5.toShort)
+  }
+
+  private def addRecord(manager: ReplicaManager, tp: TopicPartition): Unit = {
+    val log = manager.logManager.getOrCreateLog(tp, isNew = true, topicId = None)
+    log.appendAsLeader(MemoryRecords.withRecords(Compression.NONE,
+      new SimpleRecord("old-generation".getBytes(java.nio.charset.StandardCharsets.UTF_8))), 0)
+    assertEquals(1L, log.logEndOffset)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testMetadataDeletionRetiresOnlyUnhostedLogsWhenEnabled(enabled: Boolean): Unit = withManager(enabled) { (_, manager) =>
+    val logs = manager.logManager
+    val stray = new TopicPartition("bridge-stray", 0)
+    val hosted = new TopicPartition("bridge-hosted", 0)
+    val unrelated = new TopicPartition("bridge-unrelated", 0)
+    Seq(stray, hosted, unrelated).foreach(tp => addRecord(manager, tp))
+    manager.createPartition(hosted)
+    manager.maybeUpdateMetadataCache(0, update(1, Seq(stray, hosted, unrelated).map(tp => (tp, 1, List(1)))))
+    val deletions = Seq(stray, hosted).map(tp => (tp, LeaderAndIsr.LeaderDuringDelete, List(1)))
+    assertThrows(classOf[ControllerMovedException], () => manager.maybeUpdateMetadataCache(1, update(0, deletions)))
+    assertTrue(logs.getLog(stray).isDefined, "stale controllers cannot delete logs")
+    manager.maybeUpdateMetadataCache(2, update(1, deletions))
+    assertEquals(!enabled, logs.getLog(stray).isDefined)
+    assertTrue(logs.getLog(hosted).isDefined, "hosted replicas still await StopReplica")
+    assertTrue(logs.getLog(unrelated).isDefined, "an incremental deletion is not a full log image")
+    if (enabled)
+      assertEquals(0L, logs.getOrCreateLog(stray, isNew = true, topicId = None).logEndOffset)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testFullImageRetiresUnassignedLogsAndRetainsLeaderlessAssignments(enabled: Boolean): Unit = withManager(enabled) { (config, manager) =>
+    val logs = manager.logManager
+    val assigned = new TopicPartition("bridge-assigned-without-leader", 0)
+    val reassigned = new TopicPartition("bridge-reassigned-away", 0)
+    val deleted = new TopicPartition("bridge-missed-deletion", 0)
+    val later = new TopicPartition("bridge-after-initial-image", 0)
+    Seq(assigned, reassigned, deleted).foreach(tp => addRecord(manager, tp))
+    val image = Seq((assigned, LeaderAndIsr.NoLeader, List(1)), (reassigned, 0, List(0)))
+    manager.maybeUpdateMetadataCache(0, update(1, image))
+    assertTrue(logs.getLog(assigned).isDefined, "a leaderless assignment still owns its log")
+    assertEquals(!enabled, logs.getLog(reassigned).isDefined)
+    assertEquals(!enabled, logs.getLog(deleted).isDefined)
+
+    // Enabling the gate after an image was accepted must not make an incremental
+    // update look like another full image in the same controller epoch.
+    val props = new Properties
+    props.putAll(config.originals)
+    props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, "true")
+    config.updateCurrentConfig(KafkaConfig.fromProps(props))
+    addRecord(manager, later)
+    manager.maybeUpdateMetadataCache(1, update(1, Seq.empty))
+    assertTrue(logs.getLog(later).isDefined)
+    assertTrue(logs.getLog(assigned).isDefined)
+    manager.maybeUpdateMetadataCache(2, update(2, image))
+    Seq(reassigned, deleted, later).foreach(tp => assertTrue(logs.getLog(tp).isEmpty, tp.toString))
+    assertEquals(1L, logs.getLog(assigned).get.logEndOffset)
   }
 }

--- a/tests/bin/LiBridgeMetadataChurn.java
+++ b/tests/bin/LiBridgeMetadataChurn.java
@@ -22,7 +22,10 @@ import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ControllerMovedException;
+import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.errors.InvalidReplicaAssignmentException;
+import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.common.errors.NoReassignmentInProgressException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TopicExistsException;
@@ -41,6 +44,25 @@ import java.util.concurrent.TimeUnit;
 /** Continuous old-Admin metadata mutations; never relies on a quiet controller queue. */
 public final class LiBridgeMetadataChurn {
     private LiBridgeMetadataChurn() { }
+
+    static boolean retryMutation(Throwable cause) {
+        return retryTransientFailure(cause) || cause instanceof TopicExistsException ||
+            cause instanceof InvalidReplicaAssignmentException;
+    }
+
+    static boolean retryDeletion(Throwable cause) {
+        return retryTransientFailure(cause) || cause instanceof UnknownTopicOrPartitionException;
+    }
+
+    private static boolean retryTransientFailure(Throwable cause) {
+        // These data errors inherit RetriableException, but must fail qualification.
+        if (cause instanceof KafkaStorageException || cause instanceof CorruptRecordException) {
+            return false;
+        }
+        // A deliberate controller move can fence a 3.9 ZooKeeper config write.
+        // Old clients map that response to a non-retriable ControllerMovedException.
+        return cause instanceof RetriableException || cause instanceof ControllerMovedException;
+    }
 
     public static void main(String[] args) throws Exception {
         if (args.length != 2) {
@@ -97,8 +119,7 @@ public final class LiBridgeMetadataChurn {
                 } catch (ExecutionException e) {
                     Throwable cause = e.getCause();
                     System.err.println(java.time.Instant.now() + " mutation retry at " + Files.readString(directory.resolve("stage")) + ": " + cause);
-                    if (!(cause instanceof RetriableException) && !(cause instanceof TopicExistsException) &&
-                            !(cause instanceof InvalidReplicaAssignmentException)) {
+                    if (!retryMutation(cause)) {
                         throw e;
                     }
                 }
@@ -119,7 +140,7 @@ public final class LiBridgeMetadataChurn {
                     Files.move(temporary, directory.resolve("progress"), StandardCopyOption.REPLACE_EXISTING);
                 } catch (ExecutionException e) {
                     System.err.println(java.time.Instant.now() + " deletion retry: " + e.getCause());
-                    if (!(e.getCause() instanceof RetriableException) && !(e.getCause() instanceof UnknownTopicOrPartitionException)) {
+                    if (!retryDeletion(e.getCause())) {
                         throw e;
                     }
                 }

--- a/tests/bin/LiBridgeMetadataChurnRetryTest.java
+++ b/tests/bin/LiBridgeMetadataChurnRetryTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.kafka.common.protocol.Errors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Run against each real client archive before starting the migration. */
+public final class LiBridgeMetadataChurnRetryTest {
+    private LiBridgeMetadataChurnRetryTest() { }
+
+    public static void main(String[] args) {
+        List<String> failures = new ArrayList<>();
+        for (Errors error : new Errors[] {Errors.STALE_CONTROLLER_EPOCH, Errors.NOT_CONTROLLER,
+                Errors.NETWORK_EXCEPTION, Errors.REQUEST_TIMED_OUT, Errors.UNKNOWN_TOPIC_OR_PARTITION}) {
+            check(failures, error.exception(), true, true);
+        }
+        for (Errors error : new Errors[] {Errors.TOPIC_ALREADY_EXISTS, Errors.INVALID_REPLICA_ASSIGNMENT}) {
+            check(failures, error.exception(), true, false);
+        }
+        for (Errors error : new Errors[] {Errors.TOPIC_AUTHORIZATION_FAILED, Errors.CLUSTER_AUTHORIZATION_FAILED,
+                Errors.INVALID_REQUEST, Errors.INVALID_CONFIG, Errors.KAFKA_STORAGE_ERROR,
+                Errors.CORRUPT_MESSAGE, Errors.MESSAGE_TOO_LARGE}) {
+            check(failures, error.exception(), false, false);
+        }
+        check(failures, new AssertionError("record mismatch"), false, false);
+        check(failures, new InterruptedException("interrupted"), false, false);
+        check(failures, new IllegalStateException("unexpected failure"), false, false);
+        if (!failures.isEmpty()) {
+            throw new AssertionError(failures.toString());
+        }
+        System.out.println("Metadata churn retry classification: passed");
+    }
+
+    private static void check(List<String> failures, Throwable cause, boolean mutation, boolean deletion) {
+        if (LiBridgeMetadataChurn.retryMutation(cause) != mutation) {
+            failures.add(cause.getClass().getSimpleName() + " mutation retry must be " + mutation);
+        }
+        if (LiBridgeMetadataChurn.retryDeletion(cause) != deletion) {
+            failures.add(cause.getClass().getSimpleName() + " deletion retry must be " + deletion);
+        }
+    }
+}

--- a/tests/bin/README.li-bridge.md
+++ b/tests/bin/README.li-bridge.md
@@ -82,9 +82,11 @@ The fixture sets a 1 MiB client and server response limit. It checks complete re
 
 The verifier runs this fixture as the `vendor-pagination` stage. The packaged-runtime probe and broker startup check separately reject enabled pagination with a stock client. The isolated fixture does **not** select the deployed dependency or qualify an untested server version.
 
-## Phase and workload evidence (contract version 2)
+## Phase and workload evidence (contract version 2, scenario revision 3)
 
 The shell entry point runs `li_bridge_mixed_cluster_smoke.py`. The test starts all-3.0 with bridge mode off, LI async fetching on and combined control on. It tests activation and backout, both binary rollback paths, hard failures, replica recovery, and deletion followed by name reuse. It then tests native control at IBP 3.0 and a separate IBP 3.9 roll.
+
+Scenario revision 3 also keeps a former replica offline through reassignment, deletion and name reuse. It checks the replacement topic, brings the old replica back, reassigns it into ISR, promotes it, and verifies the new bytes. Both broker generations must pass. An initial full metadata image may retire unassigned logs; same-epoch incremental updates must not. Evidence from an older scenario revision does not cover this case.
 
 The same old clients and Connect worker stay alive throughout. A second old Admin client keeps creating, expanding, cancelling, shrinking and deleting a topic while brokers roll. Private APIs run with both old and new jars. The record checks compare contents, not just counts. Ordinary traffic is limited to one record pair every 100 ms so the in-memory test ledger stays bounded; this is not a throughput benchmark.
 

--- a/tests/bin/audit_li_bridge_evidence.py
+++ b/tests/bin/audit_li_bridge_evidence.py
@@ -66,7 +66,8 @@ REQUIRED_TIMING_OPERATIONS: Tuple[str, ...] = (
     "canary rollback to 3.0",
     "all-3.9 rollback to 3.0",
     "hard controller recovery",
-) + tuple(f"old clients phase {phase}" for phase in PHASES)
+) + tuple(f"old clients phase {phase}" for phase in PHASES) + tuple(
+    f"offline name-reuse {generation} records verified after promotion" for generation in ("3.0", "3.9"))
 
 REQUIRED_RESOURCE_PHASES: Tuple[str, ...] = (
     "mixed-metadata-loaded",

--- a/tests/bin/li_bridge_contract.py
+++ b/tests/bin/li_bridge_contract.py
@@ -24,6 +24,7 @@ import json
 import os
 
 CONTRACT_VERSION = 2
+SCENARIO_REVISION = 3
 MODE = "li.protocol.bridge.mode.enable"
 TOPIC_CLEANUP = "li.protocol.bridge.topic.deletion.state.cleanup.enable"
 # The Kafka registry and metric-name set are checked against this table by tests.
@@ -104,7 +105,8 @@ def transition_allowed(previous, phase):
 
 def scenario_spec(environment=None):
     environment = os.environ if environment is None else environment
-    result = {"contract_version": CONTRACT_VERSION, "profile": "legacy-async-rollback-old-clients",
+    result = {"contract_version": CONTRACT_VERSION, "scenario_revision": SCENARIO_REVISION,
+              "profile": "legacy-async-rollback-old-clients",
               "old_client_interval_ms": 100}
     for name, default in SCENARIO_DEFAULTS.items():
         raw = str(environment.get(name, default))

--- a/tests/bin/li_bridge_mixed_cluster_smoke.py
+++ b/tests/bin/li_bridge_mixed_cluster_smoke.py
@@ -173,9 +173,20 @@ class Migration:
             self.timings.append((label, round(time.monotonic() - start, 3), "failed"))
             raise
 
-    def zk(self, command):
+    def zk(self, command, timeout=30):
         return self.command([self.homes["3.9"] / "bin/zookeeper-shell.sh", f"127.0.0.1:{self.zk_port}"],
-                            input_text=command + "\n", check=False, timeout=30, allow_missing=True) or ""
+                            input_text=command + "\n", check=False, timeout=timeout, allow_missing=True) or ""
+
+    def zookeeper_ready(self):
+        process = self.processes["zookeeper"]
+        if process.poll() is not None:
+            raise AssertionError(f"ZooKeeper exited during startup: {process.returncode}")
+        try:
+            return "[zookeeper]" in self.zk("ls /", timeout=5)
+        except subprocess.TimeoutExpired:
+            # A socket may open before the server has loaded its database. Retry only
+            # this startup probe; do not hide timeouts in the migration itself.
+            return False
 
     def registered(self, identifier):
         return '"version"' in self.zk(f"get /brokers/ids/{identifier}")
@@ -378,6 +389,52 @@ class Migration:
         self.start_broker(1, "3.9")
         self.until("recovery ledger final ISR", self.healthy)
 
+    def offline_name_reuse(self, offline):
+        survivor = 1 - offline
+        offline_generation = self.generations[offline]
+        survivor_generation = self.generations[survivor]
+        topic = f"bridge-offline-name-reuse-{offline_generation}"
+        self.force_controller(survivor)
+        self.create(topic, f"{survivor}:{offline}")
+        self.java("LiBridgeRecords", "produce", self.bootstrap, topic, 0, 1, 64)
+        self.stop(f"broker-{offline}", hard=True)
+        self.until(f"{offline_generation} former replica offline for name reuse", lambda: not self.registered(offline), 60)
+
+        def reassign(replicas):
+            path = self.work / "offline-name-reuse-reassignment.json"
+            path.write_text(json.dumps({"version": 1, "partitions": [
+                {"topic": topic, "partition": 0, "replicas": replicas}]}))
+            self.admin("kafka-reassign-partitions.sh", "--reassignment-json-file", path, "--execute")
+            def complete():
+                description = self.admin("kafka-topics.sh", "--describe", "--topic", topic, check=False) or ""
+                match = re.search(r"Replicas:\s+([0-9,]+)\s+Isr:\s+([0-9,]+)", description)
+                if not match:
+                    return False
+                assigned = list(map(int, match[1].split(",")))
+                in_sync = set(map(int, match[2].split(",")))
+                return assigned == replicas and in_sync == set(replicas)
+            self.until(f"offline name-reuse assignment {replicas}", complete)
+
+        reassign([survivor])
+        self.admin("kafka-topics.sh", "--delete", "--topic", topic)
+        self.until("name deleted while former replica offline", lambda:
+                   topic not in (self.admin("kafka-topics.sh", "--list", check=False) or "").splitlines() and
+                   "Node does not exist" in self.zk(f"get /brokers/topics/{topic}"))
+        self.create(topic, str(survivor))
+        self.java("LiBridgeRecords", "produce", self.bootstrap, topic, 0, 2, 128)
+        self.java("LiBridgeRecords", "verify", self.bootstrap, topic, 0, 2, 128)
+        self.start_broker(offline, offline_generation)
+        self.until("rejoined broker ISR recovery", self.healthy)
+        reassign([survivor, offline])
+        self.stop(f"broker-{survivor}", hard=True)
+        self.until("rejoined replica promoted", lambda: f"Leader: {offline}" in
+                   (self.admin("kafka-topics.sh", "--describe", "--topic", topic, check=False) or ""), 60)
+        # Exit on a changed record immediately; retrying could hide old bytes.
+        self.until(f"offline name-reuse {offline_generation} records verified after promotion", lambda:
+                   self.java("LiBridgeRecords", "verify", self.bootstrap, topic, 0, 2, 128) is not None)
+        self.start_broker(survivor, survivor_generation)
+        self.until("offline name-reuse final ISR recovery", self.healthy)
+
     def cancellation(self):
         self.force_controller(1)
         self.start_broker(2, "3.9")
@@ -444,7 +501,7 @@ class Migration:
         write_properties(self.work / "zookeeper.properties", {"clientPort": self.zk_port,
                          "dataDir": self.work / "zk-data", "maxClientCnxns": 0, "admin.enableServer": "false"})
         self.start("zookeeper", [self.homes["3.9"] / "bin/zookeeper-server-start.sh", self.work / "zookeeper.properties"])
-        self.until("ZooKeeper startup", lambda: "[]" in self.zk("ls /brokers/ids") or "[zookeeper]" in self.zk("ls /"), 60)
+        self.until("ZooKeeper startup", self.zookeeper_ready, 60)
 
     def run(self):
         self.prepare()
@@ -486,6 +543,8 @@ class Migration:
         self.checkpoint("mixed")
         self.resources_at("mixed-old-clients-complete")
         self.recovery()
+        self.offline_name_reuse(0)
+        self.offline_name_reuse(1)
         self.cancellation()
         self.truncation()
         self.checkpoint("mixed")

--- a/tests/bin/li_bridge_mixed_cluster_smoke.py
+++ b/tests/bin/li_bridge_mixed_cluster_smoke.py
@@ -587,7 +587,9 @@ class Migration:
     def verify_protocol_logs(self):
         selected = []
         for generation in ("3.0", "3.9"):
-            logs = "\n".join(path.read_text(errors="replace") for path in self.work.glob(f"broker-*-{generation}-logs/controller.log"))
+            # Hourly rotation must not erase a protocol decision or hide an error.
+            paths = sorted(self.work.glob(f"broker-*-{generation}-logs/controller.log*"))
+            logs = "\n".join(path.read_text(errors="replace") for path in paths)
             enabled = "LI protocol bridge mode enabled: LeaderAndIsr=v2, UpdateMetadata=v5, StopReplica=v1"
             if enabled not in logs:
                 raise AssertionError(f"Missing {generation} controller bridge selection")
@@ -595,7 +597,7 @@ class Migration:
         (self.evidence / "protocol-selection.log").write_text("\n".join(selected))
         if not any("LI protocol bridge mode disabled" in line for line in selected):
             raise AssertionError("Native control selection missing")
-        for path in list(self.work.glob("broker-*.log")) + list(self.work.glob("broker-*-logs/*.log")):
+        for path in list(self.work.glob("broker-*.log*")) + list(self.work.glob("broker-*-logs/*.log*")):
             if re.search(r"UnsupportedVersionException|Error parsing.*(?:LeaderAndIsr|UpdateMetadata|StopReplica)|unknown api key",
                          path.read_text(errors="replace"), re.IGNORECASE):
                 raise AssertionError(f"Protocol error in {path}")
@@ -651,7 +653,7 @@ class Migration:
         (self.evidence / "run-summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True))
         if os.environ.get("EVIDENCE_INCLUDE_LOGS", "1") == "1":
             with tarfile.open(self.evidence / "process-logs.tgz", "w:gz") as archive:
-                for path in self.work.rglob("*.log"):
+                for path in self.work.rglob("*.log*"):
                     if not path.is_relative_to(self.evidence):
                         archive.add(path, arcname=str(path.relative_to(self.work)))
         # Preserve failures and default in-work evidence. Never silently erase the only proof.

--- a/tests/bin/li_bridge_mixed_cluster_smoke.py
+++ b/tests/bin/li_bridge_mixed_cluster_smoke.py
@@ -489,13 +489,15 @@ class Migration:
             self.homes[generation] = homes[0]
             classes = self.work / f"classes-{generation}"
             classes.mkdir()
-            helpers = ["LiBridgePrivateApiSmoke.java", "LiBridgeRecords.java"]
+            helpers = ["LiBridgePrivateApiSmoke.java", "LiBridgeRecords.java",
+                       "LiBridgeMetadataChurn.java", "LiBridgeMetadataChurnRetryTest.java"]
             if generation == "3.0":
-                helpers.extend(["LiBridgeContinuousClients.java", "LiBridgeMetadataChurn.java"])
+                helpers.append("LiBridgeContinuousClients.java")
             else:
                 helpers.extend(["LiBridgeMetadataScaleSmoke.java", "LiBridgeLiveInventory.java", "LiBridgeRuntimeProbe.java"])
             self.command(["javac", "--release", "11", "-cp", f"{homes[0] / 'libs'}/*", "-d", classes,
                           *[SCRIPT_DIR / name for name in helpers]])
+            self.java("LiBridgeMetadataChurnRetryTest", generation=generation)
         self.java("LiBridgeContinuousClients", "--self-test")
         self.java("LiBridgeRuntimeProbe", self.evidence / "packaged-runtime-39.json", "false", generation="3.9")
         write_properties(self.work / "zookeeper.properties", {"clientPort": self.zk_port,

--- a/tests/unit/li_bridge_evidence_audit_test.py
+++ b/tests/unit/li_bridge_evidence_audit_test.py
@@ -216,6 +216,16 @@ class LiBridgeEvidenceAuditTest(unittest.TestCase):
             self.write_json(path, data)
             self.assertFalse(AUDITOR.audit(root)["passed"])
 
+    def test_old_scenario_revision_does_not_qualify_offline_name_reuse(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_evidence(root)
+            path = root / "mixed-process/run-summary.json"
+            data = json.loads(path.read_text())
+            data["scenario"].pop("scenario_revision")
+            self.write_json(path, data)
+            self.assertFalse(AUDITOR.audit(root)["passed"])
+
     def supplied_evidence(self, root):
         archives = self.create_evidence(root)
         path = root / "source-fingerprints.json"
@@ -350,6 +360,19 @@ class LiBridgeEvidenceAuditTest(unittest.TestCase):
             result = AUDITOR.audit(root)
             self.assertFalse(result["passed"])
             self.assertTrue(any(missing_operation in issue for issue in result["issues"]))
+
+    def test_offline_name_reuse_requires_both_record_verifications(self):
+        for generation in ("3.0", "3.9"):
+            with self.subTest(generation=generation), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                self.create_evidence(root)
+                timings = root / "mixed-process/timings.tsv"
+                operation = f"offline name-reuse {generation} records verified after promotion"
+                timings.write_text("".join(line for line in timings.read_text().splitlines(True)
+                                           if not line.startswith(operation + "\t")))
+                result = AUDITOR.audit(root)
+                self.assertFalse(result["passed"])
+                self.assertTrue(any(operation in issue for issue in result["issues"]))
 
     def test_invalid_utf8_is_an_issue_not_an_auditor_crash(self):
         for filename in ("verification-summary.json", "commands.tsv", "mixed-process/protocol-selection.log"):

--- a/tests/unit/li_bridge_scenario_test.py
+++ b/tests/unit/li_bridge_scenario_test.py
@@ -102,6 +102,30 @@ class LiBridgeScenarioTest(unittest.TestCase):
             self.assertEqual(b"retained failure detail", data)
             self.assertTrue(rotated.exists())
 
+    def test_prepare_checks_retry_policy_with_both_client_archives(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runner = object.__new__(Migration)
+            runner.work = Path(directory)
+            runner.evidence = runner.work / "evidence"
+            runner.evidence.mkdir()
+            runner.zk_port, runner.homes, runner.archives = 22181, {}, {}
+            for generation in ("3.0", "3.9"):
+                path = runner.work / f"{generation}.tgz"
+                with tarfile.open(path, "w:gz") as archive:
+                    archive.addfile(tarfile.TarInfo("kafka/libs/fixture"))
+                runner.archives[generation] = path
+            with mock.patch("li_bridge_mixed_cluster_smoke.snapshot_archive",
+                            side_effect=lambda path, *_: {"path": str(path)}), \
+                    mock.patch.object(runner, "command") as command, \
+                    mock.patch.object(runner, "java") as java, \
+                    mock.patch.object(runner, "start"), mock.patch.object(runner, "until"):
+                runner.prepare()
+            for generation in ("3.0", "3.9"):
+                java.assert_any_call("LiBridgeMetadataChurnRetryTest", generation=generation)
+            self.assertEqual(2, command.call_count)
+            for call in command.call_args_list:
+                self.assertIn("LiBridgeMetadataChurnRetryTest.java", [Path(arg).name for arg in call.args[0]])
+
     def test_manifest_has_every_gate_and_effective_metric(self):
         root = Path(__file__).parents[2]
         config = (root / "core/src/main/scala/kafka/server/KafkaConfig.scala").read_text()

--- a/tests/unit/li_bridge_scenario_test.py
+++ b/tests/unit/li_bridge_scenario_test.py
@@ -31,6 +31,7 @@ from li_bridge_preflight import parse_properties, zk_command
 class LiBridgeScenarioTest(unittest.TestCase):
     def test_scenario_defaults_validation_and_runtime_profile(self):
         default = scenario_spec({})
+        self.assertEqual(3, default["scenario_revision"])
         self.assertEqual(default, scenario_spec({"SCALE_TOPIC_COUNT": "10"}))
         for key in ("SCALE_TOPIC_COUNT", "SCALE_PARTITION_COUNT", "RECOVERY_RECORD_COUNT", "RECOVERY_RECORD_SIZE"):
             for value in ("0", "-1", "bad", "2147483648"):
@@ -40,6 +41,20 @@ class LiBridgeScenarioTest(unittest.TestCase):
         self.assertNotEqual(default, scenario_spec({"KAFKA_HEAP_OPTS": "-Xmx2g"}))
         self.assertNotEqual(default, scenario_spec({"LI_BRIDGE_JAVA_30_HOME": "/jdk11"}))
         self.assertEqual({"dormant", "legacy-bridge", "mixed", "all-39-bridge", "native", "ibp-39"}, set(PHASES))
+
+    def test_zookeeper_startup_retries_a_probe_timeout_but_not_a_dead_server(self):
+        runner = object.__new__(Migration)
+        process = mock.Mock()
+        process.poll.return_value = None
+        runner.processes = {"zookeeper": process}
+        with mock.patch.object(runner, "zk", side_effect=[subprocess.TimeoutExpired(["zk"], 5), "[zookeeper]\n"]) as probe:
+            self.assertFalse(runner.zookeeper_ready())
+            self.assertTrue(runner.zookeeper_ready())
+            probe.assert_called_with("ls /", timeout=5)
+        process.poll.return_value = 1
+        process.returncode = 1
+        with self.assertRaisesRegex(AssertionError, "exited during startup"):
+            runner.zookeeper_ready()
 
     def test_manifest_has_every_gate_and_effective_metric(self):
         root = Path(__file__).parents[2]

--- a/tests/unit/li_bridge_scenario_test.py
+++ b/tests/unit/li_bridge_scenario_test.py
@@ -16,6 +16,7 @@
 import re
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 import unittest
@@ -55,6 +56,51 @@ class LiBridgeScenarioTest(unittest.TestCase):
         process.returncode = 1
         with self.assertRaisesRegex(AssertionError, "exited during startup"):
             runner.zookeeper_ready()
+
+    def test_protocol_selection_and_errors_include_rotated_logs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runner = object.__new__(Migration)
+            runner.work = Path(directory)
+            runner.evidence = runner.work / "evidence"
+            runner.evidence.mkdir()
+            enabled = "LI protocol bridge mode enabled: LeaderAndIsr=v2, UpdateMetadata=v5, StopReplica=v1"
+            for generation in ("3.0", "3.9"):
+                logs = runner.work / f"broker-0-{generation}-logs"
+                logs.mkdir()
+                (logs / "controller.log.2026-09-11-07").write_text(enabled)
+                (logs / "controller.log").write_text("LI protocol bridge mode disabled")
+            runner.verify_protocol_logs()
+            self.assertEqual(2, (runner.evidence / "protocol-selection.log").read_text().count(enabled))
+            rotated = logs / "server.log.2026-09-11-07"
+            for error in ("UnsupportedVersionException", "Error parsing LeaderAndIsr", "unknown api key"):
+                with self.subTest(error=error):
+                    rotated.write_text(error)
+                    with self.assertRaisesRegex(AssertionError, "Protocol error"):
+                        runner.verify_protocol_logs()
+            rotated.unlink()
+            (logs / "controller.log.2026-09-11-07").unlink()
+            with self.assertRaisesRegex(AssertionError, "Missing 3.9 controller bridge selection"):
+                runner.verify_protocol_logs()
+
+    def test_failure_archive_retains_rotated_logs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runner = object.__new__(Migration)
+            runner.work = Path(directory)
+            runner.evidence = runner.work / "evidence"
+            runner.evidence.mkdir()
+            runner.processes, runner.source_hashes, runner.archives = {}, {}, {}
+            runner.handles, runner.timings, runner.resources = [], [], []
+            runner.started = "2026-09-11T07:00:00+00:00"
+            runner.scenario = scenario_spec({})
+            rotated = runner.work / "broker-0-3.9-logs/controller.log.2026-09-11-07"
+            rotated.parent.mkdir()
+            rotated.write_text("retained failure detail")
+            with mock.patch.object(runner, "diagnostics"), mock.patch.dict("os.environ", {"EVIDENCE_INCLUDE_LOGS": "1"}):
+                self.assertFalse(runner.finish(False))
+            with tarfile.open(runner.evidence / "process-logs.tgz") as archive:
+                data = archive.extractfile(str(rotated.relative_to(runner.work))).read()
+            self.assertEqual(b"retained failure detail", data)
+            self.assertTrue(rotated.exists())
 
     def test_manifest_has_every_gate_and_effective_metric(self):
         root = Path(__file__).parents[2]


### PR DESCRIPTION
A former replica can miss deletion while offline and reintroduce old records after name reuse. The targeted test failed after ISR recovery and promotion: offset 0 contained an old 64-byte record, not the new 128-byte record. It now passes with the fix.

Behind the existing default-off cleanup gate, use the complete initial metadata image to retire unhosted logs that are no longer assigned here. Keep assigned leaderless logs, reject stale controller epochs, and never treat an incremental update as a complete image. Preserve existing JVM methods.

Both versions pass the updated stray-log and metadata-cache tests. The 3.9 follow-up requires scenario revision 3 and both broker directions, and retries only bounded ZooKeeper startup probes. All 68 Python tests pass. The expanded full verifier is running; this remains a draft, not rollout approval.