### PR TITLE
kafka: keep deletion acknowledgements through native bridge backout

### DIFF
--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -345,17 +345,20 @@ class TopicDeletionManager(config: KafkaConfig,
       }
     }
 
-    if (config.liProtocolBridgeModeEnable && allDeadReplicas.nonEmpty) {
-      // Bridge requests cannot encode the full-state cleanup used by LI after rejoin.
-      // Retain these assignments until the returning broker acknowledges StopReplica.
+    if (requiresReplicaDeletionAcknowledgements && allDeadReplicas.nonEmpty) {
+      // Retain assignments until returning replicas acknowledge StopReplica, including
+      // native-mode backout while the cleanup gate remains enabled.
       replicaStateMachine.handleStateChanges(allDeadReplicas, ReplicaDeletionIneligible)
-      markTopicIneligibleForDeletion(allDeadReplicas.map(_.topic).toSet, reason = "offline replicas in bridge mode")
+      markTopicIneligibleForDeletion(allDeadReplicas.map(_.topic).toSet, reason = "offline replicas awaiting deletion acknowledgements")
     }
 
     // send stop replica to all followers that are not in the OfflineReplica state so they stop sending fetch requests to the leader
     replicaStateMachine.handleStateChanges(allReplicasForDeletionRetry, OfflineReplica)
     replicaStateMachine.handleStateChanges(allReplicasForDeletionRetry, ReplicaDeletionStarted)
   }
+
+  private def requiresReplicaDeletionAcknowledgements: Boolean =
+    config.liProtocolBridgeModeEnable || config.liProtocolBridgeTopicDeletionStateCleanupActive
 
   private def resumeDeletions(): Unit = {
     val topicsQueuedForDeletion = Set.empty[String] ++ controllerContext.topicsToBeDeleted
@@ -365,16 +368,15 @@ class TopicDeletionManager(config: KafkaConfig,
     if (topicsQueuedForDeletion.nonEmpty)
       info(s"Handling deletion for topics ${topicsQueuedForDeletion.mkString(",")}")
 
-    // LI's native full-control path can clean up an offline replica later. In bridge mode,
-    // completing an all-offline deletion here would skip onTopicDeletion's metadata tombstone
-    // and discard the assignment before StopReplica can reach the returning broker. That leaves
-    // ghost topics in live metadata caches (CreateTopics says exists; DeleteTopics says absent).
-    val completedStates: Set[ReplicaState] = if (config.liProtocolBridgeModeEnable)
+    // Completing an all-offline deletion here skips onTopicDeletion's metadata tombstone.
+    // Keep acknowledgement fencing after bridge mode is disabled if cleanup is still enabled;
+    // otherwise online caches retain a topic whose ZooKeeper assignment has already gone.
+    val completedStates: Set[ReplicaState] = if (requiresReplicaDeletionAcknowledgements)
       Set(ReplicaDeletionSuccessful)
     else Set(ReplicaDeletionSuccessful, OfflineReplica)
 
     topicsQueuedForDeletion.foreach { topic =>
-      // In bridge mode every replica must explicitly acknowledge deletion.
+      // Recovery-enabled deletion requires every replica to acknowledge removal.
       if (controllerContext.areAllReplicasInStates(topic, completedStates)) {
         // clear up all state for this topic from controller cache and zookeeper
         completeDeleteTopic(topic)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1291,8 +1291,8 @@ object KafkaConfig {
       .define(LiProtocolBridgeConfigMetricsEnableProp, BOOLEAN, false, LOW,
         "Register bridge configuration gauges on ZooKeeper brokers. Requires a broker restart.")
       .define(LiProtocolBridgeTopicDeletionStateCleanupEnableProp, BOOLEAN, false, HIGH,
-        "Clear stale topic deletion state and reconcile the metadata cache " +
-          "from the first full update of each ZooKeeper controller epoch. Enable on every broker together.")
+        "Wait for replica deletion acknowledgements, clear stale deletion state and recover metadata/log identity. " +
+          "Enable on every ZooKeeper broker together and retain after bridge mode is disabled.")
       .define(LiUpdateMetadataDelayMsProp, LONG, Defaults.LiUpdateMetadataDelayMs, atLeast(0), LOW, LiUpdateMetadataDelayMsDoc)
       .define(LiDropFetchFollowerEnableProp, BOOLEAN, Defaults.LiDropFetchFollowerEnable, LOW, LiDropFetchFollowerEnableDoc)
       .define(LiDenyAlterIsrProp, BOOLEAN, Defaults.LiDenyAlterIsr, HIGH, LiDenyAlterIsrDoc)

--- a/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/TopicDeletionManagerTest.scala
@@ -191,9 +191,10 @@ class TopicDeletionManagerTest {
 
   @Test
   def testBridgeDeletionWaitsForOfflineReplicaAfterControllerFailover(): Unit = {
-    Seq(false, true).foreach { bridge =>
+    for (bridge <- Seq(false, true); cleanup <- Seq(false, true)) {
       val properties = TestUtils.createBrokerConfig(brokerId, "zkConnect")
       properties.put(KafkaConfig.LiProtocolBridgeModeEnableProp, bridge.toString)
+      properties.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, cleanup.toString)
       val config = KafkaConfig.fromProps(properties)
       val client = mock(classOf[DeletionClient])
       val context = initContext(Seq(1, 2), Set("foo"), numPartitions = 1, replicationFactor = 1)
@@ -209,9 +210,9 @@ class TopicDeletionManagerTest {
       val topicPartitions = context.partitionsForTopic("foo")
       val topicReplicas = context.replicasForTopic("foo")
       manager.tryTopicDeletion()
-      if (bridge) {
-        // Common control versions cannot send a full-state cleanup on rejoin. Keep the
-        // assignment/znode until the actual replica deletion is acknowledged and notify caches.
+      if (bridge || cleanup) {
+        // Keep the assignment until deletion is acknowledged, including native-mode backout.
+        // The controller must notify online caches even when every replica is offline.
         verify(client).sendMetadataUpdate(topicPartitions)
         verify(client, never()).deleteTopic("foo", context.epochZkVersion)
         assertTrue(context.topicsToBeDeleted.contains("foo"))
@@ -220,6 +221,8 @@ class TopicDeletionManagerTest {
         manager.resumeDeletionForTopics(Set("foo"))
         assertEquals(topicReplicas, context.replicasInState("foo", ReplicaDeletionStarted))
         manager.completeReplicaDeletion(topicReplicas)
+      } else {
+        verify(client, never()).sendMetadataUpdate(topicPartitions)
       }
       verify(client).deleteTopic("foo", context.epochZkVersion)
       assertTrue(context.partitionsForTopic("foo").isEmpty)


### PR DESCRIPTION
The all-3.0 dormant-backout failure was a real cache/ZooKeeper mismatch. With mode off, the old native shortcut counted an offline replica as deleted and removed its topic znode before onTopicDeletion sent a metadata tombstone. Retain acknowledgement fencing while either bridge mode or the existing cleanup gate is enabled. Both flags off preserve the native default path. The four-combination regression fails before and passes after, as do TopicDeletionManagerTest, ControllerContextTest and BridgeMetadataCacheEpochTest. A real-broker target also fails before (cached topic present, assignment gone), then passes after (cache cleared, assignment retained until replica return, replacement bytes verified). Scoped probes remain marked incomplete migrations. Mandatory complete-scenario coverage follows separately.