### PR TITLE
kafka: preserve native explicit-quota window limits

### DIFF
--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -271,11 +271,11 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   def getMaxValueInQuotaWindow(session: Session, clientId: String): Double = {
     if (quotasEnabled) {
       val clientSensors = getOrCreateQuotaSensors(session, clientId)
-      val limit = quotaLimit(clientSensors.metricTags.asJava)
-      if (limit < Long.MaxValue)
-        limit * (config.numQuotaSamples - 1) * config.quotaWindowSizeSeconds
-      else
-        Double.MaxValue
+      val staticDefault = if (config.quotaDefault < Long.MaxValue) Some(config.quotaDefault.toDouble) else None
+      Option(quotaCallback.quotaLimit(clientQuotaType, clientSensors.metricTags.asJava))
+        .map(_.toDouble).orElse(staticDefault)
+        .map(_ * (config.numQuotaSamples - 1) * config.quotaWindowSizeSeconds)
+        .getOrElse(Double.MaxValue)
     } else {
       Double.MaxValue
     }

--- a/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotaManagerTest.scala
@@ -157,6 +157,33 @@ class ClientQuotaManagerTest extends BaseClientQuotaManagerTest {
   }
 
   @Test
+  def testExplicitLargeQuotaKeepsNativeWindowCalculation(): Unit = {
+    val manager = new ClientQuotaManager(config, metrics, Fetch, time, "")
+    val session = new Session(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "userA"), InetAddress.getLocalHost)
+    try {
+      for (bound <- Seq(Long.MaxValue.toDouble, Long.MaxValue.toDouble * 2)) {
+        manager.updateQuota(Some("userA"), None, None, Some(new Quota(bound, true)))
+        val expected = bound * (config.numQuotaSamples - 1) * config.quotaWindowSizeSeconds
+        assertEquals(expected, manager.getMaxValueInQuotaWindow(session, "client1"), 0.0)
+      }
+    } finally manager.shutdown()
+  }
+
+  @Test
+  def testStaticDefaultIsOnlyAWindowLimitFallback(): Unit = {
+    val fallback = new ClientQuotaManagerConfig(4, 1, 10L)
+    val manager = new ClientQuotaManager(fallback, metrics, Fetch, time, "")
+    val session = new Session(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "userA"), InetAddress.getLocalHost)
+    try {
+      assertEquals(30.0, manager.getMaxValueInQuotaWindow(session, "client1"), 0.0)
+      manager.updateQuota(Some("userA"), None, None, Some(new Quota(Long.MaxValue.toDouble, true)))
+      assertEquals(Long.MaxValue.toDouble * 3, manager.getMaxValueInQuotaWindow(session, "client1"), 0.0)
+      manager.updateQuota(Some("userA"), None, None, None)
+      assertEquals(30.0, manager.getMaxValueInQuotaWindow(session, "client1"), 0.0)
+    } finally manager.shutdown()
+  }
+
+  @Test
   def testGetMaxValueInQuotaWindowWithNonDefaultQuotaWindow(): Unit = {
     val numFullQuotaWindows = 3   // 3 seconds window (vs. 10 seconds default)
     val nonDefaultConfig = new ClientQuotaManagerConfig(numFullQuotaWindows + 1)


### PR DESCRIPTION
The static-quota addition treated any limit at or above Long.MaxValue as absent, including an explicit dynamic quota with the bridge feature disabled. Restore the original callback calculation and use the gated static default only when the callback returns no value. The new native-path regression fails before the repair (finite 9.22e19 expected, Double.MaxValue returned). The complete ClientQuotaManagerTest, QuotaFactoryTest and RequestQuotaTest suites pass afterward, including fallback restoration after removing an override. No new feature or default is enabled.