### PR TITLE
kafka: identify native deletion responses before invoking deletion callbacks

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -848,21 +848,20 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
     val stopReplicaRequestVersion = ControllerChannelManager.stopReplicaRequestVersion(
       config.interBrokerProtocolVersion, bridgeMode)
 
-    /**
-     * For StopReplica request version < 4, we rely on the isPartitionDeleted function to check a partition's delete flag,
-     * this may not be always correct considering a later request's callback may overwrite an earlier
-     * request's callback inside the {@link ControllerRequestMerger#addStopReplicaRequest) method.
-     * For StopReplica request version 4 and above, we rely on the delete field inside the StopReplica response to
-     * check a partition's delete flag, which should be always correct.
-     */
+    // The merger may use a newer request's callback for an older response. With
+    // cleanup enabled, native v4 responses identify actual deletion responses.
+    // Older wire versions still need the request predicate; keep the disabled path unchanged.
     def responseCallback(brokerId: Int, isPartitionDeleted: TopicPartition => Boolean)
                         (response: AbstractResponse): Unit = {
       val stopReplicaResponse = response.asInstanceOf[StopReplicaResponse]
       val partitionErrorsForDeletingTopics = mutable.Map.empty[TopicPartition, Errors]
       stopReplicaResponse.partitionErrors.forEach { pe =>
         val tp = new TopicPartition(pe.topicName, pe.partitionIndex)
-        if (controllerContext.isTopicDeletionInProgress(pe.topicName) &&
-          (isPartitionDeleted(tp) || pe.deletePartition())) {
+        val deletesPartition = if (config.liProtocolBridgeTopicDeletionStateCleanupActive && stopReplicaRequestVersion >= 4)
+          pe.deletePartition()
+        else
+          isPartitionDeleted(tp) || pe.deletePartition()
+        if (controllerContext.isTopicDeletionInProgress(pe.topicName) && deletesPartition) {
           partitionErrorsForDeletingTopics += tp -> Errors.forCode(pe.errorCode)
         }
       }

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -618,6 +618,40 @@ class ControllerChannelManagerTest {
   }
 
   @Test
+  def testRecoveryUsesNativeResponseDeleteFlagInsteadOfMergedCallback(): Unit = {
+    for (bridge <- Seq(false, true); cleanup <- Seq(false, true)) {
+      val context = initContext(Seq(1, 2, 3), 1, 3, Set("foo"))
+      val properties = new Properties
+      properties.putAll(createConfig(ApiVersion.latestVersion, bridge).originals())
+      properties.put(KafkaConfig.LiProtocolBridgeTopicDeletionStateCleanupEnableProp, cleanup.toString)
+      val batch = new MockControllerBrokerRequestBatch(context, KafkaConfig.fromProps(properties))
+      val partition = new TopicPartition("foo", 0)
+      context.queueTopicDeletion(Set("foo"))
+      context.beginTopicDeletion(Set("foo"))
+      batch.newBatch()
+      context.putPartitionLeadershipInfo(partition, LeaderIsrAndControllerEpoch(LeaderAndIsr(1, List(1, 2, 3)), controllerEpoch))
+      batch.addStopReplicaRequestForBrokers(Seq(2), partition, deletePartition = true)
+      batch.sendRequestsToBrokers(controllerEpoch)
+      val callback = batch.sentRequests(2).head.responseCallback
+      val error = new StopReplicaPartitionError().setTopicName("foo").setPartitionIndex(0)
+        .setDeletePartition(false).setErrorCode(Errors.FENCED_LEADER_EPOCH.code)
+      callback(new StopReplicaResponse(new StopReplicaResponseData().setPartitionErrors(List(error).asJava)))
+      // Native responses carry the actual delete bit even when a newer delete
+      // request supplied the callback for this older non-delete merged response.
+      assertEquals(if (cleanup && !bridge) 0 else 1, batch.sentEvents.size)
+      batch.sentEvents.clear()
+      for (deletionError <- Seq(Errors.NONE, Errors.FENCED_LEADER_EPOCH)) {
+        batch.sentEvents.clear()
+        error.setDeletePartition(true).setErrorCode(deletionError.code)
+        callback(new StopReplicaResponse(new StopReplicaResponseData().setPartitionErrors(List(error).asJava)))
+        assertEquals(1, batch.sentEvents.size)
+        val event = batch.sentEvents.head.asInstanceOf[TopicDeletionStopReplicaResponseReceived]
+        assertEquals(deletionError, event.partitionErrors(partition))
+      }
+    }
+  }
+
+  @Test
   def testMixedDeleteAndNotDeleteStopReplicaRequests(): Unit = {
     testMixedDeleteAndNotDeleteStopReplicaRequests(ApiVersion.latestVersion,
       ApiKeys.STOP_REPLICA.latestVersion)


### PR DESCRIPTION
Fix the distinct dormant-backout failure retained from PR 593 CI run 34643004630. That run selected the repaired 0e15a67639 archive and passed the native offline-deletion case; it later stalled when a non-delete StopReplica error reached a newer delete request's callback.

The 3.0 merger keeps one callback per request type while queued partition states may produce several responses. The callback ORed its captured delete predicate with the response bit. This could turn a non-delete FENCED_LEADER_EPOCH response into a deletion failure. The replica was reset to OfflineReplica, and subsequent real deletion acknowledgements were rejected by the state machine.

Under the existing cleanup gate, native StopReplica v4 now uses its authoritative response delete bit. Older wire versions retain their request-predicate fallback; cleanup disabled retains existing behavior. Genuine deletion errors and acknowledgements still reach the deletion manager.

The new four-configuration regression fails before the fix (unexpected deletion event) and passes afterward. Complete ControllerChannelManagerTest, RequestSendThreadBridgeTest and TopicDeletionManagerTest suites pass. The retained CI failure is not relabelled; updated paired CI and full qualification remain required.
