### PR TITLE
kafka: verify 3.0 topic identity before reusing logs

### DIFF
--- a/core/src/main/scala/kafka/server/BridgeTopicIdentity.scala
+++ b/core/src/main/scala/kafka/server/BridgeTopicIdentity.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.errors.{InconsistentTopicIdException, KafkaStorageException}
+
+private[server] object BridgeTopicIdentity {
+  // Bridge control versions omit topic IDs. Read the existing ZooKeeper identity
+  // when handling control requests, not on the produce/fetch data path.
+  def read(topics: Set[String], client: Option[KafkaZkClient]): Map[String, Uuid] = {
+    if (topics.isEmpty) return Map.empty
+    val zk = client.getOrElse(throw new IllegalStateException("Bridge topic identity requires a ZooKeeper client"))
+    val ids = zk.getTopicIdsForTopics(topics)
+    val missing = topics.filter(topic => ids.get(topic).forall(_ == Uuid.ZERO_UUID))
+    if (missing.nonEmpty)
+      throw new KafkaStorageException(s"Cannot verify bridge topic identity for ${missing.toSeq.sorted.mkString(",")}")
+    ids.toMap
+  }
+
+  def verifyWireIds(current: Map[String, Uuid], requested: java.util.Map[String, Uuid]): Unit = {
+    current.foreach { case (topic, id) =>
+      Option(requested.get(topic)).filter(_ != Uuid.ZERO_UUID).foreach { wireId =>
+        if (wireId != id)
+          throw new InconsistentTopicIdException(s"Controller and ZooKeeper topic identities disagree for $topic")
+      }
+    }
+  }
+
+  def isObsolete(partition: TopicPartition, stored: Option[Uuid], current: Uuid, empty: Boolean): Boolean = {
+    stored match {
+      case Some(id) if id != Uuid.ZERO_UUID => id != current
+      case _ if empty => false
+      case _ =>
+        throw new KafkaStorageException(s"Cannot verify nonempty log $partition without a stored topic ID; " +
+          "retain the log and require an operator recovery decision")
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/BridgeTopicIdentity.scala
+++ b/core/src/main/scala/kafka/server/BridgeTopicIdentity.scala
@@ -26,14 +26,14 @@ private[server] object BridgeTopicIdentity {
   def read(topics: Set[String], client: Option[KafkaZkClient]): Map[String, Uuid] = {
     if (topics.isEmpty) return Map.empty
     val zk = client.getOrElse(throw new IllegalStateException("Bridge topic identity requires a ZooKeeper client"))
-    val ids = zk.getTopicIdsForTopics(topics)
-    val missing = topics.filter(topic => ids.get(topic).forall(_ == Uuid.ZERO_UUID))
-    if (missing.nonEmpty)
-      throw new KafkaStorageException(s"Cannot verify bridge topic identity for ${missing.toSeq.sorted.mkString(",")}")
-    ids.toMap
+    val identities = zk.getTopicIdentities(topics)
+    val unverified = identities.filter { case (_, id) => id.forall(_ == Uuid.ZERO_UUID) }.keys
+    if (unverified.nonEmpty)
+      throw new KafkaStorageException(s"Cannot verify bridge topic identity for ${unverified.toSeq.sorted.mkString(",")}")
+    identities.map { case (topic, id) => topic -> id.get }.toMap
   }
 
-  def verifyWireIds(current: Map[String, Uuid], requested: java.util.Map[String, Uuid]): Unit = {
+  def verifyWireIds(current: scala.collection.Map[String, Uuid], requested: java.util.Map[String, Uuid]): Unit = {
     current.foreach { case (topic, id) =>
       Option(requested.get(topic)).filter(_ != Uuid.ZERO_UUID).foreach { wireId =>
         if (wireId != id)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -2239,6 +2239,9 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   validateValues()
 
   private def validateValues(): Unit = {
+    if (liProtocolBridgeTopicDeletionStateCleanupActive && !usesTopicId)
+      throw new ConfigException(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, true,
+        "requires topic IDs (inter.broker.protocol.version 2.8 or newer)")
     if (requiresZookeeper) {
       if (zkConnect == null) {
         throw new ConfigException(s"Missing required configuration `${KafkaConfig.ZkConnectProp}` which has no default value.")

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1506,8 +1506,9 @@ class ReplicaManager(val config: KafkaConfig,
             !unassigned.contains(log.topicPartition))
           val currentIds = BridgeTopicIdentity.read(assignedLogs.map(_.topicPartition.topic).toSet, zkClient)
           val obsolete = assignedLogs.filter { log =>
-            BridgeTopicIdentity.isObsolete(log.topicPartition, log.topicId, currentIds(log.topicPartition.topic),
-              log.logEndOffset == 0L)
+            currentIds.get(log.topicPartition.topic).exists { id =>
+              BridgeTopicIdentity.isObsolete(log.topicPartition, log.topicId, id, log.logEndOffset == 0L)
+            }
           }.map(_.topicPartition)
           // StopPartition retires both current and future logs. If just one copy has
           // an obsolete identity, retain both for recovery rather than discard a valid copy.
@@ -1526,7 +1527,7 @@ class ReplicaManager(val config: KafkaConfig,
             val failures = stopPartitions(strays)
             if (failures.nonEmpty) throw failures.head._2
           }
-          bridgeMetadataReconciliationPending = false
+          bridgeMetadataReconciliationPending = assignedLogs.exists(log => !currentIds.contains(log.topicPartition.topic))
         }
         deletedPartitions
       }
@@ -1547,7 +1548,7 @@ class ReplicaManager(val config: KafkaConfig,
       breakdown("acquireReplicaStateChangeLock") = intervalMarker.markTimeAndReturnLatestInterval(time.milliseconds())
 
       val controllerId = leaderAndIsrRequest.controllerId
-      val requestPartitionStates = leaderAndIsrRequest.partitionStates.asScala
+      var requestPartitionStates = leaderAndIsrRequest.partitionStates.asScala.toSeq
       breakdown("convertLeaderAndIsrRequestPartitionStates") = intervalMarker.markTimeAndReturnLatestInterval(time.milliseconds())
       stateChangeLogger.info(s"Handling LeaderAndIsr request correlationId $correlationId from controller " +
         s"$controllerId for ${requestPartitionStates.size} partitions")
@@ -1578,6 +1579,12 @@ class ReplicaManager(val config: KafkaConfig,
             val topics = requestPartitionStates.map(_.topicName).toSet
             recoveredTopicIds = BridgeTopicIdentity.read(topics, zkClient)
             BridgeTopicIdentity.verifyWireIds(recoveredTopicIds, topicIds)
+            // Deletion can overtake a queued update. Do not admit that topic, but
+            // let unrelated partitions in the batch make progress.
+            requestPartitionStates.filterNot(state => recoveredTopicIds.contains(state.topicName)).foreach { state =>
+              responseMap.put(new TopicPartition(state.topicName, state.partitionIndex), Errors.UNKNOWN_TOPIC_OR_PARTITION)
+            }
+            requestPartitionStates = requestPartitionStates.filter(state => recoveredTopicIds.contains(state.topicName))
             val obsolete = requestPartitionStates.flatMap { state =>
               val tp = new TopicPartition(state.topicName, state.partitionIndex)
               val obsoleteCopies = Seq(logManager.getLog(tp), logManager.getLog(tp, isFuture = true)).flatten.map { log =>
@@ -1722,7 +1729,7 @@ class ReplicaManager(val config: KafkaConfig,
           updateLeaderAndFollowerMetrics(followerTopicSet)
           breakdown("updateLeaderAndFollowerMetrics") = intervalMarker.markTimeAndReturnLatestInterval(time.milliseconds())
 
-          leaderAndIsrRequest.partitionStates.forEach { partitionState =>
+          requestPartitionStates.foreach { partitionState =>
             val topicPartition = new TopicPartition(partitionState.topicName, partitionState.partitionIndex)
             /*
            * If there is offline log directory, a Partition object may have been created by getOrCreatePartition()

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -243,6 +243,8 @@ class ReplicaManager(val config: KafkaConfig,
 
   /* epoch of the controller that last changed the leader */
   @volatile private[server] var controllerEpoch: Int = KafkaController.InitialControllerEpoch
+  // Accessed under replicaStateChangeLock. A failed identity read must be retried.
+  private var bridgeMetadataReconciliationPending = false
   protected val localBrokerId = config.brokerId
   protected val allPartitions = new Pool[TopicPartition, HostedPartition](
     valueFactory = Some(tp => HostedPartition.Online(Partition(tp, time, this)))
@@ -1491,22 +1493,40 @@ class ReplicaManager(val config: KafkaConfig,
         val update = zkMetadataCache.updateMetadataAndGetResult(correlationId, updateMetadataRequest,
           config.liProtocolBridgeTopicDeletionStateCleanupActive)
         val deletedPartitions = update.deletedPartitions
+        if (update.replacedSnapshot) bridgeMetadataReconciliationPending = true
         controllerEpoch = updateMetadataRequest.controllerEpoch
         if (config.liProtocolBridgeTopicDeletionStateCleanupActive) {
           // A returning broker may have missed every deletion notification. Only a
           // complete image can identify those unassigned logs; incremental updates cannot.
-          val unassigned = if (update.replacedSnapshot) {
-            logManager.allLogs.map(_.topicPartition).filter { tp =>
-              !zkMetadataCache.getPartitionInfo(tp.topic, tp.partition).exists(_.replicas.contains(config.brokerId))
-            }.toSeq
-          } else Seq.empty
+          val localLogs = if (bridgeMetadataReconciliationPending) logManager.allLogs.toVector else Vector.empty
+          val unassigned = localLogs.iterator.map(_.topicPartition).filter { tp =>
+            !zkMetadataCache.getPartitionInfo(tp.topic, tp.partition).exists(_.replicas.contains(config.brokerId))
+          }.toSet
+          val assignedLogs = localLogs.filter(log => getPartition(log.topicPartition) == HostedPartition.None &&
+            !unassigned.contains(log.topicPartition))
+          val currentIds = BridgeTopicIdentity.read(assignedLogs.map(_.topicPartition.topic).toSet, zkClient)
+          val obsolete = assignedLogs.filter { log =>
+            BridgeTopicIdentity.isObsolete(log.topicPartition, log.topicId, currentIds(log.topicPartition.topic),
+              log.logEndOffset == 0L)
+          }.map(_.topicPartition)
+          // StopPartition retires both current and future logs. If just one copy has
+          // an obsolete identity, retain both for recovery rather than discard a valid copy.
+          val logsByPartition = localLogs.groupBy(_.topicPartition)
+          obsolete.distinct.foreach { tp =>
+            val copies = logsByPartition(tp)
+            if (!copies.forall(log => BridgeTopicIdentity.isObsolete(tp, log.topicId, currentIds(tp.topic),
+              log.logEndOffset == 0L)))
+              throw new KafkaStorageException(s"Conflicting current/future log identities for $tp; retain both for recovery")
+          }
           // Hosted replicas still use StopReplica, which also controls remote deletion.
-          val strays = (deletedPartitions ++ unassigned).filter(tp => getPartition(tp) == HostedPartition.None &&
-            logManager.getLog(tp).isDefined).map(tp => StopPartition(tp, deleteLocalLog = true)).toSet
+          val strays = (deletedPartitions ++ unassigned ++ obsolete).filter(tp => getPartition(tp) == HostedPartition.None &&
+            (logManager.getLog(tp).isDefined || logManager.getLog(tp, isFuture = true).isDefined))
+            .map(tp => StopPartition(tp, deleteLocalLog = true)).toSet
           if (strays.nonEmpty) {
             val failures = stopPartitions(strays)
             if (failures.nonEmpty) throw failures.head._2
           }
+          bridgeMetadataReconciliationPending = false
         }
         deletedPartitions
       }
@@ -1538,14 +1558,10 @@ class ReplicaManager(val config: KafkaConfig,
             s"epoch ${leaderAndIsrRequest.controllerEpoch}")
         }
       val topicIds = leaderAndIsrRequest.topicIds()
-      def topicIdFromRequest(topicName: String): Option[Uuid] = {
-        val topicId = topicIds.get(topicName)
-        // if invalid topic ID return None
-        if (topicId == null || topicId == Uuid.ZERO_UUID)
-          None
-        else
-          Some(topicId)
-      }
+      val identityRecovery = config.liProtocolBridgeTopicDeletionStateCleanupActive
+      var recoveredTopicIds = Map.empty[String, Uuid]
+      def topicIdFromRequest(topicName: String): Option[Uuid] =
+        Option(topicIds.get(topicName)).filter(_ != Uuid.ZERO_UUID).orElse(recoveredTopicIds.get(topicName))
 
       val response = {
         if (leaderAndIsrRequest.controllerEpoch < controllerEpoch) {
@@ -1555,6 +1571,28 @@ class ReplicaManager(val config: KafkaConfig,
           leaderAndIsrRequest.getErrorResponse(0, Errors.STALE_CONTROLLER_EPOCH.exception)
         } else {
           val responseMap = new mutable.HashMap[TopicPartition, Errors]
+          if (identityRecovery) {
+            // Missing wire IDs cannot establish a generation, even for an existing
+            // hosted replica. Batch the identity reads on the control path.
+            controllerEpoch = leaderAndIsrRequest.controllerEpoch
+            val topics = requestPartitionStates.map(_.topicName).toSet
+            recoveredTopicIds = BridgeTopicIdentity.read(topics, zkClient)
+            BridgeTopicIdentity.verifyWireIds(recoveredTopicIds, topicIds)
+            val obsolete = requestPartitionStates.flatMap { state =>
+              val tp = new TopicPartition(state.topicName, state.partitionIndex)
+              val obsoleteCopies = Seq(logManager.getLog(tp), logManager.getLog(tp, isFuture = true)).flatten.map { log =>
+                BridgeTopicIdentity.isObsolete(tp, log.topicId, topicIdFromRequest(tp.topic).get, log.logEndOffset == 0L)
+              }
+              if (obsoleteCopies.contains(true) && obsoleteCopies.contains(false))
+                throw new KafkaStorageException(s"Conflicting current/future log identities for $tp; retain both for recovery")
+              if (obsoleteCopies.contains(true)) Some(StopPartition(tp, deleteLocalLog = true)) else None
+            }.toSet
+            // Validate every identity before deleting any log or creating a Partition.
+            if (obsolete.nonEmpty) {
+              val failures = stopPartitions(obsolete)
+              if (failures.nonEmpty) throw failures.head._2
+            }
+          }
           controllerEpoch = leaderAndIsrRequest.controllerEpoch
 
           val partitionStates = new mutable.HashMap[Partition, LeaderAndIsrPartitionState]()

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -773,10 +773,22 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient,
   }
 
   /**
-   * Gets the topic IDs for the given topics.
-   * @param topics the topics we wish to retrieve the Topic IDs for
-   * @return the Topic IDs
+   * Return existing topic znodes and their optional IDs. Missing znodes are omitted;
+   * an existing znode without an ID remains present with None. Propagate read errors.
    */
+  def getTopicIdentities(topics: Set[String]): Map[String, Option[Uuid]] = {
+    val requests = topics.toSeq.map(topic => GetDataRequest(TopicZNode.path(topic), ctx = Some(topic)))
+    retryRequestsUntilConnected(requests).flatMap { response =>
+      val topic = response.ctx.get.asInstanceOf[String]
+      response.resultCode match {
+        case Code.OK => Some(topic -> TopicZNode.decode(topic, response.data).topicId)
+        case Code.NONODE => None
+        case _ => throw response.resultException.get
+      }
+    }.toMap
+  }
+
+  /** Return the known topic IDs, omitting missing topics and topics without IDs. */
   def getTopicIdsForTopics(topics: Set[String]): Map[String, Uuid] = {
     val getDataRequests = topics.map(topic => GetDataRequest(TopicZNode.path(topic), ctx = Some(topic)))
     val getDataResponses = retryRequestsUntilConnected(getDataRequests.toSeq)

--- a/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
@@ -52,8 +52,8 @@ class BridgeStrayLogDeletionTest {
     val quotas = QuotaFactory.instantiate(config, metrics, time, "")
     val logs = TestUtils.createLogManager(config.logDirs.map(new File(_)))
     val zk = mock(classOf[KafkaZkClient])
-    when(zk.getTopicIdsForTopics(any[Set[String]])).thenAnswer { invocation =>
-      invocation.getArgument[Set[String]](0).map(_ -> currentTopicId).toMap
+    when(zk.getTopicIdentities(any[Set[String]])).thenAnswer { invocation =>
+      invocation.getArgument[Set[String]](0).map(_ -> Some(currentTopicId)).toMap
     }
     val manager = new ReplicaManager(config, metrics, time, Some(zk), new MockScheduler(time), logs, None,
       new java.util.concurrent.atomic.AtomicBoolean(false), quotas, new BrokerTopicStats,
@@ -168,11 +168,32 @@ class BridgeStrayLogDeletionTest {
   }
 
   @org.junit.jupiter.api.Test
+  def testDeletedTopicDoesNotBlockAnUnrelatedLeaderRequest(): Unit = withManager(enabled = true) { (_, manager) =>
+    val gone = new TopicPartition("bridge-gone", 0)
+    val live = new TopicPartition("bridge-live", 0)
+    addRecord(manager, gone)
+    when(manager.zkClient.get.getTopicIdentities(Set(gone.topic, live.topic)))
+      .thenReturn(Map(live.topic -> Some(currentTopicId)))
+    val states = Seq(gone, live).map { tp =>
+      new LeaderAndIsrPartitionState().setTopicName(tp.topic).setPartitionIndex(0)
+        .setControllerEpoch(1).setLeader(1).setLeaderEpoch(0).setIsNew(true)
+        .setReplicas(java.util.Arrays.asList(Int.box(1))).setIsr(java.util.Arrays.asList(Int.box(1)))
+    }
+    val request = new LeaderAndIsrRequest.Builder(2.toShort, 0, 1, 1L, 1L, states.asJava,
+      java.util.Collections.emptyMap[String, Uuid](), java.util.Collections.emptySet[org.apache.kafka.common.Node]()).build()
+    val response = manager.becomeLeaderOrFollower(0, request, (_, _) => ())
+    assertTrue(response.errorCounts().containsKey(org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION))
+    assertEquals(HostedPartition.None, manager.getPartition(gone))
+    assertEquals(1L, manager.logManager.getLog(gone).get.logEndOffset)
+    assertEquals(Some(currentTopicId), manager.logManager.getLog(live).get.topicId)
+  }
+
+  @org.junit.jupiter.api.Test
   def testIdentityFailureRetriesTheSameFullImage(): Unit = withManager(enabled = true) { (_, manager) =>
     val partition = new TopicPartition("bridge-retry-identity", 0)
     addRecord(manager, partition, Some(Uuid.randomUuid()))
-    when(manager.zkClient.get.getTopicIdsForTopics(Set(partition.topic)))
-      .thenReturn(Map.empty[String, Uuid], Map(partition.topic -> currentTopicId))
+    when(manager.zkClient.get.getTopicIdentities(Set(partition.topic)))
+      .thenReturn(Map(partition.topic -> None), Map(partition.topic -> Some(currentTopicId)))
     val request = update(1, Seq((partition, 1, List(1))))
     assertThrows(classOf[KafkaStorageException], () => manager.maybeUpdateMetadataCache(0, request))
     assertEquals(1L, manager.logManager.getLog(partition).get.logEndOffset)

--- a/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BridgeStrayLogDeletionTest.scala
@@ -20,33 +20,42 @@ import java.io.File
 import java.util.Properties
 import kafka.api.LeaderAndIsr
 import kafka.utils.TestUtils
-import org.apache.kafka.common.TopicPartition
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.common.record.CompressionType
-import org.apache.kafka.common.errors.ControllerMovedException
+import org.apache.kafka.common.errors.{ControllerMovedException, KafkaStorageException}
 import org.apache.kafka.common.message.UpdateMetadataRequestData
+import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataPartitionState, UpdateMetadataTopicState}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.MessageUtil
 import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
-import org.apache.kafka.common.requests.UpdateMetadataRequest
+import org.apache.kafka.common.requests.{LeaderAndIsrRequest, UpdateMetadataRequest}
 import kafka.utils.{MockScheduler, MockTime}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.Mockito.mock
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, when}
 
 import scala.jdk.CollectionConverters._
 
 class BridgeStrayLogDeletionTest {
+  private val currentTopicId = Uuid.randomUuid()
   private def withManager(enabled: Boolean)(test: (KafkaConfig, ReplicaManager) => Unit): Unit = {
     val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
     props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, enabled.toString)
+    props.put("log.dirs", TestUtils.tempDir().getAbsolutePath + "," + TestUtils.tempDir().getAbsolutePath)
     val config = KafkaConfig.fromProps(props)
     val time = new MockTime
     val metrics = new Metrics
     val quotas = QuotaFactory.instantiate(config, metrics, time, "")
     val logs = TestUtils.createLogManager(config.logDirs.map(new File(_)))
-    val manager = new ReplicaManager(config, metrics, time, None, new MockScheduler(time), logs, None,
+    val zk = mock(classOf[KafkaZkClient])
+    when(zk.getTopicIdsForTopics(any[Set[String]])).thenAnswer { invocation =>
+      invocation.getArgument[Set[String]](0).map(_ -> currentTopicId).toMap
+    }
+    val manager = new ReplicaManager(config, metrics, time, Some(zk), new MockScheduler(time), logs, None,
       new java.util.concurrent.atomic.AtomicBoolean(false), quotas, new BrokerTopicStats,
       MetadataCache.zkMetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size),
       mock(classOf[AlterIsrManager]), mock(classOf[TransferLeaderManager]))
@@ -72,8 +81,9 @@ class BridgeStrayLogDeletionTest {
     UpdateMetadataRequest.parse(MessageUtil.toByteBuffer(data, 5.toShort), 5.toShort)
   }
 
-  private def addRecord(manager: ReplicaManager, tp: TopicPartition): Unit = {
-    val log = manager.logManager.getOrCreateLog(tp, isNew = true, topicId = None)
+  private def addRecord(manager: ReplicaManager, tp: TopicPartition,
+                        id: Option[Uuid] = Some(currentTopicId)): Unit = {
+    val log = manager.logManager.getOrCreateLog(tp, isNew = true, topicId = id)
     log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE,
       new SimpleRecord("old-generation".getBytes(java.nio.charset.StandardCharsets.UTF_8))), 0)
     assertEquals(1L, log.logEndOffset)
@@ -98,6 +108,93 @@ class BridgeStrayLogDeletionTest {
     assertTrue(logs.getLog(unrelated).isDefined, "an incremental deletion is not a full log image")
     if (enabled)
       assertEquals(0L, logs.getOrCreateLog(stray, isNew = true, topicId = None).logEndOffset)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testBridgeLeaderRequestPersistsIdentityBeforeAcceptingRecords(enabled: Boolean): Unit = withManager(enabled) { (_, manager) =>
+    val partition = new TopicPartition("bridge-new-log", 0)
+    val state = new LeaderAndIsrPartitionState().setTopicName(partition.topic).setPartitionIndex(0)
+      .setControllerEpoch(1).setLeader(1).setLeaderEpoch(0).setIsNew(true)
+      .setReplicas(java.util.Arrays.asList(Int.box(1))).setIsr(java.util.Arrays.asList(Int.box(1)))
+    val request = new LeaderAndIsrRequest.Builder(2.toShort, 0, 1, 1L, 1L,
+      java.util.Collections.singletonList(state), java.util.Collections.emptyMap[String, Uuid](),
+      java.util.Collections.emptySet[org.apache.kafka.common.Node]()).build()
+    manager.becomeLeaderOrFollower(0, request, (_, _) => ())
+    val log = manager.logManager.getLog(partition).get
+    assertEquals(if (enabled) Some(currentTopicId) else None, log.topicId)
+    assertEquals(0L, log.logEndOffset)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testReplicaRequestRechecksAnExistingHostedLog(enabled: Boolean): Unit = withManager(enabled) { (_, manager) =>
+    val partition = new TopicPartition("bridge-new-hosted-generation", 0)
+    val oldId = Uuid.randomUuid()
+    addRecord(manager, partition, Some(oldId))
+    manager.createPartition(partition)
+    val state = new LeaderAndIsrPartitionState().setTopicName(partition.topic).setPartitionIndex(0)
+      .setControllerEpoch(1).setLeader(1).setLeaderEpoch(0).setIsNew(false)
+      .setReplicas(java.util.Arrays.asList(Int.box(1))).setIsr(java.util.Arrays.asList(Int.box(1)))
+    val request = new LeaderAndIsrRequest.Builder(2.toShort, 0, 1, 1L, 1L,
+      java.util.Collections.singletonList(state), java.util.Collections.emptyMap[String, Uuid](),
+      java.util.Collections.emptySet[org.apache.kafka.common.Node]()).build()
+    manager.becomeLeaderOrFollower(0, request, (_, _) => ())
+    val log = manager.logManager.getLog(partition).get
+    assertEquals(Some(if (enabled) currentTopicId else oldId), log.topicId)
+    assertEquals(if (enabled) 0L else 1L, log.logEndOffset)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testAssignedOldTopicIdentityIsNotReused(enabled: Boolean): Unit = withManager(enabled) { (_, manager) =>
+    val partition = new TopicPartition("bridge-recreated-assigned", 0)
+    addRecord(manager, partition, Some(Uuid.randomUuid()))
+    manager.maybeUpdateMetadataCache(0, update(1, Seq((partition, 1, List(1)))))
+    assertEquals(!enabled, manager.logManager.getLog(partition).isDefined)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testUnknownNonemptyLogIdentityIsRetainedForRecovery(enabled: Boolean): Unit = withManager(enabled) { (_, manager) =>
+    val partition = new TopicPartition("bridge-unidentified-log", 0)
+    addRecord(manager, partition, None)
+    val request = update(1, Seq((partition, 1, List(1))))
+    if (enabled) {
+      assertThrows(classOf[KafkaStorageException], () => manager.maybeUpdateMetadataCache(0, request))
+      assertThrows(classOf[KafkaStorageException], () => manager.maybeUpdateMetadataCache(1, request))
+    } else manager.maybeUpdateMetadataCache(0, request)
+    assertEquals(1L, manager.logManager.getLog(partition).get.logEndOffset)
+  }
+
+  @org.junit.jupiter.api.Test
+  def testIdentityFailureRetriesTheSameFullImage(): Unit = withManager(enabled = true) { (_, manager) =>
+    val partition = new TopicPartition("bridge-retry-identity", 0)
+    addRecord(manager, partition, Some(Uuid.randomUuid()))
+    when(manager.zkClient.get.getTopicIdsForTopics(Set(partition.topic)))
+      .thenReturn(Map.empty[String, Uuid], Map(partition.topic -> currentTopicId))
+    val request = update(1, Seq((partition, 1, List(1))))
+    assertThrows(classOf[KafkaStorageException], () => manager.maybeUpdateMetadataCache(0, request))
+    assertEquals(1L, manager.logManager.getLog(partition).get.logEndOffset)
+    manager.maybeUpdateMetadataCache(1, request)
+    assertTrue(manager.logManager.getLog(partition).isEmpty)
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(false, true))
+  def testConflictingCurrentAndFutureIdentitiesAreRetained(enabled: Boolean): Unit = withManager(enabled) { (config, manager) =>
+    val partition = new TopicPartition("bridge-conflicting-copies", 0)
+    addRecord(manager, partition)
+    val current = manager.logManager.getLog(partition).get
+    val otherDirectory = config.logDirs.find(dir => new File(dir).getAbsolutePath != current.dir.getParentFile.getAbsolutePath).get
+    manager.logManager.maybeUpdatePreferredLogDir(partition, otherDirectory)
+    manager.logManager.getOrCreateLog(partition, isNew = true, isFuture = true, topicId = Some(Uuid.randomUuid()))
+    val request = update(1, Seq((partition, 1, List(1))))
+    if (enabled)
+      assertThrows(classOf[KafkaStorageException], () => manager.maybeUpdateMetadataCache(0, request))
+    else manager.maybeUpdateMetadataCache(0, request)
+    assertEquals(1L, manager.logManager.getLog(partition).get.logEndOffset)
+    assertTrue(manager.logManager.getLog(partition, isFuture = true).isDefined)
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/BridgeTopicIdentityTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BridgeTopicIdentityTest.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.errors.{InconsistentTopicIdException, KafkaStorageException}
+import org.apache.zookeeper.KeeperException.ConnectionLossException
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.{mock, when}
+
+class BridgeTopicIdentityTest {
+  @Test
+  def testCleanupRequiresAnIbpWithTopicIdentity(): Unit = {
+    val props = new java.util.Properties
+    props.put("zookeeper.connect", "localhost:2181")
+    props.put("inter.broker.protocol.version", "2.7")
+    KafkaConfig.fromProps(props)
+    props.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, "true")
+    assertThrows(classOf[org.apache.kafka.common.config.ConfigException], () => KafkaConfig.fromProps(props))
+    props.put("inter.broker.protocol.version", "3.0")
+    assertTrue(KafkaConfig.fromProps(props).liProtocolBridgeTopicDeletionStateCleanupActive)
+  }
+
+  @Test
+  def testOnlyKnownMismatchedIdentityCanBeDiscarded(): Unit = {
+    val partition = new TopicPartition("identity", 0)
+    val current = Uuid.randomUuid()
+    assertFalse(BridgeTopicIdentity.isObsolete(partition, Some(current), current, empty = false))
+    assertTrue(BridgeTopicIdentity.isObsolete(partition, Some(Uuid.randomUuid()), current, empty = false))
+    for (unknown <- Seq(None, Some(Uuid.ZERO_UUID))) {
+      assertFalse(BridgeTopicIdentity.isObsolete(partition, unknown, current, empty = true))
+      assertThrows(classOf[KafkaStorageException], () =>
+        BridgeTopicIdentity.isObsolete(partition, unknown, current, empty = false))
+    }
+  }
+
+  @Test
+  def testIdentityReadRejectsMissingOrZeroIds(): Unit = {
+    val client = mock(classOf[KafkaZkClient])
+    val topics = Set("identity")
+    for (ids <- Seq(Map.empty[String, Uuid], Map("identity" -> Uuid.ZERO_UUID))) {
+      when(client.getTopicIdsForTopics(topics)).thenReturn(ids)
+      assertThrows(classOf[KafkaStorageException], () => BridgeTopicIdentity.read(topics, Some(client)))
+    }
+    val current = Map("identity" -> Uuid.randomUuid())
+    when(client.getTopicIdsForTopics(topics)).thenReturn(current)
+    assertEquals(current, BridgeTopicIdentity.read(topics, Some(client)))
+    assertEquals(Map.empty[String, Uuid], BridgeTopicIdentity.read(Set.empty, None))
+    assertThrows(classOf[IllegalStateException], () => BridgeTopicIdentity.read(topics, None))
+  }
+
+  @Test
+  def testWireIdentityMustAgreeWhenPresent(): Unit = {
+    val current = Uuid.randomUuid()
+    val expected = Map("identity" -> current)
+    BridgeTopicIdentity.verifyWireIds(expected, java.util.Collections.emptyMap[String, Uuid]())
+    BridgeTopicIdentity.verifyWireIds(expected, java.util.Collections.singletonMap("identity", Uuid.ZERO_UUID))
+    BridgeTopicIdentity.verifyWireIds(expected, java.util.Collections.singletonMap("identity", current))
+    assertThrows(classOf[InconsistentTopicIdException], () => BridgeTopicIdentity.verifyWireIds(expected,
+      java.util.Collections.singletonMap("identity", Uuid.randomUuid())))
+  }
+
+  @Test
+  def testIdentityReadPreservesZooKeeperFailure(): Unit = {
+    val client = mock(classOf[KafkaZkClient])
+    val failure = new ConnectionLossException
+    when(client.getTopicIdsForTopics(Set("identity"))).thenAnswer(_ => throw failure)
+    assertSame(failure, assertThrows(classOf[ConnectionLossException], () =>
+      BridgeTopicIdentity.read(Set("identity"), Some(client))))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/BridgeTopicIdentityTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BridgeTopicIdentityTest.scala
@@ -51,16 +51,18 @@ class BridgeTopicIdentityTest {
   }
 
   @Test
-  def testIdentityReadRejectsMissingOrZeroIds(): Unit = {
+  def testExistingTopicRequiresAValidIdentity(): Unit = {
     val client = mock(classOf[KafkaZkClient])
     val topics = Set("identity")
-    for (ids <- Seq(Map.empty[String, Uuid], Map("identity" -> Uuid.ZERO_UUID))) {
-      when(client.getTopicIdsForTopics(topics)).thenReturn(ids)
+    for (id <- Seq(None, Some(Uuid.ZERO_UUID))) {
+      when(client.getTopicIdentities(topics)).thenReturn(Map("identity" -> id))
       assertThrows(classOf[KafkaStorageException], () => BridgeTopicIdentity.read(topics, Some(client)))
     }
-    val current = Map("identity" -> Uuid.randomUuid())
-    when(client.getTopicIdsForTopics(topics)).thenReturn(current)
-    assertEquals(current, BridgeTopicIdentity.read(topics, Some(client)))
+    val id = Uuid.randomUuid()
+    when(client.getTopicIdentities(topics)).thenReturn(Map("identity" -> Some(id)))
+    assertEquals(Map("identity" -> id), BridgeTopicIdentity.read(topics, Some(client)))
+    when(client.getTopicIdentities(topics)).thenReturn(Map.empty[String, Option[Uuid]])
+    assertEquals(Map.empty[String, Uuid], BridgeTopicIdentity.read(topics, Some(client)))
     assertEquals(Map.empty[String, Uuid], BridgeTopicIdentity.read(Set.empty, None))
     assertThrows(classOf[IllegalStateException], () => BridgeTopicIdentity.read(topics, None))
   }
@@ -80,7 +82,7 @@ class BridgeTopicIdentityTest {
   def testIdentityReadPreservesZooKeeperFailure(): Unit = {
     val client = mock(classOf[KafkaZkClient])
     val failure = new ConnectionLossException
-    when(client.getTopicIdsForTopics(Set("identity"))).thenAnswer(_ => throw failure)
+    when(client.getTopicIdentities(Set("identity"))).thenAnswer(_ => throw failure)
     assertSame(failure, assertThrows(classOf[ConnectionLossException], () =>
       BridgeTopicIdentity.read(Set("identity"), Some(client))))
   }

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -274,6 +274,17 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
   }
 
   @Test
+  def testTopicIdentitiesDistinguishDeletedAndUnidentifiedTopics(): Unit = {
+    zkClient.createTopLevelPaths()
+    val id = Uuid.randomUuid()
+    zkClient.createTopicAssignment("identified", Some(id), Map(new TopicPartition("identified", 0) -> Seq(1)))
+    zkClient.createTopicAssignment("unidentified", None, Map(new TopicPartition("unidentified", 0) -> Seq(1)))
+    val topics = Set("identified", "unidentified", "deleted")
+    assertEquals(Map("identified" -> Some(id), "unidentified" -> None), zkClient.getTopicIdentities(topics))
+    assertEquals(Map("identified" -> id), zkClient.getTopicIdsForTopics(topics))
+  }
+
+  @Test
   def testGetAllTopicsInClusterTriggersWatch(): Unit = {
     zkClient.createTopLevelPaths()
     val latch = registerChildChangeHandler(1)


### PR DESCRIPTION
Fix the assigned-before-return variant described in #584. Assignment does not identify a recreated topic generation because bridge control messages omit topic IDs.

Under the existing default-off cleanup flag, read the authoritative ZooKeeper topic IDs on the control path, persist IDs before accepting records, and retire only known obsolete generations. Keep unidentified nonempty logs and conflicting current/future copies for recovery. Validate supplied wire IDs, fence failed controller updates, and retry failed full-image checks. Reject cleanup on an IBP without topic IDs. Flag-off behavior is unchanged.

Both full ReplicaManagerTest suites and dedicated identity/cache tests pass. The assigned-before-return target failed before the repair and passed with the initial repair; the tightened current safety paths have fresh unit coverage. All 68 Python tests pass. Scenario revision 4 now requires both broker generations and both assignment timings; its complete process run is active. Old scenario evidence is rejected.

This is a draft, not rollout approval. The private wrapper dependency refresh requires the internal network/VPN, so current final wrapper qualification is blocked. Production client/state/runtime/capacity and named security/release approvals remain separate gates.