### PR TITLE
kafka: gate 3.0 bridge-state MBean registration

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -459,6 +459,7 @@ object KafkaConfig {
   val LiAsyncFetcherEnableProp = "li.async.fetcher.enable"
   val LiCombinedControlRequestEnableProp = "li.combined.control.request.enable"
   val LiProtocolBridgeModeEnableProp = "li.protocol.bridge.mode.enable"
+  val LiProtocolBridgeConfigMetricsEnableProp = "li.protocol.bridge.config.metrics.enable"
   val LiProtocolBridgeTopicDeletionStateCleanupEnableProp =
     "li.protocol.bridge.topic.deletion.state.cleanup.enable"
   val LiUpdateMetadataDelayMsProp = "li.update.metadata.delay.ms"
@@ -1287,6 +1288,8 @@ object KafkaConfig {
       .define(LiAsyncFetcherEnableProp, BOOLEAN, Defaults.LiAsyncFetcherEnabled, HIGH, LiAsyncFetcherEnableDoc)
       .define(LiCombinedControlRequestEnableProp, BOOLEAN, Defaults.LiCombinedControlRequestEnabled, HIGH, LiCombinedControlRequestEnableDoc)
       .define(LiProtocolBridgeModeEnableProp, BOOLEAN, Defaults.LiProtocolBridgeModeEnabled, HIGH, LiProtocolBridgeModeEnableDoc)
+      .define(LiProtocolBridgeConfigMetricsEnableProp, BOOLEAN, false, LOW,
+        "Register bridge configuration gauges on ZooKeeper brokers. Requires a broker restart.")
       .define(LiProtocolBridgeTopicDeletionStateCleanupEnableProp, BOOLEAN, false, HIGH,
         "Clear stale topic deletion state and reconcile the metadata cache " +
           "from the first full update of each ZooKeeper controller epoch. Enable on every broker together.")
@@ -1847,6 +1850,8 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val liAsyncFetcherEnable = getBoolean(KafkaConfig.LiAsyncFetcherEnableProp)
   def liCombinedControlRequestEnable = getBoolean(KafkaConfig.LiCombinedControlRequestEnableProp)
   def liProtocolBridgeModeEnable = getBoolean(KafkaConfig.LiProtocolBridgeModeEnableProp)
+  def liProtocolBridgeConfigMetricsActive: Boolean =
+    requiresZookeeper && getBoolean(KafkaConfig.LiProtocolBridgeConfigMetricsEnableProp)
   def liProtocolBridgeTopicDeletionStateCleanupActive: Boolean =
     requiresZookeeper && getBoolean(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp)
   def liUpdateMetadataDelayMs = getLong(KafkaConfig.LiUpdateMetadataDelayMsProp)

--- a/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
+++ b/core/src/main/scala/kafka/server/LiProtocolBridgeMetrics.scala
@@ -23,6 +23,7 @@ import scala.util.Try
 
 object LiProtocolBridgeMetrics {
   val ModeEnabled = "ModeEnabled"
+  val ConfigMetricsEnabled = "ConfigMetricsEnabled"
   val TopicDeletionStateCleanupEnabled = "TopicDeletionStateCleanupEnabled"
   val FollowerRecoveryEnabled = "FollowerRecoveryEnabled"
   val RecommendedLeaderElectionEnabled = "RecommendedLeaderElectionEnabled"
@@ -48,7 +49,7 @@ object LiProtocolBridgeMetrics {
   val LegacyRequestMetricsEnabled = "LegacyRequestMetricsEnabled"
   val LogTruncationMetricsEnabled = "LogTruncationMetricsEnabled"
 
-  val MetricNames: Seq[String] = Seq(ModeEnabled, TopicDeletionStateCleanupEnabled, FollowerRecoveryEnabled,
+  val MetricNames: Seq[String] = Seq(ModeEnabled, ConfigMetricsEnabled, TopicDeletionStateCleanupEnabled, FollowerRecoveryEnabled,
     RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled, MoveControllerEnabled,
     ShutdownSafetyOverrideEnabled, PreferredControllerEnabled, FederatedTopicsEnabled,
     RackIdMapperEnabled, ZookeeperPaginationEnabled, DynamicTopicDeletionEnabled,
@@ -64,41 +65,47 @@ final class LiProtocolBridgeMetrics(config: KafkaConfig) extends KafkaMetricsGro
 
   private val tags = Map("broker-id" -> config.brokerId.toString)
 
-  newGauge(ModeEnabled, () => if (config.liProtocolBridgeModeEnable) 1 else 0, tags)
-  newGauge(TopicDeletionStateCleanupEnabled,
-    () => if (config.liProtocolBridgeTopicDeletionStateCleanupActive) 1 else 0, tags)
-  // These behaviors are built in and ungated on the 3.0-li line. A value of one tells operators
-  // which equivalent default-off settings must be enabled on 3.9-li during the mixed roll.
-  Seq(FollowerRecoveryEnabled, RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled,
-    MoveControllerEnabled, ShutdownSafetyOverrideEnabled, PreferredControllerEnabled,
-    FederatedTopicsEnabled, DynamicTopicDeletionEnabled, RequestMetricBucketsEnabled,
-    RequestChannelWatchdogEnabled, ReassignmentCancellationSafetyEnabled,
-    ListOffsetsInstrumentationEnabled, ReplicaRequestTimeoutEnabled, OffsetsTopicConfigEnabled,
-    LeaderTransferEnabled, LegacyRequestMetricsEnabled, LogTruncationMetricsEnabled).foreach { name =>
-    newGauge(name, () => 1, tags)
+  private val registrationEnabled = config.liProtocolBridgeConfigMetricsActive
+  if (registrationEnabled) {
+    newGauge(ConfigMetricsEnabled, () => 1, tags)
+    newGauge(ModeEnabled, () => if (config.liProtocolBridgeModeEnable) 1 else 0, tags)
+    newGauge(TopicDeletionStateCleanupEnabled,
+      () => if (config.liProtocolBridgeTopicDeletionStateCleanupActive) 1 else 0, tags)
+    // These behaviors are built in and ungated on the 3.0-li line. A value of one tells operators
+    // which equivalent default-off settings must be enabled on 3.9-li during the mixed roll.
+    Seq(FollowerRecoveryEnabled, RecommendedLeaderElectionEnabled, ExcludePartitionsEnabled,
+      MoveControllerEnabled, ShutdownSafetyOverrideEnabled, PreferredControllerEnabled,
+      FederatedTopicsEnabled, DynamicTopicDeletionEnabled, RequestMetricBucketsEnabled,
+      RequestChannelWatchdogEnabled, ReassignmentCancellationSafetyEnabled,
+      ListOffsetsInstrumentationEnabled, ReplicaRequestTimeoutEnabled, OffsetsTopicConfigEnabled,
+      LeaderTransferEnabled, LegacyRequestMetricsEnabled, LogTruncationMetricsEnabled).foreach { name =>
+      newGauge(name, () => 1, tags)
+    }
+    newGauge(RackIdMapperEnabled, () => {
+      val mapper = config.getString(KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp)
+      if (mapper == null || mapper.isEmpty) 0 else 1
+    }, tags)
+    newGauge(ZookeeperPaginationEnabled,
+      () => if (config.liZookeeperPaginationEnable) 1 else 0, tags)
+    newGauge(ControllerInitializationThreads, () => config.liNumControllerInitThreads, tags)
+    newGauge(ProduceRequestInstrumentationEnabled,
+      () => if (config.longTailProduceRequestLogRatio > 0.0) 1 else 0, tags)
+    newGauge(MinimumLogRollEnabled, () => {
+      // This is a topic-level log setting, so KafkaConfig does not validate a broker-level original.
+      // Treat a malformed original as disabled rather than letting an MBean read fail.
+      val configuredValue = Option(config.originals.get(KafkaConfig.LiMinLogRollTimeMillisProp))
+        .flatMap(value => Try(value.toString.toLong).toOption)
+        .getOrElse(0L)
+      if (configuredValue > 0L) 1 else 0
+    }, tags)
+    newGauge(StaticDefaultQuotasEnabled, () => {
+      val producerDefault = config.producerQuotaBytesPerSecondDefault
+      val consumerDefault = config.consumerQuotaBytesPerSecondDefault
+      if (producerDefault < Long.MaxValue || consumerDefault < Long.MaxValue) 1 else 0
+    }, tags)
   }
-  newGauge(RackIdMapperEnabled, () => {
-    val mapper = config.getString(KafkaConfig.LiRackIdMapperClassNameForRackAwareReplicaAssignmentProp)
-    if (mapper == null || mapper.isEmpty) 0 else 1
-  }, tags)
-  newGauge(ZookeeperPaginationEnabled,
-    () => if (config.liZookeeperPaginationEnable) 1 else 0, tags)
-  newGauge(ControllerInitializationThreads, () => config.liNumControllerInitThreads, tags)
-  newGauge(ProduceRequestInstrumentationEnabled,
-    () => if (config.longTailProduceRequestLogRatio > 0.0) 1 else 0, tags)
-  newGauge(MinimumLogRollEnabled, () => {
-    // This is a topic-level log setting, so KafkaConfig does not validate a broker-level original.
-    // Treat a malformed original as disabled rather than letting an MBean read fail.
-    val configuredValue = Option(config.originals.get(KafkaConfig.LiMinLogRollTimeMillisProp))
-      .flatMap(value => Try(value.toString.toLong).toOption)
-      .getOrElse(0L)
-    if (configuredValue > 0L) 1 else 0
-  }, tags)
-  newGauge(StaticDefaultQuotasEnabled, () => {
-    val producerDefault = config.producerQuotaBytesPerSecondDefault
-    val consumerDefault = config.consumerQuotaBytesPerSecondDefault
-    if (producerDefault < Long.MaxValue || consumerDefault < Long.MaxValue) 1 else 0
-  }, tags)
 
-  override def close(): Unit = MetricNames.foreach(name => removeMetric(name, tags))
+  override def close(): Unit = {
+    if (registrationEnabled) MetricNames.foreach(name => removeMetric(name, tags))
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LiProtocolBridgeMetricsTest.scala
@@ -20,19 +20,65 @@ package kafka.server
 import com.yammer.metrics.core.Gauge
 import kafka.metrics.KafkaYammerMetrics
 import kafka.utils.TestUtils
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
 
+import java.util.Properties
 import scala.collection.JavaConverters._
 
 class LiProtocolBridgeMetricsTest {
   @Test
+  def testNoMetricsWithoutOptIn(): Unit = {
+    val brokerId = 988
+    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(brokerId, "localhost:2181"))
+    val metrics = new LiProtocolBridgeMetrics(config)
+    try assertTrue(metricValues(brokerId).isEmpty)
+    finally metrics.close()
+  }
+
+  @Test
+  def testGateRequiresRestartAndDisabledClosePreservesOtherMetrics(): Unit = {
+    val brokerId = 989
+    val props = enabledProps(brokerId)
+    val config = KafkaConfig.fromProps(props)
+    val metrics = new LiProtocolBridgeMetrics(config)
+    try {
+      assertFalse(DynamicBrokerConfig.AllDynamicConfigs.contains(KafkaConfig.LiProtocolBridgeConfigMetricsEnableProp))
+      val update = new Properties
+      update.put(KafkaConfig.LiProtocolBridgeConfigMetricsEnableProp, "false")
+      config.dynamicConfig.updateDefaultConfig(update)
+      assertTrue(config.liProtocolBridgeConfigMetricsActive)
+      props.remove(KafkaConfig.LiProtocolBridgeConfigMetricsEnableProp)
+      new LiProtocolBridgeMetrics(KafkaConfig.fromProps(props)).close()
+      assertEquals(LiProtocolBridgeMetrics.MetricNames.toSet, metricValues(brokerId).keySet)
+      assertEquals(1, metricValues(brokerId)(LiProtocolBridgeMetrics.ConfigMetricsEnabled))
+    } finally metrics.close()
+    assertTrue(metricValues(brokerId).isEmpty)
+  }
+
+  @Test
+  def testKRaftDoesNotRegisterBridgeMetrics(): Unit = {
+    val props = new Properties
+    Map("broker.id" -> "990", "node.id" -> "990", "process.roles" -> "broker,controller",
+      "controller.quorum.voters" -> "990@localhost:19093", "controller.listener.names" -> "CONTROLLER",
+      "listeners" -> "PLAINTEXT://localhost:19092,CONTROLLER://localhost:19093",
+      "listener.security.protocol.map" -> "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT",
+      KafkaConfig.LiProtocolBridgeConfigMetricsEnableProp -> "true").foreach { case (key, value) => props.put(key, value) }
+    val config = KafkaConfig.fromProps(props)
+    assertFalse(config.liProtocolBridgeConfigMetricsActive)
+    val metrics = new LiProtocolBridgeMetrics(config)
+    try assertTrue(metricValues(990).isEmpty)
+    finally metrics.close()
+  }
+
+  @Test
   def testEffectiveValuesAndCleanup(): Unit = {
-    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(4, "localhost:2181"))
+    val config = KafkaConfig.fromProps(enabledProps(4))
     val metrics = new LiProtocolBridgeMetrics(config)
     try {
       val values = metricValues(4)
       assertEquals(LiProtocolBridgeMetrics.MetricNames.toSet, values.keySet)
+      assertEquals(1, values(LiProtocolBridgeMetrics.ConfigMetricsEnabled))
       assertEquals(0, values(LiProtocolBridgeMetrics.ModeEnabled))
       assertEquals(0, values(LiProtocolBridgeMetrics.TopicDeletionStateCleanupEnabled))
       assertEquals(1, values(LiProtocolBridgeMetrics.FollowerRecoveryEnabled))
@@ -57,7 +103,7 @@ class LiProtocolBridgeMetricsTest {
 
   @Test
   def testModeGaugeTracksDynamicConfig(): Unit = {
-    val config = KafkaConfig.fromProps(TestUtils.createBrokerConfig(5, "localhost:2181"))
+    val config = KafkaConfig.fromProps(enabledProps(5))
     val metrics = new LiProtocolBridgeMetrics(config)
     try {
       assertEquals(0, metricValues(5)(LiProtocolBridgeMetrics.ModeEnabled))
@@ -74,7 +120,7 @@ class LiProtocolBridgeMetricsTest {
 
   @Test
   def testMalformedMinimumLogRollValueDoesNotBreakGauge(): Unit = {
-    val props = TestUtils.createBrokerConfig(6, "localhost:2181")
+    val props = enabledProps(6)
     props.put(KafkaConfig.LiMinLogRollTimeMillisProp, "not-a-number")
     val metrics = new LiProtocolBridgeMetrics(KafkaConfig.fromProps(props))
     try {
@@ -82,6 +128,12 @@ class LiProtocolBridgeMetricsTest {
     } finally {
       metrics.close()
     }
+  }
+
+  private def enabledProps(brokerId: Int): Properties = {
+    val props = TestUtils.createBrokerConfig(brokerId, "localhost:2181")
+    props.put(KafkaConfig.LiProtocolBridgeConfigMetricsEnableProp, "true")
+    props
   }
 
   private def metricValues(brokerId: Int): Map[String, Int] = {


### PR DESCRIPTION
Make registration of the new bridge-state MBeans opt-in, rather than changing the default Kafka metric registry.

`li.protocol.bridge.config.metrics.enable` defaults to false. It applies only to ZooKeeper brokers and requires a restart. When explicitly enabled, it reports the current behavior flags without enabling those behaviors. Disabled instances do not unregister gauges owned by an enabled instance. Existing JVM constructors remain available.

The default-off regression fails before the fix on both release lines. Enabled values, dynamic behavior flags, restart scope, KRaft exclusion and cleanup tests pass afterward. The 3.9 process profile enables diagnostics explicitly; preflight requires the setting in every migration phase, including dormant mode. All 72 Python tests pass.

This is a paired follow-up to the identity-recovery stack. The wrapper mapping/test changes are being qualified against matching new jars. Final-source process and wrapper qualification are still required; this PR is not rollout approval.
